### PR TITLE
Adding client-side query routing to bib page for items.

### DIFF
--- a/src/app/components/BibPage/BibPage.jsx
+++ b/src/app/components/BibPage/BibPage.jsx
@@ -21,6 +21,7 @@ const BibPage = (props) => {
   const items = LibraryItem.getItems(bib);
   const bNumber = bib && bib.idBnum ? bib.idBnum : '';
   const searchURL = createAPIQuery({});
+  const itemPage = props.location.search;
   let shortenItems = true;
 
   if (props.location.pathname.indexOf('all') === -1) {
@@ -71,6 +72,7 @@ const BibPage = (props) => {
                   items={items}
                   bibId={bibId}
                   title="AVAILABILITY"
+                  itemPage={itemPage}
                 />
                 <MarcRecord bNumber={bNumber[0]} />
                 <BibDetails

--- a/src/app/components/Item/ItemHoldings.jsx
+++ b/src/app/components/Item/ItemHoldings.jsx
@@ -29,15 +29,27 @@ class ItemHoldings extends React.Component {
     // Mostly things we want to do on the client-side only:
     const items = this.props.items;
     let chunkedItems = [];
+    let noItemPage = false;
 
     if (items && items.length >= 20) {
       chunkedItems = this.chunk(items, 20);
     }
 
+    // If the `itemPage` URL query is more than the number of pages, then
+    // go back to page 1 in the state and remove the query from the URL.
+    if (this.state.page > chunkedItems.length) {
+      noItemPage = true;
+    }
+
     this.setState({
       js: true,
       chunkedItems,
+      page: noItemPage ? 1 : this.state.page,
     });
+
+    if (noItemPage) {
+      this.context.router.push(`/bib/${this.props.bibId}`);
+    }
   }
 
   /*
@@ -78,11 +90,11 @@ class ItemHoldings extends React.Component {
 
     return (
       (itemsToDisplay && _isArray(itemsToDisplay) && itemsToDisplay.length) ?
-      <dl>
-        <dd className="multi-item-list">
-          <ItemTable items={itemsToDisplay} bibId={bibId} getRecord={this.getRecord} />
-        </dd>
-      </dl> : null
+        <dl>
+          <dd className="multi-item-list">
+            <ItemTable items={itemsToDisplay} bibId={bibId} getRecord={this.getRecord} />
+          </dd>
+        </dl> : null
     );
   }
 

--- a/src/app/components/Item/ItemHoldings.jsx
+++ b/src/app/components/Item/ItemHoldings.jsx
@@ -16,7 +16,7 @@ class ItemHoldings extends React.Component {
       chunkedItems: [],
       showAll: false,
       js: false,
-      page: 1,
+      page: parseInt(this.props.itemPage.substring(10), 10) || 1,
     };
 
     this.getRecord = this.getRecord.bind(this);
@@ -93,6 +93,7 @@ class ItemHoldings extends React.Component {
    */
   updatePage(page) {
     this.setState({ page });
+    this.context.router.push(`/bib/${this.props.bibId}?itemPage=${page}`);
   }
 
   /*
@@ -128,6 +129,7 @@ class ItemHoldings extends React.Component {
           perPage={20}
           page={this.state.page}
           updatePage={this.updatePage}
+          to={{ pathname: `/bib/${this.props.bibId}?itemPage=` }}
         />
       );
 
@@ -164,6 +166,7 @@ class ItemHoldings extends React.Component {
 ItemHoldings.propTypes = {
   items: PropTypes.array,
   title: PropTypes.string,
+  itemPage: PropTypes.string,
   bibId: PropTypes.string,
   shortenItems: PropTypes.bool,
 };

--- a/src/app/components/Pagination/Pagination.jsx
+++ b/src/app/components/Pagination/Pagination.jsx
@@ -27,11 +27,13 @@ class Pagination extends React.Component {
     const intPage = parseInt(page, 10);
     const pageNum = type === 'Next' ? intPage + 1 : intPage - 1;
     const svg = type === 'Next' ? <RightArrowIcon /> : <LeftArrowIcon />;
-    const url = this.props.createAPIQuery({ page: pageNum });
+    const apiUrl = this.props.createAPIQuery({ page: pageNum });
+    const localUrl = `${this.props.to.pathname}${pageNum}`;
+    const url = apiUrl ? { pathname: `/search?${apiUrl}` } : { pathname: localUrl };
 
     return (
       <Link
-        to={url ? { pathname: `/search?${url}` } : this.props.to}
+        to={url}
         rel={type.toLowerCase()}
         aria-controls={this.props.ariaControls}
         onClick={(e) => this.onClick(e, pageNum)}

--- a/src/client/App.jsx
+++ b/src/client/App.jsx
@@ -33,7 +33,7 @@ window.onload = () => {
   Iso.bootstrap((state, container) => {
     alt.bootstrap(state);
 
-    const appHistory = useScroll(useRouterHistory(createBrowserHistory))();
+    const appHistory = (useRouterHistory(createBrowserHistory))();
 
     ReactDOM.render(
       <Router history={appHistory}>{routes}</Router>,


### PR DESCRIPTION
Fixes #482 .
When the API is back up again, check out this bib: http://dev-discovery.nypl.org/bib/b12403270.

When you click on the next/prev buttons, the url will change to `/bib/b12403270?itemPage=2`, `/bib/b12403270?itemPage=3`, etc. It should work if you copy the url and open it up in a new browser. But, this won't (and shouldn't) work in a no-js scenarios. If there's no js, there's no pagination so the url query won't do anything.

