### PR TITLE
changes a to Link where applicable on ItemPage

### DIFF
--- a/src/app/components/ItemPage/ItemPage.jsx
+++ b/src/app/components/ItemPage/ItemPage.jsx
@@ -156,7 +156,7 @@ class ItemPage extends React.Component {
           <Link
             to={{ pathname: '/search', query: { q: `filter[contributorLiteral]=${author}` } }}
             title={`Make a new search for contributor: "${author}"`}
-            onClick={(e) => this.onClick(e, `contributorLiteral:"${author}"`)}
+            onClick={(e) => this.onClick(e, `filter[contributorLiteral]=${author}`)}
           >
             {author}
           </Link>,&nbsp;

--- a/src/app/components/ItemPage/ItemPage.jsx
+++ b/src/app/components/ItemPage/ItemPage.jsx
@@ -109,7 +109,7 @@ class ItemPage extends React.Component {
               return (
                 <span key={i}>
                   <Link
-                    onClick={e => this.onClick(e, `${f.field}:"${value}"`)}
+                    onClick={e => this.onClick(e, `filters[${f.field}]=${value}`)}
                     title={`Make a new search for ${f.label}: "${value}"`}
                     to={`/search?q=${encodeURIComponent(`filters[${f.field}]=${value}`)}`}
                   >
@@ -126,7 +126,7 @@ class ItemPage extends React.Component {
               <ul>{record[f.field].map((value, i) => (
                 <li key={i}>
                   <Link
-                    onClick={e => this.onClick(e, `${f.field}:"${value}"`)}
+                    onClick={e => this.onClick(e, `filters[${f.field}]=${value}`)}
                     title={`Make a new search for ${f.label}: "${value}"`}
                     to={`/search?q=${encodeURIComponent(`filters[${f.field}]=${value}`)}`}
                   >{value}</Link>
@@ -156,7 +156,7 @@ class ItemPage extends React.Component {
           <Link
             to={{ pathname: '/search', query: { q: `filter[contributorLiteral]=${author}` } }}
             title={`Make a new search for contributor: "${author}"`}
-            onClick={(e) => this.onClick(e, `contributor:"${author}"`)}
+            onClick={(e) => this.onClick(e, `contributorLiteral:"${author}"`)}
           >
             {author}
           </Link>,&nbsp;

--- a/src/app/components/ItemPage/ItemPage.jsx
+++ b/src/app/components/ItemPage/ItemPage.jsx
@@ -92,7 +92,7 @@ class ItemPage extends React.Component {
             <ul>{record[f.field].map((obj, i) => (
               <li key={i}>
                 <Link
-                  onClick={e => this.onClick(e, `${f.field}:"${obj['@id']}"`)}
+                  onClick={e => this.onClick(e, `filters[${f.field}]=${obj['@id']}`)}
                   title={`Make a new search for ${f.label}: ${obj.prefLabel}`}
                   to={`/search?q=${encodeURIComponent(`filters[${f.field}]=${obj['@id']}`)}`}
                 >{obj.prefLabel}</Link>

--- a/src/app/components/ItemPage/ItemPage.jsx
+++ b/src/app/components/ItemPage/ItemPage.jsx
@@ -91,11 +91,11 @@ class ItemPage extends React.Component {
           definition: (
             <ul>{record[f.field].map((obj, i) => (
               <li key={i}>
-                <a
+                <Link
                   onClick={e => this.onClick(e, `${f.field}:"${obj['@id']}"`)}
                   title={`Make a new search for ${f.label}: ${obj.prefLabel}`}
-                  href={`/search?q=${encodeURIComponent(`${f.field}:"${obj['@id']}"`)}`}
-                >{obj.prefLabel}</a>
+                  to={`/search?q=${encodeURIComponent(`${f.field}:"${obj['@id']}"`)}`}
+                >{obj.prefLabel}</Link>
               </li>))}
             </ul>),
         });
@@ -108,13 +108,13 @@ class ItemPage extends React.Component {
               const comma = record[f.field].length > 1 ? ', ' : ' ';
               return (
                 <span key={i}>
-                  <a
+                  <Link
                     onClick={e => this.onClick(e, `${f.field}:"${value}"`)}
                     title={`Make a new search for ${f.label}: "${value}"`}
-                    href={`/search?q=${encodeURIComponent(`${f.field}:"${value}"`)}`}
+                    to={`/search?q=${encodeURIComponent(`${f.field}:"${value}"`)}`}
                   >
                     {value}
-                  </a>{comma}
+                  </Link>{comma}
                 </span>
               );
             }),
@@ -125,11 +125,11 @@ class ItemPage extends React.Component {
             definition: (
               <ul>{record[f.field].map((value, i) => (
                 <li key={i}>
-                  <a
+                  <Link
                     onClick={e => this.onClick(e, `${f.field}:"${value}"`)}
                     title={`Make a new search for ${f.label}: "${value}"`}
-                    href={`/search?q=${encodeURIComponent(`${f.field}:"${value}"`)}`}
-                  >{value}</a>
+                    to={`/search?q=${encodeURIComponent(`${f.field}:"${value}"`)}`}
+                  >{value}</Link>
                 </li>))}
               </ul>),
           });

--- a/src/app/components/ItemPage/ItemPage.jsx
+++ b/src/app/components/ItemPage/ItemPage.jsx
@@ -154,7 +154,7 @@ class ItemPage extends React.Component {
       record.contributor.map((author, i) => (
         <span key={i}>
           <Link
-            to={{ pathname: '/search', query: { q: `filter[contributor]=${author}` } }}
+            to={{ pathname: '/search', query: { q: `filter[contributorLiteral]=${author}` } }}
             title={`Make a new search for contributor: "${author}"`}
             onClick={(e) => this.onClick(e, `contributor:"${author}"`)}
           >

--- a/src/app/components/ItemPage/ItemPage.jsx
+++ b/src/app/components/ItemPage/ItemPage.jsx
@@ -167,7 +167,7 @@ class ItemPage extends React.Component {
       <Link
         to={{ pathname: '/search', query: { q: `filter[publisher]=${record.publisher[0]}` } }}
         title={`Make a new search for publisher: "${record.publisher[0]}"`}
-        onClick={(e) => this.onClick(e, `publisher:"${record.publisher[0]}"`)}
+        onClick={(e) => this.onClick(e, `filter[publisher]=${record.publisher[0]}`)}
       >
         {record.publisher[0]}
       </Link>

--- a/src/app/components/ItemPage/ItemPage.jsx
+++ b/src/app/components/ItemPage/ItemPage.jsx
@@ -94,7 +94,7 @@ class ItemPage extends React.Component {
                 <Link
                   onClick={e => this.onClick(e, `${f.field}:"${obj['@id']}"`)}
                   title={`Make a new search for ${f.label}: ${obj.prefLabel}`}
-                  to={`/search?q=${encodeURIComponent(`${f.field}:"${obj['@id']}"`)}`}
+                  to={`/search?q=${encodeURIComponent(`filters[${f.field}]=${obj['@id']}`)}`}
                 >{obj.prefLabel}</Link>
               </li>))}
             </ul>),
@@ -111,7 +111,7 @@ class ItemPage extends React.Component {
                   <Link
                     onClick={e => this.onClick(e, `${f.field}:"${value}"`)}
                     title={`Make a new search for ${f.label}: "${value}"`}
-                    to={`/search?q=${encodeURIComponent(`${f.field}:"${value}"`)}`}
+                    to={`/search?q=${encodeURIComponent(`filters[${f.field}]=${value}`)}`}
                   >
                     {value}
                   </Link>{comma}
@@ -128,7 +128,7 @@ class ItemPage extends React.Component {
                   <Link
                     onClick={e => this.onClick(e, `${f.field}:"${value}"`)}
                     title={`Make a new search for ${f.label}: "${value}"`}
-                    to={`/search?q=${encodeURIComponent(`${f.field}:"${value}"`)}`}
+                    to={`/search?q=${encodeURIComponent(`filters[${f.field}]=${value}`)}`}
                   >{value}</Link>
                 </li>))}
               </ul>),
@@ -154,7 +154,7 @@ class ItemPage extends React.Component {
       record.contributor.map((author, i) => (
         <span key={i}>
           <Link
-            to={{ pathname: '/search', query: { q: `contributor:"${author}"` } }}
+            to={{ pathname: '/search', query: { q: `filter[contributor]=${author}` } }}
             title={`Make a new search for contributor: "${author}"`}
             onClick={(e) => this.onClick(e, `contributor:"${author}"`)}
           >
@@ -165,7 +165,7 @@ class ItemPage extends React.Component {
       : null;
     const publisher = record.publisher && record.publisher.length ?
       <Link
-        to={{ pathname: '/search', query: { q: `publisher:"${record.publisher[0]}"` } }}
+        to={{ pathname: '/search', query: { q: `filter[publisher]=${record.publisher[0]}` } }}
         title={`Make a new search for publisher: "${record.publisher[0]}"`}
         onClick={(e) => this.onClick(e, `publisher:"${record.publisher[0]}"`)}
       >


### PR DESCRIPTION
this is related to #340. There are a few other `a` tags that don't belong in the results list but they are related to holds, so not being used right now...