### PR TITLE
Moving column grid wrapper around the search box and moving it to spe…

### DIFF
--- a/src/app/components/Home/Home.jsx
+++ b/src/app/components/Home/Home.jsx
@@ -15,9 +15,11 @@ const Home = ({ sortBy }) => (
 
     <div className="content-wrapper">
       <div className="nypl-column-three-quarters nypl-column-offset-one">
-        <p className="lead">Search the New York Public Library Research Catalog
-          for materials available to use in one of four research libraries located
-          in New York City.
+        <p className="lead">Search The New York Public Library's world-renowned collections for
+          items available for use at our
+          <a href="https://www.nypl.org/locations/map?libraries=research"> research centers</a>.
+          Be sure to <a href="https://www.nypl.org/help/request-research-materials">request
+          materials</a> in advance to make the most of your time on site.
         </p>
         <div className="search home">
           <Search sortBy={sortBy} />

--- a/src/app/components/Home/Home.jsx
+++ b/src/app/components/Home/Home.jsx
@@ -14,13 +14,11 @@ const Home = ({ sortBy }) => (
     </div>
 
     <div className="content-wrapper">
-      <div className="half">
+      <div className="nypl-column-three-quarters nypl-column-offset-one">
         <p className="lead">Search the New York Public Library Research Catalog
           for materials available to use in one of four research libraries located
           in New York City.
         </p>
-      </div>
-      <div className="half">
         <div className="search home">
           <Search sortBy={sortBy} />
         </div>

--- a/src/app/components/Home/Home.jsx
+++ b/src/app/components/Home/Home.jsx
@@ -22,9 +22,8 @@ const Home = ({ sortBy }) => (
             Be sure to <a href="https://www.nypl.org/help/request-research-materials">request
             materials</a> in advance to make the most of your time on site.
           </p>
-          <div className="search home">
-            <Search sortBy={sortBy} />
-          </div>
+
+          <Search sortBy={sortBy} />
         </div>
       </div>
     </div>

--- a/src/app/components/Home/Home.jsx
+++ b/src/app/components/Home/Home.jsx
@@ -13,16 +13,18 @@ const Home = ({ sortBy }) => (
       </div>
     </div>
 
-    <div className="content-wrapper">
-      <div className="nypl-column-three-quarters nypl-column-offset-one">
-        <p className="lead">Search The New York Public Library's world-renowned collections for
-          items available for use at our
-          <a href="https://www.nypl.org/locations/map?libraries=research"> research centers</a>.
-          Be sure to <a href="https://www.nypl.org/help/request-research-materials">request
-          materials</a> in advance to make the most of your time on site.
-        </p>
-        <div className="search home">
-          <Search sortBy={sortBy} />
+    <div className="nypl-full-width-wrapper">
+      <div className="nypl-row">
+        <div className="nypl-column-three-quarters nypl-column-offset-one">
+          <p className="nypl-lead">Search The New York Public Library's world-renowned collections for
+            items available for use at our
+            <a href="https://www.nypl.org/locations/map?libraries=research"> research centers</a>.
+            Be sure to <a href="https://www.nypl.org/help/request-research-materials">request
+            materials</a> in advance to make the most of your time on site.
+          </p>
+          <div className="search home">
+            <Search sortBy={sortBy} />
+          </div>
         </div>
       </div>
     </div>

--- a/src/app/components/ItemPage/ItemPage.jsx
+++ b/src/app/components/ItemPage/ItemPage.jsx
@@ -216,7 +216,9 @@ class ItemPage extends React.Component {
 
         <div className="nypl-full-width-wrapper">
           <div className="nypl-row">
-            <Search sortBy={sortBy} />
+            <div className="nypl-column-three-quarters nypl-column-offset-one">
+              <Search sortBy={sortBy} />
+            </div>
           </div>
 
           <div className="nypl-row">

--- a/src/app/components/Search/Search.jsx
+++ b/src/app/components/Search/Search.jsx
@@ -106,31 +106,29 @@ class Search extends React.Component {
 
   render() {
     return (
-      <div className="nypl-column-three-quarters nypl-column-offset-one">
-        <form onKeyPress={this.triggerSubmit}>
-          <fieldset className={`nypl-omnisearch nypl-spinner-field ${this.state.spinning ? 'spinning' : ''}`}>
-            <SearchButton
-              id="nypl-omni-button"
-              type="submit"
-              value="Search"
-              onClick={this.submitSearchRequest}
-            />
-            <span className="nypl-omni-fields">
-              <label forHtml="search-by-field">Search in</label>
-              <select id="search-by-field"><option value="all">All fields</option><option value="title">Title</option><option value="contributor">Author/Contributor</option><option value="subject">Subject</option><option value="series">Series</option><option value="call_number">Call number</option></select>
-            </span>
-            <input
-              type="text"
-              id="search-query"
-              aria-labelledby="nypl-omni-button"
-              placeholder={this.state.placeholder}
-              onChange={this.inputChange}
-              value={this.state.searchKeywords}
-              ref="keywords"
-            />
-          </fieldset>
-        </form>
-      </div>
+      <form onKeyPress={this.triggerSubmit}>
+        <fieldset className={`nypl-omnisearch nypl-spinner-field ${this.state.spinning ? 'spinning' : ''}`}>
+          <SearchButton
+            id="nypl-omni-button"
+            type="submit"
+            value="Search"
+            onClick={this.submitSearchRequest}
+          />
+          <span className="nypl-omni-fields">
+            <label forHtml="search-by-field">Search in</label>
+            <select id="search-by-field"><option value="all">All fields</option><option value="title">Title</option><option value="contributor">Author/Contributor</option><option value="subject">Subject</option><option value="series">Series</option><option value="call_number">Call number</option></select>
+          </span>
+          <input
+            type="text"
+            id="search-query"
+            aria-labelledby="nypl-omni-button"
+            placeholder={this.state.placeholder}
+            onChange={this.inputChange}
+            value={this.state.searchKeywords}
+            ref="keywords"
+          />
+        </fieldset>
+      </form>
     );
   }
 }

--- a/src/app/components/SearchResultsPage/SearchResultsPage.jsx
+++ b/src/app/components/SearchResultsPage/SearchResultsPage.jsx
@@ -35,10 +35,12 @@ class SearchResultsPage extends React.Component {
       </div>
       <div className="nypl-full-width-wrapper">
         <div className="nypl-row">
-          <Search
-            sortBy={sortBy}
-            selectedFacets={selectedFacets}
-          />
+          <div className="nypl-column-three-quarters nypl-column-offset-one">
+            <Search
+              sortBy={sortBy}
+              selectedFacets={selectedFacets}
+            />
+          </div>
         </div>
 
         <div className="nypl-row">


### PR DESCRIPTION
…cific instances where <Search /> is called.

--
Moving the wrapper so `<Search />` can look better on the homepage. May need to rethink this because now we have to maintain the grid in two places.
From:
![screen shot 2017-05-10 at 12 09 59 pm](https://cloud.githubusercontent.com/assets/1280564/25909004/d0f60050-3579-11e7-91c1-34433e63ff40.png)
To:
![screen shot 2017-05-10 at 12 10 03 pm](https://cloud.githubusercontent.com/assets/1280564/25909010/d46f1e42-3579-11e7-9def-ffeae7cac100.png)

The Search Results page and Item page remains the same.