### PR TITLE
Adding table styling from the design toolkit repo and …

### DIFF
--- a/src/app/components/HoldPage/HoldConfirmation.jsx
+++ b/src/app/components/HoldPage/HoldConfirmation.jsx
@@ -73,12 +73,12 @@ class HoldConfirmation extends React.Component {
             <div className="two-third">
               <Tabs
                 tabs={[
-                  {title: 'Directions to building', id: 'building'},
-                  {title: 'Directions to room', id: 'room'},
+                  { title: 'Directions to building', id: 'building' },
+                  { title: 'Directions to room', id: 'room' },
                 ]}
               >
                 <TabPanel id="building">
-                  <iframe src={`${location.address["map-embed-uri"]}`} height="450" frameBorder="0" style={{border: 0}} allowFullScreen title="Google Map" tabIndex="-1"></iframe>
+                  <iframe src={`${location.address['map-embed-uri']}`} height="450" frameBorder="0" style={{ border: 0 }} allowFullScreen title="Google Map" tabIndex="-1"></iframe>
                 </TabPanel>
                 <TabPanel id="room">
                   <img src="/src/client/images/floor_plan.png" alt="Floor plan of first floor of Stephen A. Schwarzman Building" />
@@ -87,32 +87,34 @@ class HoldConfirmation extends React.Component {
             </div>
             <div className="third">
               <p>
-                <a href={`${location.uri}`}>{location["full-name"]}</a><br />
+                <a href={`${location.uri}`}>{location['full-name']}</a><br />
                 {location.address.address1}<br />
                 {location.prefLabel}
               </p>
               <p>Regular hours:</p>
-              <table className="generic-table">
+              <table>
                 <caption className="visuallyHidden">Location hours</caption>
-                <tbody>
+                <thead>
                   <tr>
                     <th scope="col">Day</th>
                     <th scope="col">Hours</th>
                   </tr>
+                </thead>
+                <tbody>
                   {
                     location.hours.map((h, i) => (
                       <tr key={i}>
                         <td scope="col">{h.day}</td>
-                          {!h.closed &&
-                            <td scope="col">
-                              {h.open} - {h.close}
-                            </td>
-                          }
-                          {h.closed &&
-                            <td scope="col">
+                        {!h.closed &&
+                          <td scope="col">
+                            {h.open} - {h.close}
+                          </td>
+                        }
+                        {h.closed &&
+                          <td scope="col">
                             <em>Closed</em>
-                            </td>
-                          }
+                          </td>
+                        }
                       </tr>
                     ))
                   }
@@ -130,6 +132,7 @@ HoldConfirmation.propTypes = {
   item: React.PropTypes.object,
   location: React.PropTypes.object,
   searchKeywords: React.PropTypes.string,
+  params: React.PropTypes.object,
 };
 
 export default HoldConfirmation;

--- a/src/app/components/ItemPage/ItemHoldings.jsx
+++ b/src/app/components/ItemPage/ItemHoldings.jsx
@@ -6,7 +6,7 @@ class ItemHoldings extends React.Component {
     super(props);
 
     this.state = {
-      expanded: false
+      expanded: false,
     };
   }
 
@@ -20,11 +20,6 @@ class ItemHoldings extends React.Component {
     );
   }
 
-  showMoreItems(e){
-    e.preventDefault();
-    this.setState({ expanded: true });
-  }
-
   getRow(holdings) {
     const holdingCount = holdings.length;
     const maxDisplay = 7;
@@ -35,8 +30,11 @@ class ItemHoldings extends React.Component {
       <tbody>
         {
           holdings.map((h, i) => (
-            <tr className={`${h.availability} ${i>=maxDisplay && collapsed ? 'collapsed' : ''}`} key={i}>
-              <td dangerouslySetInnerHTML={this.createMarkup(`<span class="status ${h.availability}">${h.status}</span>`)}></td>
+            <tr
+              key={i}
+              className={`${h.availability} ${i >= maxDisplay && collapsed ? 'collapsed' : ''}`}
+            >
+              <td dangerouslySetInnerHTML={this.createMarkup(this.getAvailability(h))}></td>
               <td dangerouslySetInnerHTML={this.createMarkup(h.location)}></td>
               <td dangerouslySetInnerHTML={this.createMarkup(h.callNumber)}></td>
               <td>
@@ -56,22 +54,30 @@ class ItemHoldings extends React.Component {
         }
         {
           moreCount > 0 && collapsed ?
-            (
-              <tr className="more">
-                <td colSpan="4">
-                  <Link
-                    onClick={(e) => this.showMoreItems(e)}
-                    href="#see-more"
-                    className="more-link">
-                    See {moreCount} more {moreCount > 1 ? 'copies' : 'copy'}
-                  </Link>
-                </td>
-              </tr>
-            )
+            (<tr className="more">
+              <td colSpan="4">
+                <Link
+                  onClick={(e) => this.showMoreItems(e)}
+                  href="#see-more"
+                  className="more-link"
+                >
+                  See {moreCount} more {moreCount > 1 ? 'copies' : 'copy'}
+                </Link>
+              </td>
+            </tr>)
             : null
         }
       </tbody>
     );
+  }
+
+  getAvailability(hold) {
+    return `<span class="status ${hold.availability}">${hold.status}</span>`;
+  }
+
+  showMoreItems(e) {
+    e.preventDefault();
+    this.setState({ expanded: true });
   }
 
   createMarkup(html) {
@@ -90,8 +96,10 @@ class ItemHoldings extends React.Component {
     return (
       <div className="item-holdings">
         <h2>{this.props.title}</h2>
-        <table className="generic-table holdings-table">
-          <caption className="visuallyHidden">Item availability, location, call number, and request a hold.</caption>
+        <table className="holdings-table">
+          <caption className="visuallyHidden">
+            Item availability, location, call number, and request a hold.
+          </caption>
           {heading}
           {body}
         </table>
@@ -102,6 +110,7 @@ class ItemHoldings extends React.Component {
 
 ItemHoldings.propTypes = {
   holdings: React.PropTypes.array,
+  title: React.PropTypes.string,
 };
 
 export default ItemHoldings;

--- a/src/client/styles/components/HoldPage.scss
+++ b/src/client/styles/components/HoldPage.scss
@@ -96,10 +96,13 @@ label.group {
 
 .map-container {
   font-size: 1.3rem;
+
   .col:first-child {
     padding-left: 0;
   }
+
   table {
+    @include basic-table;
     font-size: 1rem;
   }
 }

--- a/src/client/styles/components/Item.scss
+++ b/src/client/styles/components/Item.scss
@@ -62,8 +62,10 @@
 }
 
 .holdings-table {
+  @include basic-table;
+
   .collapsed {
-      display: none;
+    display: none;
   }
 }
 

--- a/src/client/styles/main.scss
+++ b/src/client/styles/main.scss
@@ -3,6 +3,7 @@ Import style rules from NYPL Design Toolkit
 */
 @import "toolkit/nypl-normalize.scss";
 @import "toolkit/grid";
+@import "toolkit/table-results";
 
 /*
 App-specific utilities and defaults
@@ -103,6 +104,10 @@ button {
 
 .inner {
   @include inner-block;
+}
+
+table {
+  @include views-table;
 }
 
 // Overrides for other components

--- a/src/client/styles/toolkit/_table-results.scss
+++ b/src/client/styles/toolkit/_table-results.scss
@@ -1,0 +1,236 @@
+@mixin basic-table {
+  position: relative;
+  width: 100%;
+
+  th,
+  td {
+    overflow: hidden;
+    padding: 0.125rem 0.25rem;
+    text-overflow: ellipsis;
+  }
+
+  td {
+    padding-bottom: 1rem;
+  }
+}
+
+@mixin results-summary {
+  line-height: 1;
+  margin-bottom: 1.5rem;
+  margin-top: 1rem;
+  @include clearfix;
+
+  .results-count {
+    display: inline-block;
+    float: left;
+    font-size: 3rem;
+    font-weight: bold;
+    margin-bottom: 1rem;
+    margin-right: 0.5rem;
+  }
+
+  button {
+    @include basic-button($text-color: $nypl-gray, $background-color: $page-background-color, $hover-text-color: $link-color, $hover-background-color: $page-background-color, $height: 1rem, $border-width: 0);
+    display: inline-block;
+    margin: 0;
+    padding: 0;
+    vertical-align: super;
+  }
+}
+
+@mixin results-pagination {
+  font-size: 1.5rem;
+  margin-top: 1.5rem;
+  margin-bottom: 3rem;
+  @include clearfix;
+
+  .page-count,
+  a {
+    display: block;
+    float: left;
+    text-decoration: none;
+    width: 30%;
+    @include clearfix;
+  }
+
+  .page-count {
+    text-align: center;
+    width: 40%;
+
+    @include media($mobile-breakpoint) {
+      font-size: 1rem;
+    }
+  }
+
+  a:last-child {
+    text-align: right;
+  }
+
+  a:first-child svg {
+    float: left;
+  }
+
+  a {
+    svg {
+      @include nypl-icon;
+      display: block;
+      fill: $link-color;
+      float: right;
+      height: 2em;
+      width: 2em;
+    }
+
+    @include media($mobile-breakpoint) {
+      line-height: 1.3;
+
+      &:first-child svg {
+        float: none;
+      }
+
+      &:last-child svg {
+        margin-left: 100%;
+      }
+    }
+  }
+}
+
+@mixin views-table {
+  display: table;
+  border-collapse: collapse;
+
+  tr,
+  .views-table-row {
+    border-bottom: 1px solid $nypl-light-gray;
+    display: table-row;
+  }
+
+  .views-table-row .views-table-header,
+  thead,
+  th {
+    border-bottom: 1px solid $page-color;
+    text-align: left;
+  }
+
+  td,
+  th,
+  .views-table-header,
+  .views-table-cell {
+    display: table-cell;
+  }
+
+  th,
+  .views-table-header {
+    font-weight: bold;
+  }
+
+  .views-table-header.event-time {
+    width: 20%;
+  }
+
+  .views-table-header.event-title {
+    width: 40%;
+  }
+
+  .views-table-header.event-location {
+    width: 20%;
+  }
+
+  .views-table-header.event-audience {
+    width: 20%;
+  }
+
+  .views-table-header.resource-availability {
+    width: 25%;
+  }
+
+  .views-table-header.resouce-description {
+    width: 65%;
+  }
+
+  td,
+  .views-table-cell {
+    border-bottom: 1px solid $nypl-light-gray;
+    padding: 0.5rem 0.5rem 3rem 0;
+    vertical-align: top;
+  }
+
+  .channel-title {
+    color: $highlight-color;
+    text-transform: uppercase;
+  }
+
+  .signup-method {
+    color: $highlight-color;
+  }
+
+  .resource-title {
+    font-weight: bold;
+  }
+
+  &.collapses {
+    @include media($mobile-breakpoint) {
+      thead,
+      th,
+      .views-table-header,
+      .views-table-row:first-child {
+        display: none;
+      }
+
+      td,
+      .views-table-cell {
+        display: block;
+        float: left;
+        margin: 0;
+        padding: 1rem 0;
+      }
+
+      tr:first-child,
+      .views-table-row:first-child {
+        border-top: 1px solid $nypl-light-gray;
+      }
+
+      .event-time,
+      .event-audience,
+      .event-title {
+        border: 0;
+        display: block;
+      }
+
+      .event-time {
+        width: 20%;
+      }
+
+      .event-title,
+      .event-location,
+      .event-audience {
+        width: 30%;
+      }
+
+      .event-title {
+        margin-right: 5%;
+        width: 45%;
+        max-height: 12rem;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+
+      .event-location {
+        border-bottom: 0;
+        font-weight: bold;
+      }
+
+      .event-audience::before {
+        content: "For: ";
+      }
+
+      .resource-availability {
+        width: 25%;
+      }
+
+      .resouce-description {
+        width: 65%;
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
…updating the tables on the item page and hold confirmation page.

Also ESLint-ing.

Compare what's live now http://dev-discovery.nypl.org/item/b11183568 with:
![screen shot 2017-01-03 at 4 28 26 pm](https://cloud.githubusercontent.com/assets/1280564/21623699/be1d692a-d1d1-11e6-8ef1-1ba568a7d9f1.png)

If you request a hold, the date table on the confirmation page will look like:
![screen shot 2017-01-03 at 4 14 09 pm](https://cloud.githubusercontent.com/assets/1280564/21623718/d4c97ee8-d1d1-11e6-927e-c5928427f0b9.png)

