### PR TITLE
Update colors from updated toolkit colors #147

### DIFF
--- a/src/client/styles/components/Account.scss
+++ b/src/client/styles/components/Account.scss
@@ -1,27 +1,27 @@
 table.generic-table {
-  border-top: 2px solid $bordercolor;
+  border-top: 2px solid $border-color;
   margin-top: 1rem;
   th {
     white-space: nowrap;
     padding-right: 1rem;
-    color: $linkcolor;
+    color: $link-color;
     text-decoration: underline;
     cursor: pointer;
     &:hover, &:visited:hover {
-      color: $linkhovercolor;
+      color: $link-hover-color;
     }
   }
 }
 
 .status {
   &.ready {
-    color: $statusavailablecolor;
+    color: $status-available-color;
   }
   &.requested {
-    color: $statusdefaultcolor;
+    color: $status-default-color;
   }
   &.cancelled,
   &.completed {
-    color: $statusunavailablecolor;
+    color: $status-unavailable-color;
   }
 }

--- a/src/client/styles/components/Advanced.scss
+++ b/src/client/styles/components/Advanced.scss
@@ -13,7 +13,7 @@
   }
   p {
     margin: 1rem 0;
-    border-top: 1px solid $bordercolor;
+    border-top: 1px solid $border-color;
   }
   fieldset {
     border: 0;
@@ -21,12 +21,12 @@
   }
   input {
     padding: 0.25rem 0.4rem;
-    border: 1px solid $bordercolor;
+    border: 1px solid $border-color;
     vertical-align: middle;
   }
   button[type="submit"] {
     margin-top: 1.5rem;
-    color: $buttontextcolor;
+    color: $button-text-color;
   }
 }
 
@@ -57,7 +57,7 @@
 }
 
 .guide {
-  border: 1px solid $bordercolor;
+  border: 1px solid $border-color;
   padding: 0.35rem 0.75rem;
 }
 

