### PR TITLE
Displaying the request hold button for NYPL ReCAP items.

### DIFF
--- a/src/app/components/HoldPage/HoldConfirmation.jsx
+++ b/src/app/components/HoldPage/HoldConfirmation.jsx
@@ -41,7 +41,8 @@ class HoldConfirmation extends React.Component {
   }
 
   render() {
-    const item = this.props.item;
+    // Need to better clarify variable names later.
+    const item = this.props.bib;
     const title = (item && _isArray(item.title) && item.title.length > 0) ?
       item.title[0] : '';
     const id = (item && item['@id'] && typeof item['@id'] === 'string') ?
@@ -107,14 +108,14 @@ class HoldConfirmation extends React.Component {
 }
 
 HoldConfirmation.propTypes = {
-  item: React.PropTypes.object,
+  bib: React.PropTypes.object,
   location: React.PropTypes.object,
   searchKeywords: React.PropTypes.string,
   params: React.PropTypes.object,
 };
 
 HoldConfirmation.defaultProps = {
-  item: {},
+  bib: {},
   searchKeywords: '',
   params: {},
 };

--- a/src/app/components/HoldRequest/HoldRequest.jsx
+++ b/src/app/components/HoldRequest/HoldRequest.jsx
@@ -141,7 +141,7 @@ class HoldRequest extends React.Component {
           </div>
           <div className="item-summary">
             <div className="item">
-              <h2>Something wrong with your request</h2>
+              <h2>Something went wrong with your request</h2>
               <Link href={`/bib/${bibId}`}>{title}</Link>
             </div>
           </div>

--- a/src/app/components/HoldRequest/HoldRequest.jsx
+++ b/src/app/components/HoldRequest/HoldRequest.jsx
@@ -57,13 +57,13 @@ class HoldRequest extends React.Component {
   renderLoggedInInstruction(patronName) {
     return (patronName) ?
       <p className="loggedInInstruction">You are currently logged in as <strong>{patronName}</strong>. If this is not you, please <a href="https://isso.nypl.org/auth/logout">Log out</a> and sign in using your library card.</p>
-      : <p className="loggedInInstruction">Something went wrong during retrieving your patron data.</p>;
+      : <p className="loggedInInstruction">Something went wrong retrieving your personal information.</p>;
   }
 
   render() {
     const searchKeywords = this.state.data.searchKeywords || '';
-    const record = (this.state.data.item && !_isEmpty(this.state.data.item)) ?
-      this.state.data.item : null;
+    const record = (this.state.data.bib && !_isEmpty(this.state.data.bib)) ?
+      this.state.data.bib : null;
     const title = (record && _isArray(record.title) && record.title.length) ?
       record.title[0] : '';
     const bibId = (record && record['@id'] && typeof record['@id'] === 'string') ?

--- a/src/app/utils/item.js
+++ b/src/app/utils/item.js
@@ -66,7 +66,14 @@ function LibraryItem() {
           url = item.electronicLocator[0].url;
           actionLabel = 'View online';
           actionLabelHelper = `resource for ${recordTitle}`;
+          // Temporary for ReCAP items.
         } else if (accessMessage === 'adv request' && !item.holdingLocation) {
+          requestHold = true;
+          actionLabel = accessMessage;
+          actionLabelHelper = 'request hold on ${recordTitle}';
+          // Temporary for NYPL ReCAP items.
+        } else if (item.holdingLocation && item.holdingLocation.length &&
+          item.holdingLocation[0].prefLabel.indexOf('offsite') !== -1) {
           requestHold = true;
           actionLabel = accessMessage;
           actionLabelHelper = 'request hold on ${recordTitle}';

--- a/src/app/utils/item.js
+++ b/src/app/utils/item.js
@@ -70,13 +70,15 @@ function LibraryItem() {
         } else if (accessMessage === 'adv request' && !item.holdingLocation) {
           requestHold = true;
           actionLabel = accessMessage;
-          actionLabelHelper = 'request hold on ${recordTitle}';
+          actionLabelHelper = `request hold on ${recordTitle}`;
           // Temporary for NYPL ReCAP items.
+          // Making sure that if there is a holding location, that the location code starts with
+          // rc. Ids are in the format of `loc:x` where x is the location code.
         } else if (item.holdingLocation && item.holdingLocation.length &&
-          item.holdingLocation[0].prefLabel.indexOf('offsite') !== -1) {
+          item.holdingLocation[0]['@id'].substring(4, 6) === 'rc') {
           requestHold = true;
           actionLabel = accessMessage;
-          actionLabelHelper = 'request hold on ${recordTitle}';
+          actionLabelHelper = `request hold on ${recordTitle}`;
         } else if (availability === 'available') {
           url = this.getLocationHoldUrl(locationDetails);
           actionLabel = 'Request for in-library use';


### PR DESCRIPTION
Fixes #414 to include NYPL ReCAP items to the "request a hold" list.
Simple logic for now. Just checking to see that if there is a `holdingLocation`, that the word `offsite` is there.

We will be getting better checks later on. 

