### PR TITLE
Adding grid system and other related toolkit scss.

### DIFF
--- a/src/app/components/FacetSidebar/FacetSidebar.jsx
+++ b/src/app/components/FacetSidebar/FacetSidebar.jsx
@@ -174,7 +174,7 @@ class FacetSidebar extends React.Component {
     }
 
     return (
-      <div className="facets">
+      <div className={`facets ${this.props.className}`}>
         <form className="facets-form">
           <h2>Filter results by</h2>
           {
@@ -212,6 +212,11 @@ FacetSidebar.propTypes = {
   keywords: React.PropTypes.string,
   selectedFacets: React.PropTypes.object,
   sortBy: React.PropTypes.string,
+  className: React.PropTypes.string,
+};
+
+FacetSidebar.defaultProps = {
+  className: '',
 };
 
 FacetSidebar.contextTypes = {

--- a/src/app/components/HoldPage/HoldConfirmation.jsx
+++ b/src/app/components/HoldPage/HoldConfirmation.jsx
@@ -30,7 +30,7 @@ class HoldConfirmation extends React.Component {
     return (
       <div id="mainContent">
         <div className="page-header">
-          <div className="container">
+          <div className="content-wrapper">
             <Breadcrumbs
               query={searchKeywords}
               type="holdConfirmation"
@@ -40,13 +40,13 @@ class HoldConfirmation extends React.Component {
           </div>
         </div>
 
-        <div className="container holds-container">
+        <div className="content-wrapper">
           <div className="item-header">
             <h1>Research item request confirmation</h1>
           </div>
 
           <div className="item-summary row">
-            <div className="details col span-2-3">
+            <div className="details two-third">
               <h2>Item request details</h2>
               <ul className="generic-list">
                 <li>Item: <Link to={`/item/${id}`}>{title}</Link></li>
@@ -60,7 +60,7 @@ class HoldConfirmation extends React.Component {
                 { /* <li>Book will be held until {dateDisplayEnd}, 5:00pm</li> */ }
               </ul>
             </div>
-            <div className="actions col span-1-3">
+            <div className="actions third">
               <h2>Available actions</h2>
               <ul className="generic-list">
                 <li>Visit your <a href="http://myaccount-beta.nypl.org/my-account/holds">patron account page</a> to view the status of this item hold</li>
@@ -69,8 +69,8 @@ class HoldConfirmation extends React.Component {
             </div>
           </div>
 
-          <div className="row map-container">
-            <div className="col span-3-5">
+          <div className="map-container">
+            <div className="two-third">
               <Tabs
                 tabs={[
                   {title: 'Directions to building', id: 'building'},
@@ -85,7 +85,7 @@ class HoldConfirmation extends React.Component {
                 </TabPanel>
               </Tabs>
             </div>
-            <div className="col span-2-5">
+            <div className="third">
               <p>
                 <a href={`${location.uri}`}>{location["full-name"]}</a><br />
                 {location.address.address1}<br />

--- a/src/app/components/HoldPage/HoldPage.jsx
+++ b/src/app/components/HoldPage/HoldPage.jsx
@@ -34,7 +34,7 @@ class HoldPage extends React.Component {
     return (
       <div id="mainContent">
         <div className="page-header">
-          <div className="container">
+          <div className="content-wrapper">
             <Breadcrumbs
               query={searchKeywords}
               type="hold"
@@ -44,7 +44,7 @@ class HoldPage extends React.Component {
           </div>
         </div>
 
-        <div className="container holds-container">
+        <div className="content-wrapper">
           <div className="item-header">
             <h1>Research item hold</h1>
           </div>

--- a/src/app/components/HoldRequest/HoldRequest.jsx
+++ b/src/app/components/HoldRequest/HoldRequest.jsx
@@ -15,8 +15,11 @@ class HoldRequest extends React.Component {
       data: Store.getState(),
       patron: PatronStore.getState(),
     };
-    this.requireUser();
     this.onChange = this.onChange.bind(this);
+  }
+
+  componentDidMount() {
+    this.requireUser();
   }
 
   onChange() {
@@ -53,7 +56,7 @@ class HoldRequest extends React.Component {
     return (
       <div id="mainContent">
         <div className="page-header">
-          <div className="container">
+          <div className="content-wrapper">
             <Breadcrumbs
               query={searchKeywords}
               type="hold"
@@ -63,7 +66,7 @@ class HoldRequest extends React.Component {
           </div>
         </div>
 
-        <div className="container holds-container">
+        <div className="content-wrapper">
           <div className="item-header">
             <h1>Research item hold request</h1>
           </div>

--- a/src/app/components/Home/Home.jsx
+++ b/src/app/components/Home/Home.jsx
@@ -7,26 +7,23 @@ import Search from '../Search/Search.jsx';
 const Home = ({ sortBy }) => (
   <div className="home" id="mainContent">
     <div className="page-header">
-      <div className="container">
+      <div className="content-wrapper">
         <Breadcrumbs />
         <h2>New York Public Library Research Catalog</h2>
       </div>
     </div>
 
-    <div className="container item-container">
-
-      <div className="row primary">
-        <div className="col span-1-2">
-          <p className="lead">Search the New York Public Library Research Catalog
-            for materials available to use in one of four research libraries located
-            in New York City.
-          </p>
-        </div>
-        <div className="col span-1-2">
-          <div className="search home">
-            <Search sortBy={sortBy} />
-            <p><Link to="/advanced">Use advanced search</Link></p>
-          </div>
+    <div className="content-wrapper">
+      <div className="half">
+        <p className="lead">Search the New York Public Library Research Catalog
+          for materials available to use in one of four research libraries located
+          in New York City.
+        </p>
+      </div>
+      <div className="half">
+        <div className="search home">
+          <Search sortBy={sortBy} />
+          <p><Link to="/advanced">Use advanced search</Link></p>
         </div>
       </div>
     </div>

--- a/src/app/components/ItemPage/ItemPage.jsx
+++ b/src/app/components/ItemPage/ItemPage.jsx
@@ -67,7 +67,7 @@ class ItemPage extends React.Component {
   getDisplayFields(record, data) {
     if (!data.length) return [];
 
-    let displayFields = [];
+    const displayFields = [];
     data.forEach((f) => {
       // skip absent fields
       if (!record[f.field] || !record[f.field].length) return false;
@@ -77,10 +77,14 @@ class ItemPage extends React.Component {
       if (f.url) {
         displayFields.push({
           term: f.label,
-          definition: <ul>{record[f.field].map((value, i) => {
-            const v = f.field === 'idOwi' ? value.substring(8) : value;
-            return <li key={i}><a target="_blank" href={f.url(v)}>{v}</a></li>
-          })}</ul>,
+          definition: (
+            <ul>
+              {record[f.field].map((value, i) => {
+                const v = f.field === 'idOwi' ? value.substring(8) : value;
+                return <li key={i}><a target="_blank" href={f.url(v)}>{v}</a></li>;
+              })}
+            </ul>
+          ),
         });
 
       // list of links
@@ -150,10 +154,10 @@ class ItemPage extends React.Component {
       { label: 'LCC', field: 'idLcc' },
     ];
 
-    let externalLinks = this.getDisplayFields(record, externalFields);
-    let itemDetails = this.getDisplayFields(record, displayFields);
+    const externalLinks = this.getDisplayFields(record, externalFields);
+    const itemDetails = this.getDisplayFields(record, displayFields);
     let searchURL = this.props.searchKeywords;
-    
+
     _mapObject(this.props.selectedFacets, (val, key) => {
       if (val.value !== '') {
         searchURL += ` ${key}:"${val.id}"`;
@@ -163,7 +167,7 @@ class ItemPage extends React.Component {
     return (
       <div id="mainContent">
         <div className="page-header">
-          <div className="container">
+          <div className="content-wrapper">
             <Breadcrumbs
               query={searchURL}
               type="item"
@@ -172,26 +176,30 @@ class ItemPage extends React.Component {
           </div>
         </div>
 
-        <div className="container item-container">
+        <div className="content-wrapper">
           <div className="item-header">
             <div className="item-info">
               <h1>{title}</h1>
-                {authors &&
-                  <div className="description author">
-                  By {authors}
-                </div>}
-                {publisher &&
-                  <div className="description">
-                  Publisher: {publisher}
-                </div>}
+                {
+                  authors &&
+                    <div className="description author">
+                      By {authors}
+                    </div>
+                }
+                {
+                  publisher &&
+                    <div className="description">
+                      Publisher: {publisher}
+                    </div>
+                }
               <div className="description">
                 Year published:
-                  <Link
-                    to={{ pathname: '/search', query: {q: `date:${record.startYear}`}}}
-                    onClick={(e) => this.onClick(e, `date:${record.startYear}`)}
-                  >
-                    {record.startYear}
-                  </Link>
+                <Link
+                  to={{ pathname: '/search', query: { q: `date:${record.startYear}` } }}
+                  onClick={(e) => this.onClick(e, `date:${record.startYear}`)}
+                >
+                  {record.startYear}
+                </Link>
               </div>
             </div>
           </div>
@@ -239,6 +247,7 @@ ItemPage.propTypes = {
   item: React.PropTypes.object,
   searchKeywords: React.PropTypes.string,
   location: React.PropTypes.object,
+  selectedFacets: React.PropTypes.object,
 };
 
 ItemPage.contextTypes = {

--- a/src/app/components/SearchResultsPage/SearchResultsPage.jsx
+++ b/src/app/components/SearchResultsPage/SearchResultsPage.jsx
@@ -40,7 +40,7 @@ class SearchResultsPage extends React.Component {
     const results = searchResults ? collapse({ searchResults }).searchResults.itemListElement : [];
     const breadcrumbs = (
       <div className="page-header">
-        <div className="container">
+        <div className="content-wrapper">
           <Breadcrumbs query={searchKeywords} type="search" />
         </div>
       </div>
@@ -51,20 +51,29 @@ class SearchResultsPage extends React.Component {
 
         {breadcrumbs}
 
-        <div className="search-container">
+        <div className="content-wrapper">
           <Search sortBy={sortBy} />
         </div>
 
-        <div className="container search-results-container">
+        <div className="content-wrapper">
 
           <FacetSidebar
             facets={facetList}
             selectedFacets={selectedFacets}
             keywords={searchKeywords}
             sortBy={sortBy}
+            className="quarter"
           />
 
-          <div className="results" role="region" id="results-region" aria-live="polite" aria-atomic="true" aria-relevant="additions removals" aria-describedby="results-description">
+          <div
+            className="results three-quarter"
+            role="region"
+            id="results-region"
+            aria-live="polite"
+            aria-atomic="true"
+            aria-relevant="additions removals"
+            aria-describedby="results-description"
+          >
             <Hits
               hits={totalHits}
               query={searchKeywords}

--- a/src/client/styles/components/FacetSidebar.scss
+++ b/src/client/styles/components/FacetSidebar.scss
@@ -4,16 +4,16 @@ $facetsWidth: 200px;
   @include clearfix();
 }
 
-.facets {
-  width: $facetsWidth;
-  float: left;
-  margin-top: 1rem;
-}
-
-.results {
-  margin-left: ($facetsWidth + 20px);
-  margin-top: 1rem;
-}
+// .facets {
+//   width: $facetsWidth;
+//   float: left;
+//   margin-top: 1rem;
+// }
+//
+// .results {
+//   margin-left: ($facetsWidth + 20px);
+//   margin-top: 1rem;
+// }
 
 .facets-form {
   h2 {

--- a/src/client/styles/main.scss
+++ b/src/client/styles/main.scss
@@ -5,6 +5,7 @@
 @import "toolkit/measurements.scss";
 @import "utils/base.scss";
 @import "toolkit/forms.scss";
+@import "toolkit/grid.scss";
 
 /*
 Import style rules from NYPL React module components
@@ -33,7 +34,7 @@ button {
 }
 
 .page-header {
-  background: $pagecolorlight;
+  @include page-header;
 }
 
 .container {
@@ -56,6 +57,46 @@ button {
   &.available {
     color: $statusavailablecolor;
   }
+}
+
+.content-wrapper {
+  @include full-width-wrapper;
+}
+
+.page-header {
+  @include page-header;
+}
+
+#filter-search {
+  @include search-form;
+}
+
+.full {
+  @include column-full;
+}
+
+.quarter {
+  @include column-one-quarter;
+}
+
+.third {
+  @include column-one-third;
+}
+
+.half {
+  @include column-half;
+}
+
+.two-third {
+  @include column-two-thirds;
+}
+
+.three-quarter {
+  @include column-three-quarters;
+}
+
+.inner {
+  @include inner-block;
 }
 
 // Overrides for other components

--- a/src/client/styles/toolkit/_css3.scss
+++ b/src/client/styles/toolkit/_css3.scss
@@ -1,0 +1,90 @@
+// CSS 3 mixins taken from https://github.com/alphagov/govuk_frontend_toolkit
+
+// This file includes mixins for CSS properties that require vendor prefixes.
+
+// Please add more mixins here as you need them, rather than adding them to
+// your application - this lets us manage them in one place.
+
+// You can use the @warn directive to deprecate a mixin where the property
+// no longer needs prefixes.
+
+// This style of indentation is preferred as it is easier to scan
+// Allow more than two spaces per indentation level and don't require a space after a colon
+// scss-lint:disable Indentation SpaceAfterPropertyColon
+
+@mixin border-radius($radius) {
+  -webkit-border-radius: $radius; // Chrome 4.0, Safari 3.1 to 4.0, Mobile Safari 3.2, Android Browser 2.1
+     -moz-border-radius: $radius; // Firefox 2.0 to 3.6
+          border-radius: $radius;
+}
+
+@mixin box-shadow($shadow) {
+  -webkit-box-shadow: $shadow; // Chrome 4.0 to 9.0, Safari 3.1 to 5.0, Mobile Safari 3.2 to 4.3, Android Browser 2.1 to 3.0
+     -moz-box-shadow: $shadow; // Firefox 3.5 to 3.6
+          box-shadow: $shadow;
+}
+
+@mixin scale($x, $y, $transform-origin: 50% 50% 0) {
+  // $x and $y should be numeric values without units
+  -webkit-transform: scale($x, $y); // Still in use now, started at: Chrome 4.0, Safari 3.1, Mobile Safari 3.2, Android 2.1
+     -moz-transform: scale($x, $y); // Firefox 3.5 to 15.0
+      -ms-transform: scale($x, $y); // IE9 only
+          transform: scale($x, $y);
+
+  -webkit-transform-origin: $transform-origin; // Chrome, Safari 3.1
+     -moz-transform-origin: $transform-origin; // Firefox 10 to 15.0
+      -ms-transform-origin: $transform-origin; // IE9
+          transform-origin: $transform-origin;
+}
+
+@mixin translate($x, $y) {
+  -webkit-transform: translate($x, $y); // Still in use now, started at: Chrome 4.0, Safari 3.1, Mobile Safari 3.2, Android 2.1
+     -moz-transform: translate($x, $y); // Firefox 3.5 to 15.0
+      -ms-transform: translate($x, $y); // IE9 only
+       -o-transform: translate($x, $y); // Opera 10.5 to 12.0
+          transform: translate($x, $y);
+}
+
+@mixin gradient($from, $to) {
+  // Creates a vertical gradient where $from is the colour at the top of the element
+  // and $to is the colour at the bottom. The top colour is used as a background-color
+  // for browsers that don't support gradients.
+  background-color: $from;
+  background-image: -webkit-gradient(linear, 0% 0%, 0% 100%, from($from), to($to)); // Safari 4.0 to 5.1, Chrome 1.0 to 10.0, old deprecated syntax
+  background-image: -webkit-linear-gradient($from, $to); // Chrome 10.0 to 25.0, Safari 5.1 to 6.0, Mobile Safari 5.0 to 6.1, Android Browser 4.0 to 4.3
+  background-image:    -moz-linear-gradient($from, $to); // Firefox 3.6 to 15.0
+  background-image:      -o-linear-gradient($from, $to); // Opera 11.1 to 12.0
+  background-image:         linear-gradient($from, $to);
+  filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#{$from}', endColorstr='#{$to}',GradientType=0 ); // IE6 to IE9
+}
+
+@mixin transition($property, $duration, $function, $delay: 0s) {
+  -webkit-transition: ($property $duration $function $delay); // Chrome 4.0 to 25.0, Safari 3.1 to 6.0, Mobile Safari 3.2 to 6.1, Android Browser 2.1 to 4.3
+     -moz-transition: ($property $duration $function $delay); // Firefox 4.0 to 15.0
+       -o-transition: ($property $duration $function $delay); // Opera 10.5 to 12.0
+          transition: ($property $duration $function $delay);
+}
+
+// @mixin box-sizing($type) {
+//   // http://www.w3.org/TR/css3-ui/#box-sizing
+//   // $type can be one of: content-box | padding-box | border-box | inherit
+//   -webkit-box-sizing: $type; // Chrome 4.0 to 9.0, Safari 3.1 to 5.0, Mobile Safari 3.2 to 4.3, Android Browser 2.1 to 3.0
+//      -moz-box-sizing: $type; // Firefox 2.0 to 28.0, Firefox for Android 26.0 onwards
+//           box-sizing: $type;
+// }
+
+@mixin appearance($appearance) {
+  -webkit-appearance: $appearance;
+     -moz-appearance: $appearance;
+}
+
+@mixin calc($property, $calc) {
+  #{$property}: -webkit-calc(#{$calc}); // Chrome 19.0 to 25.0, Safari 6.0, Mobile Safari 6.0 to 6.1
+  #{$property}:         calc(#{$calc});
+}
+
+@mixin opacity($trans) {
+  zoom: 1;
+  filter: unquote('alpha(opacity=' + ($trans * 100) + ')'); // IE6 to IE8
+  opacity: $trans;
+}

--- a/src/client/styles/toolkit/_grid.scss
+++ b/src/client/styles/toolkit/_grid.scss
@@ -1,0 +1,74 @@
+@import "measurements";
+@import "css3";
+@import "microformats-mixins";
+@import "media-queries";
+
+@warn "remove magic numbers";
+
+@mixin banner-alert() {
+  background-color: $alertcolor;
+  padding: 0.8rem 0;
+  -webkit-animation: alert 2s linear;
+  animation: alert 2s linear;
+}
+
+@mixin full-width-wrapper {
+  margin: 0 auto;
+  max-width: calc(#{$max-width - $general-padding} - (#{$logo-width + $general-padding}));
+  padding: $general-padding $general-padding $general-padding ($logo-width + $general-padding);
+  position: relative;
+  @include clearfix;
+
+  @include media($mobile-breakpoint) {
+    padding-left: $general-padding;
+  }
+}
+
+@mixin column-type($float: left) {
+  float: $float;
+  margin-bottom: 2rem;
+  min-height: 1rem;
+  padding: 0 0.5rem 0 0.5rem;
+  @include clearfix;
+  @include box-sizing(border-box);
+
+  @include media($mobile-breakpoint) {
+    float: none;
+    padding: 0;
+    width: auto;
+  }
+}
+
+@mixin column-full {
+  width: $full-width;
+  @include column-type(none);
+}
+
+@mixin column-half {
+  width: $half;
+  @include column-type;
+}
+
+@mixin column-one-quarter {
+  width: $one-quarter;
+  @include column-type;
+}
+
+@mixin column-one-third {
+  width: $one-third;
+  @include column-type;
+}
+
+@mixin column-two-thirds {
+  width: $two-thirds;
+  @include column-type;
+}
+
+@mixin column-three-quarters {
+  width: $three-quarters;
+  @include column-type;
+}
+
+@mixin inner-block {
+  @warn "deprecated. use row-column pattern instead.";
+}

--- a/src/client/styles/toolkit/_media-queries.scss
+++ b/src/client/styles/toolkit/_media-queries.scss
@@ -1,0 +1,57 @@
+$is-ie: false !default;
+// $mobile-ie6: true !default;
+
+@mixin media($max-width, $min-width: false, $ignore-for-ie: false) {
+  @media (max-width: $max-width) {
+    @content;
+  }
+  // @if $is-ie and ($ignore-for-ie == false) {
+  //   @if $size != mobile {
+  //     @if ($ie-version == 6 and $mobile-ie6 == false) or $ie-version > 6 {
+  //       @content;
+  //     }
+  //   }
+  // } @else {
+  //   @if $size == desktop {
+  //     @media (min-width: 769px){
+  //       @content;
+  //     }
+  //   } @else if $size == tablet {
+  //     @media (min-width: 641px){
+  //       @content;
+  //     }
+  //   } @else if $size == mobile {
+  //     @media (max-width: 640px){
+  //       @content;
+  //     }
+  //   } @else if $max-width != false {
+  //     @media (max-width: $max-width){
+  //       @content;
+  //     }
+  //   } @else if $min-width != false {
+  //     @media (min-width: $min-width){
+  //       @content;
+  //     }
+  //   } @else {
+  //     @media (min-width: $size){
+  //       @content
+  //     }
+  //   }
+  // }
+}
+
+@mixin ie-lte($version) {
+  @if $is-ie {
+    @if $ie-version <= $version {
+      @content;
+    }
+  }
+}
+
+// @mixin ie($version) {
+//   @if $is-ie {
+//     @if $ie-version == $version {
+//       @content;
+//     }
+//   }
+// }

--- a/src/client/styles/toolkit/_microformats-mixins.scss
+++ b/src/client/styles/toolkit/_microformats-mixins.scss
@@ -1,0 +1,150 @@
+@mixin clearfix() {
+    &:before,
+    &:after {
+        content: "";
+        display: table;
+    }
+    &:after {
+        clear: both;
+    }
+}
+
+@warn "remove magic numbers";
+
+@mixin page-header {
+  background-color: $pagecolorlight;
+
+  h1 {
+    margin: 0;
+  }
+}
+
+@mixin secondary-title {
+  font-size: 1.2rem;
+  font-weight: bold;
+  line-height: 1.5;
+  margin: 0;
+}
+
+@mixin location-info {
+  border-left: 1rem solid $nypllightgray;
+  padding-left: 1rem;
+  margin-bottom: 2rem;
+
+  p {
+    margin: 0;
+    margin-bottom: 0.5em;
+  }
+
+  .room {
+    font-weight: bold;
+  }
+
+  .access {
+    color: $highlightcolor;
+    font-weight: bold;
+  }
+}
+
+@mixin location-hours {
+  position: relative;
+  width: 100%;
+
+  th, td {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    width: (100% / 7);
+  }
+
+  td {
+    padding-bottom: 1rem;
+  }
+
+  @include media($mobile-breakpoint) {
+    tr:first-child {
+      display: none;
+    }
+
+    tr {
+      border: none;
+    }
+
+    td {
+      display: block;
+      position: relative;
+      width: 100%;
+
+      &::before {
+        display: block;
+        float: left;
+        font-weight: bold;
+        margin-bottom: 2rem;
+        width: 40%;
+      }
+
+      &:nth-of-type(1)::before {
+        content: "Monday";
+      }
+
+      &:nth-of-type(2)::before {
+        content: "Tuesday";
+      }
+
+      &:nth-of-type(3)::before {
+        content: "Wednesday";
+      }
+
+      &:nth-of-type(4)::before {
+        content: "Thursday";
+      }
+
+      &:nth-of-type(5)::before {
+        content: "Friday";
+      }
+
+      &:nth-of-type(6)::before {
+        content: "Saturday";
+      }
+
+      &:nth-of-type(7)::before {
+        content: "Sunday";
+      }
+    }
+
+  }
+}
+@warn "Move these mixins out of the microformats partial since they effect the entire style guide...";
+@mixin related-links {
+  border-top: $related-links-border-width solid $nyplgray;
+  padding-top: 2rem;
+}
+
+@mixin toolkit-example {
+  border: $simple-border solid $nypllightgray;
+  padding: ($general-padding * 3) $general-padding ($general-padding * 0.5);
+  position: relative;
+
+  &:before {
+    border: $simple-border solid $nypllightgray;
+    border-left: none;
+    border-top: none;
+    color: $nyplgray;
+    content: "EXAMPLE";
+    display: inline-block;
+    font-size: 1em;
+    font-weight: normal;
+    left: 0;
+    padding: 0.3em $general-padding;
+    position: absolute;
+    text-transform: uppercase;
+    top: 0;
+  }
+}
+
+@mixin toolkit-example-dark {
+  background: $footercolor;
+
+  &:before {
+    background-color: $invertedlinkcolor;
+  }
+}

--- a/src/client/styles/utils/variables.scss
+++ b/src/client/styles/utils/variables.scss
@@ -20,6 +20,8 @@ $pagecolorlight: lighten($nypllightgray, 7%);
 $invertedbackgroundcolor: $nypldarkgray;
 $bordercolor: $nypllightgray;
 $focuswidth: 3px;
+$logo-width: 5rem;
+$logo-height: 3rem;
 
 // Layout
 $containerWidth: 1200px;


### PR DESCRIPTION
Updating related pages to use the grid system.

Updated layout can be found on dev-discovery.nypl.org. This is a partial PR where I want feedback to see how the layout is building up, so only the large components on the page have been updated. All pages use the `content-wrapper` rules, the search results page the facets use 1/4 of the width and the results 3/4 of the width, and the item hold request and confirmation pages are broken down into three parts.