### PR TITLE
updates to use filters in breadcrumbs query

### DIFF
--- a/src/app/components/Breadcrumbs/Breadcrumbs.jsx
+++ b/src/app/components/Breadcrumbs/Breadcrumbs.jsx
@@ -37,7 +37,7 @@ const Breadcrumbs = ({ query, type, title, url }) => {
           (<li>
             <Link
               title={`Make a new search for ${query}`}
-              to={`/search?q=${query}`}
+              to={`/search?${query}`}
             >Items</Link></li>)
           : null
         }

--- a/src/app/components/Breadcrumbs/Breadcrumbs.jsx
+++ b/src/app/components/Breadcrumbs/Breadcrumbs.jsx
@@ -37,7 +37,7 @@ const Breadcrumbs = ({ query, type, title, url }) => {
           (<li>
             <Link
               title={`Make a new search for ${query}`}
-              to={`/search?${query}`}
+              to={`/search?q=${query}`}
             >Items</Link></li>)
           : null
         }

--- a/src/app/components/ItemPage/ItemPage.jsx
+++ b/src/app/components/ItemPage/ItemPage.jsx
@@ -206,7 +206,7 @@ class ItemPage extends React.Component {
 
     _mapObject(this.props.selectedFacets, (val, key) => {
       if (val.value !== '') {
-        searchURL += ` ${key}:"${val.id}"`;
+        searchURL += `&filters[${key}]=${val.id}`;
       }
     });
 


### PR DESCRIPTION
For #341.

Is this the right syntax for combo search and filtering? Working for me. This is the only place it is triggered -- when searching and filtering, then clicking down to the item page. The "Items" breadcrumb is where this is applied.