### PR TITLE
Adding functionality to show more facets.

### DIFF
--- a/src/app/components/FacetSidebar/Facet.jsx
+++ b/src/app/components/FacetSidebar/Facet.jsx
@@ -14,7 +14,7 @@ import {
   getFacetParams,
 } from '../../utils/utils';
 
-const facetShowLimit = 9;
+const facetShowLimit = 4;
 
 class Facet extends React.Component {
   constructor(props) {

--- a/src/app/components/FacetSidebar/Facet.jsx
+++ b/src/app/components/FacetSidebar/Facet.jsx
@@ -24,6 +24,7 @@ class Facet extends React.Component {
       spinning: false,
       openFacet: true,
       [this.props.facet.field]: { id: '', value: '' },
+      showMoreFacets: false,
     }, Store.getState());
 
     this.onChange = this.onChange.bind(this);
@@ -105,9 +106,19 @@ class Facet extends React.Component {
     this.context.router.push(path);
   }
 
-  showGetTenMore(facet, valueCount) {
-    if (valueCount > facetShowLimit) {
-      return (<button className="nypl-link-button">Show 10 more</button>);
+  showMoreFacets(e) {
+    e.preventDefault();
+    this.setState({ showMoreFacets: true });
+  }
+
+  showGetTenMore(valueCount) {
+    const moreFacetsToShow = valueCount - facetShowLimit;
+    if (valueCount > facetShowLimit && !this.state.showMoreFacets) {
+      return (
+        <button className="nypl-link-button" onClick={(e) => this.showMoreFacets(e)}>
+          Show {moreFacetsToShow} more
+        </button>
+      );
     }
     return null;
   }
@@ -173,6 +184,8 @@ class Facet extends React.Component {
               facet.values.map((f, j) => {
                 const percentage = Math.floor(f.count / this.props.totalHits * 100);
                 const valueLabel = (f.value).toString().replace(/:/, '_');
+                const hiddenFacet = (j > facetShowLimit && !this.state.showMoreFacets) ?
+                  'hiddenFacet' : '';
                 let selectLabel = f.value;
                 if (f.label) {
                   selectLabel = f.label;
@@ -182,7 +195,7 @@ class Facet extends React.Component {
                     key={j}
                     id={`${field}-${valueLabel}-label`}
                     htmlFor={`${field}-${valueLabel}`}
-                    className={`nypl-bar_${percentage}`}
+                    className={`nypl-bar_${percentage} ${hiddenFacet}`}
                   >
                     <input
                       id={`${field}-${valueLabel}`}
@@ -200,7 +213,7 @@ class Facet extends React.Component {
               })
             }
           </div>
-          {this.showGetTenMore(facet, facet.values.length)}
+          {this.showGetTenMore(facet.values.length)}
         </div>
       </div>
     );

--- a/src/client/styles/components/FacetSidebar.scss
+++ b/src/client/styles/components/FacetSidebar.scss
@@ -3,3 +3,11 @@ $facets-width: 200px;
 .search-results-container {
   @include clearfix();
 }
+
+.nypl-searchable-field {
+  .nypl-facet-list {
+    label.hiddenFacet {
+      display: none;
+    }
+  }
+}


### PR DESCRIPTION
Added functionality to display more facets when there are more than X number of them. The API is currently only returning at most 10 values, so I tested with a max display of 5 items.

![screen shot 2017-05-12 at 5 16 27 pm](https://cloud.githubusercontent.com/assets/1280564/26017358/25746d24-3737-11e7-8952-034aa0fd1d44.png)

So 5 facets will display and the button will tell you how many more are available to show. The 5 number was just for the picture, I reverted back to a minimum of 10 to display and the button will show how many more can be displayed.