### PR TITLE
376 refactor hold request component

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,9 @@ To run the tests continuously for active development, run
 
     $ npm run test-dev
 
-To run a specific test file, run
+To run a specific test file in the `test/unit` folder, run
 
-    $ npm run test-file test/SearchResultsPage.test.js
+    $ TEST_FILE=[file name] npm run test
 
 ### Code Coverage
 [Istanbul](https://istanbul.js.org/) is used for checking code coverage.

--- a/README.md
+++ b/README.md
@@ -24,9 +24,11 @@ To run locally in development mode run
 
 The default environment for APIs is development. If you would like to update the environmenrt, run
 
-    $ APP_ENV=[environment] npm start
+    $ APP_ENV=[environment variable] npm start
 
-and visit `localhost:3001`.
+`environment variable` is the names of different environments, such as `development`.
+
+At last, visit `localhost:3001`.
 
 To run locally in production mode run
 

--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@ To install packages run
 
 To run locally in development mode run
 
-    $ npm start
+    $ npm run dev-start
 
-The default environment for APIs is development. If you would like to update the environmenrt, run
+If you would like to run in different the environments, run
 
     $ APP_ENV=[environment variable] npm start
 
-`environment variable` is the names of different environments, such as `development`.
+`environment variable` is the names of different environments, such as `qa`.
 
 At last, visit `localhost:3001`.
 

--- a/README.md
+++ b/README.md
@@ -56,9 +56,9 @@ To run the tests continuously for active development, run
 
     $ npm run test-dev
 
-To run a specific test file in the `test/unit` folder, run
+To run a specific test file, run
 
-    $ TEST_FILE=[file name] npm run test
+    $ npm run test-file test/SearchResultsPage.test.js
 
 ### Code Coverage
 [Istanbul](https://istanbul.js.org/) is used for checking code coverage.

--- a/README.md
+++ b/README.md
@@ -22,11 +22,9 @@ To run locally in development mode run
 
     $ npm start
 
-    or
+The default environment for APIs is development. If you would like to update the environmenrt, run
 
     $ APP_ENV=[environment] npm start
-
-The App will call different APIs based on the environment variables. Default is development.
 
 and visit `localhost:3001`.
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ If you would like to run in different the environments, run
 
     $ APP_ENV=[environment variable] npm start
 
-`environment variable` is the names of different environments, such as `qa`.
+`environment variable` is the name of the particular environment, such as `qa`.
 
 At last, visit `localhost:3001`.
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,13 @@ To install packages run
 
 To run locally in development mode run
 
-    $ APP_ENV=development npm start
+    $ npm start
+
+    or
+
+    $ APP_ENV=[environment] npm start
+
+The App will call different APIs based on the environment variables. Default is development.
 
 and visit `localhost:3001`.
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Isomorphic React boilerplate",
   "main": "index.js",
   "scripts": {
-    "start": "APP_ENV=development node index",
+    "start": "node index",
+    "dev-start": "APP_ENV=development node index",
     "eb-start": "npm run dist && APP_ENV=development node index",
     "dist": "NODE_ENV=production webpack --config webpack.config.js",
     "postinstall": "npm run dist",

--- a/package.json
+++ b/package.json
@@ -8,9 +8,8 @@
     "eb-start": "npm run dist && APP_ENV=development node index",
     "dist": "NODE_ENV=production webpack --config webpack.config.js",
     "postinstall": "npm run dist",
-    "test": "node_modules/.bin/mocha test/helpers/browser.js test/unit/*.test.js",
+    "test": "node_modules/.bin/mocha test/helpers/browser.js test/unit/$TEST_FILE",
     "test-dev": "node_modules/.bin/mocha -w test/helpers/browser.js test/unit/*.test.js",
-    "test-file": "node_modules/.bin/mocha -w test/helpers/browser.js",
     "coverage": "BABEL_ENV=test node_modules/.bin/nyc --require mocha npm test",
     "coverage-report": "BABEL_ENV=test node_modules/.bin/nyc report --reporter=lcov",
     "nightwatch": "./node_modules/.bin/nightwatch"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Isomorphic React boilerplate",
   "main": "index.js",
   "scripts": {
-    "start": "node index",
+    "start": "APP_ENV=development node index",
     "eb-start": "npm run dist && APP_ENV=development node index",
     "dist": "NODE_ENV=production webpack --config webpack.config.js",
     "postinstall": "npm run dist",

--- a/package.json
+++ b/package.json
@@ -9,8 +9,9 @@
     "eb-start": "npm run dist && APP_ENV=development node index",
     "dist": "NODE_ENV=production webpack --config webpack.config.js",
     "postinstall": "npm run dist",
-    "test": "node_modules/.bin/mocha test/helpers/browser.js test/unit/$TEST_FILE",
+    "test": "node_modules/.bin/mocha test/helpers/browser.js test/unit/*.test.js",
     "test-dev": "node_modules/.bin/mocha -w test/helpers/browser.js test/unit/*.test.js",
+    "test-file": "node_modules/.bin/mocha -w test/helpers/browser.js",
     "coverage": "BABEL_ENV=test node_modules/.bin/nyc --require mocha npm test",
     "coverage-report": "BABEL_ENV=test node_modules/.bin/nyc report --reporter=lcov",
     "nightwatch": "./node_modules/.bin/nightwatch"

--- a/src/app/components/HoldRequest/HoldRequest.jsx
+++ b/src/app/components/HoldRequest/HoldRequest.jsx
@@ -29,7 +29,7 @@ class HoldRequest extends React.Component {
   }
 
   requireUser() {
-    if (this.state.patron && _isArray(this.state.patron.id) && this.state.patron.id.length) {
+    if (this.state.patron && this.state.patron.id.length) {
       return true;
     }
 
@@ -49,8 +49,8 @@ class HoldRequest extends React.Component {
       this.state.patron.names && _isArray(this.state.patron.names) && this.state.patron.names.length
     ) ? this.state.patron.names[0] : '';
     const loggedInInstruction = (patronName) ?
-      <p>You are currently logged in as <strong>{patronName}</strong>. If this is not you, please <a href="https://isso.nypl.org/auth/logout">Log out</a> and sign in using your library card.</p>
-      : <p>Something wrong with your attempt to log in.</p>;
+      <p className='loggedInInstruction'>You are currently logged in as <strong>{patronName}</strong>. If this is not you, please <a href="https://isso.nypl.org/auth/logout">Log out</a> and sign in using your library card.</p>
+      : <p className='loggedInInstruction'>Something wrong with your attempt to log in.</p>;
 
     if (!record) {
       return (
@@ -123,7 +123,7 @@ class HoldRequest extends React.Component {
             <form className="place-hold-form form" action={`/hold/request/${itemId}`} method="POST">
               <h2>Confirm account</h2>
 
-              <p>You are currently logged in as <strong>{this.state.patron.names[0]}</strong>. If this is not you, please <a href="https://isso.nypl.org/auth/logout">Log out</a> and sign in using your library card.</p>
+              {loggedInInstruction}
 
               <h2>Confirm delivery location</h2>
 

--- a/src/app/components/HoldRequest/HoldRequest.jsx
+++ b/src/app/components/HoldRequest/HoldRequest.jsx
@@ -81,67 +81,71 @@ class HoldRequest extends React.Component {
     const day = date.getDate();
     const monthIndex = date.getMonth();
     const dateDisplay = `${monthNames[monthIndex]} ${day}`;
-    const content = (record) ? (
-      <div className="content-wrapper">
-        <div className="item-header">
-          <h1>Research item hold request</h1>
-        </div>
+    let content = null;
 
-        <div className="item-summary">
-          <div className="item">
-            <h2>You are about to request a hold on the following research item:</h2>
-            <Link href={`/item/${bibId}`}>{title}</Link>
+    if (record) {
+      content =
+        <div className="content-wrapper">
+          <div className="item-header">
+            <h1>Research item hold request</h1>
           </div>
-        </div>
 
-        <form className="place-hold-form form" action={`/hold/request/${itemId}`} method="POST">
-          <h2>Confirm account</h2>
-          {this.renderLoggedInInstruction(patronName)}
-          <h2>Confirm delivery location</h2>
-          <p>When this item is ready, you will use it in the following location:</p>
-          <fieldset className="select-location-fieldset">
-            <legend className="visuallyHidden">Select a pickup location</legend>
-            <div className="group selected">
-              <span className="col location">
-                <a href={`${location.uri}`}>{location['full-name']}</a><br />{location.address.address1}<br />
-                {location.prefLabel}
-                {location.offsite &&
-                  <span>
-                    <br /><small>(requested from offsite storage)</small><br />
+          <div className="item-summary">
+            <div className="item">
+              <h2>You are about to request a hold on the following research item:</h2>
+              <Link href={`/item/${bibId}`}>{title}</Link>
+            </div>
+          </div>
+
+          <form className="place-hold-form form" action={`/hold/request/${itemId}`} method="POST">
+            <h2>Confirm account</h2>
+            {this.renderLoggedInInstruction(patronName)}
+            <h2>Confirm delivery location</h2>
+            <p>When this item is ready, you will use it in the following location:</p>
+            <fieldset className="select-location-fieldset">
+              <legend className="visuallyHidden">Select a pickup location</legend>
+              <div className="group selected">
+                <span className="col location">
+                  <a href={`${location.uri}`}>{location['full-name']}</a><br />{location.address.address1}<br />
+                  {location.prefLabel}
+                  {location.offsite &&
+                    <span>
+                      <br /><small>(requested from offsite storage)</small><br />
+                    </span>
+                  }
+                </span>
+                {selectedItem.shelfMark &&
+                  <span className="col">
+                    <small>Call number:</small><br />{selectedItem.shelfMark[0]}
                   </span>
                 }
-              </span>
-              {selectedItem.shelfMark &&
-                <span className="col">
-                  <small>Call number:</small><br />{selectedItem.shelfMark[0]}
-                </span>
-              }
-              {/* <span className="col"><small>Ready by approximately:</small><br />{dateDisplay}, 9am.</span> */}
-            </div>
-          </fieldset>
+                {/* <span className="col"><small>Ready by approximately:</small><br />{dateDisplay}, 9am.</span> */}
+              </div>
+            </fieldset>
 
-          <input type="hidden" name="pickupLocation" value={location.code} />
+            <input type="hidden" name="pickupLocation" value={location.code} />
 
-          <button type="submit" className="large">
-            Submit your item hold request
-          </button>
-        </form>
-      </div>
-    ) : (
-      <div className="content-wrapper">
-        <div className="item-header">
-          <h1>Research item hold request</h1>
-        </div>
-        <div className="item-summary">
-          <div className="item">
-            <h2>Something wrong with your request</h2>
-            <Link href={`/item/${bibId}`}>{title}</Link>
+            <button type="submit" className="large">
+              Submit your item hold request
+            </button>
+          </form>
+        </div>;
+    } else {
+      content =
+        <div className="content-wrapper">
+          <div className="item-header">
+            <h1>Research item hold request</h1>
           </div>
-        </div>
-        <h2>Confirm account</h2>
-        {this.renderLoggedInInstruction(patronName)}
-      </div>
-    );
+          <div className="item-summary">
+            <div className="item">
+              <h2>Something wrong with your request</h2>
+              <Link href={`/item/${bibId}`}>{title}</Link>
+            </div>
+          </div>
+          <h2>Confirm account</h2>
+          {this.renderLoggedInInstruction(patronName)}
+        </div>;
+    }
 
     return (
       <div id="mainContent">

--- a/src/app/components/HoldRequest/HoldRequest.jsx
+++ b/src/app/components/HoldRequest/HoldRequest.jsx
@@ -57,7 +57,7 @@ class HoldRequest extends React.Component {
   renderLoggedInInstruction(patronName) {
     return (patronName) ?
       <p className="loggedInInstruction">You are currently logged in as <strong>{patronName}</strong>. If this is not you, please <a href="https://isso.nypl.org/auth/logout">Log out</a> and sign in using your library card.</p>
-      : <p className="loggedInInstruction">Something wrong during retrieving your patron data.</p>;
+      : <p className="loggedInInstruction">Something went wrong during retrieving your patron data.</p>;
   }
 
   render() {

--- a/src/app/components/HoldRequest/HoldRequest.jsx
+++ b/src/app/components/HoldRequest/HoldRequest.jsx
@@ -38,14 +38,10 @@ class HoldRequest extends React.Component {
   }
 
   render() {
-    const searchKeywords = this.props.searchKeywords || '';
-    const record = this.props.bib || null;
-    // const record = { title: ['this is a test title'], '@id': 'ThisIsATestId', };
-    const title = 'this is a test title';
-    const bibId = 'ThisIsATestId';
-    // const title = (_isArray(record.title) && record.title.length > 0 && record.title[0]) ? record.title[0] : '';
-    // const bibId = (record['@id'] && typeof record['@id'] === 'string') ? record['@id'].substring(4) : '';
-console.log(record);
+    const searchKeywords = this.state.data.searchKeywords || '';
+    const record = this.state.data.item || null;
+    const title = (_isArray(record.title) && record.title.length && record.title[0]) ? record.title[0] : '';
+    const bibId = (record['@id'] && typeof record['@id'] === 'string') ? record['@id'].substring(4) : '';
     if (!record) {
       return (
         <div id="mainContent">

--- a/src/app/components/HoldRequest/HoldRequest.jsx
+++ b/src/app/components/HoldRequest/HoldRequest.jsx
@@ -33,7 +33,7 @@ class HoldRequest extends React.Component {
    * requireUser()
    * Redirectes the patron to OAuth log in page if he/she hasn't been logged in yet.
    *
-   * @return {boolean}
+   * @return {Boolean}
    */
   requireUser() {
     if (this.state.patron && this.state.patron.id) {
@@ -51,7 +51,7 @@ class HoldRequest extends React.Component {
    * renderLoggedInInstruction(patronName)
    * Renders the HTML elements and contents based on the patron data
    *
-   * @param {string} patronName
+   * @param {String} patronName
    * @return {HTML Element}
    */
   renderLoggedInInstruction(patronName) {

--- a/src/app/components/HoldRequest/HoldRequest.jsx
+++ b/src/app/components/HoldRequest/HoldRequest.jsx
@@ -1,13 +1,14 @@
 import React from 'react';
 import { Link } from 'react-router';
-
 import Breadcrumbs from '../Breadcrumbs/Breadcrumbs.jsx';
 import Store from '../../stores/Store.js';
 import PatronStore from '../../stores/PatronStore.js';
 import config from '../../../../appConfig.js';
 import LibraryItem from '../../utils/item.js';
-
-import { isArray as _isArray, isEmpty as _isEmpty } from 'underscore';
+import {
+  isArray as _isArray,
+  isEmpty as _isEmpty,
+} from 'underscore';
 
 class HoldRequest extends React.Component {
   constructor(props) {
@@ -42,124 +43,108 @@ class HoldRequest extends React.Component {
 
   render() {
     const searchKeywords = this.state.data.searchKeywords || '';
-    const record = (this.state.data.item && !_isEmpty(this.state.data.item)) ? this.state.data.item : null;
-    const title = (record && _isArray(record.title) && record.title.length) ? record.title[0] : '';
-    const bibId = (record && record['@id'] && typeof record['@id'] === 'string') ? record['@id'].substring(4) : '';
+    const record = (this.state.data.item && !_isEmpty(this.state.data.item)) ?
+      this.state.data.item : null;
+    const title = (record && _isArray(record.title) && record.title.length) ?
+      record.title[0] : '';
+    const bibId = (record && record['@id'] && typeof record['@id'] === 'string') ?
+      record['@id'].substring(4) : '';
     const patronName = (
       this.state.patron.names && _isArray(this.state.patron.names) && this.state.patron.names.length
     ) ? this.state.patron.names[0] : '';
     const loggedInInstruction = (patronName) ?
-      <p className='loggedInInstruction'>You are currently logged in as <strong>{patronName}</strong>. If this is not you, please <a href="https://isso.nypl.org/auth/logout">Log out</a> and sign in using your library card.</p>
-      : <p className='loggedInInstruction'>Something wrong with your attempt to log in.</p>;
+      <p className="loggedInInstruction">You are currently logged in as <strong>{patronName}</strong>. If this is not you, please <a href="https://isso.nypl.org/auth/logout">Log out</a> and sign in using your library card.</p>
+      : <p className="loggedInInstruction">Something wrong with your attempt to log in.</p>;
+    const itemId = (this.props.params && this.props.params.id) ? this.props.params.id : '';
+    const selectedItem = (record && itemId) ? LibraryItem.getItem(record, itemId) : null;
+    const location = (record && itemId) ? LibraryItem.getLocation(record, itemId) : null;
+    const monthNames = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'June', 'July',
+      'Aug', 'Sept', 'Oct', 'Nov', 'Dec'];
+    const date = new Date();
+    date.setDate(date.getDate() + 7);
+    const day = date.getDate();
+    const monthIndex = date.getMonth();
+    const dateDisplay = `${monthNames[monthIndex]} ${day}`;
+    const content = (record) ? (
+      <div className="content-wrapper">
+        <div className="item-header">
+          <h1>Research item hold request</h1>
+        </div>
 
-    if (!record) {
-      return (
-        <div id="mainContent">
-          <div className="page-header">
-            <div className="content-wrapper">
-              <Breadcrumbs
-                query={searchKeywords}
-                type="hold"
-                title={title}
-                url={bibId}
-              />
-            </div>
-          </div>
-
-          <div className="content-wrapper">
-            <div className="item-header">
-              <h1>Research item hold request</h1>
-            </div>
-
-            <div className="item-summary">
-              <div className="item">
-                <h2>Something wrong with your request</h2>
-                <Link href={`/item/${bibId}`}>{title}</Link>
-              </div>
-            </div>
-            <h2>Confirm account</h2>
-            {loggedInInstruction}
+        <div className="item-summary">
+          <div className="item">
+            <h2>You are about to request a hold on the following research item:</h2>
+            <Link href={`/item/${bibId}`}>{title}</Link>
           </div>
         </div>
-      );
-    } else {
-      const itemId = (this.props.params && this.props.params.id) ? this.props.params.id : '';
-      const selectedItem = (record && itemId) ? LibraryItem.getItem(record, itemId) : null;
-      const location = (record && itemId) ? LibraryItem.getLocation(record, itemId) : null;
 
-      const monthNames = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'June', 'July',
-        'Aug', 'Sept', 'Oct', 'Nov', 'Dec'];
-      let date = new Date();
-      date.setDate(date.getDate() + 7);
-      const day = date.getDate();
-      const monthIndex = date.getMonth();
-      const dateDisplay = `${monthNames[monthIndex]} ${day}`;
+        <form className="place-hold-form form" action={`/hold/request/${itemId}`} method="POST">
+          <h2>Confirm account</h2>
 
-      return (
-        <div id="mainContent">
-          <div className="page-header">
-            <div className="content-wrapper">
-              <Breadcrumbs
-                query={searchKeywords}
-                type="hold"
-                title={title}
-                url={bibId}
-              />
-            </div>
-          </div>
+          {loggedInInstruction}
 
-          <div className="content-wrapper">
-            <div className="item-header">
-              <h1>Research item hold request</h1>
-            </div>
+          <h2>Confirm delivery location</h2>
 
-            <div className="item-summary">
-              <div className="item">
-                <h2>You are about to request a hold on the following research item:</h2>
-                <Link href={`/item/${bibId}`}>{title}</Link>
-              </div>
-            </div>
+          <p>When this item is ready, you will use it in the following location:</p>
 
-            <form className="place-hold-form form" action={`/hold/request/${itemId}`} method="POST">
-              <h2>Confirm account</h2>
-
-              {loggedInInstruction}
-
-              <h2>Confirm delivery location</h2>
-
-              <p>When this item is ready, you will use it in the following location:</p>
-
-              <fieldset className="select-location-fieldset">
-                <legend className="visuallyHidden">Select a pickup location</legend>
-                <div className="group selected">
-                  <span className="col location">
-                    <a href={`${location.uri}`}>{location["full-name"]}</a><br />{location.address.address1}<br />
-                    {location.prefLabel}
-                    {location.offsite &&
-                      <span>
-                        <br /><small>(requested from offsite storage)</small><br />
-                      </span>
-                    }
+          <fieldset className="select-location-fieldset">
+            <legend className="visuallyHidden">Select a pickup location</legend>
+            <div className="group selected">
+              <span className="col location">
+                <a href={`${location.uri}`}>{location['full-name']}</a><br />{location.address.address1}<br />
+                {location.prefLabel}
+                {location.offsite &&
+                  <span>
+                    <br /><small>(requested from offsite storage)</small><br />
                   </span>
-                  {selectedItem.shelfMark &&
-                    <span className="col">
-                      <small>Call number:</small><br />{selectedItem.shelfMark[0]}
-                    </span>
-                  }
-                  {/*<span className="col"><small>Ready by approximately:</small><br />{dateDisplay}, 9am.</span>*/}
-                </div>
-              </fieldset>
+                }
+              </span>
+              {selectedItem.shelfMark &&
+                <span className="col">
+                  <small>Call number:</small><br />{selectedItem.shelfMark[0]}
+                </span>
+              }
+              {/* <span className="col"><small>Ready by approximately:</small><br />{dateDisplay}, 9am.</span> */}
+            </div>
+          </fieldset>
 
-              <input type="hidden" name="pickupLocation" value={location.code} />
+          <input type="hidden" name="pickupLocation" value={location.code} />
 
-              <button type="submit" className="large">
-                Submit your item hold request
-              </button>
-            </form>
+          <button type="submit" className="large">
+            Submit your item hold request
+          </button>
+        </form>
+      </div>
+    ) : (
+      <div className="content-wrapper">
+        <div className="item-header">
+          <h1>Research item hold request</h1>
+        </div>
+        <div className="item-summary">
+          <div className="item">
+            <h2>Something wrong with your request</h2>
+            <Link href={`/item/${bibId}`}>{title}</Link>
           </div>
         </div>
-      );
-    }
+        <h2>Confirm account</h2>
+        {loggedInInstruction}
+      </div>);
+
+    return (
+      <div id="mainContent">
+        <div className="page-header">
+          <div className="content-wrapper">
+            <Breadcrumbs
+              query={searchKeywords}
+              type="hold"
+              title={title}
+              url={bibId}
+            />
+          </div>
+        </div>
+        {content}
+      </div>
+    );
   }
 }
 
@@ -173,6 +158,7 @@ HoldRequest.propTypes = {
   location: React.PropTypes.object,
   bib: React.PropTypes.object,
   searchKeywords: React.PropTypes.string,
+  params: React.PropTypes.object,
 };
 
 export default HoldRequest;

--- a/src/app/components/HoldRequest/HoldRequest.jsx
+++ b/src/app/components/HoldRequest/HoldRequest.jsx
@@ -7,6 +7,8 @@ import PatronStore from '../../stores/PatronStore.js';
 import config from '../../../../appConfig.js';
 import LibraryItem from '../../utils/item.js';
 
+import { isArray as _isArray } from 'underscore';
+
 class HoldRequest extends React.Component {
   constructor(props) {
     super(props);
@@ -36,86 +38,122 @@ class HoldRequest extends React.Component {
   }
 
   render() {
-    const searchKeywords = this.props.searchKeywords;
-    const record = this.props.bib;
-    const title = record.title[0];
-    const bibId = record['@id'].substring(4);
-    const itemId = this.props.params.id;
-    const selectedItem = LibraryItem.getItem(record, itemId);
-    const location = LibraryItem.getLocation(record, itemId);
-
-    const monthNames = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'June', 'July',
-      'Aug', 'Sept', 'Oct', 'Nov', 'Dec'];
-    let date = new Date();
-    date.setDate(date.getDate() + 7);
-    const day = date.getDate();
-    const monthIndex = date.getMonth();
-    const dateDisplay = `${monthNames[monthIndex]} ${day}`;
-
-    return (
-      <div id="mainContent">
-        <div className="page-header">
-          <div className="content-wrapper">
-            <Breadcrumbs
-              query={searchKeywords}
-              type="hold"
-              title={title}
-              url={bibId}
-            />
-          </div>
-        </div>
-
-        <div className="content-wrapper">
-          <div className="item-header">
-            <h1>Research item hold request</h1>
-          </div>
-
-          <div className="item-summary">
-            <div className="item">
-              <h2>You are about to request a hold on the following research item:</h2>
-              <Link href={`/item/${bibId}`}>{title}</Link>
+    const searchKeywords = this.props.searchKeywords || '';
+    const record = this.props.bib || null;
+    // const record = { title: ['this is a test title'], '@id': 'ThisIsATestId', };
+    const title = 'this is a test title';
+    const bibId = 'ThisIsATestId';
+    // const title = (_isArray(record.title) && record.title.length > 0 && record.title[0]) ? record.title[0] : '';
+    // const bibId = (record['@id'] && typeof record['@id'] === 'string') ? record['@id'].substring(4) : '';
+console.log(record);
+    if (!record) {
+      return (
+        <div id="mainContent">
+          <div className="page-header">
+            <div className="content-wrapper">
+              <Breadcrumbs
+                query={searchKeywords}
+                type="hold"
+                title={title}
+                url={bibId}
+              />
             </div>
           </div>
 
-          <form className="place-hold-form form" action={`/hold/request/${itemId}`} method="POST">
+          <div className="content-wrapper">
+            <div className="item-header">
+              <h1>Research item hold request</h1>
+            </div>
+
+            <div className="item-summary">
+              <div className="item">
+                <h2>Something wrong with your request</h2>
+                <Link href={`/item/${bibId}`}>{title}</Link>
+              </div>
+            </div>
             <h2>Confirm account</h2>
-
             <p>You are currently logged in as <strong>{this.state.patron.names[0]}</strong>. If this is not you, please <a href="https://isso.nypl.org/auth/logout">Log out</a> and sign in using your library card.</p>
+          </div>
+        </div>
+      );
+    } else {
+      const itemId = (this.props.params && this.props.params.id) ? this.props.params.id : '';
+      const selectedItem = (record && itemId) ? LibraryItem.getItem(record, itemId) : null;
+      const location = (record && itemId) ? LibraryItem.getLocation(record, itemId) : null;
 
-            <h2>Confirm delivery location</h2>
+      const monthNames = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'June', 'July',
+        'Aug', 'Sept', 'Oct', 'Nov', 'Dec'];
+      let date = new Date();
+      date.setDate(date.getDate() + 7);
+      const day = date.getDate();
+      const monthIndex = date.getMonth();
+      const dateDisplay = `${monthNames[monthIndex]} ${day}`;
 
-            <p>When this item is ready, you will use it in the following location:</p>
+      return (
+        <div id="mainContent">
+          <div className="page-header">
+            <div className="content-wrapper">
+              <Breadcrumbs
+                query={searchKeywords}
+                type="hold"
+                title={title}
+                url={bibId}
+              />
+            </div>
+          </div>
 
-            <fieldset className="select-location-fieldset">
-              <legend className="visuallyHidden">Select a pickup location</legend>
-              <div className="group selected">
-                <span className="col location">
-                  <a href={`${location.uri}`}>{location["full-name"]}</a><br />{location.address.address1}<br />
-                  {location.prefLabel}
-                  {location.offsite &&
-                    <span>
-                      <br /><small>(requested from offsite storage)</small><br />
+          <div className="content-wrapper">
+            <div className="item-header">
+              <h1>Research item hold request</h1>
+            </div>
+
+            <div className="item-summary">
+              <div className="item">
+                <h2>You are about to request a hold on the following research item:</h2>
+                <Link href={`/item/${bibId}`}>{title}</Link>
+              </div>
+            </div>
+
+            <form className="place-hold-form form" action={`/hold/request/${itemId}`} method="POST">
+              <h2>Confirm account</h2>
+
+              <p>You are currently logged in as <strong>{this.state.patron.names[0]}</strong>. If this is not you, please <a href="https://isso.nypl.org/auth/logout">Log out</a> and sign in using your library card.</p>
+
+              <h2>Confirm delivery location</h2>
+
+              <p>When this item is ready, you will use it in the following location:</p>
+
+              <fieldset className="select-location-fieldset">
+                <legend className="visuallyHidden">Select a pickup location</legend>
+                <div className="group selected">
+                  <span className="col location">
+                    <a href={`${location.uri}`}>{location["full-name"]}</a><br />{location.address.address1}<br />
+                    {location.prefLabel}
+                    {location.offsite &&
+                      <span>
+                        <br /><small>(requested from offsite storage)</small><br />
+                      </span>
+                    }
+                  </span>
+                  {selectedItem.shelfMark &&
+                    <span className="col">
+                      <small>Call number:</small><br />{selectedItem.shelfMark[0]}
                     </span>
                   }
-                </span>
-                {selectedItem.shelfMark &&
-                  <span className="col">
-                    <small>Call number:</small><br />{selectedItem.shelfMark[0]}
-                  </span>
-                }
-                {/*<span className="col"><small>Ready by approximately:</small><br />{dateDisplay}, 9am.</span>*/}
-              </div>
-            </fieldset>
+                  {/*<span className="col"><small>Ready by approximately:</small><br />{dateDisplay}, 9am.</span>*/}
+                </div>
+              </fieldset>
 
-            <input type="hidden" name="pickupLocation" value={location.code} />
+              <input type="hidden" name="pickupLocation" value={location.code} />
 
-            <button type="submit" className="large">
-              Submit your item hold request
-            </button>
-          </form>
+              <button type="submit" className="large">
+                Submit your item hold request
+              </button>
+            </form>
+          </div>
         </div>
-      </div>
-    );
+      );
+    }
   }
 }
 

--- a/src/app/components/HoldRequest/HoldRequest.jsx
+++ b/src/app/components/HoldRequest/HoldRequest.jsx
@@ -30,7 +30,7 @@ class HoldRequest extends React.Component {
   }
 
   requireUser() {
-    if (this.state.patron && this.state.patron.id.length) {
+    if (this.state.patron && this.state.patron.id) {
       return true;
     }
 

--- a/src/app/components/HoldRequest/HoldRequest.jsx
+++ b/src/app/components/HoldRequest/HoldRequest.jsx
@@ -29,6 +29,12 @@ class HoldRequest extends React.Component {
     this.setState({ data: Store.getState() });
   }
 
+  /**
+   * requireUser()
+   * Redirectes the patron to OAuth log in page if he/she hasn't been logged in yet.
+   *
+   * @return {boolean}
+   */
   requireUser() {
     if (this.state.patron && this.state.patron.id) {
       return true;
@@ -41,6 +47,19 @@ class HoldRequest extends React.Component {
     return false;
   }
 
+  /**
+   * renderLoggedInInstruction(patronName)
+   * Renders the HTML elements and contents based on the patron data
+   *
+   * @param {string} patronName
+   * @return {HTML Element}
+   */
+  renderLoggedInInstruction(patronName) {
+    return (patronName) ?
+      <p className="loggedInInstruction">You are currently logged in as <strong>{patronName}</strong>. If this is not you, please <a href="https://isso.nypl.org/auth/logout">Log out</a> and sign in using your library card.</p>
+      : <p className="loggedInInstruction">Something wrong during retrieving your patron data.</p>;
+  }
+
   render() {
     const searchKeywords = this.state.data.searchKeywords || '';
     const record = (this.state.data.item && !_isEmpty(this.state.data.item)) ?
@@ -51,10 +70,7 @@ class HoldRequest extends React.Component {
       record['@id'].substring(4) : '';
     const patronName = (
       this.state.patron.names && _isArray(this.state.patron.names) && this.state.patron.names.length
-    ) ? this.state.patron.names[0] : '';
-    const loggedInInstruction = (patronName) ?
-      <p className="loggedInInstruction">You are currently logged in as <strong>{patronName}</strong>. If this is not you, please <a href="https://isso.nypl.org/auth/logout">Log out</a> and sign in using your library card.</p>
-      : <p className="loggedInInstruction">Something wrong with your attempt to log in.</p>;
+      ) ? this.state.patron.names[0] : '';
     const itemId = (this.props.params && this.props.params.id) ? this.props.params.id : '';
     const selectedItem = (record && itemId) ? LibraryItem.getItem(record, itemId) : null;
     const location = (record && itemId) ? LibraryItem.getLocation(record, itemId) : null;
@@ -80,13 +96,9 @@ class HoldRequest extends React.Component {
 
         <form className="place-hold-form form" action={`/hold/request/${itemId}`} method="POST">
           <h2>Confirm account</h2>
-
-          {loggedInInstruction}
-
+          {this.renderLoggedInInstruction(patronName)}
           <h2>Confirm delivery location</h2>
-
           <p>When this item is ready, you will use it in the following location:</p>
-
           <fieldset className="select-location-fieldset">
             <legend className="visuallyHidden">Select a pickup location</legend>
             <div className="group selected">
@@ -127,8 +139,9 @@ class HoldRequest extends React.Component {
           </div>
         </div>
         <h2>Confirm account</h2>
-        {loggedInInstruction}
-      </div>);
+        {this.renderLoggedInInstruction(patronName)}
+      </div>
+    );
 
     return (
       <div id="mainContent">

--- a/src/app/stores/PatronStore.js
+++ b/src/app/stores/PatronStore.js
@@ -8,12 +8,18 @@ class PatronStore {
     });
 
     this.state = {
-      patronData: {},
+      id: '',
+      names: [],
+      barcodes: [],
     };
   }
 
   updatePatronData(data) {
-    this.setState({ patronData: data });
+    this.setState({
+      id: data.id,
+      names: data.names,
+      barcodes: data.barcodes,
+    });
   }
 }
 

--- a/src/app/utils/item.js
+++ b/src/app/utils/item.js
@@ -13,14 +13,18 @@ function LibraryItem() {
    * @param (String) itemId
    */
   this.getItem = (record, itemId) => {
-    // look for item id in record's items
-    const items = record.items;
     let thisItem = {};
-    items.forEach((i) => {
-      if (i['@id'].substring(4) === itemId) {
-        thisItem = i;
-      }
-    });
+    // look for item id in record's items
+    const items = (record && record.items) ? record.items : null;
+
+    if (items && itemId) {
+      items.forEach((i) => {
+        if (i['@id'] && i['@id'].substring(4) === itemId) {
+          thisItem = i;
+        }
+      });
+    }
+
     return thisItem;
   };
 
@@ -126,12 +130,12 @@ function LibraryItem() {
     if (thisItem && thisItem.location && thisItem.location.length > 0) {
       location = thisItem.location[0][0];
     }
-    const locationCode = location['@id'].substring(4);
-    const prefLabel = location.prefLabel;
-    const isOffsite = this.isOffsite(location);
+    const locationCode = (location['@id'] && typeof location['@id'] === 'string') ? location['@id'].substring(4) : '';
+    const prefLabel = (location) ? location.prefLabel : '';
+    const isOffsite = (location) ? this.isOffsite(location) : false;
 
     // retrieve location data
-    if (locationCode in LocationCodes) {
+    if (locationCode && locationCode in LocationCodes) {
       location = Locations[LocationCodes[locationCode].location];
     } else {
       location = Locations[LocationCodes[defaultLocation['@id'].substring(4)].location];
@@ -139,8 +143,8 @@ function LibraryItem() {
 
     // retrieve delivery location
     let deliveryLocationCode = defaultLocation['@id'].substring(4);
-    if (locationCode in LocationCodes) {
-      deliveryLocationCode = LocationCodes[locationCode].delivery_location;
+    if (locationCode && locationCode in LocationCodes) {
+      deliveryLocationCode = LocationCodes[locationCode].delivery_location || '';
     }
 
     location.offsite = isOffsite;

--- a/src/app/utils/item.js
+++ b/src/app/utils/item.js
@@ -8,9 +8,11 @@ function LibraryItem() {
   });
 
   /**
-   * getItem(record, 'b18207658-i24609501')
-   * @param (Object) record
-   * @param (String) itemId
+   * getItem(record, itemId)
+   *
+   * @param {Object} record
+   * @param {String} itemId
+   * @return {Object}
    */
   this.getItem = (record, itemId) => {
     let thisItem = {};
@@ -30,7 +32,9 @@ function LibraryItem() {
 
   /**
    * getItems(record)
-   * @param (Object) record
+   *
+   * @param {Object} record
+   * @return {Object}
    */
   this.getItems = (record) => {
     const recordTitle = record.title ? record.title[0] : '';
@@ -115,9 +119,11 @@ function LibraryItem() {
   };
 
   /**
-   * getLocation(record, 'b18207658-i24609501')
-   * @param (Object) record
-   * @param (String) itemId
+   * getLocation(record, itemId)
+   *
+   * @param {Object} record
+   * @param {String} itemId
+   * @return {Object}
    */
   this.getLocation = (record, itemId) => {
     const thisItem = this.getItem(record, itemId);

--- a/src/server/ApiRoutes/itemSearch.js
+++ b/src/server/ApiRoutes/itemSearch.js
@@ -9,6 +9,7 @@ function retrieveItem(q, cb, errorcb) {
     .get(`${apiBase}/discovery/resources/${q}`)
     .then(response => cb(response.data))
     .catch(error => {
+      console.log('Ia m url', `${apiBase}/discovery/resources/${q}`);
       console.error(`RetrieveItem error: ${JSON.stringify(error, null, 2)}`);
 
       errorcb(error);
@@ -66,13 +67,13 @@ function requireUser(req, res) {
 
 function newHoldRequest(req, res, next) {
   const loggedIn = requireUser(req, res);
+
   if (!loggedIn) return false;
 
   // Retrieve item
   return retrieveItem(
     req.params.id,
     (data) => {
-      // console.log('Item data', data)
       res.locals.data.Store = {
         item: data,
         searchKeywords: '',
@@ -80,7 +81,6 @@ function newHoldRequest(req, res, next) {
       next();
     },
     (error) => {
-      console.log(error);
       res.locals.data.Store = {
         item: {},
         searchKeywords: '',

--- a/src/server/ApiRoutes/itemSearch.js
+++ b/src/server/ApiRoutes/itemSearch.js
@@ -9,7 +9,6 @@ function retrieveItem(q, cb, errorcb) {
     .get(`${apiBase}/discovery/resources/${q}`)
     .then(response => cb(response.data))
     .catch(error => {
-      console.log('Ia m url', `${apiBase}/discovery/resources/${q}`);
       console.error(`RetrieveItem error: ${JSON.stringify(error, null, 2)}`);
 
       errorcb(error);
@@ -59,6 +58,7 @@ function requireUser(req, res) {
     !req.tokenResponse.decodedPatron.sub) {
     // redirect to login
     const fullUrl = encodeURIComponent(`${req.protocol}://${req.get('host')}${req.originalUrl}`);
+
     res.redirect(`${appConfig.loginUrl}?redirect_uri=${fullUrl}`);
     return false;
   }

--- a/test/unit/HoldRequest.test.js
+++ b/test/unit/HoldRequest.test.js
@@ -1,14 +1,10 @@
 /* eslint-env mocha */
 import React from 'react';
-import axios from 'axios';
 import sinon from 'sinon';
-import MockAdapter from 'axios-mock-adapter';
 import { expect } from 'chai';
 import { mount } from 'enzyme';
 // Import the component that is going to be tested
 import HoldRequest from './../../src/app/components/HoldRequest/HoldRequest.jsx';
-
-import PatronStore from './../../src/app/stores/PatronStore.js';
 import Actions from './../../src/app/actions/Actions.js';
 
 describe('HoldRequest', () => {
@@ -52,7 +48,9 @@ describe('HoldRequest', () => {
     });
 
     it('should display log in error message.', () => {
-      expect(component.find('.loggedInInstruction').text()).to.equal('Something wrong with your attempt to log in.');
+      expect(component.find('.loggedInInstruction').text()).to.equal(
+        'Something wrong with your attempt to log in.'
+      );
     });
   });
 
@@ -61,7 +59,11 @@ describe('HoldRequest', () => {
     let requireUser;
 
     before(() => {
-      Actions.updatePatronData({ id: '6677200', names: ['Leonard, Mike'], barcodes: ['162402680435300'] });
+      Actions.updatePatronData({
+        id: '6677200',
+        names: ['Leonard, Mike'],
+        barcodes: ['162402680435300'],
+      });
       requireUser = sinon.spy(HoldRequest.prototype, 'requireUser');
 
       component = mount(<HoldRequest />);
@@ -73,20 +75,21 @@ describe('HoldRequest', () => {
     });
 
     it('should pass the patron data check in requireUser().', () => {
-      console.log(component.state().patron);
       expect(requireUser.returnValues[0]).to.equal(true);
     });
 
-    it('should display the layout of error page.', () => {
-
+    it('should deliver the patron\'s name on the page', () => {
+      expect(component.find('.loggedInInstruction').find('strong').text())
+        .to.equal('Leonard, Mike');
     });
 
-    it('should deliver the patron\'s name on the page', () => {
-
+    it('should display the layout of error page.', () => {
+      expect(component.find('.item').find('h2').text())
+        .to.equal('Something wrong with your request');
     });
 
     it('should not deliver request button with the respective URL on the page', () => {
-
+      expect(component.find('.place-hold-form').find('button')).to.have.length(0);
     });
   });
 
@@ -103,190 +106,4 @@ describe('HoldRequest', () => {
 
     });
   });
-
-
-
-    // it('should have <Header>, <Footer>, and <section>.', () => {
-    //   expect(component.find('.nypl-library-card-app').find('Header')).to.have.length(1);
-    //   expect(component.find('.nypl-library-card-app').find('Footer')).to.have.length(1);
-    //   expect(component.find('.nypl-library-card-app').find('section')).to.have.length(1);
-    // });
-
-    // it('should have a <section> with the ID, "main-content".', () => {
-    //   expect(component.find('.nypl-library-card-app').find('section').prop('id'))
-    //     .to.equal('main-content');
-    // });
-
-    // it('should have a <section> that contains a <div> with class "barcode-container"', () => {
-    //   expect(component.find('section').find('.barcode-container')).to.have.length(1);
-    //   expect(component.find('.barcode-container').type()).to.equal('div');
-    // });
-
-    // it('should have a <section> that contains a <div> with class "get-card-message"', () => {
-    //   expect(component.find('.barcode-container').find('.get-card-message')).to.have.length(1);
-    //   expect(component.find('.get-card-message').type()).to.equal('div');
-    // });
-
-    // it('should have the state of "accessToken" with the value of ""', () => {
-    //   expect(component.state().accessToken).to.deep.equal('');
-    // });
-
-    // it('should have the state of "patronName" with the value of ""', () => {
-    //   expect(component.state().patronName).to.deep.equal('');
-    // });
-
-    // it('should have the state of "barcodeSrc" with a value of ""', () => {
-    //   expect(component.state().barcodeSrc).to.deep.equal('');
-    // });
-
-    // it('should have the state of "barcodeNumber" with a value of ""', () => {
-    //   expect(component.state().barcodeNumber).to.deep.equal('');
-    // });
-
-    // it('should try to get the "access_token" from the "nyplIdentityPatron" cookie', () => {
-    //   expect(getOAuthAccessToken.calledOnce).to.equal(true);
-    //   getOAuthAccessToken.alwaysCalledWithExactly('nyplIdentityPatron');
-    // });
-  // });
-
-  // describe('If "nyplIdentityPatron" cookie and its "access_token" does not exist, <BarcodeContainer>', () => {
-  //   let component;
-  //   let hasCookie;
-  //   let goToOAuthLogIn;
-
-  //   before(() => {
-  //     hasCookie = sinon.stub(CookieUtils, 'hasCookie')
-  //       .withArgs('nyplIdentityPatron')
-  //       .returns(false);
-
-  //     goToOAuthLogIn = sinon.spy(BarcodeContainer.prototype, 'goToOAuthLogIn');
-
-  //     component = mount(<BarcodeContainer />);
-  //   });
-
-  //   after(() => {
-  //     CookieUtils.hasCookie.restore();
-  //     goToOAuthLogIn.restore();
-  //   });
-
-  //   it('should lead the user to OAuth log in page.', () => {
-  //     expect(goToOAuthLogIn.calledOnce).to.equal(true);
-  //   });
-  // });
-
-  // describe('If "access_token" exists and valid, <BarcodeContainer>', () => {
-  //   let component;
-  //   let hasCookie;
-  //   let getCookie;
-  //   let setState;
-  //   let fetchBarcode;
-  //   let getBarcodeData;
-
-  //   before(() => {
-  //     // We need stubs here for hasCookie() and getCookie() to control the value of
-  //     // "nyplIdentityPatron". While we need a spy for setState() to test the real function.
-  //     hasCookie = sinon.stub(CookieUtils, 'hasCookie')
-  //       .withArgs('nyplIdentityPatron')
-  //       .returns(true);
-
-  //     getCookie = sinon.stub(CookieUtils, 'getCookie')
-  //       .withArgs('nyplIdentityPatron')
-  //       .returns(mockBarcodeContainerTestData.nyplIdentityPatronCookie);
-
-  //     setState = sinon.spy(BarcodeContainer.prototype, 'setState');
-
-  //     fetchBarcode = sinon.spy(BarcodeContainer.prototype, 'fetchBarcode');
-
-  //     getBarcodeData = sinon.spy(CallAPIUtils, 'getBarcodeData');
-
-  //     component = mount(<BarcodeContainer />);
-  //   });
-
-  //   after(() => {
-  //     // stubs don't have restore(), the way to restore them is go back to the original functions.
-  //     // However, if the sutbs only use the methods that belong to spies, restore() will work.
-  //     CookieUtils.hasCookie.restore();
-  //     CookieUtils.getCookie.restore();
-  //     setState.restore();
-  //     fetchBarcode.restore();
-  //     getBarcodeData.restore();
-  //   });
-
-  //   it('should update its state of "accessToken" and "patronID".', () => {
-  //     expect(setState.calledTwice).to.equal(true);
-  //     expect(component.state().accessToken).to.deep.equal(mockBarcodeContainerTestData.accessToken);
-  //     expect(component.state().patronID).to.deep.equal(mockBarcodeContainerTestData.patronID);
-  //   });
-
-  //   it('should call the barcode API endpoint based on its state of "accessToken".', () => {
-  //     expect(fetchBarcode.calledOnce).to.equal(true);
-  //     fetchBarcode.alwaysCalledWithExactly(
-  //       mockBarcodeContainerTestData.accessToken,
-  //       mockBarcodeContainerTestData.patronID
-  //     );
-  //     expect(getBarcodeData.calledOnce).to.equal(true);
-  //     getBarcodeData.alwaysCalledWithExactly(
-  //       mockBarcodeContainerTestData.accessToken,
-  //       mockBarcodeContainerTestData.patronID
-  //     );
-  //   });
-  // });
-
-  // describe('If the API call to the barcode endpoint fails, <BarcodeContainer>', () => {
-  //   let component;
-  //   const mock = new MockAdapter(axios);
-  //   const mockAPI = `/library-card/new/get-barcode/${mockBarcodeContainerTestData.patronID}/${mockBarcodeContainerTestData.accessToken}`;
-  //   // const callBarcodeAPI = (component = {}) => {
-  //   //   axios
-  //   //     .get(mockApi)
-  //   //     .then(result => {
-  //   //       component.setState({
-  //   //         patronName: result.data.response.name || '',
-  //   //         barcodeSrc,
-  //   //         barcodeNumber: result.data.response.barCode || '',
-  //   //       });
-  //   //     })
-  //   //     .catch();
-  //   // };
-
-  //   before(() => {
-  //     mock
-  //       .onGet(mockAPI)
-  //       .reply(400, mockBarcodeContainerTestData.apiErrorResponse);
-
-  //     component = mount(<BarcodeContainer />);
-  //   });
-
-  //   after(() => {
-  //     mock.reset();
-  //   });
-
-  //   it('should have a <div> with the class "barcode-container" ' +
-  //     'that contains a <div> with class "get-card-message"',
-  //     (done) => {
-  //       setTimeout(
-  //         () => {
-  //           expect(component.find('.barcode-container').find('.get-card-message')).to.have.length(1);
-  //           expect(component.find('.barcode-container').find('.get-card-message').type()).to.equal('div');
-  //           done();
-  //         }, 1500
-  //       );
-  //     }
-  //   );
-
-  //   it('should have the state of "patronName" with the value of "", ' +
-  //     'the state of "barcodeSrc" with a value of "", ' +
-  //     'and the state of "barcodeNumber" with a value of ""',
-  //     (done) => {
-  //       setTimeout(
-  //         () => {
-  //           expect(component.state().patronName).to.deep.equal('');
-  //           expect(component.state().barcodeSrc).to.deep.equal('');
-  //           expect(component.state().barcodeNumber).to.deep.equal('');
-  //           done();
-  //         }, 1500
-  //       );
-  //     }
-  //   );
-  // });
 });

--- a/test/unit/HoldRequest.test.js
+++ b/test/unit/HoldRequest.test.js
@@ -47,7 +47,7 @@ describe('HoldRequest', () => {
 
     it('should display log in error message.', () => {
       expect(component.find('.loggedInInstruction').text()).to.equal(
-        'Something wrong during retrieving your patron data.'
+        'Something went wrong during retrieving your patron data.'
       );
     });
   });

--- a/test/unit/HoldRequest.test.js
+++ b/test/unit/HoldRequest.test.js
@@ -14,7 +14,6 @@ describe('HoldRequest', () => {
 
     before(() => {
       requireUser = sinon.spy(HoldRequest.prototype, 'requireUser');
-
       component = mount(<HoldRequest />);
     });
 
@@ -34,7 +33,6 @@ describe('HoldRequest', () => {
 
     before(() => {
       requireUser = sinon.spy(HoldRequest.prototype, 'requireUser');
-
       component = mount(<HoldRequest />);
     });
 
@@ -65,7 +63,6 @@ describe('HoldRequest', () => {
         barcodes: ['162402680435300'],
       });
       requireUser = sinon.spy(HoldRequest.prototype, 'requireUser');
-
       component = mount(<HoldRequest />);
     });
 

--- a/test/unit/HoldRequest.test.js
+++ b/test/unit/HoldRequest.test.js
@@ -49,7 +49,7 @@ describe('HoldRequest', () => {
 
     it('should display log in error message.', () => {
       expect(component.find('.loggedInInstruction').text()).to.equal(
-        'Something wrong with your attempt to log in.'
+        'Something wrong during retrieving your patron data.'
       );
     });
   });

--- a/test/unit/HoldRequest.test.js
+++ b/test/unit/HoldRequest.test.js
@@ -1,0 +1,238 @@
+/* eslint-env mocha */
+import React from 'react';
+import axios from 'axios';
+import sinon from 'sinon';
+import MockAdapter from 'axios-mock-adapter';
+import { expect } from 'chai';
+import { mount } from 'enzyme';
+// Import the component that is going to be tested
+import HoldRequest from './../../src/app/components/HoldRequest/HoldRequest.jsx';
+
+describe('HoldRequest', () => {
+  describe('After being rendered, <HoldRequest>', () => {
+    let component;
+    let requireUser;
+
+    before(() => {
+      requireUser = sinon.spy(HoldRequest.prototype, 'requireUser');
+
+      component = mount(<HoldRequest />);
+    });
+
+    after(() => {
+      requireUser.restore();
+    });
+
+    it('should check if the patron is logged in.', () => {
+      // expect(component.find('.nypl-library-card-app').find('Header')).to.have.length(1);
+      // expect(component.find('.nypl-library-card-app').find('Footer')).to.have.length(1);
+      // expect(component.find('.nypl-library-card-app').find('section')).to.have.length(1);
+    });
+  });
+
+  describe('If the patron is not logged in, <HoldRequest>', () => {
+    it('should redirect the patron to OAuth log in page.', () => {
+
+    });
+  });
+
+  describe('If the patron is logged in, <HoldRequest>', () => {
+    it('should display the layout of hold request.', () => {
+
+    });
+
+    it('should deliver the patron\'s name on the page', () => {
+
+    });
+
+    it('should deliver request button with the respective URL on the page', () => {
+
+    });
+  });
+
+
+
+    // it('should have <Header>, <Footer>, and <section>.', () => {
+    //   expect(component.find('.nypl-library-card-app').find('Header')).to.have.length(1);
+    //   expect(component.find('.nypl-library-card-app').find('Footer')).to.have.length(1);
+    //   expect(component.find('.nypl-library-card-app').find('section')).to.have.length(1);
+    // });
+
+    // it('should have a <section> with the ID, "main-content".', () => {
+    //   expect(component.find('.nypl-library-card-app').find('section').prop('id'))
+    //     .to.equal('main-content');
+    // });
+
+    // it('should have a <section> that contains a <div> with class "barcode-container"', () => {
+    //   expect(component.find('section').find('.barcode-container')).to.have.length(1);
+    //   expect(component.find('.barcode-container').type()).to.equal('div');
+    // });
+
+    // it('should have a <section> that contains a <div> with class "get-card-message"', () => {
+    //   expect(component.find('.barcode-container').find('.get-card-message')).to.have.length(1);
+    //   expect(component.find('.get-card-message').type()).to.equal('div');
+    // });
+
+    // it('should have the state of "accessToken" with the value of ""', () => {
+    //   expect(component.state().accessToken).to.deep.equal('');
+    // });
+
+    // it('should have the state of "patronName" with the value of ""', () => {
+    //   expect(component.state().patronName).to.deep.equal('');
+    // });
+
+    // it('should have the state of "barcodeSrc" with a value of ""', () => {
+    //   expect(component.state().barcodeSrc).to.deep.equal('');
+    // });
+
+    // it('should have the state of "barcodeNumber" with a value of ""', () => {
+    //   expect(component.state().barcodeNumber).to.deep.equal('');
+    // });
+
+    // it('should try to get the "access_token" from the "nyplIdentityPatron" cookie', () => {
+    //   expect(getOAuthAccessToken.calledOnce).to.equal(true);
+    //   getOAuthAccessToken.alwaysCalledWithExactly('nyplIdentityPatron');
+    // });
+  // });
+
+  // describe('If "nyplIdentityPatron" cookie and its "access_token" does not exist, <BarcodeContainer>', () => {
+  //   let component;
+  //   let hasCookie;
+  //   let goToOAuthLogIn;
+
+  //   before(() => {
+  //     hasCookie = sinon.stub(CookieUtils, 'hasCookie')
+  //       .withArgs('nyplIdentityPatron')
+  //       .returns(false);
+
+  //     goToOAuthLogIn = sinon.spy(BarcodeContainer.prototype, 'goToOAuthLogIn');
+
+  //     component = mount(<BarcodeContainer />);
+  //   });
+
+  //   after(() => {
+  //     CookieUtils.hasCookie.restore();
+  //     goToOAuthLogIn.restore();
+  //   });
+
+  //   it('should lead the user to OAuth log in page.', () => {
+  //     expect(goToOAuthLogIn.calledOnce).to.equal(true);
+  //   });
+  // });
+
+  // describe('If "access_token" exists and valid, <BarcodeContainer>', () => {
+  //   let component;
+  //   let hasCookie;
+  //   let getCookie;
+  //   let setState;
+  //   let fetchBarcode;
+  //   let getBarcodeData;
+
+  //   before(() => {
+  //     // We need stubs here for hasCookie() and getCookie() to control the value of
+  //     // "nyplIdentityPatron". While we need a spy for setState() to test the real function.
+  //     hasCookie = sinon.stub(CookieUtils, 'hasCookie')
+  //       .withArgs('nyplIdentityPatron')
+  //       .returns(true);
+
+  //     getCookie = sinon.stub(CookieUtils, 'getCookie')
+  //       .withArgs('nyplIdentityPatron')
+  //       .returns(mockBarcodeContainerTestData.nyplIdentityPatronCookie);
+
+  //     setState = sinon.spy(BarcodeContainer.prototype, 'setState');
+
+  //     fetchBarcode = sinon.spy(BarcodeContainer.prototype, 'fetchBarcode');
+
+  //     getBarcodeData = sinon.spy(CallAPIUtils, 'getBarcodeData');
+
+  //     component = mount(<BarcodeContainer />);
+  //   });
+
+  //   after(() => {
+  //     // stubs don't have restore(), the way to restore them is go back to the original functions.
+  //     // However, if the sutbs only use the methods that belong to spies, restore() will work.
+  //     CookieUtils.hasCookie.restore();
+  //     CookieUtils.getCookie.restore();
+  //     setState.restore();
+  //     fetchBarcode.restore();
+  //     getBarcodeData.restore();
+  //   });
+
+  //   it('should update its state of "accessToken" and "patronID".', () => {
+  //     expect(setState.calledTwice).to.equal(true);
+  //     expect(component.state().accessToken).to.deep.equal(mockBarcodeContainerTestData.accessToken);
+  //     expect(component.state().patronID).to.deep.equal(mockBarcodeContainerTestData.patronID);
+  //   });
+
+  //   it('should call the barcode API endpoint based on its state of "accessToken".', () => {
+  //     expect(fetchBarcode.calledOnce).to.equal(true);
+  //     fetchBarcode.alwaysCalledWithExactly(
+  //       mockBarcodeContainerTestData.accessToken,
+  //       mockBarcodeContainerTestData.patronID
+  //     );
+  //     expect(getBarcodeData.calledOnce).to.equal(true);
+  //     getBarcodeData.alwaysCalledWithExactly(
+  //       mockBarcodeContainerTestData.accessToken,
+  //       mockBarcodeContainerTestData.patronID
+  //     );
+  //   });
+  // });
+
+  // describe('If the API call to the barcode endpoint fails, <BarcodeContainer>', () => {
+  //   let component;
+  //   const mock = new MockAdapter(axios);
+  //   const mockAPI = `/library-card/new/get-barcode/${mockBarcodeContainerTestData.patronID}/${mockBarcodeContainerTestData.accessToken}`;
+  //   // const callBarcodeAPI = (component = {}) => {
+  //   //   axios
+  //   //     .get(mockApi)
+  //   //     .then(result => {
+  //   //       component.setState({
+  //   //         patronName: result.data.response.name || '',
+  //   //         barcodeSrc,
+  //   //         barcodeNumber: result.data.response.barCode || '',
+  //   //       });
+  //   //     })
+  //   //     .catch();
+  //   // };
+
+  //   before(() => {
+  //     mock
+  //       .onGet(mockAPI)
+  //       .reply(400, mockBarcodeContainerTestData.apiErrorResponse);
+
+  //     component = mount(<BarcodeContainer />);
+  //   });
+
+  //   after(() => {
+  //     mock.reset();
+  //   });
+
+  //   it('should have a <div> with the class "barcode-container" ' +
+  //     'that contains a <div> with class "get-card-message"',
+  //     (done) => {
+  //       setTimeout(
+  //         () => {
+  //           expect(component.find('.barcode-container').find('.get-card-message')).to.have.length(1);
+  //           expect(component.find('.barcode-container').find('.get-card-message').type()).to.equal('div');
+  //           done();
+  //         }, 1500
+  //       );
+  //     }
+  //   );
+
+  //   it('should have the state of "patronName" with the value of "", ' +
+  //     'the state of "barcodeSrc" with a value of "", ' +
+  //     'and the state of "barcodeNumber" with a value of ""',
+  //     (done) => {
+  //       setTimeout(
+  //         () => {
+  //           expect(component.state().patronName).to.deep.equal('');
+  //           expect(component.state().barcodeSrc).to.deep.equal('');
+  //           expect(component.state().barcodeNumber).to.deep.equal('');
+  //           done();
+  //         }, 1500
+  //       );
+  //     }
+  //   );
+  // });
+});

--- a/test/unit/HoldRequest.test.js
+++ b/test/unit/HoldRequest.test.js
@@ -8,6 +8,9 @@ import { mount } from 'enzyme';
 // Import the component that is going to be tested
 import HoldRequest from './../../src/app/components/HoldRequest/HoldRequest.jsx';
 
+import PatronStore from './../../src/app/stores/PatronStore.js';
+import Actions from './../../src/app/actions/Actions.js';
+
 describe('HoldRequest', () => {
   describe('After being rendered, <HoldRequest>', () => {
     let component;
@@ -21,22 +24,54 @@ describe('HoldRequest', () => {
 
     after(() => {
       requireUser.restore();
+      component.unmount();
     });
 
     it('should check if the patron is logged in.', () => {
-      // expect(component.find('.nypl-library-card-app').find('Header')).to.have.length(1);
-      // expect(component.find('.nypl-library-card-app').find('Footer')).to.have.length(1);
-      // expect(component.find('.nypl-library-card-app').find('section')).to.have.length(1);
+      expect(requireUser.calledOnce).to.equal(true);
     });
   });
 
   describe('If the patron is not logged in, <HoldRequest>', () => {
-    it('should redirect the patron to OAuth log in page.', () => {
+    let component;
+    let requireUser;
 
+    before(() => {
+      requireUser = sinon.spy(HoldRequest.prototype, 'requireUser');
+
+      component = mount(<HoldRequest />);
+    });
+
+    after(() => {
+      requireUser.restore();
+      component.unmount();
+    });
+
+    it('should redirect the patron to OAuth log in page.', () => {
+      expect(requireUser.returnValues[0]).to.equal(false);
     });
   });
 
   describe('If the patron is logged in but the App doesn\'t get valid data, <HoldRequest>', () => {
+    let component;
+    let requireUser;
+
+    before(() => {
+      Actions.updatePatronData({ id: '6677200', names: ['Leonard, Mike'], barcodes: ['162402680435300'] });
+      requireUser = sinon.spy(HoldRequest.prototype, 'requireUser');
+
+      component = mount(<HoldRequest />);
+    });
+
+    after(() => {
+      requireUser.restore();
+      component.unmount();
+    });
+
+    it('should pass the patron data check in requireUser().', () => {
+      expect(requireUser.returnValues[0]).to.equal(true);
+    });
+
     it('should display the layout of error page.', () => {
 
     });

--- a/test/unit/HoldRequest.test.js
+++ b/test/unit/HoldRequest.test.js
@@ -36,7 +36,21 @@ describe('HoldRequest', () => {
     });
   });
 
-  describe('If the patron is logged in, <HoldRequest>', () => {
+  describe('If the patron is logged in but the App doesn\'t get valid data, <HoldRequest>', () => {
+    it('should display the layout of error page.', () => {
+
+    });
+
+    it('should deliver the patron\'s name on the page', () => {
+
+    });
+
+    it('should not deliver request button with the respective URL on the page', () => {
+
+    });
+  });
+
+  describe('If the patron is logged in and the App receives valid data, <HoldRequest>', () => {
     it('should display the layout of hold request.', () => {
 
     });

--- a/test/unit/HoldRequest.test.js
+++ b/test/unit/HoldRequest.test.js
@@ -50,6 +50,10 @@ describe('HoldRequest', () => {
     it('should redirect the patron to OAuth log in page.', () => {
       expect(requireUser.returnValues[0]).to.equal(false);
     });
+
+    it('should display log in error message.', () => {
+      expect(component.find('.loggedInInstruction').text()).to.equal('Something wrong with your attempt to log in.');
+    });
   });
 
   describe('If the patron is logged in but the App doesn\'t get valid data, <HoldRequest>', () => {
@@ -69,6 +73,7 @@ describe('HoldRequest', () => {
     });
 
     it('should pass the patron data check in requireUser().', () => {
+      console.log(component.state().patron);
       expect(requireUser.returnValues[0]).to.equal(true);
     });
 


### PR DESCRIPTION
For [#376](https://github.com/NYPL-discovery/discovery-front-end/issues/376) 

This PR is to refactor HoldRequest component. Generally, it adds checks and fallbacks for the props passed to it. Also, it adds an error page for no records found and an error instruction for invalid patron data. As updating these fallbacks, this PR makes minor updates to related functions in `src/utils`, too.

This PR also adds unit tests for HoldRequest.