### PR TITLE
Adding percentage class to individual facets.

### DIFF
--- a/src/app/components/FacetSidebar/FacetSidebar.jsx
+++ b/src/app/components/FacetSidebar/FacetSidebar.jsx
@@ -9,6 +9,7 @@ import {
 
 import {
   findWhere as _findWhere,
+  chain as _chain,
 } from 'underscore';
 
 class FacetSidebar extends React.Component {
@@ -110,6 +111,10 @@ class FacetSidebar extends React.Component {
         }
 
         const selectedValue = this.state[field] ? this.state[field].id : '';
+        const totalCountFacet = _chain(facet.values)
+          .pluck('count')
+          .reduce((x, y) => x + y, 0)
+          .value();
 
         return (
           <div key={`${facet.field}-${facet.value}`} className="nypl-searchable-field">
@@ -126,7 +131,11 @@ class FacetSidebar extends React.Component {
                 }
 
                 return (
-                  <label key={j} htmlFor={`${facet.field}-${f.value}`} className={`nypl-bar_${f.count}`}>
+                  <label
+                    key={j}
+                    htmlFor={`${facet.field}-${f.value}`}
+                    className={`nypl-bar_${Math.floor(f.count / totalCountFacet * 100)}`}
+                  >
                     <input id={`${facet.field}-${f.value}`} type="checkbox" name="subject" value={f.value} />
                     <span>{selectLabel}</span>
                     <span className="nypl-facet-count">{f.count}</span>

--- a/src/app/components/FacetSidebar/FacetSidebar.jsx
+++ b/src/app/components/FacetSidebar/FacetSidebar.jsx
@@ -125,6 +125,7 @@ class FacetSidebar extends React.Component {
             <div className="nypl-facet-list">
             {
               facet.values.map((f, j) => {
+                const percentage = Math.floor(f.count / totalCountFacet * 100);
                 let selectLabel = f.value;
                 if (f.label) {
                   selectLabel = f.label;
@@ -134,11 +135,11 @@ class FacetSidebar extends React.Component {
                   <label
                     key={j}
                     htmlFor={`${facet.field}-${f.value}`}
-                    className={`nypl-bar_${Math.floor(f.count / totalCountFacet * 100)}`}
+                    className={`nypl-bar_${percentage}`}
                   >
                     <input id={`${facet.field}-${f.value}`} type="checkbox" name="subject" value={f.value} />
                     <span>{selectLabel}</span>
-                    <span className="nypl-facet-count">{f.count}</span>
+                    <span className="nypl-facet-count">{f.count.toLocaleString()}</span>
                   </label>
                 );
               })


### PR DESCRIPTION
Getting the total count for each facet field and then adding the correct percentage to each individual facet item.

I noticed that when a number has more than 5 digits (also depending on the length of the facet name), it begins to float past the right border. I will open a ticket for this in design-toolkit.

<img width="309" alt="screen shot 2017-04-20 at 11 53 49 pm" src="https://cloud.githubusercontent.com/assets/1280564/25262235/aa81339a-2624-11e7-8c80-a5470f01fab3.png">
