### PR TITLE
Facet sidebar refactor

### DIFF
--- a/src/app/components/FacetSidebar/Facet.jsx
+++ b/src/app/components/FacetSidebar/Facet.jsx
@@ -46,7 +46,7 @@ class Facet extends React.Component {
     Actions.updateSpinner(true);
     const value = e.target.value;
     const checked = e.target.checked;
-    const pickedFacet = _pick(this.state, field)
+    const pickedFacet = _pick(this.state, field);
 
     let strSearch = '';
 
@@ -79,21 +79,10 @@ class Facet extends React.Component {
       Actions.updateSelectedFacets(pickedFacet);
       Actions.updatePage('1');
       this.routeHandler(
-        null,
-        `/search?q=${encodeURIComponent(this.props.keywords)}${strSearch}${sortQuery}`,
+        `/search?q=${encodeURIComponent(this.props.keywords)}${strSearch}${sortQuery}`
       );
       Actions.updateSpinner(false);
     });
-  }
-
-  routeHandler(e, path) {
-    if (e) e.preventDefault();
-
-    if (path === '/') {
-      Actions.updateSelectedFacets({});
-    }
-
-    this.context.router.push(path);
   }
 
   getFacetLabel(field) {
@@ -103,17 +92,26 @@ class Facet extends React.Component {
     return field.charAt(0).toUpperCase() + field.slice(1);
   }
 
-  showGetTenMore(facet, valueCount){
+  routeHandler(path) {
+    if (path === '/') {
+      Actions.updateSelectedFacets({});
+    }
+
+    this.context.router.push(path);
+  }
+
+  showGetTenMore(facet, valueCount) {
     if (valueCount > facetShowLimit) {
       return (<button className="nypl-link-button">Show 10 more</button>);
     }
+    return null;
   }
 
   showFacet(facet) {
-    let ref = this.refs[`nypl-${facet}-facet-button`];
+    const ref = this.refs[`nypl-${facet}-facet-button`];
 
     if (this.state.openFacet === false) {
-      this.setState({ openFacet: true })
+      this.setState({ openFacet: true });
       if (ref.parentElement && ref.nextSibling) {
         ref.parentElement.classList.remove('collapsed');
         ref.nextSibling.classList.remove('collapsed');
@@ -127,8 +125,8 @@ class Facet extends React.Component {
     }
   }
 
-  checkNoSearch(valueCount){
-    return valueCount > facetShowLimit ? '' : ' nosearch'
+  checkNoSearch(valueCount) {
+    return valueCount > facetShowLimit ? '' : ' nosearch';
   }
 
   toggleFacetsMobile() {
@@ -146,17 +144,20 @@ class Facet extends React.Component {
   }
 
   render() {
-    const field = this.props.field;
     const facet = this.props.facet;
+    const field = facet.field;
+
     return (
       <div
         key={`${field}-${facet.value}`}
-        className={`nypl-searchable-field nypl-spinner-field ${this.checkNoSearch(facet.values.length)} ${this.state.spinning ? 'spinning' : ''}`}
+        className={`nypl-searchable-field nypl-spinner-field
+          ${this.checkNoSearch(facet.values.length)} ${this.state.spinning ? 'spinning' : ''}`
+        }
       >
         <button
           type="button"
           className={`nypl-facet-toggle ${this.state.facetOpen ? '' : 'collapsed'}`}
-          aria-controls={`nypl-searchable-field_${facet.field}`}
+          aria-controls={`nypl-searchable-field_${field}`}
           aria-expanded={this.state.facetOpen}
           ref={`nypl-${field}-facet-button`}
           onClick={() => this.showFacet(field)}
@@ -208,7 +209,7 @@ class Facet extends React.Component {
                     name="subject"
                     checked={this.props.selectedValue === f.value}
                     value={f.value}
-                    onClick={e => this.onFacetUpdate(e, facet.field)}
+                    onClick={e => this.onFacetUpdate(e, field)}
                   />
                   <span className="nypl-facet-count">{f.count.toLocaleString()}</span>
                   {selectLabel}

--- a/src/app/components/FacetSidebar/Facet.jsx
+++ b/src/app/components/FacetSidebar/Facet.jsx
@@ -1,0 +1,233 @@
+import React from 'react';
+
+import {
+  extend as _extend,
+  findWhere as _findWhere,
+  chain as _chain,
+  pick as _pick,
+} from 'underscore';
+
+import Actions from '../../actions/Actions';
+import Store from '../../stores/Store';
+import {
+  ajaxCall,
+  getSortQuery,
+  getFacetParams,
+} from '../../utils/utils';
+
+const facetShowLimit = 9;
+
+class Facet extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = _extend({
+      spinning: false,
+    }, Store.getState());
+
+    this.onChange = this.onChange.bind(this);
+    this.routeHandler = this.routeHandler.bind(this);
+    this.onFacetUpdate = this.onFacetUpdate.bind(this);
+  }
+
+  componentDidMount() {
+    Store.listen(this.onChange);
+  }
+
+  componentWillUnmount() {
+    Store.unlisten(this.onChange);
+  }
+
+  onChange() {
+    this.setState(_extend(this.state, Store.getState()));
+  }
+
+  onFacetUpdate(e, field) {
+    Actions.updateSpinner(true);
+    const value = e.target.value;
+    const checked = e.target.checked;
+    const pickedFacet = _pick(this.state, field)
+
+    let strSearch = '';
+
+    if (!checked) {
+      this.setState({
+        [field]: {
+          id: '',
+          value: '',
+        },
+      });
+    } else {
+      const searchValue = field === 'date' ? parseInt(value, 10) : value;
+      const facetObj = _findWhere(this.props.facets, { field });
+      const facet = _findWhere(facetObj.values, { value: searchValue });
+
+      this.setState({
+        [field]: {
+          id: facet.value,
+          value: facet.label || facet.value,
+        },
+      });
+      strSearch = getFacetParams(pickedFacet, field, value);
+    }
+
+    const sortQuery = getSortQuery(this.props.sortBy);
+
+    ajaxCall(`/api?q=${this.props.keywords}${strSearch}${sortQuery}`, (response) => {
+      Actions.updateSearchResults(response.data.searchResults);
+      Actions.updateFacets(response.data.facets);
+      Actions.updateSelectedFacets(pickedFacet);
+      Actions.updatePage('1');
+      this.routeHandler(
+        null,
+        `/search?q=${encodeURIComponent(this.props.keywords)}${strSearch}${sortQuery}`,
+      );
+      Actions.updateSpinner(false);
+    });
+  }
+
+  routeHandler(e, path) {
+    if (e) e.preventDefault();
+
+    if (path === '/') {
+      Actions.updateSelectedFacets({});
+    }
+
+    this.context.router.push(path);
+  }
+
+  getFacetLabel(field) {
+    if (field === 'materialType') {
+      return 'Material Type';
+    }
+    return field.charAt(0).toUpperCase() + field.slice(1);
+  }
+
+  showGetTenMore(facet, valueCount){
+    if (valueCount > facetShowLimit) {
+      return (<button className="nypl-link-button">Show 10 more</button>);
+    }
+  }
+
+  showFacet(facet) {
+    let ref = this.refs[`nypl-${facet}-facet-button`];
+
+    if (this.state.openFacet === false) {
+      this.setState({ openFacet: true })
+      if (ref.parentElement && ref.nextSibling) {
+        ref.parentElement.classList.remove('collapsed');
+        ref.nextSibling.classList.remove('collapsed');
+      }
+    } else {
+      this.setState({ openFacet: false });
+      if (ref.parentElement && ref.nextSibling) {
+        ref.parentElement.className += ' collapsed';
+        ref.nextSibling.className += ' collapsed';
+      }
+    }
+  }
+
+  checkNoSearch(valueCount){
+    return valueCount > facetShowLimit ? '' : ' nosearch'
+  }
+
+  toggleFacetsMobile() {
+    if (this.state.mobileView) {
+      this.setState({
+        mobileView: false,
+        mobileViewText: 'Refine search',
+      });
+    } else {
+      this.setState({
+        mobileView: true,
+        mobileViewText: 'Hide facets',
+      });
+    }
+  }
+
+  render() {
+    const field = this.props.field;
+    const facet = this.props.facet;
+    return (
+      <div
+        key={`${field}-${facet.value}`}
+        className={`nypl-searchable-field nypl-spinner-field ${this.checkNoSearch(facet.values.length)} ${this.state.spinning ? 'spinning' : ''}`}
+      >
+        <button
+          type="button"
+          className={`nypl-facet-toggle ${this.state.facetOpen ? '' : 'collapsed'}`}
+          aria-controls={`nypl-searchable-field_${facet.field}`}
+          aria-expanded={this.state.facetOpen}
+          ref={`nypl-${field}-facet-button`}
+          onClick={() => this.showFacet(field)}
+        >
+          {`${this.getFacetLabel(field)}`}
+          <svg
+            aria-hidden="true"
+            className="nypl-icon"
+            preserveAspectRatio="xMidYMid meet"
+            viewBox="0 0 68 24"
+          >
+            <title>wedge down icon</title>
+            <polygon points="67.938 0 34 24 0 0 10 0 34.1 16.4 58.144 0 67.938 0"></polygon>
+          </svg>
+        </button>
+        <div
+          className={`nypl-collapsible ${this.state.facetOpen ? '' : 'collapsed'}`}
+          id={`nypl-searchable-field_${field}`}
+          aria-expanded={this.state.facetOpen}
+        >
+          <div className={`nypl-facet-search nypl-spinner-field ${this.state.spinning ? 'spinning' : ''}`}>
+            <label htmlFor={`facet-${field}-search`}>{`${this.getFacetLabel(field)}`}</label>
+            <input
+              id={`facet-${field}-search`}
+              type="text"
+              placeholder={`Search ${this.getFacetLabel(field)}`}
+            />
+          </div>
+          <div className="nypl-facet-list">
+            {
+            facet.values.map((f, j) => {
+              const percentage = Math.floor(f.count / this.props.totalHits * 100);
+              const valueLabel = (f.value).toString().replace(/:/, '_');
+              let selectLabel = f.value;
+              if (f.label) {
+                selectLabel = f.label;
+              }
+              return (
+                <label
+                  key={j}
+                  id={`${field}-${valueLabel}`}
+                  htmlFor={`${field}-${valueLabel}`}
+                  className={`nypl-bar_${percentage}`}
+                >
+                  <input
+                    id={`${field}-${valueLabel}`}
+                    aria-labelledby={`${field} ${valueLabel}`}
+                    type="checkbox"
+                    name="subject"
+                    checked={this.props.selectedValue === f.value}
+                    value={f.value}
+                    onClick={e => this.onFacetUpdate(e, facet.field)}
+                  />
+                  <span className="nypl-facet-count">{f.count.toLocaleString()}</span>
+                  {selectLabel}
+                </label>
+              );
+            })
+          }
+          </div>
+          {this.showGetTenMore(facet, facet.values.length)}
+        </div>
+      </div>
+    );
+  }
+}
+
+Facet.contextTypes = {
+  router: function contextType() {
+    return React.PropTypes.func.isRequired;
+  },
+};
+
+export default Facet;

--- a/src/app/components/FacetSidebar/FacetSidebar.jsx
+++ b/src/app/components/FacetSidebar/FacetSidebar.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {
   extend as _extend,
   findWhere as _findWhere,
-  chain as _chain,
+  forEach as _forEach,
 } from 'underscore';
 
 import Store from '../../stores/Store';
@@ -17,7 +17,7 @@ class FacetSidebar extends React.Component {
       mobileViewText: 'Refine search',
     }, Store.getState());
 
-    this.props.facets.map((facet) => {
+    _forEach(this.props.facets, (facet) => {
       let id = '';
       let value = '';
 
@@ -62,22 +62,17 @@ class FacetSidebar extends React.Component {
     ];
 
     if (facets.length) {
-      facetsElm = orderedFacets.map((facet) => {
-        const field = facet.field;
-
+      facetsElm = orderedFacets.map((facet, i) => {
         if (facet.values.length < 1) {
           return null;
         }
 
+        const field = facet.field;
         const selectedValue = this.state[field] ? this.state[field].id : '';
-        const totalCountFacet = _chain(facet.values)
-          .pluck('count')
-          .reduce((x, y) => x + y, 0)
-          .value();
 
         return (
           <Facet
-            field={field}
+            key={i}
             facet={facet}
             totalHits={totalHits}
             selectedValue={selectedValue}

--- a/src/app/components/FacetSidebar/FacetSidebar.jsx
+++ b/src/app/components/FacetSidebar/FacetSidebar.jsx
@@ -1,28 +1,18 @@
 import React from 'react';
-
 import {
   extend as _extend,
   findWhere as _findWhere,
   chain as _chain,
-  pick as _pick,
 } from 'underscore';
 
-import Actions from '../../actions/Actions';
 import Store from '../../stores/Store';
-import {
-  ajaxCall,
-  getSortQuery,
-  getFacetParams,
-} from '../../utils/utils';
-
-const facetShowLimit = 9;
+import Facet from './Facet';
 
 class FacetSidebar extends React.Component {
   constructor(props) {
     super(props);
 
     this.state = _extend({
-      spinning: false,
       mobileView: false,
       mobileViewText: 'Refine search',
     }, Store.getState());
@@ -38,101 +28,6 @@ class FacetSidebar extends React.Component {
 
       this.state[facet.field] = { id, value };
     });
-
-    this.onChange = this.onChange.bind(this);
-    this.routeHandler = this.routeHandler.bind(this);
-    this.onFacetUpdate = this.onFacetUpdate.bind(this);
-  }
-
-  componentDidMount() {
-    Store.listen(this.onChange);
-  }
-
-  componentWillUnmount() {
-    Store.unlisten(this.onChange);
-  }
-
-  onChange() {
-    this.setState(_extend(this.state, Store.getState()));
-  }
-
-  onFacetUpdate(e, field) {
-    Actions.updateSpinner(true);
-    const value = e.target.value;
-    const checked = e.target.checked;
-    const pickedFacet = _pick(this.state, field)
-
-    let strSearch = '';
-
-    if (!checked) {
-      this.setState({
-        [field]: {
-          id: '',
-          value: '',
-        },
-      });
-    } else {
-      const searchValue = field === 'date' ? parseInt(value, 10) : value;
-      const facetObj = _findWhere(this.props.facets, { field });
-      const facet = _findWhere(facetObj.values, { value: searchValue });
-
-      this.setState({
-        [field]: {
-          id: facet.value,
-          value: facet.label || facet.value,
-        },
-      });
-      strSearch = getFacetParams(pickedFacet, field, value);
-    }
-
-    const sortQuery = getSortQuery(this.props.sortBy);
-
-    ajaxCall(`/api?q=${this.props.keywords}${strSearch}${sortQuery}`, (response) => {
-      Actions.updateSearchResults(response.data.searchResults);
-      Actions.updateFacets(response.data.facets);
-      Actions.updateSelectedFacets(pickedFacet);
-      Actions.updatePage('1');
-      this.routeHandler(
-        null,
-        `/search?q=${encodeURIComponent(this.props.keywords)}${strSearch}${sortQuery}`,
-      );
-      Actions.updateSpinner(false);
-    });
-  }
-
-  getFacetLabel(field) {
-    if (field === 'materialType') {
-      return 'Material Type';
-    }
-    return field.charAt(0).toUpperCase() + field.slice(1);
-  }
-
-  showGetTenMore(facet, valueCount){
-    if (valueCount > facetShowLimit) {
-      return (<button className="nypl-link-button">Show 10 more</button>);
-    }
-  }
-
-  showFacet(facet) {
-    let ref = this.refs[`nypl-${facet}-facet-button`];
-
-    if (this.state.openFacet === false) {
-      this.setState({ openFacet: true })
-      if (ref.parentElement && ref.nextSibling) {
-        ref.parentElement.classList.remove('collapsed');
-        ref.nextSibling.classList.remove('collapsed');
-      }
-    } else {
-      this.setState({ openFacet: false });
-      if (ref.parentElement && ref.nextSibling) {
-        ref.parentElement.className += ' collapsed';
-        ref.nextSibling.className += ' collapsed';
-      }
-    }
-  }
-
-  checkNoSearch(valueCount){
-    return valueCount > facetShowLimit ? '' : ' nosearch'
   }
 
   toggleFacetsMobile() {
@@ -149,29 +44,21 @@ class FacetSidebar extends React.Component {
     }
   }
 
-  routeHandler(e, path) {
-    if (e) e.preventDefault();
-
-    if (path === '/') {
-      Actions.updateSelectedFacets({});
-    }
-
-    this.context.router.push(path);
-  }
-
   render() {
     const {
       facets,
       totalHits,
+      sortBy,
+      keywords,
     } = this.props;
     let facetsElm = null;
 
     const orderedFacets = [
-      _findWhere(this.props.facets, { id: 'materialType' }),
-      _findWhere(this.props.facets, { id: 'subject' }),
-      _findWhere(this.props.facets, { id: 'issuance' }),
-      _findWhere(this.props.facets, { id: 'publisher' }),
-      _findWhere(this.props.facets, { id: 'language' }),
+      _findWhere(facets, { id: 'materialType' }),
+      _findWhere(facets, { id: 'subject' }),
+      _findWhere(facets, { id: 'issuance' }),
+      _findWhere(facets, { id: 'publisher' }),
+      _findWhere(facets, { id: 'language' }),
     ];
 
     if (facets.length) {
@@ -189,77 +76,15 @@ class FacetSidebar extends React.Component {
           .value();
 
         return (
-          <div
-            key={`${field}-${facet.value}`}
-            className={`nypl-searchable-field nypl-spinner-field ${this.checkNoSearch(facet.values.length)} ${this.state.spinning ? 'spinning' : ''}`}
-          >
-            <button
-              type="button"
-              className={`nypl-facet-toggle ${this.state.facetOpen ? '' : 'collapsed'}`}
-              aria-controls={`nypl-searchable-field_${facet.field}`}
-              aria-expanded={this.state.facetOpen}
-              ref={`nypl-${field}-facet-button`}
-              onClick={() => this.showFacet(field)}
-            >
-              {`${this.getFacetLabel(field)}`}
-              <svg
-                aria-hidden="true"
-                className="nypl-icon"
-                preserveAspectRatio="xMidYMid meet"
-                viewBox="0 0 68 24"
-              >
-                <title>wedge down icon</title>
-                <polygon points="67.938 0 34 24 0 0 10 0 34.1 16.4 58.144 0 67.938 0"></polygon>
-              </svg>
-            </button>
-            <div
-              className={`nypl-collapsible ${this.state.facetOpen ? '' : 'collapsed'}`}
-              id={`nypl-searchable-field_${field}`}
-              aria-expanded={this.state.facetOpen}
-            >
-              <div className={`nypl-facet-search nypl-spinner-field ${this.state.spinning ? 'spinning' : ''}`}>
-                <label htmlFor={`facet-${field}-search`}>{`${this.getFacetLabel(field)}`}</label>
-                <input
-                  id={`facet-${field}-search`}
-                  type="text"
-                  placeholder={`Search ${this.getFacetLabel(field)}`}
-                />
-              </div>
-              <div className="nypl-facet-list">
-                {
-                facet.values.map((f, j) => {
-                  const percentage = Math.floor(f.count / totalHits * 100);
-                  const valueLabel = (f.value).toString().replace(/:/, '_');
-                  let selectLabel = f.value;
-                  if (f.label) {
-                    selectLabel = f.label;
-                  }
-                  return (
-                    <label
-                      key={j}
-                      id={`${field}-${valueLabel}`}
-                      htmlFor={`${field}-${valueLabel}`}
-                      className={`nypl-bar_${percentage}`}
-                    >
-                      <input
-                        id={`${field}-${valueLabel}`}
-                        aria-labelledby={`${field} ${valueLabel}`}
-                        type="checkbox"
-                        name="subject"
-                        checked={selectedValue === f.value}
-                        value={f.value}
-                        onClick={e => this.onFacetUpdate(e, facet.field)}
-                      />
-                      <span className="nypl-facet-count">{f.count.toLocaleString()}</span>
-                      {selectLabel}
-                    </label>
-                  );
-                })
-              }
-              </div>
-              {this.showGetTenMore(facet, facet.values.length)}
-            </div>
-          </div>
+          <Facet
+            field={field}
+            facet={facet}
+            totalHits={totalHits}
+            selectedValue={selectedValue}
+            sortBy={sortBy}
+            keywords={keywords}
+            facets={facets}
+          />
         );
       });
     }
@@ -278,7 +103,7 @@ class FacetSidebar extends React.Component {
         </div>
         <form
           id="filter-search"
-          className={`nypl-search-form ${this.state.mobileView ? 'active' : '' }`}
+          className={`nypl-search-form ${this.state.mobileView ? 'active' : ''}`}
         >
           {facetsElm}
         </form>

--- a/src/app/components/FacetSidebar/FacetSidebar.jsx
+++ b/src/app/components/FacetSidebar/FacetSidebar.jsx
@@ -78,7 +78,6 @@ class FacetSidebar extends React.Component {
             selectedValue={selectedValue}
             sortBy={sortBy}
             keywords={keywords}
-            facets={facets}
           />
         );
       });


### PR DESCRIPTION
This is a big one...

Each facet will now control its own state. This creates a bug where only one facet is selected at a time, but it's easier to debug now.

Also, the first facet clicked should show up now. We had the problem were the previous selection showed up instead of the current one.

This also addresses #237 - collapsing the facets on page load.