--- a/src/client/styles/components/Breadcrumbs.scss
+++ b/src/client/styles/components/Breadcrumbs.scss
@@ -1,6 +1,7 @@
 .breadcrumbs {
-  a {
-    background-color: $pagecolorlight;
+  a,
+  a:hover {
+    color: $page-color;
   }
 
   .breadcrumb {
@@ -10,7 +11,7 @@
       content: "»";
       display: inline-block;
       margin: 0 0.5rem;
-      color: $pagetextcolor;
+      color: $page-text-color;
     }
 
     &:last-child:after {

--- a/src/client/styles/components/FacetSidebar.scss
+++ b/src/client/styles/components/FacetSidebar.scss
@@ -1,24 +1,24 @@
-$facetsWidth: 200px;
+$facets-width: 200px;
 
 .search-results-container {
   @include clearfix();
 }
 
 // .facets {
-//   width: $facetsWidth;
+//   width: $facets-width;
 //   float: left;
 //   margin-top: 1rem;
 // }
 //
 // .results {
-//   margin-left: ($facetsWidth + 20px);
+//   margin-left: ($facets-width + 20px);
 //   margin-top: 1rem;
 // }
 
 .facets-form {
   h2 {
     font-size: 1rem;
-    color: $nyplsearchcolor;
+    color: $nypl-search-color;
     font-weight: normal;
     margin: 0;
   }
@@ -31,21 +31,13 @@ $facetsWidth: 200px;
   .button-selected {
     font-size: 1em;
     width: 100%;
-    background: $invertedbackgroundcolor;
-    color: $invertedlinkcolor;
     display: block;
-    border-color: $invertedbackgroundcolor;
     text-align: left;
     padding-right: 2rem;
     position: relative;
     white-space: nowrap;
     overflow: hidden;
     @include box-sizing();
-
-    &:hover {
-      background: lighten($invertedbackgroundcolor, 10%);
-      border-color: lighten($invertedbackgroundcolor, 10%);
-    }
 
     &:after {
       display: block;

--- a/src/client/styles/components/Feedback.scss
+++ b/src/client/styles/components/Feedback.scss
@@ -8,9 +8,9 @@
 }
 
 .feedback-button {
-  background: $alertcolor;
+  background: $alert-color;
   display: inline-block;
-  color: $pagetextcolor;
+  color: $page-text-color;
   cursor: pointer;
   box-sizing: border-box;
   padding: 0.5rem 1rem;
@@ -19,14 +19,14 @@
   font-size: 1rem;
 
   &:hover {
-    background: lighten($alertcolor, 10%);
+    background: lighten($alert-color, 10%);
   }
 }
 
 .feedback-form-container {
   display: none;
-  background: $pagecolorlight;
-  border: 1px solid $bordercolor;
+  background: $page-colorlight;
+  border: 1px solid $border-color;
   box-shadow: -1px 0 1px 0 rgba(0,0,0,0.3);
   padding: 0.35rem 0.5rem;
   text-align: left;
@@ -36,7 +36,7 @@
   }
 
   p {
-    border-bottom: 1px solid $bordercolor;
+    border-bottom: 1px solid $border-color;
     margin-bottom: 0.35rem;
     padding-bottom: 0.35rem;
   }
@@ -61,7 +61,7 @@
   textarea {
     display: block;
     width: 100%;
-    background-color: $backgroundcolor;
+    background-color: $background-color;
     border: 0;
     font-size: 1rem;
     line-height: 1.2;

--- a/src/client/styles/components/HoldPage.scss
+++ b/src/client/styles/components/HoldPage.scss
@@ -8,7 +8,7 @@
 }
 
 .item-summary {
-  background: $pagecolorlight;
+  background: $page-colorlight;
   padding: 0.6rem 0.75rem;
   margin-bottom: 1.2rem;
   @include clearfix();
@@ -74,18 +74,18 @@ label.group {
   }
 
   &.selected {
-    background: $alertcolor;
+    background: $alert-color;
   }
 
   &:first-child .col {
-    border-top: 1px solid $bordercolor;
+    border-top: 1px solid $border-color;
   }
 
   .col {
     display: table-cell;
     vertical-align: middle;
     padding: 0.35rem 1rem;
-    border-bottom: 1px solid $bordercolor;
+    border-bottom: 1px solid $border-color;
   }
 
   small {

--- a/src/client/styles/components/Home.scss
+++ b/src/client/styles/components/Home.scss
@@ -18,7 +18,7 @@
 }
 
 a.site-title {
-  color: $invertedlinkcolor;
+  color: $inverted-link-color;
   background-color: inherit;
   // background: url("../img/nypl.svg") no-repeat scroll 0px 0px/5rem auto white;
   overflow: hidden;
@@ -27,7 +27,7 @@ a.site-title {
   height: 50px;
   width: 5rem;
   &:hover {
-    color: $invertedlinkcolor;
+    color: $inverted-link-color;
   }
 }
 
@@ -51,20 +51,20 @@ a.site-title {
 
   .search-select {
     // width: 240px;
-    border-color: $nyplsearchcolor;
+    border-color: $nypl-search-color;
   }
   .search-button {
     width: 84px;
   }
   .search-input {
     padding-right: (84px + 4px);
-    border-color: $nyplsearchcolor;
+    border-color: $nypl-search-color;
   }
 }
 
 .home-secondary {
   margin-top: 3rem;
-  border-top: 1px solid $bordercolor;
+  border-top: 1px solid $nypl-search-color;
   padding-top: 1rem;
 }
 
@@ -74,7 +74,7 @@ a.site-title {
 
 .browse-box {
   h3 {
-    color: $nyplsearchcolor;
+    color: $nypl-search-color;
     background-color: inherit;
   }
 }
@@ -109,7 +109,7 @@ a.site-title {
   }
 
   .count {
-    color: $nyplsearchcolor;
+    color: $nypl-search-color;
     background-color: inherit;
   }
 
@@ -117,7 +117,7 @@ a.site-title {
     li {
       margin-bottom: 0.75rem;
       padding-bottom: 0.75rem;
-      border-bottom: 1px solid $bordercolor;
+      border-bottom: 1px solid $border-color;
       @include clearfix();
       &:last-child {
         border-bottom: 0;

--- a/src/client/styles/components/Item.scss
+++ b/src/client/styles/components/Item.scss
@@ -37,7 +37,7 @@
 .item-holdings,
 .item-details,
 .item-document-viewer {
-  border-top: 1px solid $bordercolor;
+  border-top: 1px solid $border-color;
   padding-top: 0.5rem;
   margin-top: 2rem;
 
@@ -73,12 +73,12 @@
 
     &:before {
       display: inline-block;
-      color: $pagetextcolor;
+      color: $page-text-color;
       content: " ";
       height: 0.5rem;
       width: 0.5rem;
-      border-left: 2px solid $pagetextcolor;
-      border-bottom: 2px solid $pagetextcolor;
+      border-left: 2px solid $page-text-color;
+      border-bottom: 2px solid $page-text-color;
       margin-right: 0.2rem;
     }
 
@@ -100,9 +100,9 @@
 
 .status {
   font-weight: bold;
-  color: $statusdefaultcolor;
+  color: $status-default-color;
 
   &.available {
-    color: $statusavailablecolor;
+    color: $status-available-color;
   }
 }

--- a/src/client/styles/components/Results.scss
+++ b/src/client/styles/components/Results.scss
@@ -35,12 +35,23 @@
 .paginate {
   text-decoration: none;
   cursor: pointer;
+  font-size: 1rem;
+  line-height: 1rem;
+  font-weight: bold;
+
+  &.previous,
+  &.next {
+    background: $background-color;
+    color: $page-text-color;
+    border: none;
+    text-decoration: underline;
+  }
 
   &.previous:before {
     content: '‹';
     display: inline-block;
     margin-right: 0.2rem;
-    font-size: 1.2rem;
+    font-size: 1rem;
     line-height: 1rem;
   }
 
@@ -48,7 +59,7 @@
     content: '›';
     display: inline-block;
     margin-left: 0.2rem;
-    font-size: 1.2rem;
+    font-size: 1rem;
     line-height: 1rem;
   }
 }
@@ -62,7 +73,7 @@
 }
 .result-item {
   padding: 0.5rem 0 1rem;
-  border-top: 1px solid $bordercolor;
+  border-top: 1px solid $border-color;
   display: flex;
   flex-direction: row;
 
@@ -81,7 +92,7 @@
   &.person {
     padding: 0.65rem;
     margin: 0.65rem 0;
-    border: 1px solid $bordercolor;
+    border: 1px solid $border-color;
     @include box-shadow(0px 1px 2px rgba(0,0,0,0.2));
 
     & + .result-item {
@@ -122,11 +133,11 @@
     }
 
     .description {
-      color: $pagetextcolor;
+      color: $page-text-color;
     }
 
     .label {
-      color: $statusunavailablecolor;
+      color: $status-unavailable-color;
     }
 
     .sub-items {
@@ -137,8 +148,8 @@
       .see-more-link {
         display: block;
         padding: 0.2rem 0.5rem;
-        border-top: 1px solid $bordercolor;
-        background: $bordercolor;
+        background: $page-colorlight;
+        color: $page-text-color;
       }
     }
 
@@ -147,7 +158,7 @@
       display: table;
       width: 100%;
       padding: 0;
-      background: $pagecolorlight;
+      background: $page-colorlight;
       margin-bottom: 0;
     }
 
@@ -169,28 +180,28 @@
       }
 
       .view-online {
-        background: $buttoncolor;
-        color: $buttontextcolor;
+        background: $button-background-color;
+        color: $button-text-color;
         text-decoration: none;
         padding: 0.1rem 0.35rem;
         margin-right: 0.35rem;
 
         &:hover {
-          background: $buttonhovercolor;
-          color: $buttontextcolor;
+          background: $button-text-color;
+          color: $button-background-color;
         }
       }
 
       .message {
         white-space: nowrap;
         font-weight: normal;
-        color: $pagetextcolor;
+        color: $page-text-color;
       }
 
       span.call-no {
         font-weight: normal;
         font-style: italic;
-        color: $pagetextcolor;
+        color: $page-text-color;
       }
 
       .button {
@@ -204,7 +215,7 @@
         display: table-cell;
         vertical-align: middle;
         padding: 0.5rem 0.5rem;
-        border-top: 1px solid $bordercolor;
+        border-top: 1px solid $border-color;
         &:last-child {
           text-align: right;
         }
@@ -221,7 +232,7 @@
       font-size: 2rem;
       line-height: 0.8rem;
       vertical-align: middle;
-      color: $pagetextcolor;
+      color: $page-text-color;
 
       &:before {
         content: "·";
@@ -242,7 +253,7 @@
       }
       span {
         padding-left: 0.35rem;
-        color: $pagetextcolor;
+        color: $page-text-color;
       }
     }
   }
@@ -268,7 +279,7 @@
       }
       span {
         padding-left: 0.35rem;
-        color: $pagetextcolor;
+        color: $page-text-color;
       }
     }
   }

--- a/src/client/styles/components/Search.scss
+++ b/src/client/styles/components/Search.scss
@@ -1,7 +1,7 @@
 .search {
   &-container {
     // margin: 50px;
-    max-width: $containerWidth;
+    max-width: $container-width;
     padding: 0.5rem 1rem;
     margin: 0 auto;
     @include box-sizing();
@@ -20,7 +20,7 @@
       font-size: 12px;
 
       a {
-        color: $linkcolor;
+        color: $link-color;
       }
 
       @include min-screen($tablet-portrait) {
@@ -40,7 +40,7 @@
       -moz-appearance: none;
       -webkit-appearance: none;
       appearance: none;
-      background: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDIwLjAuMCwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCA0LjkgMTAiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDQuOSAxMDsiIHhtbDpzcGFjZT0icHJlc2VydmUiPgo8c3R5bGUgdHlwZT0idGV4dC9jc3MiPgoJLnN0MHtmaWxsOiM0NDQ0NDQ7fQo8L3N0eWxlPgo8dGl0bGU+YXJyb3dzPC90aXRsZT4KPHBvbHlnb24gY2xhc3M9InN0MCIgcG9pbnRzPSIxLjQsNC43IDIuNSwzLjIgMy41LDQuNyAiLz4KPHBvbHlnb24gY2xhc3M9InN0MCIgcG9pbnRzPSIzLjUsNS4zIDIuNSw2LjggMS40LDUuMyAiLz4KPC9zdmc+Cg==) no-repeat 98% 50% $nyplsearchcolorlight;
+      background: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDIwLjAuMCwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCA0LjkgMTAiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDQuOSAxMDsiIHhtbDpzcGFjZT0icHJlc2VydmUiPgo8c3R5bGUgdHlwZT0idGV4dC9jc3MiPgoJLnN0MHtmaWxsOiM0NDQ0NDQ7fQo8L3N0eWxlPgo8dGl0bGU+YXJyb3dzPC90aXRsZT4KPHBvbHlnb24gY2xhc3M9InN0MCIgcG9pbnRzPSIxLjQsNC43IDIuNSwzLjIgMy41LDQuNyAiLz4KPHBvbHlnb24gY2xhc3M9InN0MCIgcG9pbnRzPSIzLjUsNS4zIDIuNSw2LjggMS40LDUuMyAiLz4KPC9zdmc+Cg==) no-repeat 98% 50% $nypl-search-color-light;
       border: 0;
       border-radius: 0;
       font-size: 16px;
@@ -54,7 +54,7 @@
   &-select {
     width: 29%;
     float: left;
-    border: 1px solid $nyplsearchcolor;
+    border: 1px solid $nypl-search-color;
     border-right: none;
     border-top-right-radius: 0;
     border-bottom-right-radius: 0;
@@ -76,7 +76,7 @@
     font-size: 1em;
     font-style: italic;
     text-indent: 10px;
-    border: 1px solid $nyplsearchcolor;
+    border: 1px solid $nypl-search-color;
     border-top-right-radius: 4px;
     border-bottom-right-radius: 4px;
     height: 52px;
@@ -95,8 +95,8 @@
     width: 100%;
     text-transform: uppercase;
     margin-top: 10px;
-    background-color: $buttoncolor;
-    color: $buttontextcolor;
+    background-color: $button-background-color;
+    color: $button-text-color;
     border: none;
     height: 52px;
     border-radius: 4px;
@@ -125,14 +125,14 @@
 }
 
 .related-items {
-  border-left: 4px solid $bordercolor;
+  border-left: 4px solid $page-colorlight;
   padding-left: 1rem;
   margin: 1rem 2rem 0 0.5rem;
 
   h4 {
     margin-top: 0;
-    color: $nyplsearchcolor;
-    background-color: $backgroundcolor;
+    color: $nypl-search-color;
+    background-color: $background-color;
   }
 
   & > ul {

--- a/src/client/styles/components/Tabs.scss
+++ b/src/client/styles/components/Tabs.scss
@@ -8,7 +8,7 @@
   .tab {
     flex-grow: 1;
     text-align: center;
-    color: $pagetextcolor;
+    color: $page-text-color;
     text-decoration: none;
     height: auto;
     line-height: normal;
@@ -21,16 +21,16 @@
     margin-bottom: 0;
 
     &:hover {
-      background: $buttonhovercolor;
-      color: $buttontextcolor;
+      background: $button-text-color;
+      color: $button-background-color;
     }
 
     &[aria-selected="true"] {
-      background: $backgroundcolor;
-      color: $pagetextcolor;
+      background: $button-text-color;
+      color: $button-background-color;
       cursor: default;
-      border-color: $bordercolor;
-      border-bottom: 2px solid $backgroundcolor;
+      border-color: $border-color;
+      border-bottom: 2px solid $button-text-color;
       margin-bottom: -2px;
     }
   }
@@ -39,7 +39,7 @@
 .tabpanel {
   display: none;
   min-height: 60px;
-  border: 1px solid $bordercolor;
+  border: 1px solid $border-color;
 
   img {
     width: 100%;
@@ -53,7 +53,7 @@
 .tabpanel-item {
   line-height: normal;
   padding: 0.35rem;
-  border-top: 1px solid $bordercolor;
+  border-top: 1px solid $border-color;
   display: flex;
   flex-direction: row;
 
@@ -87,7 +87,7 @@
 
     .type,
     .description {
-      color: $pagetextcolor;
+      color: $page-text-color;
       font-size: 0.7rem;
     }
 
@@ -100,7 +100,7 @@
     }
 
     .description {
-      color: $pagetextcolor;
+      color: $page-text-color;
     }
 
     .divider {
@@ -109,7 +109,7 @@
       font-size: 2rem;
       line-height: 0.8rem;
       vertical-align: middle;
-      color: $pagetextcolor;
+      color: $page-text-color;
 
       &:before {
         content: "·";
@@ -120,13 +120,13 @@
 
 a.tabpanel-link-full {
   display: block;
-  background: $buttoncolor;
-  color: $buttontextcolor;
+  background: $button-background-color;
+  color: $button-text-color;
   text-align: center;
   text-decoration: none;
   line-height: 2rem;
   &:hover {
-    background: $buttonhovercolor;
-    color: $buttontextcolor;
+    background: $button-text-color;
+    color: $button-background-color;
   }
 }

--- a/src/client/styles/main.scss
+++ b/src/client/styles/main.scss
@@ -30,7 +30,7 @@ Import style rules from NYPL React module components
 }
 
 button {
-  color: $buttontextcolor;
+  color: $button-text-color;
 }
 
 .page-header {
@@ -38,7 +38,7 @@ button {
 }
 
 .container {
-  max-width: $containerWidth;
+  max-width: $container-width;
   padding: 0.5rem 1rem;
   margin: 0 auto;
   @include box-sizing();
@@ -50,12 +50,12 @@ button {
 
 .status {
   font-weight: bold;
-  color: $statusdefaultcolor;
+  color: $status-default-color;
   background-color: inherit;
   text-transform: capitalize;
 
   &.available {
-    color: $statusavailablecolor;
+    color: $status-available-color;
   }
 }
 

--- a/src/client/styles/toolkit/_colors.scss
+++ b/src/client/styles/toolkit/_colors.scss
@@ -1,31 +1,78 @@
-// colors
-$nyplgray: #7B756F;
-$nypldarkgray: darken($nyplgray, 40%);
-$nypllightgray: lighten($nyplgray, 40%);
-$nyplyellow: #FEE24A;
-$nyplorange: #ffb81d;
-$nyplred: #e32b31;
-$nypldarkgreen: #4C842E;
-$nypllightgreen: lighten($nypldarkgreen, 20%);
-$nyplblue: #1DA1D4;
-$nyplbluedark: #1980a9;
+@warn "_colors.scss now using set from Marketing. Probably do some magic for eaching to prefix nypl automatically to each variable...";
+// nypl _colors.scss
+// NYPL Reds
+$nypl-red: #d0343a;
+
+$nypl-red-dark: #97272c;
+
+$nypl-red-tint: tint($nypl-red, 30%);
+
+// NYPL Blues
+$nypl-blue: #2799c5;
+
+$nypl-blue-dark: #135772;
+
+$nypl-blue-tint: tint($nypl-blue, 30%);
+
+// NYPL Monochromatic
+$nypl-gray-cool: #76777b;
+
+$nypl-gray: #776e64;
+
+$nypl-gray-brown: #54514a;
+
+$nypl-dark-gray: darken($nypl-gray, 40%);
+
+$nypl-light-gray: lighten($nypl-gray, 40%);
+
+$nypl-white: #fff;
+
+$nypl-black: #111;
+
+
+// NYPL Yellows for Alerts & Focus halos etc.
+$nypl-yellow: #fee24a;
+
+$nypl-yellow-tint: tint($nypl-yellow, 50%);
+
+$nypl-orange: #ffb81d;
+
+$nypl-organe-destaurated: desaturate($nypl-orange, 40%);
+
+// NYPL Greens
+$nypl-green: #799a05;
+
+$nypl-green-dark: #497629;
+
+$nypl-green-tint: tint($nypl-green, 40%);
 
 // semantic colors
-$nyplsearchcolor: $nyplgray;
-$nyplsearchcolordark: darken($nyplsearchcolor, 10%);
-$nyplsearchcolorlight: lighten($nyplsearchcolor, 30%);
-$focuscolor: $nyplorange;
-$pagecolor: $nypldarkgray;
-$pagecolorlight: $nypllightgray;
-$pagetextcolor: $nypldarkgray;
-$footercolor: #54514A;
-$highlightcolor: $nyplbluedark;
-$alertcolor: $nyplyellow;
-$backgroundcolor: #fff;
+$nypl-search-color: $nypl-gray;
+$nypl-search-color-dark: darken($nypl-search-color, 10%);
+$nypl-search-color-light: lighten($nypl-search-color, 30%);
+
+$focus-color: $nypl-orange;
+
+$page-color: $nypl-dark-gray;
+$page-colorlight: $nypl-light-gray;
+$page-text-color: $nypl-dark-gray;
+
+$nypl-footer-color: $nypl-gray-brown;
+$highlight-color: $nypl-red;
+$alert-color: $nypl-yellow;
+$background-color: $nypl-white;
 
 // link colors
-$linkcolor: $nyplred;
-$linkvisitedcolor: darken($linkcolor, 20%);
-$linkhovercolor: lighten($linkcolor, 10%);
-$invertedlinkcolor: white;
-$invertedlinkvisitedcolor: darken($invertedlinkcolor, 10%);
+$link-color: $nypl-blue;
+$link-visited-color: darken($link-color, 10%);
+$link-hover-color: lighten($link-color, 10%);
+$inverted-link-color: $nypl-white;
+$inverted-link-visited-color: darken($inverted-link-color, 10%);
+
+// button colors not already defined above.
+$button-text-color: $nypl-white;
+
+$button-border-color: $nypl-dark-gray;
+
+$button-background-color: $nypl-white;
+//

--- a/src/client/styles/toolkit/_forms.scss
+++ b/src/client/styles/toolkit/_forms.scss
@@ -8,7 +8,7 @@
   }
 
   #{$tag}:focus {
-    outline-color: $focuscolor;
+    outline-color: $focus-color;
     outline-style: solid;
     outline-width: $focus-width;
   }
@@ -21,7 +21,7 @@
 }
 
 @mixin fieldset {
-  background-color: $nyplsearchcolorlight;
+  background-color: $nypl-search-color-light;
   border: none;
   margin: 0 0 1rem;
   padding: 0;
@@ -33,12 +33,12 @@
 }
 
 @mixin input {
-  background-color: $nyplsearchcolorlight;
+  background-color: $nypl-search-color-light;
   border: none;
   padding: 0;
 }
 
-@mixin simple-button($main-color: $nyplsearchcolordark, $focus-color: $focuscolor) {
+@mixin simple-button($main-color: $nypl-search-color-dark, $focus-color: $focus-color) {
   @include input;
   background-color: $main-color;
   color: white;
@@ -46,7 +46,7 @@
   padding: 0 1rem;
 
   &:focus {
-    box-shadow: inset 0 0 0 4px $focuscolor;
+    box-shadow: inset 0 0 0 4px $focus-color;
     outline: none;
   }
 }
@@ -54,7 +54,7 @@
 @mixin textfield {
   @include input;
 
-  box-shadow: inset 0 0 0 2px $nyplsearchcolorlight;
+  box-shadow: inset 0 0 0 2px $nypl-search-color-light;
   height: 2rem;
   margin-right: 1px;
   padding: 1.5em 0 0;
@@ -68,8 +68,8 @@
 
   &:focus {
     background-color: white;
-    box-shadow: inset 0 0 0 4px $focuscolor !important;
-    color: $nyplsearchcolordark;
+    box-shadow: inset 0 0 0 4px $focus-color !important;
+    color: $nypl-search-color-dark;
     outline: none;
   }
 }
@@ -98,7 +98,7 @@
     -moz-appearance: none;
     -webkit-appearance: none;
     appearance: none;
-    background: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDIwLjAuMCwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCA0LjkgMTAiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDQuOSAxMDsiIHhtbDpzcGFjZT0icHJlc2VydmUiPgo8c3R5bGUgdHlwZT0idGV4dC9jc3MiPgoJLnN0MHtmaWxsOiM0NDQ0NDQ7fQo8L3N0eWxlPgo8dGl0bGU+YXJyb3dzPC90aXRsZT4KPHBvbHlnb24gY2xhc3M9InN0MCIgcG9pbnRzPSIxLjQsNC43IDIuNSwzLjIgMy41LDQuNyAiLz4KPHBvbHlnb24gY2xhc3M9InN0MCIgcG9pbnRzPSIzLjUsNS4zIDIuNSw2LjggMS40LDUuMyAiLz4KPC9zdmc+Cg==) no-repeat 98% 50% $nyplsearchcolorlight;
+    background: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDIwLjAuMCwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCA0LjkgMTAiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDQuOSAxMDsiIHhtbDpzcGFjZT0icHJlc2VydmUiPgo8c3R5bGUgdHlwZT0idGV4dC9jc3MiPgoJLnN0MHtmaWxsOiM0NDQ0NDQ7fQo8L3N0eWxlPgo8dGl0bGU+YXJyb3dzPC90aXRsZT4KPHBvbHlnb24gY2xhc3M9InN0MCIgcG9pbnRzPSIxLjQsNC43IDIuNSwzLjIgMy41LDQuNyAiLz4KPHBvbHlnb24gY2xhc3M9InN0MCIgcG9pbnRzPSIzLjUsNS4zIDIuNSw2LjggMS40LDUuMyAiLz4KPC9zdmc+Cg==) no-repeat 98% 50% $nypl-search-color-light;
     border: 0;
     border-radius: 0;
     font-size: 16px;
@@ -112,7 +112,7 @@
 @mixin simple-radiobutton {
   label {
     // @warn "fix !important";
-    background-color: $nyplsearchcolorlight;
+    background-color: $nypl-search-color-light;
     font-weight: normal !important;
     padding: 3px 5px;
   }
@@ -137,7 +137,7 @@
 
   a, span {
     // @warn "fix those !importants";
-    color: $pagecolor;
+    color: $page-color;
     display: inline-block !important;
     font-weight: normal !important;
     margin: 0 0 0.5em 0.5em;
@@ -148,7 +148,7 @@
   }
 
   a {
-    background-color: $nyplsearchcolorlight;
+    background-color: $nypl-search-color-light;
 
     &:hover {
       background-color: white;
@@ -156,7 +156,7 @@
   }
 
   span {
-    background-color: $nypllightgray;
+    background-color: $nypl-light-gray;
   }
 
   span.long {

--- a/src/client/styles/toolkit/_grid.scss
+++ b/src/client/styles/toolkit/_grid.scss
@@ -6,7 +6,7 @@
 @warn "remove magic numbers";
 
 @mixin banner-alert() {
-  background-color: $alertcolor;
+  background-color: $alert-color;
   padding: 0.8rem 0;
   -webkit-animation: alert 2s linear;
   animation: alert 2s linear;

--- a/src/client/styles/toolkit/_microformats-mixins.scss
+++ b/src/client/styles/toolkit/_microformats-mixins.scss
@@ -12,7 +12,7 @@
 @warn "remove magic numbers";
 
 @mixin page-header {
-  background-color: $pagecolorlight;
+  background-color: $page-colorlight;
 
   h1 {
     margin: 0;
@@ -27,7 +27,7 @@
 }
 
 @mixin location-info {
-  border-left: 1rem solid $nypllightgray;
+  border-left: 1rem solid $nypl-light-gray;
   padding-left: 1rem;
   margin-bottom: 2rem;
 
@@ -41,7 +41,7 @@
   }
 
   .access {
-    color: $highlightcolor;
+    color: $highlight-color;
     font-weight: bold;
   }
 }
@@ -115,20 +115,20 @@
 }
 @warn "Move these mixins out of the microformats partial since they effect the entire style guide...";
 @mixin related-links {
-  border-top: $related-links-border-width solid $nyplgray;
+  border-top: $related-links-border-width solid $nypl-gray;
   padding-top: 2rem;
 }
 
 @mixin toolkit-example {
-  border: $simple-border solid $nypllightgray;
+  border: $simple-border solid $nypl-light-gray;
   padding: ($general-padding * 3) $general-padding ($general-padding * 0.5);
   position: relative;
 
   &:before {
-    border: $simple-border solid $nypllightgray;
+    border: $simple-border solid $nypl-light-gray;
     border-left: none;
     border-top: none;
-    color: $nyplgray;
+    color: $nypl-gray;
     content: "EXAMPLE";
     display: inline-block;
     font-size: 1em;
@@ -142,9 +142,9 @@
 }
 
 @mixin toolkit-example-dark {
-  background: $footercolor;
+  background: $nypl-footer-color;
 
   &:before {
-    background-color: $invertedlinkcolor;
+    background-color: $inverted-link-color;
   }
 }

--- a/src/client/styles/utils/base.scss
+++ b/src/client/styles/utils/base.scss
@@ -7,47 +7,48 @@ html {
 }
 
 body {
-  color: $pagetextcolor;
-  background-color: $backgroundcolor;
+  color: $page-text-color;
+  background-color: $background-color;
   padding-bottom: 100px;
 }
 
 a {
   &, &:link {
-    color: $linkcolor;
+    color: $link-color;
     background-color: inherit;
   }
 
   &:visited {
-    color: $linkvisitedcolor;
+    color: $link-visited-color;
   }
 
   &:hover, &:visited:hover {
-    color: $linkhovercolor;
+    color: $link-hover-color;
   }
 
   &.button {
-    color: $buttontextcolor;
-    background: $buttoncolor;
+    color: $button-text-color;
+    background: $button-background-color;
     padding: 0.35rem 0.65rem;
     text-decoration: none;
     white-space: nowrap;
 
     &:hover {
-      color: $buttontextcolor;
-      background: $buttonhovercolor;
+      color: $button-background-color;
+      background: $button-text-color;
     }
   }
 }
 
 button {
-  color: $buttontextcolor;
-  background: $buttoncolor;
-  border: 1px solid $buttoncolor;
+  color: $button-text-color;
+  background: $button-background-color;
+  border: 1px solid $button-background-color;
 
   &:hover {
-    background: $buttonhovercolor;
-    border-color: $buttonhovercolor;
+    color: $button-background-color;
+    background: $button-text-color;
+    border-color: $button-text-color;
   }
 
   &.large {
@@ -91,9 +92,9 @@ a, input, select, button {
   border-radius: 0;
 
   &:focus {
-    outline-color: $focuscolor;
+    outline-color: $focus-color;
     outline-style: solid;
-    outline-width: $focuswidth;
+    outline-width: $focus-width;
   }
 }
 
@@ -113,7 +114,7 @@ a, input, select, button {
 // }
 
 .radio-group {
-  background: $pagecolorlight;
+  background: $page-colorlight;
   padding: 0.35rem 0.5rem;
   label,
   input {
@@ -188,7 +189,7 @@ iframe {
 
 .inline-form {
   input {
-    border: 1px solid $bordercolor;
+    border: 1px solid $border-color;
     padding: 0.2rem 0;
     text-indent: 0.2rem;
     width: 12rem;
@@ -204,7 +205,7 @@ table.generic-table {
     text-align: left;
   }
   tr {
-    border-bottom: 1px solid $bordercolor;
+    border-bottom: 1px solid $border-color;
     &.more {
       border-bottom: 0;
     }
@@ -269,7 +270,7 @@ table.generic-table {
 }
 
 .container {
-  max-width: $containerWidth;
+  max-width: $container-width;
   padding: 0.5rem 1rem;
   margin: 0 auto;
   @include box-sizing();

--- a/src/client/styles/utils/variables.scss
+++ b/src/client/styles/utils/variables.scss
@@ -1,30 +1,21 @@
 @import "../toolkit/colors";
 
-// red is too overwhelming to have for all links
-$linkcolor: $pagetextcolor;
-$linkvisitedcolor: $pagetextcolor;
-$linkhovercolor: $nyplred;
-
-// make buttons blue
-$buttoncolor: darken($nyplbluedark, 2%);
-$buttonhovercolor: lighten($buttoncolor, 5%);
-$buttontextcolor: $invertedlinkcolor;
+// buttons
+$button-background-color: $nypl-search-color-dark;
 
 // status
-$statusavailablecolor: darken($nypldarkgreen, 5%);
-$statusdefaultcolor: darken($nyplorange, 30%);
-$statusunavailablecolor: $nyplgray;
+$status-available-color: darken($nypl-green-dark, 5%);
+$status-default-color: darken($nypl-orange, 30%);
+$status-unavailable-color: $nypl-gray;
 
 // misc
-$pagecolorlight: lighten($nypllightgray, 7%);
-$invertedbackgroundcolor: $nypldarkgray;
-$bordercolor: $nypllightgray;
-$focuswidth: 3px;
+$border-color: $page-text-color;
+$focus-width: 3px;
 $logo-width: 5rem;
 $logo-height: 3rem;
 
 // Layout
-$containerWidth: 1200px;
-$headerHeight: 60px;
-$headerComponentHeight: 40px;
-$headerComponentMargin: ($headerHeight - $headerComponentHeight)/2;
+$container-width: 1200px;
+$header-height: 60px;
+$header-component-height: 40px;
+$header-component-margin: ($header-height - $header-component-height)/2;


### PR DESCRIPTION
Colors and color variable names have been updated in design toolkit:
https://github.com/NYPL/design-toolkit/blob/master/sass/_colors.scss

Hyphenation is the variable name pattern now: e.g. `pagetextcolor` becomes `page-text-color`

Link, button, background, and border colors have been updated.  I [flagged](https://github.com/NYPL/design-toolkit/issues/22) the color contrast issues in the design toolkit.  Some of the styling looks weird (e.g. tables), but that should be fixed in subsequent PRs.