### PR TITLE
Encoding search keywords before adding to query for the API endpoint.

### DIFF
--- a/src/server/ApiRoutes/Search.js
+++ b/src/server/ApiRoutes/Search.js
@@ -26,7 +26,7 @@ const axiosApiCall = (query) => axios.get(`${apiBase}/discovery/resources${query
 
 function search(searchKeywords, page, sortBy, order, field, filters, cb, errorcb) {
   const apiQuery = createAPIQuery({
-    searchKeywords,
+    searchKeywords: encodeURIComponent(searchKeywords),
     sortBy: sortBy ? `${sortBy}_${order}` : '',
     selectedFacets: filters,
     field,


### PR DESCRIPTION
Fixes #256 

Examples: 
* http://dev-discovery.nypl.org/search?q=华 now gives the correct results (based on https://api.nypltech.org/api/v0.1/discovery/resources?q=华)
* http://dev-discovery.nypl.org/search?q=m%C3%A9xico%20y%20sus%20alrededores now returns correct results (based on https://api.nypltech.org/api/v0.1/discovery/resources?q=m%C3%A9xico%20y%20sus%20alrededores)