### PR TITLE
Hardcode delivery location

### DIFF
--- a/src/app/components/HoldPage/HoldConfirmation.jsx
+++ b/src/app/components/HoldPage/HoldConfirmation.jsx
@@ -43,14 +43,14 @@ class HoldConfirmation extends React.Component {
 
   render() {
     // Need to better clarify variable names later.
-    const item = this.props.bib;
-    const title = (item && _isArray(item.title) && item.title.length > 0) ?
-      item.title[0] : '';
-    const id = (item && item['@id'] && typeof item['@id'] === 'string') ?
-      item['@id'].substring(4) : '';
-    const itemId = (this.props.params && this.props.params.id) ? this.props.params.id : '';
-    const selectedItem = LibraryItem.getItem(item, itemId);
-    const location = LibraryItem.getLocation(item, itemId);
+    const bib = this.props.bib;
+    const title = (bib && _isArray(bib.title) && bib.title.length > 0) ?
+      bib.title[0] : '';
+    const id = (bib && bib['@id'] && typeof bib['@id'] === 'string') ?
+      bib['@id'].substring(4) : '';
+    const itemId = (this.props.params && this.props.params.itemId) ? this.props.params.itemId : '';
+    const selectedItem = LibraryItem.getItem(bib, itemId);
+    const deliveryLocations = selectedItem.deliveryLocations[0];
     const shelfMarkInfo =
       (selectedItem && _isArray(selectedItem.shelfMark) && selectedItem.shelfMark.length > 0) ?
         <li>Call number: {selectedItem.shelfMark[0]}</li> : null;
@@ -96,9 +96,9 @@ class HoldConfirmation extends React.Component {
           <div className="map-container">
             <div className="third">
               <p>
-                <a href={`${location.uri}`}>{location['full-name']}</a><br />
-                {location.address.address1}<br />
-                {location.prefLabel}
+                <a href={`${deliveryLocations.uri}`}>{deliveryLocations['full-name']}</a><br />
+                {deliveryLocations.address.address1}<br />
+                {deliveryLocations.prefLabel}
               </p>
             </div>
           </div>

--- a/src/app/components/HoldRequest/HoldRequest.jsx
+++ b/src/app/components/HoldRequest/HoldRequest.jsx
@@ -117,11 +117,11 @@ class HoldRequest extends React.Component {
       ) ? this.state.patron.names[0] : '';
     const itemId = (this.props.params && this.props.params.itemId) ? this.props.params.itemId : '';
     const selectedItem = (bib && itemId) ? LibraryItem.getItem(bib, itemId) : null;
-    const shelfMarkInfo =
-      (selectedItem && _isArray(selectedItem.shelfMark) && selectedItem.shelfMark.length > 0) ?
+    const callNo =
+      (selectedItem && selectedItem.callNumber && selectedItem.callNumber.length) ?
       (
         <span className="col">
-          <small>Call number:</small><br />{selectedItem.shelfMark[0]}
+          <small>Call number:</small><br />{selectedItem.callNumber}
         </span>
       ) : null;
     const deliveryLocations = selectedItem.deliveryLocations;
@@ -152,7 +152,7 @@ class HoldRequest extends React.Component {
             <p>When this item is ready, you will use it in the following location:</p>
             <fieldset className="select-location-fieldset">
               <legend className="visuallyHidden">Select a pickup location</legend>
-              {this.renderDeliveryLocation(deliveryLocations, shelfMarkInfo)}
+              {this.renderDeliveryLocation(deliveryLocations, callNo)}
             </fieldset>
 
             <input type="hidden" name="pickupLocation" value="test" />

--- a/src/app/components/HoldRequest/HoldRequest.jsx
+++ b/src/app/components/HoldRequest/HoldRequest.jsx
@@ -85,19 +85,37 @@ class HoldRequest extends React.Component {
       : <p className="loggedInInstruction">Something went wrong retrieving your personal information.</p>;
   }
 
+  renderDeliveryLocation(deliveryLocations = [], callNo) {
+    return deliveryLocations.map((location, i) => (
+      <div key={i} className="group selected">
+        <span className="col location">
+          <a href={`${location.uri}`}>{location['full-name']}</a>
+          <br />{location.address.address1}<br />
+          {location.prefLabel}
+          {location.offsite &&
+            <span>
+              <br /><small>(requested from offsite storage)</small><br />
+            </span>
+          }
+        </span>
+        {callNo}
+      </div>
+    ));
+  }
+
   render() {
     const searchKeywords = this.props.searchKeywords || '';
-    const record = (this.props.bib && !_isEmpty(this.props.bib)) ?
+    const bib = (this.props.bib && !_isEmpty(this.props.bib)) ?
       this.props.bib : null;
-    const title = (record && _isArray(record.title) && record.title.length) ?
-      record.title[0] : '';
-    const bibId = (record && record['@id'] && typeof record['@id'] === 'string') ?
-      record['@id'].substring(4) : '';
+    const title = (bib && _isArray(bib.title) && bib.title.length) ?
+      bib.title[0] : '';
+    const bibId = (bib && bib['@id'] && typeof bib['@id'] === 'string') ?
+      bib['@id'].substring(4) : '';
     const patronName = (
       this.state.patron.names && _isArray(this.state.patron.names) && this.state.patron.names.length
       ) ? this.state.patron.names[0] : '';
     const itemId = (this.props.params && this.props.params.id) ? this.props.params.id : '';
-    const selectedItem = (record && itemId) ? LibraryItem.getItem(record, itemId) : null;
+    const selectedItem = (bib && itemId) ? LibraryItem.getItem(bib, itemId) : null;
     const shelfMarkInfo =
       (selectedItem && _isArray(selectedItem.shelfMark) && selectedItem.shelfMark.length > 0) ?
       (
@@ -105,17 +123,10 @@ class HoldRequest extends React.Component {
           <small>Call number:</small><br />{selectedItem.shelfMark[0]}
         </span>
       ) : null;
-    const location = (record && itemId) ? LibraryItem.getLocation(record, itemId) : null;
-    const monthNames = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'June', 'July',
-      'Aug', 'Sept', 'Oct', 'Nov', 'Dec'];
-    const date = new Date();
-    date.setDate(date.getDate() + 7);
-    const day = date.getDate();
-    const monthIndex = date.getMonth();
-    const dateDisplay = `${monthNames[monthIndex]} ${day}`;
+    const deliveryLocations = selectedItem.deliveryLocations;
     let content = null;
 
-    if (record) {
+    if (bib) {
       content =
         <div className="content-wrapper">
           <div className="item-header">
@@ -136,22 +147,10 @@ class HoldRequest extends React.Component {
             <p>When this item is ready, you will use it in the following location:</p>
             <fieldset className="select-location-fieldset">
               <legend className="visuallyHidden">Select a pickup location</legend>
-              <div className="group selected">
-                <span className="col location">
-                  <a href={`${location.uri}`}>{location['full-name']}</a><br />{location.address.address1}<br />
-                  {location.prefLabel}
-                  {location.offsite &&
-                    <span>
-                      <br /><small>(requested from offsite storage)</small><br />
-                    </span>
-                  }
-                </span>
-                {shelfMarkInfo}
-                {/* <span className="col"><small>Ready by approximately:</small><br />{dateDisplay}, 9am.</span> */}
-              </div>
+              {this.renderDeliveryLocation(deliveryLocations, shelfMarkInfo)}
             </fieldset>
 
-            <input type="hidden" name="pickupLocation" value={location.code} />
+            <input type="hidden" name="pickupLocation" value="test" />
 
             <button type="submit" className="large" onClick={(e) => this.submitRequest(e, itemId)}>
               Submit your item hold request

--- a/src/app/components/Item/ItemHoldings.jsx
+++ b/src/app/components/Item/ItemHoldings.jsx
@@ -91,7 +91,7 @@ class ItemHoldings extends React.Component {
               let itemDisplay = null;
 
               if (h.requestHold) {
-                itemLink = h.availability === 'available' ?
+                itemLink = h.available ?
                   <Link
                     className="button"
                     to={`/hold/request/${h.id}`}
@@ -111,8 +111,8 @@ class ItemHoldings extends React.Component {
                 <tr key={i} className={h.availability}>
                   <td>{h.location}</td>
                   <td>{itemDisplay}</td>
-                  <td>{h.status}</td>
-                  <td>{h.accessMessage}</td>
+                  <td>{h.status.prefLabel}</td>
+                  <td>{h.accessMessage.prefLabel}</td>
                   <td>{itemLink}</td>
                 </tr>
               );

--- a/src/app/utils/item.js
+++ b/src/app/utils/item.js
@@ -1,8 +1,9 @@
 import Locations from '../../../locations.js';
 import LocationCodes from '../../../locationCodes.js';
 import {
-  isEmpty as _isEmpty,
   findWhere as _findWhere,
+  isEmpty as _isEmpty,
+  extend as _extend,
 } from 'underscore';
 
 function LibraryItem() {
@@ -14,6 +15,7 @@ function LibraryItem() {
   this.getDefaultLocation = () => ({
     '@id': 'loc:mal',
     prefLabel: 'Stephen A. Schwarzman Building - Rose Main Reading Room 315',
+    customerCode: 'NH',
   });
 
   /**
@@ -25,113 +27,150 @@ function LibraryItem() {
     {
       '@id': 'loc:mal',
       prefLabel: 'Stephen A. Schwarzman Building - Rose Main Reading Room 315',
+      customerCode: 'NH',
     },
     {
       '@id': 'loc:mai',
       prefLabel: 'Stephen A. Schwarzman Building - Milstein Microform Reading Room 119',
+      customerCode: 'NF',
     },
     {
       '@id': 'loc:myr',
       prefLabel: 'Library of Performing Arts - Print Delivery Desk 3rd Floor',
+      customerCode: 'NP',
     },
   ];
+
+  /**
+   * mapItem(item, title)
+   * Massage data and update an item's properties.
+   * @param {object} item The item to update the data for.
+   * @param {string} title The bib's title.
+   * @return {object}
+   */
+  this.mapItem = (item = {}, title) => {
+    const id = item && item['@id'] ? item['@id'].substring(4) : '';
+    // Taking the first object in the accessMessage array.
+    const accessMessage = item.accessMessage && item.accessMessage.length ?
+      item.accessMessage[0] : {};
+    // Taking first callNumber.
+    const callNumber = item.shelfMark && item.shelfMark.length ? item.shelfMark[0] : '';
+    const holdingLocation = this.getHoldingLocation(item);
+    // Taking the first value in the array.
+    const requestable = item.requestable && item.requestable.length ?
+      item.requestable[0] : false;
+    // Taking the first value in the array;
+    const suppressed = item.suppressed && item.suppressed.length ?
+      item.suppressed[0] : false;
+    const isElectronicResource = this.isElectronicResource(item);
+    // Taking the first status object in the array.
+    let status = item.status && item.status.length ? item.status[0] : {};
+    let availability = !_isEmpty(status) && status.prefLabel ?
+      status.prefLabel.replace(/\W/g, '').toLowerCase() : '';
+    const available = availability === 'available';
+    let url = null;
+    let actionLabel = null;
+    let actionLabelHelper = null;
+    // Currently using requestHold to display the Request button, only for ReCAP items.
+    let requestHold = false;
+    // non-NYPL ReCAP
+    const recap = accessMessage.prefLabel === 'ADV REQUEST' && !item.holdingLocation;
+    // nypl-owned ReCAP
+    const nyplRecap = !!(holdingLocation && !_isEmpty(holdingLocation) &&
+      holdingLocation['@id'].substring(4, 6) === 'rc');
+    let deliveryLocations = item.deliveryLocation && item.deliveryLocation.length ?
+      item.deliveryLocation : this.getDeliveryLocations(item, true);
+
+    if (isElectronicResource && item.electronicLocator[0].url) {
+      status = { '@id': '', prefLabel: 'Available' };
+      availability = 'available';
+      url = item.electronicLocator[0].url;
+      actionLabel = 'View online';
+      actionLabelHelper = `resource for ${title}`;
+      // The logic for this should be updated, but right now non-NYPL ReCAP items
+      // don't have a holdingLocation (but a default gets added here);
+    } else if (recap) {
+      requestHold = true;
+      actionLabel = accessMessage.prefLabel;
+      actionLabelHelper = `request hold on ${title}`;
+    } else if (nyplRecap) {
+      // Temporary for NYPL ReCAP items.
+      // Making sure that if there is a holding location, that the location code starts with
+      // rc. Ids are in the format of `loc:x` where x is the location code.
+      requestHold = true;
+      actionLabel = accessMessage.prefLabel;
+      actionLabelHelper = `request hold on ${title}`;
+      deliveryLocations = this.getDeliveryLocations(item, false);
+    } else if (availability === 'available') {
+      // For all items that we want to send to the Hold Request Form.
+      url = this.getLocationHoldUrl(holdingLocation);
+      actionLabel = 'Request for in-library use';
+      actionLabelHelper = `for ${title} for use in library`;
+    }
+
+    return {
+      id,
+      status,
+      availability,
+      available,
+      accessMessage,
+      isElectronicResource,
+      location: holdingLocation.prefLabel,
+      callNumber,
+      url,
+      actionLabel,
+      actionLabelHelper,
+      requestHold,
+      requestable,
+      suppressed,
+      deliveryLocations,
+    };
+  };
 
   /**
    * getItem(bib, itemId)
    * Look for specific item in the bib's item array. Return it if found.
    * @param {object} bib
    * @param {string} itemId
-   * @return {object}
+   * @return {array}
    */
   this.getItem = (bib, itemId) => {
     const items = (bib && bib.items) ? bib.items : [];
 
     if (itemId && items.length) {
       // Will return undefined if not found.
-      return _findWhere(items, { '@id': `res:${itemId}` });
+      const item = _findWhere(items, { '@id': `res:${itemId}` });
+      if (item) {
+        return this.mapItem(item, bib.title ? bib.title[0] : '');
+      }
     }
 
     return undefined;
   };
 
   /**
-   * getItems(record)
-   *
-   * @param {Object} record
-   * @return {Object}
+   * getItems(bib)
+   * Return an array of items with updated data properties.
+   * @param {object} bib
+   * @return {array}
    */
-  this.getItems = (record) => {
-    const recordTitle = record.title ? record.title[0] : '';
+  this.getItems = (bib) => {
+    const title = bib.title ? bib.title[0] : '';
     // filter out anything without a status or location
-    const rItems = record && record.items && record.items.length ? record.items : [];
-    const items = rItems
-      .filter((item) => item.status || item.electronicLocator)
-      // map items
-      .map((item) => {
-        const id = item['@id'].substring(4);
-        let status = item.status && item.status[0].prefLabel ? item.status[0].prefLabel : '';
-        let availability = status.replace(/\W/g, '').toLowerCase();
-        let accessMessage = item.accessMessage && item.accessMessage.length ?
-          item.accessMessage[0].prefLabel.toLowerCase() : '';
-        const callNumber = item.shelfMark && item.shelfMark.length ? item.shelfMark[0] : '';
-        const locationDetails = this.getLocationDetails(item);
-        let url = null;
-        let actionLabel = null;
-        let actionLabelHelper = null;
-        let requestHold = false;
-        const isElectronicResource = this.isElectronicResource(item);
-
-        if (isElectronicResource && item.electronicLocator[0].url) {
-          status = 'Available';
-          availability = 'available';
-          url = item.electronicLocator[0].url;
-          actionLabel = 'View online';
-          actionLabelHelper = `resource for ${recordTitle}`;
-          // Temporary for ReCAP items.
-        } else if (accessMessage === 'adv request' && !item.holdingLocation) {
-          requestHold = true;
-          actionLabel = accessMessage;
-          actionLabelHelper = `request hold on ${recordTitle}`;
-          // Temporary for NYPL ReCAP items.
-          // Making sure that if there is a holding location, that the location code starts with
-          // rc. Ids are in the format of `loc:x` where x is the location code.
-        } else if (item.holdingLocation && item.holdingLocation.length &&
-          item.holdingLocation[0]['@id'].substring(4, 6) === 'rc') {
-          requestHold = true;
-          actionLabel = accessMessage;
-          actionLabelHelper = `request hold on ${recordTitle}`;
-        } else if (availability === 'available') {
-          url = this.getLocationHoldUrl(locationDetails);
-          actionLabel = 'Request for in-library use';
-          actionLabelHelper = `for ${recordTitle} for use in library`;
-        }
-
-        return {
-          id,
-          status,
-          availability,
-          available: (availability === 'available'),
-          accessMessage,
-          isElectronicResource,
-          location: locationDetails.prefLabel,
-          callNumber,
-          url,
-          actionLabel,
-          actionLabelHelper,
-          requestHold,
-        };
-      });
+    const bibItems = bib && bib.items && bib.items.length ? bib.items : [];
+    const finalItems = bibItems.map((item) => this.mapItem(item, title));
 
     // sort: physical available items, then electronic resources, then everything else
-    items.sort((a, b) => {
-      let aAvailability = a.status === 'available' ? -1 : 1;
-      let bAvailability = b.status === 'available' ? -1 : 1;
-      if (a.isElectronicResource) aAvailability = 0;
-      if (b.isElectronicResource) bAvailability = 0;
-      return aAvailability - bAvailability;
-    });
+    // Update: Remove sorting for now.
+    // finalItems.sort((a, b) => {
+    //   let aAvailability = a.status === 'available' ? -1 : 1;
+    //   let bAvailability = b.status === 'available' ? -1 : 1;
+    //   if (a.isElectronicResource) aAvailability = 0;
+    //   if (b.isElectronicResource) bAvailability = 0;
+    //   return aAvailability - bAvailability;
+    // });
 
-    return items;
+    return finalItems;
   };
 
   /**
@@ -141,8 +180,7 @@ function LibraryItem() {
    * @return {string}
    */
   this.getLocationHoldUrl = (location) => {
-    const holdingLocationId =
-      location && location['@id'] ? location['@id'].substring(4) : '';
+    const holdingLocationId = location && location['@id'] ? location['@id'].substring(4) : '';
     let url = '';
     let shortLocation = 'schwarzman';
 
@@ -177,59 +215,78 @@ function LibraryItem() {
   };
 
   /**
-   * getDeliveryLocations(bib, itemId)
+   * getDeliveryLocations(item, single, bib, itemId)
    * Get delivery locations for an item.
-   * @param {object} bib
+   * @param {object} item
+   * @param {boolean} single Whether or not to just display one delivery location - temporary.
+   * @param {string} bib
    * @param {string} itemId
    * @return {object}
    */
-  this.getDeliveryLocations = (bib, itemId) => {
-    const item = this.getItem(bib, itemId);
+  this.getDeliveryLocations = (item, single = true, bib = '', itemId = '') => {
+    const thisItem = !_isEmpty(item) ? item : this.getItem(bib, itemId);
     // default to SASB - RMRR
-    const defaultLocation = this.getDefaultLocation();
+    const defaultDeliveryLocations = this.defaultDeliveryLocations();
 
     // get location and location code
-    let location = defaultLocation;
-    if (item) {
-      // loop through item's delivery locations
+    let deliveryLocations = defaultDeliveryLocations;
+    let locations = [];
+
+    if (thisItem) {
+      if (thisItem.deliveryLocations && thisItem.deliveryLocations.length &&
+        !(thisItem.id.substring(4) === 'i16429984')) {
+        deliveryLocations = thisItem.deliveryLocations;
+      }
+
+      deliveryLocations.forEach((location) => {
+        const locationCode = (location['@id'] && typeof location['@id'] === 'string') ?
+          location['@id'].substring(4) : '';
+        // location is set to defaultDeliveryLocations so it the following will always be false:
+        const isOffsite = this.isOffsite(location.prefLabel);
+        // retrieve delivery location
+        let deliveryLocationCode = location['@id'].substring(4);
+        let returnLocation = {};
+
+        // retrieve location data
+        if (locationCode && locationCode in LocationCodes) {
+          returnLocation = Locations[LocationCodes[locationCode].location];
+          deliveryLocationCode = LocationCodes[locationCode].delivery_location || '';
+        } else {
+          returnLocation =
+            Locations[LocationCodes[defaultDeliveryLocations[0]['@id'].substring(4)].location];
+        }
+
+        if (isOffsite && deliveryLocationCode === defaultDeliveryLocations[0]['@id'].substring(4)) {
+          returnLocation.prefLabel = defaultDeliveryLocations[0].prefLabel;
+        }
+
+        returnLocation = _extend({
+          customerCode: location.customerCode,
+          prefLabel: location.prefLabel,
+          offsite: isOffsite,
+          code: deliveryLocationCode,
+        }, returnLocation);
+
+        locations.push(returnLocation);
+      });
     }
-    const locationCode = (location['@id'] && typeof location['@id'] === 'string') ?
-      location['@id'].substring(4) : '';
-    const prefLabel = location.prefLabel;
-    // location is set to defaultLocation so it the following will always be false:
-    const isOffsite = this.isOffsite(location);
 
-    // retrieve location data
-    if (locationCode && locationCode in LocationCodes) {
-      location = Locations[LocationCodes[locationCode].location];
-    } else {
-      location = Locations[LocationCodes[defaultLocation['@id'].substring(4)].location];
+    // Temporary for now
+    if (single) {
+      // just return the first element in the array.
+      locations = [locations[0]];
     }
 
-    // retrieve delivery location
-    let deliveryLocationCode = defaultLocation['@id'].substring(4);
-    if (locationCode && locationCode in LocationCodes) {
-      deliveryLocationCode = LocationCodes[locationCode].delivery_location || '';
-    }
-
-    location.offsite = isOffsite;
-    location.code = deliveryLocationCode;
-    location.prefLabel = prefLabel;
-
-    if (isOffsite && deliveryLocationCode === defaultLocation['@id'].substring(4)) {
-      location.prefLabel = defaultLocation.prefLabel;
-    }
-
-    return location;
+    return locations;
   };
 
   /**
-   * getLocationDetails(item)
+   * getHoldingLocation(item)
    * Returns updated location data.
    * @param {object} item
    * @return {object}
    */
-  this.getLocationDetails = (item) => {
+  this.getHoldingLocation = (item) => {
     const defaultLocation = this.getDefaultLocation();
     let location = this.getDefaultLocation();
 
@@ -239,14 +296,13 @@ function LibraryItem() {
     // this is an electronic resource
     } else if (item.electronicLocator && item.electronicLocator.length) {
       location = item.electronicLocator[0];
-      if (!location.prefLabel && location.label) {
-        location.prefLabel = location.label;
-      }
+      location['@id'] = '';
     }
 
-    if (this.isOffsite(location)) {
+    if (this.isOffsite(location.prefLabel)) {
       location.prefLabel = `${defaultLocation.prefLabel} (requested from offsite storage)`;
     }
+
     return location;
   };
 
@@ -259,14 +315,12 @@ function LibraryItem() {
   this.isElectronicResource = (item) => item.electronicLocator && item.electronicLocator.length;
 
   /**
-   * isOffsite(location)
+   * isOffsite(prefLabel)
    * Return whether an item is offsite or not.
-   * @param {object} location
+   * @param {string} prefLabel
    * @return {boolean}
    */
-  this.isOffsite = (location) => (
-    location && location.prefLabel && location.prefLabel.substring(0, 7).toLowerCase() === 'offsite'
-  );
+  this.isOffsite = (prefLabel = '') => prefLabel.substring(0, 7).toLowerCase() === 'offsite';
 }
 
 export default new LibraryItem;


### PR DESCRIPTION
WIP until we get the final say regarding delivery locations, but this is part of it, to have default/hardcoded delivery locations. I also reworked a lot of the data workflow and updated variables names to be more consistent.

A lot of it here. The `HoldRequest` component is now (actually, again) rendering the delivery locations as multiple options. It's not a list but we can worry about that later once we get the actual design.

I also hardcoded a specific nypl-owned recap item to test: b13340250 (http://dev-discovery.nypl.org/bib/b13340250 -> go to Hold Request page - it should have three delivery locations just to display).

All other non-nypl ReCAP items should have one delivery location going to SASB.

Non-ReCAP items just don't display the "Request" button at all.