### PR TITLE
Results redesign #165

### DIFF
--- a/src/app/components/Hits/Hits.jsx
+++ b/src/app/components/Hits/Hits.jsx
@@ -20,14 +20,13 @@ class Hits extends React.Component {
   getKeyword(keyword) {
     if (keyword) {
       return (
-        <span>&nbsp;with keywords <strong>"{keyword}"</strong>
+        <span>&nbsp;with keywords <strong>{keyword}</strong>
           <button
             onClick={() => this.removeKeyword(keyword)}
-            className="removeKeyword"
+            className="remove-keyword"
             aria-controls="results-region"
           >
-            remove
-            <span className="visuallyHidden"> keyword filter&nbsp;{keyword}</span>
+            <span className="visuallyHidden">remove keyword filter&nbsp;{keyword}</span>
           </button>
         </span>
       );
@@ -40,14 +39,13 @@ class Hits extends React.Component {
     if (!facets.length) return null;
 
     return facets.map((facet, i) => (
-      <span key={i}>&nbsp;with {facet.key} <strong>"{facet.val.value}"</strong>
+      <span key={i}>&nbsp;with {facet.key} <strong>{facet.val.value}</strong>
         <button
           onClick={() => this.removeFacet(facet.key)}
-          className="removeFacet"
+          className="remove-facet"
           aria-controls="results-region"
         >
-          remove
-          <span className="visuallyHidden"> filter&nbsp;{facet.val.value}</span>
+          <span className="visuallyHidden">remove filter&nbsp;{facet.val.value}</span>
         </button>
       </span>
     ));
@@ -100,10 +98,10 @@ class Hits extends React.Component {
     const activeFacetsElm = this.getFacetElements(activeFacetsArray);
 
     return (
-      <div id="results-description" className="results-message">
+      <div id="results-description" className="results-summary">
         {
           hits !== 0 ?
-          (<p>Found <strong>{hitsF}</strong> results{keyword}{activeFacetsElm}.</p>)
+          (<p><strong className="results-count">{hitsF}</strong> results found{keyword}{activeFacetsElm}.</p>)
           : (<p>No results found{keyword}{activeFacetsElm}.</p>)
         }
       </div>

--- a/src/app/components/Results/ResultItems.jsx
+++ b/src/app/components/Results/ResultItems.jsx
@@ -21,37 +21,30 @@ class ResultsItems extends React.Component {
       const collapsed = this.state.collapsed;
 
       return (
-        <li key={i}>
-          <div className={`sub-item ${i >= MAXDISPLAY && collapsed ? 'more' : ''}`}>
-            <div>
-              <span className={`status ${availability}`}>{status}</span>
-              {
-                available ? ' to use in ' : ' at location '
-              }
-              <span>{item.location}</span>
-              {
-                item.callNumber.length ?
-                (<span className="call-no"> with call no. {item.callNumber}</span>)
-                : null
-              }
-            </div>
-            <div>
-              {
-                item.url && item.url.length ?
-                (
-                  <a
-                    href={item.url}
-                    className="button"
-                  >
-                    {item.actionLabel}
-                    <span className="visuallyHidden"> {item.actionLabelHelper}</span>
-                  </a>
-                )
-                : null
-              }
-            </div>
-          </div>
-        </li>
+        <tr key={i} className={`sub-item ${i >= MAXDISPLAY && collapsed ? 'more' : ''}`}>
+          <td>
+            {item.location}
+          </td>
+          <td>
+            {
+              item.callNumber.length ? item.callNumber : null
+            }
+          </td>
+          <td>
+            {
+              item.url && item.url.length ?
+              (
+                <a
+                  href={item.url}
+                  className="request-hold-link"
+                >
+                  {item.actionLabel}
+                </a>
+              )
+              : null
+            }
+          </td>
+        </tr>
       );
     });
   }
@@ -65,16 +58,18 @@ class ResultsItems extends React.Component {
     return (
       moreCount > 0 && collapsed ?
       (
-        <li>
-          <a
-            href="#"
-            className="see-more-link"
-            onClick={(e) => this.showMoreItems(e)}
-          >
-            See {moreCount} more item{moreCount > 1 ? 's' : ''}
-            <span className="visuallyHidden"> in collapsed menu for {resultTitle}</span>
-          </a>
-        </li>
+        <tr className="see-more-row">
+          <td colSpan="3">
+            <a
+              href="#"
+              className="see-more-link"
+              onClick={(e) => this.showMoreItems(e)}
+            >
+              See {moreCount} more item{moreCount > 1 ? 's' : ''}
+              <span className="visuallyHidden"> in collapsed menu for {resultTitle}</span>
+            </a>
+          </td>
+        </tr>
       )
       : null
     );
@@ -93,15 +88,29 @@ class ResultsItems extends React.Component {
     }
 
     return (
-      <ul
-        tabIndex="0"
-        className="sub-items"
-        aria-label={`This bibliographical record has ${items.length}` +
-          ` item${items.length > 1 ? 's' : ''}.`}
-      >
-        {this.getItems(items)}
-        {this.getMoreLink(items)}
-      </ul>
+      <div className="result-item-formats">
+        <p>
+          <strong>Items available:</strong>
+        </p>
+        <table
+          tabIndex="0"
+          className="sub-items result-item-formats-table"
+          aria-label={`This bibliographical record has ${items.length}` +
+            ` item${items.length > 1 ? 's' : ''}.`}
+        >
+          <thead className="visuallyHidden">
+            <tr>
+              <th>Item</th>
+              <th>Call Number</th>
+              <th>Action</th>
+            </tr>
+          </thead>
+          <tbody>
+            {this.getItems(items)}
+            {this.getMoreLink(items)}
+          </tbody>
+        </table>
+      </div>
     );
   }
 }

--- a/src/app/components/Results/ResultsList.jsx
+++ b/src/app/components/Results/ResultsList.jsx
@@ -66,24 +66,38 @@ class ResultsList extends React.Component {
       <li key={i} className="result-item">
         <div className="result-text">
           {/*<div className="type">{result.type ? result.type[0].prefLabel : null}</div>*/}
-          <Link
-            onClick={(e) => this.getRecord(e, id, 'item')}
-            href={`/item/${id}`}
-            className="title"
-          >
-            {itemTitle}
-          </Link>
+          <h4>
+            <Link
+              onClick={(e) => this.getRecord(e, id, 'item')}
+              href={`/item/${id}`}
+              className="title"
+            >
+              {itemTitle}
+            </Link>
+          </h4>
           {
-            author &&
-            (<div className="description author">
-              {authors} {result.created}
-            </div>)
+            authors &&
+            (<p className="description">
+              <strong>By:</strong> {authors}
+            </p>)
+          }
+          {
+            result.publisher &&
+            (<p className="description">
+              <strong>Publisher:</strong> {result.publisher}
+            </p>)
+          }
+          {
+            result.created &&
+            (<p className="description">
+              <strong>Year published:</strong> {result.created}
+            </p>)
           }
           {
             hathiAvailable &&
-            (<div className="description">
+            (<p className="description">
               <em>Available to view on this website</em>
-            </div>)
+            </p>)
           }
           {
             items.length ? <ResultItems items={items} itemTitle={itemTitle} /> : null

--- a/src/app/utils/item.js
+++ b/src/app/utils/item.js
@@ -58,7 +58,7 @@ function LibraryItem() {
 
       } else if (availability === 'available') {
         url = `/hold/request/${id}`;
-        actionLabel = 'Request a hold';
+        actionLabel = 'Request for in-library use';
         actionLabelHelper = `for ${recordTitle} for use in library`;
       }
 

--- a/src/client/styles/components/Results.scss
+++ b/src/client/styles/components/Results.scss
@@ -81,216 +81,33 @@
   padding: 0;
 }
 .result-item {
-  padding: 0.5rem 0 1rem;
-  border-top: 1px solid $border-color;
-  display: flex;
-  flex-direction: row;
+  @include results-item;
+}
+.result-item-formats {
+  @include results-item-formats;
 
-  .result-image {
-    flex: 0 0 60px;
-    max-height: 100px;
-    overflow: hidden;
-
-    img {
-      width: 100%;
-      margin: 0 auto;
-      display: block;
-    }
+  th:first-child,
+  td:first-child,
+  th:last-child,
+  td:last-child {
+    width: auto;
   }
 
-  &.person {
-    padding: 0.65rem;
-    margin: 0.65rem 0;
-    border: 1px solid $border-color;
-    @include box-shadow(0px 1px 2px rgba(0,0,0,0.2));
-
-    & + .result-item {
-      border-top: 0;
-    }
-
-    .result-image {
-      flex: 0 0 80px;
-      max-height: 120px;
-    }
+  th:last-child,
+  td:last-child {
+    white-space: nowrap;
   }
 
-  .result-text {
-    text-decoration: none;
-    flex-grow: 1;
-    position: relative;
-
-    .type,
-    .title,
-    .description {
-      display: block;
-    }
-
-    .type,
-    .description,
-    .sub-item {
-      font-size: 0.95rem;
-    }
-
-    .type {
-      text-transform: uppercase;
-    }
-
-    .title {
-      font-size: 1rem;
-      line-height: 1.35;
-      font-weight: bold;
-    }
-
-    .description {
-      color: $page-text-color;
-    }
-
-    .label {
-      color: $status-unavailable-color;
-    }
-
-    .sub-items {
-      margin-top: 0.35rem;
-      max-width: 800px;
-      padding: 0;
-
-      .see-more-link {
-        display: block;
-        padding: 0.2rem 0.5rem;
-        background: $page-color-light;
-        color: $page-text-color;
-      }
-    }
-
-    .sub-items > div,
-    .sub-items > li {
-      display: table;
-      width: 100%;
-      padding: 0;
-      background: $page-color-light;
-      margin-bottom: 0;
-    }
-
-    .sub-item {
-      display: table-row;
-      line-height: 1.2;
-      padding: 0.2rem 0;
-
-      &.more {
-        display: none;
-      }
-
-      span {
-        font-weight: bold;
-      }
-
-      .call-no {
-        white-space: nowrap;
-      }
-
-      .view-online {
-        background: $button-background-color;
-        color: $button-text-color;
-        text-decoration: none;
-        padding: 0.1rem 0.35rem;
-        margin-right: 0.35rem;
-
-        &:hover {
-          background: $button-text-color;
-          color: $button-background-color;
-        }
-      }
-
-      .message {
-        white-space: nowrap;
-        font-weight: normal;
-        color: $page-text-color;
-      }
-
-      span.call-no {
-        font-weight: normal;
-        font-style: italic;
-        color: $page-text-color;
-      }
-
-      .button {
-        padding: 0.2rem 0.65rem;
-        min-width: 110px;
-        display: inline-block;
-        text-align: center;
-      }
-
-      > div {
-        display: table-cell;
-        vertical-align: middle;
-        padding: 0.5rem 0.5rem;
-        border-top: 1px solid $border-color;
-        &:last-child {
-          text-align: right;
-        }
-      }
-    }
-
-    .sub-item:first-child > div {
-      border-top: 0;
-    }
-
-    .divider {
-      display: inline-block;
-      margin: 0 0.35rem;
-      font-size: 2rem;
-      line-height: 0.8rem;
-      vertical-align: middle;
-      color: $page-text-color;
-
-      &:before {
-        content: "·";
-      }
-    }
-
-    .select-label {
-      position: absolute;
-      top: 0;
-      right: 0;
-      font-size: 0.8rem;
-      display: block;
-
-      input,
-      span {
-        display: inline-block;
-        vertical-align: middle;
-      }
-      span {
-        padding-left: 0.35rem;
-        color: $page-text-color;
-      }
-    }
+  .more {
+    display: none;
   }
+}
+.result-item-formats-table {
+  @include basic-table;
 
-  .result-actions {
-    flex: 0 0 110px;
-
-    display: flex;
-    align-items: center;
-    // justify-content: right;
-    // text-align: right;
-
-    .select-label {
-      white-space: nowrap;
-      display: block;
-      margin-top: 1rem;
-      padding-left: 0.35rem;
-
-      input,
-      span {
-        display: inline-block;
-        vertical-align: middle;
-      }
-      span {
-        padding-left: 0.35rem;
-        color: $page-text-color;
-      }
-    }
+  tr.see-more-row,
+  tr.see-more-row td {
+    border: none;
   }
 }
 

--- a/src/client/styles/components/Results.scss
+++ b/src/client/styles/components/Results.scss
@@ -1,18 +1,30 @@
 .results-nav {
-  display: flex;
-  flex-direction: row;
-  align-items: flex-start;
-  margin-top: 1rem;
+  @include results-sorting-controls();
+  padding-bottom: 0.2rem;
 
   .pagination {
-    flex: 4 0 0;
+    float: left;
+    height: 2rem;
+    line-height: 2rem;
   }
 
   .sort {
-    flex: 1 0 0;
+    float: right;
 
     fieldset {
       @include select-fieldset;
+      white-space: nowrap;
+      background-color: $page-background-color;
+      margin: 0;
+
+      label,
+      select {
+        display: inline-block;
+        background-color: $page-background-color;
+      }
+      select {
+        width: auto;
+      }
     }
   }
 }
@@ -22,16 +34,13 @@
     padding-left: 0;
   }
 }
-
 .pagination-total,
 .paginate {
   padding: 0 0.35rem;
 }
-
 .pagination-total {
   font-weight: bold;
 }
-
 .paginate {
   text-decoration: none;
   cursor: pointer;

--- a/src/client/styles/components/Results.scss
+++ b/src/client/styles/components/Results.scss
@@ -82,9 +82,16 @@
 }
 .result-item {
   @include results-item;
+  h4 {
+    margin-bottom: 0.3rem;
+  }
+  p {
+    margin: 0;
+  }
 }
 .result-item-formats {
   @include results-item-formats;
+  margin-top: 0.5rem;
 
   th:first-child,
   td:first-child,

--- a/src/client/styles/components/Results.scss
+++ b/src/client/styles/components/Results.scss
@@ -285,14 +285,17 @@
   }
 }
 
-.results-message {
-  .removeFacet,
-  .removeKeyword {
-    padding: 0.05rem 0.25rem;
+.results-summary {
+  @include results-summary();
+  p {
+    margin: 0;
+    padding: 0;
     line-height: 1;
-    font-size: 0.9rem;
-    display: inline-block;
-    margin-left: 0.1rem;
-    font-weight: bold;
+  }
+  .remove-facet,
+  .remove-keyword {
+    &:before {
+      content: 'x';
+    }
   }
 }

--- a/src/client/styles/components/Search.scss
+++ b/src/client/styles/components/Search.scss
@@ -125,13 +125,12 @@
 }
 
 .related-items {
-  border-left: 4px solid $page-color-light;
+  border-left: 0.5rem solid $page-color-light;
   padding-left: 1rem;
-  margin: 1rem 2rem 0 0.5rem;
+  margin: 1rem 2rem 0 0;
 
   h4 {
     margin-top: 0;
-    color: $nypl-search-color;
     background-color: $page-background-color;
   }
 

--- a/test/unit/Hits.test.js
+++ b/test/unit/Hits.test.js
@@ -64,9 +64,9 @@ describe('Hits', () => {
         component = shallow(<Hits />);
       });
 
-      it('should be wrapped in a .results-message class', () => {
-        expect(component.find('.results-message')).to.exist;
-        expect(component.find('div').first().hasClass('results-message')).to.equal(true);
+      it('should be wrapped in a .results-summary class', () => {
+        expect(component.find('.results-summary')).to.exist;
+        expect(component.find('div').first().hasClass('results-summary')).to.equal(true);
       });
 
       it('should output that no results were found', () => {
@@ -99,7 +99,7 @@ describe('Hits', () => {
       it('should output that no results were found', () => {
         expect(component.find('p')).to.exist;
         expect(component.find('p').text())
-          .to.equal('No results found with owner "Stephen A. Schwarzman Building"remove filter' +
+          .to.equal('No results found with owner Stephen A. Schwarzman Buildingremove filter' +
             ' Stephen A. Schwarzman Building.');
       });
     });
@@ -110,17 +110,17 @@ describe('Hits', () => {
 
     it('should output that 40 results were found', () => {
       component = shallow(<Hits hits={40} />);
-      expect(component.find('p').text()).to.equal('Found 40 results.');
+      expect(component.find('p').text()).to.equal('40 results found.');
     });
 
     it('should output that 4,000 results were found from input 4000', () => {
       component = shallow(<Hits hits={4000} />);
-      expect(component.find('p').text()).to.equal('Found 4,000 results.');
+      expect(component.find('p').text()).to.equal('4,000 results found.');
     });
 
     it('should output that 4,000,000 results were found from input 4000000', () => {
       component = shallow(<Hits hits={4000000} />);
-      expect(component.find('p').text()).to.equal('Found 4,000,000 results.');
+      expect(component.find('p').text()).to.equal('4,000,000 results found.');
     });
   });
 
@@ -133,8 +133,8 @@ describe('Hits', () => {
       });
 
       it('should output the search keyword and the selected facet with two results', () => {
-        expect(component.find('p').text()).to.equal('Found 2 results with keywords "fire"' +
-          'remove keyword filter fire with owner "Stephen A. Schwarzman Building"remove filter' +
+        expect(component.find('p').text()).to.equal('2 results found with keywords fire' +
+          'remove keyword filter fire with owner Stephen A. Schwarzman Buildingremove filter' +
           ' Stephen A. Schwarzman Building.');
       });
     });
@@ -147,9 +147,9 @@ describe('Hits', () => {
       });
 
       it('should output the search keyword and the two selected facets', () => {
-        expect(component.find('p').text()).to.equal('Found 2 results with keywords "fire"remove' +
-          ' keyword filter fire with owner "Stephen A. Schwarzman Building"remove filter ' +
-          'Stephen A. Schwarzman Building with subject "Children\'s art El Salvador."remove ' +
+        expect(component.find('p').text()).to.equal('2 results found with keywords fireremove' +
+          ' keyword filter fire with owner Stephen A. Schwarzman Buildingremove filter ' +
+          'Stephen A. Schwarzman Building with subject Children\'s art El Salvador.remove ' +
           'filter Children\'s art El Salvador..');
       });
     });
@@ -162,9 +162,9 @@ describe('Hits', () => {
       });
 
       it('should output the search keyword and the two selected facets', () => {
-        expect(component.find('p').text()).to.equal('Found 2 results with owner "Stephen A. ' +
-          'Schwarzman Building"remove filter Stephen A. Schwarzman Building with subject ' +
-          '"Children\'s art El Salvador."remove filter Children\'s art El Salvador..');
+        expect(component.find('p').text()).to.equal('2 results found with owner Stephen A. ' +
+          'Schwarzman Buildingremove filter Stephen A. Schwarzman Building with subject ' +
+          'Children\'s art El Salvador.remove filter Children\'s art El Salvador..');
       });
     });
   });
@@ -204,7 +204,7 @@ describe('Hits', () => {
       });
 
       it('should be clicked and Action called', () => {
-        component.find('.removeKeyword').simulate('click');
+        component.find('.remove-keyword').simulate('click');
 
         expect(spyAxios.callCount).to.equal(1);
         expect(spyAxios.calledWithExactly('/api?q= owner:"orgs:1000"')).to.be.true;
@@ -253,7 +253,7 @@ describe('Hits', () => {
       });
 
       it('should be clicked and Action called', () => {
-        component.find('.removeKeyword').simulate('click');
+        component.find('.remove-keyword').simulate('click');
 
         expect(spyAxios.calledOnce).to.be.true;
         expect(spyAxios.calledWith('/api?q= owner:"orgs:1000"')).to.be.true;
@@ -304,13 +304,13 @@ describe('Hits', () => {
       });
 
       it('should output the search keyword and the selected facet', () => {
-        expect(component.find('p').text()).to.equal('Found 2 results with keywords "fire"remove' +
-          ' keyword filter fire with owner "Stephen A. Schwarzman Building"remove filter Stephen' +
+        expect(component.find('p').text()).to.equal('2 results found with keywords fireremove' +
+          ' keyword filter fire with owner Stephen A. Schwarzman Buildingremove filter Stephen' +
           ' A. Schwarzman Building.');
       });
 
       it('should be clicked and Actions to remove the facet and update called', () => {
-        component.find('.removeFacet').simulate('click');
+        component.find('.remove-facet').simulate('click');
 
         expect(spyAxios.calledOnce).to.be.true;
         expect(spyAxios.calledWith('/api?q=fire')).to.be.true;
@@ -359,13 +359,13 @@ describe('Hits', () => {
       });
 
       it('should output the search keyword and the selected facet', () => {
-        expect(component.find('p').text()).to.equal('Found 2 results with keywords "fire"remove' +
-          ' keyword filter fire with owner "Stephen A. Schwarzman Building"remove filter Stephen' +
+        expect(component.find('p').text()).to.equal('2 results found with keywords fireremove' +
+          ' keyword filter fire with owner Stephen A. Schwarzman Buildingremove filter Stephen' +
           ' A. Schwarzman Building.');
       });
 
       it('should be clicked and Actions to remove the facet and update called', () => {
-        component.find('.removeFacet').simulate('click');
+        component.find('.remove-facet').simulate('click');
 
         expect(spyAxios.calledOnce).to.be.true;
         expect(spyAxios.calledWith('/api?q=fire')).to.be.true;

--- a/test/unit/ResultItems.test.js
+++ b/test/unit/ResultItems.test.js
@@ -15,7 +15,7 @@ const items = {
       location: 'SASB - Rose Main Rdg Rm 315 (requested from offsite storage)',
       callNumber: '|hMAB (Shaw, T. L. War on critics)',
       url: '/hold/request/b19707253-i29470386',
-      actionLabel: 'Request a hold',
+      actionLabel: 'Request for in-library use',
       actionLabelHelper: 'for War on critics. for use in library',
     },
   ],
@@ -28,7 +28,7 @@ const items = {
       location: 'SASB - Rose Main Rdg Rm 315 (requested from offsite storage)',
       callNumber: '|hVWZW (War Department technical manual)',
       url: '/hold/request/b18207658-i24609507',
-      actionLabel: 'Request a hold',
+      actionLabel: 'Request for in-library use',
       actionLabelHelper: 'for War Department technical manual. for use in library',
     },
     {
@@ -39,7 +39,7 @@ const items = {
       location: 'SASB - Rose Main Rdg Rm 315 (requested from offsite storage)',
       callNumber: '|hVWZW (War Department technical manual)',
       url: '/hold/request/b18207658-i24609507',
-      actionLabel: 'Request a hold',
+      actionLabel: 'Request for in-library use',
       actionLabelHelper: 'for War Department technical manual. for use in library',
     },
     {
@@ -50,7 +50,7 @@ const items = {
       location: 'SASB - Rose Main Rdg Rm 315 (requested from offsite storage)',
       callNumber: '|hVWZW (War Department technical manual)',
       url: '/hold/request/b18207658-i24609507',
-      actionLabel: 'Request a hold',
+      actionLabel: 'Request for in-library use',
       actionLabelHelper: 'for War Department technical manual. for use in library',
     },
     {
@@ -61,7 +61,7 @@ const items = {
       location: 'SASB - Rose Main Rdg Rm 315 (requested from offsite storage)',
       callNumber: '|hVWZW (War Department technical manual)',
       url: '/hold/request/b18207658-i24609507',
-      actionLabel: 'Request a hold',
+      actionLabel: 'Request for in-library use',
       actionLabelHelper: 'for War Department technical manual. for use in library',
     },
     {
@@ -72,7 +72,7 @@ const items = {
       location: 'SASB - Rose Main Rdg Rm 315 (requested from offsite storage)',
       callNumber: '|hVWZW (War Department technical manual)',
       url: '/hold/request/b18207658-i24609507',
-      actionLabel: 'Request a hold',
+      actionLabel: 'Request for in-library use',
       actionLabelHelper: 'for War Department technical manual. for use in library',
     },
     {
@@ -83,7 +83,7 @@ const items = {
       location: 'SASB - Rose Main Rdg Rm 315 (requested from offsite storage)',
       callNumber: '|hVWZW (War Department technical manual)',
       url: '/hold/request/b18207658-i24609507',
-      actionLabel: 'Request a hold',
+      actionLabel: 'Request for in-library use',
       actionLabelHelper: 'for War Department technical manual. for use in library',
     },
   ],
@@ -121,13 +121,13 @@ describe('ResultItems', () => {
       component = shallow(<ResultItems items={items.single} itemTitle="War on critics" />);
     });
 
-    it('should render an unordered list with wrapper class "sub-items"', () => {
-      expect(component.type()).to.equal('ul');
-      expect(component.hasClass('sub-items')).to.be.true;
+    it('should render a div with wrapper class "result-item-formats"', () => {
+      expect(component.type()).to.equal('div');
+      expect(component.hasClass('result-item-formats')).to.be.true;
     });
 
     it('should have a single list item', () => {
-      expect(component.find('li')).to.have.length(1);
+      expect(component.find('.sub-item')).to.have.length(1);
     });
   });
 
@@ -140,18 +140,17 @@ describe('ResultItems', () => {
 
     it('should display that the item is available at SASB and call number', () => {
       expect(component.find('.sub-item').children().first().text()).to.equal(
-        'Available to use in SASB - Rose Main Rdg Rm 315 (requested from offsite storage) with ' +
-        'call no. |hMAB (Shaw, T. L. War on critics)'
+        'SASB - Rose Main Rdg Rm 315 (requested from offsite storage)'
       );
     });
 
-    it('should have a button with label "Request a hold"', () => {
-      expect(component.find('.button').text())
-        .to.equal('Request a hold for War on critics. for use in library');
+    it('should have a link with label "Request for in-library use"', () => {
+      expect(component.find('.request-hold-link').text())
+        .to.equal('Request for in-library use');
     });
 
     it('should have a descriptive aria label', () => {
-      expect(component.props()['aria-label']).to.equal('This bibliographical record has 1 item.');
+      expect(component.find('.sub-items').props()['aria-label']).to.equal('This bibliographical record has 1 item.');
     });
   });
 
@@ -162,21 +161,21 @@ describe('ResultItems', () => {
     before(() => {
       component =
         shallow(<ResultItems items={items.six} itemTitle="War Department technical manual." />);
-      moreLink = component.find('li').last().children();
+      moreLink = component.find('.see-more-link')
     });
 
     it('should seven list items, six bib items and one "more" list item', () => {
-      expect(component.find('li')).to.have.length(7);
+      expect(component.find('.sub-item')).to.have.length(7);
     });
 
     it('should have a descriptive aria label', () => {
-      expect(component.props()['aria-label']).to.equal('This bibliographical record has 6 items.');
+      expect(component.find('.sub-items').props()['aria-label']).to.equal('This bibliographical record has 6 items.');
     });
 
     it('should have the last bib item with a class of "more"', () => {
       expect(
         // The second to last li element has a div with the "more" class.
-        component.childAt(5).find('div').first().hasClass('sub-item more')
+        component.find('.sub-items tbody').childAt(5).hasClass('sub-item more')
       ).to.be.true;
     });
 
@@ -198,14 +197,14 @@ describe('ResultItems', () => {
     before(() => {
       component =
         shallow(<ResultItems items={items.six} itemTitle="War Department technical manual." />);
-      moreLink = component.find('li').last().children();
+      moreLink = component.find('.see-more-link')
     });
 
     // This is the hidden item.
     it('should have the last bib item with a class of "more"', () => {
       // The last bib item li element has a div with the "more" class which hides it
       expect(
-        component.childAt(5).find('div').first().hasClass('sub-item more')
+        component.find('.sub-items tbody').childAt(5).hasClass('sub-item more')
       ).to.be.true;
     });
 
@@ -214,7 +213,7 @@ describe('ResultItems', () => {
 
       // Clicking on the "more" link unhides elements, in this case only one more bib item
       expect(
-        component.childAt(5).find('div').first().hasClass('sub-item')
+        component.find('.sub-items tbody').childAt(5).hasClass('sub-item')
       ).to.be.true;
     });
   });


### PR DESCRIPTION
Based on [design toolkit UI for search results](https://nypl.github.io/design-toolkit/discovery-search.html), I made an initial effort to implement those design recommendations.

This only should affect the right-hand-side of the search results page.  Mostly changes to CSS and HTML.  I made an effort to update the tests as well, but I may have missed some.

Known differences between this PR and the design specs (to be addressed another time):
- No "start over" button
- Sort component remains a select tag (the design had a hidden list component and button)
- Call number remains
- Original pagination styles remain