### PR TITLE
Reorder facets

### DIFF
--- a/src/app/components/FacetSidebar/FacetSidebar.jsx
+++ b/src/app/components/FacetSidebar/FacetSidebar.jsx
@@ -150,8 +150,16 @@ class FacetSidebar extends React.Component {
     } = this.props;
     let facetsElm = null;
 
+    const orderedFacets = [
+      _findWhere(this.props.facets, { id: 'materialType' }),
+      _findWhere(this.props.facets, { id: 'subject' }),
+      _findWhere(this.props.facets, { id: 'issuance' }),
+      _findWhere(this.props.facets, { id: 'publisher' }),
+      _findWhere(this.props.facets, { id: 'language' }),
+    ];
+
     if (facets.length) {
-      facetsElm = facets.map((facet) => {
+      facetsElm = orderedFacets.map((facet) => {
         const field = facet.field;
 
         if (facet.values.length < 1 || field === 'carrierType' || field === 'mediaType') {

--- a/src/app/components/FacetSidebar/FacetSidebar.jsx
+++ b/src/app/components/FacetSidebar/FacetSidebar.jsx
@@ -162,7 +162,7 @@ class FacetSidebar extends React.Component {
       facetsElm = orderedFacets.map((facet) => {
         const field = facet.field;
 
-        if (facet.values.length < 1 || field === 'carrierType' || field === 'mediaType') {
+        if (facet.values.length < 1) {
           return null;
         }
 
@@ -171,37 +171,6 @@ class FacetSidebar extends React.Component {
           .pluck('count')
           .reduce((x, y) => x + y, 0)
           .value();
-
-        if (facet.field === 'date') {
-          return (
-            <div className={`nypl-facet-search nypl-spinner-field ${this.state.spinning ? 'spinning' : ''}`}>
-              <div className="nypl-text-field">
-                <label
-                  key="date-from"
-                  htmlFor="date-from"
-                >On or After Year</label>
-                <input
-                  id={`facet-${facet.field}-from-search`}
-                  type="text"
-                  className="form-text"
-                  placeholder=""
-                />
-              </div>
-              <div className="nypl-text-field">
-                <label
-                  key="date-to"
-                  htmlFor="date-to"
-                >On or Before Year</label>
-                <input
-                  id={`facet-${facet.field}-to-search`}
-                  type="text"
-                  className="form-text"
-                  placeholder=""
-                />
-              </div>
-            </div>
-          );
-        }
         return (
           <div
             key={`${facet.field}-${facet.value}`}


### PR DESCRIPTION
#246.

This also removes the date fields, in alignment with the removal of dates as facets in the Discovery API. (You can see they no longer appear in the deployed site or in beta-v1/master). We can discuss how we want to bring this back (as a filter and not as a facet?), but for now it is gone.