### PR TITLE
Edd form validate server

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "sinon": "1.17.5",
     "style-loader": "0.13.0",
     "underscore": "1.8.3",
-    "validator": "^7.2.0",
+    "validator": "7.2.0",
     "webpack": "1.12.14",
     "webpack-dev-server": "1.10.1",
     "webpack-merge": "0.8.4"

--- a/src/app/actions/Actions.js
+++ b/src/app/actions/Actions.js
@@ -45,6 +45,10 @@ class Actions {
   updateField(data) {
     return data;
   }
+
+  updateForm(data) {
+    return data;
+  }
 }
 
 export default alt.createActions(Actions);

--- a/src/app/components/ElectronicDelivery/ElectronicDelivery.jsx
+++ b/src/app/components/ElectronicDelivery/ElectronicDelivery.jsx
@@ -106,6 +106,7 @@ class ElectronicDelivery extends React.Component {
     } = this.state;
     const bib = (this.props.bib && !_isEmpty(this.props.bib)) ? this.props.bib : null;
     const callNo = bib && bib.shelfMark && bib.shelfMark.length ? bib.shelfMark[0] : null;
+    const { error, form } = this.props;
 
     return (
       <div id="mainContent">
@@ -149,6 +150,8 @@ class ElectronicDelivery extends React.Component {
                 bibId={bibId}
                 itemId={itemId}
                 submitRequest={this.submitRequest}
+                error={error}
+                form={form}
               />
             </div>
           </div>
@@ -167,6 +170,8 @@ ElectronicDelivery.propTypes = {
   bib: PropTypes.object,
   searchKeywords: PropTypes.string,
   params: PropTypes.object,
+  error: PropTypes.object,
+  form: PropTypes.object,
 };
 
 export default ElectronicDelivery;

--- a/src/app/components/ElectronicDelivery/ElectronicDeliveryForm.jsx
+++ b/src/app/components/ElectronicDelivery/ElectronicDeliveryForm.jsx
@@ -12,6 +12,10 @@ class ElectronicDeliveryForm extends React.Component {
   constructor(props) {
     super(props);
 
+    // NOTE
+    // this.props.form and this.props.error are coming from the server only in the
+    // no-js scenario. If they're not available, then we use this 'fallback', but the
+    // empty object structure is needed.
     this.state = {
       form: !_isEmpty(this.props.form) ? this.props.form :
         {
@@ -52,6 +56,9 @@ class ElectronicDeliveryForm extends React.Component {
   }
 
   handleUpdate(e, input) {
+    // Kind of hard to read. Basically, the `form` property is being updated and all
+    // the values are being retained. If we don't `extend` the object value for `form`,
+    // then only the last value in the form gets updated and the rest are gone.
     this.setState({ form: _extend(this.state.form, { [input]: e.target.value }) });
   }
 
@@ -72,6 +79,9 @@ class ElectronicDeliveryForm extends React.Component {
       errorClass[key] = this.state.error[key] ? 'nypl-field-error' : '';
     });
 
+    // A lot of this can be refactored to be in a loop but that's a later and next step.
+    // I was thinking each `nypl-text-field` or `nypl-year-field` div can be
+    // its own component in a loop with the required props and errors passed down.
     return (
       <form
         className="place-hold-form form electronic-delivery-form"

--- a/src/app/components/ElectronicDelivery/ElectronicDeliveryForm.jsx
+++ b/src/app/components/ElectronicDelivery/ElectronicDeliveryForm.jsx
@@ -1,11 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {
-  isEmail,
-  isLength,
-  isNumeric,
-} from 'validator';
-// import { isDate } from '../../utils/formValidationUtils';
+import { validate } from '../../utils/formValidationUtils';
 import {
   mapObject as _mapObject,
   extend as _extend,
@@ -18,28 +13,30 @@ class ElectronicDeliveryForm extends React.Component {
     super(props);
 
     this.state = {
-      form: {
-        name: '',
-        email: '',
-        chapter: '',
-        author: '',
-        date: '',
-        volume: '',
-        issue: '',
-        'starting-page': '',
-        'ending-page': '',
-      },
-      error: {
-        name: '',
-        email: '',
-        chapter: '',
-        author: '',
-        date: '',
-        volume: '',
-        issue: '',
-        'starting-page': '',
-        'ending-page': '',
-      },
+      form: !_isEmpty(this.props.form) ? this.props.form :
+        {
+          name: '',
+          email: '',
+          chapter: '',
+          author: '',
+          date: '',
+          volume: '',
+          issue: '',
+          'starting-page': '',
+          'ending-page': '',
+        },
+      error: !_isEmpty(this.props.error) ? this.props.error :
+        {
+          name: '',
+          email: '',
+          chapter: '',
+          author: '',
+          date: '',
+          volume: '',
+          issue: '',
+          'starting-page': '',
+          'ending-page': '',
+        },
     };
 
     this.submit = this.submit.bind(this);
@@ -49,74 +46,13 @@ class ElectronicDeliveryForm extends React.Component {
   submit(e) {
     e.preventDefault();
 
-    if (this.validate()) {
+    if (validate(this.state.form, (error) => this.setState({ error }))) {
       this.props.submitRequest(this.state);
     }
   }
 
   handleUpdate(e, input) {
     this.setState({ form: _extend(this.state.form, { [input]: e.target.value }) });
-  }
-
-  validate() {
-    const validate = {
-      name: {
-        validate: (val) => !!val,
-        errorMsg: 'Please enter your name',
-      },
-      email: {
-        validate: (val) => (val.trim().length && isEmail(val)),
-        errorMsg: 'Please enter a correct email',
-      },
-      chapter: {
-        validate: (val) => !!val && isNumeric(val),
-        errorMsg: 'Please enter the item chapter',
-      },
-      // optional
-      author: {
-        validate: () => true,
-        errorMsg: '',
-      },
-      date: {
-        validate: (val) => isNumeric(val) && isLength(val, { min: 1, max: 4 }),
-        errorMsg: 'Please enter the date published',
-      },
-      volume: {
-        validate: (val) => !!val && isNumeric(val),
-        errorMsg: 'Please enter the item volume',
-      },
-      // optional
-      issue: {
-        validate: () => true,
-        errorMsg: '',
-      },
-      'starting-page': {
-        validate: (val) => isNumeric(val),
-        errorMsg: 'Please enter the starting page',
-      },
-      'ending-page': {
-        validate: (val) => isNumeric(val),
-        errorMsg: 'Please enter the end page',
-      },
-    };
-
-    const error = {};
-    _mapObject(this.state.form, (val, key) => {
-      const isValid = validate[key].validate(val);
-
-      if (!isValid) {
-        error[key] = validate[key].errorMsg;
-      }
-    });
-
-
-    this.setState({ error });
-
-    if (!_isEmpty(error)) {
-      return false;
-    }
-
-    return true;
   }
 
   render() {
@@ -390,6 +326,8 @@ ElectronicDeliveryForm.propTypes = {
   submitRequest: PropTypes.func,
   bibId: PropTypes.string,
   itemId: PropTypes.string,
+  error: PropTypes.object,
+  form: PropTypes.object,
 };
 
 export default ElectronicDeliveryForm;

--- a/src/app/stores/Store.js
+++ b/src/app/stores/Store.js
@@ -16,6 +16,7 @@ class Store {
       updateSortBy: Actions.updateSortBy,
       updateSpinner: Actions.updateSpinner,
       updateField: Actions.updateField,
+      updateForm: Actions.updateForm,
     });
 
     this.state = {
@@ -29,6 +30,7 @@ class Store {
       spinning: false,
       field: 'all',
       error: {},
+      form: {},
     };
   }
 
@@ -76,6 +78,10 @@ class Store {
 
   updateField(data) {
     this.setState({ field: data });
+  }
+
+  updateForm(data) {
+    this.setState({ form: data });
   }
 }
 

--- a/src/app/utils/formValidationUtils.js
+++ b/src/app/utils/formValidationUtils.js
@@ -1,4 +1,14 @@
 import React from 'react';
+import {
+  isEmail,
+  isLength,
+  isNumeric,
+} from 'validator';
+// import { isDate } from '../../utils/formValidationUtils';
+import {
+  mapObject as _mapObject,
+  isEmpty as _isEmpty,
+} from 'underscore';
 
 function isDate(input, minYear = 1902, maxYear = new Date().getFullYear()) {
   // regular expression to match required date format
@@ -122,7 +132,75 @@ function renderServerValidationError(object) {
   return errorMessages;
 }
 
+/**
+ * validate(form, cb)
+ *
+ * @param {object} form
+ * @param {function} cb
+ * return {boolean}
+ */
+function validate(form, cb) {
+  const fieldsToCheck = {
+    name: {
+      validate: (val) => !!val,
+      errorMsg: 'Please enter your name',
+    },
+    email: {
+      validate: (val) => (val.trim().length && isEmail(val)),
+      errorMsg: 'Please enter a correct email',
+    },
+    chapter: {
+      validate: (val) => !!val && isNumeric(val),
+      errorMsg: 'Please enter the item chapter',
+    },
+    // optional
+    author: {
+      validate: () => true,
+      errorMsg: '',
+    },
+    date: {
+      validate: (val) => isNumeric(val) && isLength(val, { min: 1, max: 4 }),
+      errorMsg: 'Please enter the date published',
+    },
+    volume: {
+      validate: (val) => !!val && isNumeric(val),
+      errorMsg: 'Please enter the item volume',
+    },
+    // optional
+    issue: {
+      validate: () => true,
+      errorMsg: '',
+    },
+    'starting-page': {
+      validate: (val) => isNumeric(val),
+      errorMsg: 'Please enter the starting page',
+    },
+    'ending-page': {
+      validate: (val) => isNumeric(val),
+      errorMsg: 'Please enter the end page',
+    },
+  };
+
+  const error = {};
+  _mapObject(form, (val, key) => {
+    const isValid = fieldsToCheck[key].validate(val);
+
+    if (!isValid) {
+      error[key] = fieldsToCheck[key].errorMsg;
+    }
+  });
+
+  cb(error);
+
+  if (!_isEmpty(error)) {
+    return false;
+  }
+
+  return true;
+}
+
 export {
   isDate,
   renderServerValidationError,
+  validate,
 };

--- a/src/server/ApiRoutes/Hold.js
+++ b/src/server/ApiRoutes/Hold.js
@@ -8,16 +8,15 @@ import {
   omit as _omit,
 } from 'underscore';
 
-function postHoldAPI(req, cb, errorCb) {
+function postHoldAPI(req, pickedUpItemId, cb, errorCb) {
   // retrieve access token and patron info
   const accessToken = req.tokenResponse.accessToken;
   const patronId = req.tokenResponse.decodedPatron.sub;
   const patronHoldsApi = `${appConfig.api.development}/hold-requests`;
 
   // get item id and pickup location
-  // NOTE: The implementation for this needs to be redone, or
-  // we may get it directly from the API.
-  let itemId = req.params.itemId;
+  // NOTE: pickedUpItemId and pickedUpBibId are coming from the EDD form function below:
+  let itemId = req.params.itemId || pickedUpItemId;
   let nyplSource = 'sierra-nypl';
 
   if (itemId.indexOf('-') >= 0) {
@@ -130,6 +129,7 @@ function createHoldRequestServer(req, res, pickedUpBibId = '', pickedUpItemId = 
 
   return postHoldAPI(
     req,
+    itemId,
     (response) => {
       // console.log('Holds API response:', response);
       console.log('Hold Request Id:', response.data.data.id);
@@ -155,6 +155,7 @@ function createHoldRequestAjax(req, res) {
 
   return postHoldAPI(
     req,
+    req.params.itemId,
     (response) => {
       res.json({
         id: response.data.data.id,

--- a/src/server/ApiRoutes/Hold.js
+++ b/src/server/ApiRoutes/Hold.js
@@ -126,7 +126,7 @@ function createHoldRequestServer(req, res, pickedUpBibId = '', pickedUpItemId = 
     .catch(error => {
       // console.log(error);
       console.log(`Error calling Holds API : ${error.data.message}`);
-      res.redirect(`/hold/request/${bibId}-s${itemId}?errorMessage=${error.data.message}`);
+      res.redirect(`/hold/request/${bibId}-${itemId}?errorMessage=${error.data.message}`);
     }); /* end axios call */
 }
 


### PR DESCRIPTION
Fixes #492 - adding server side validation to the form.

The validation function is used for both the server and client side so updating it for both should be easy once the updated requirements are fulfilled by management.

Example: http://dev-discovery.nypl.org/hold/request/b95618-i138987/edd

Turn JS off and try submitting. The url you will get back if there are errors looks url, but it's the easiest way to pass patron and error data from the server to the client to be rendered. Next step can be to make it better but for now it works and I think we should keep moving with that. Besides, not many will use it without js.

Please try to break it and let me know if there are any issues. Again, this is just a skeleton since it's not hooked up to an actual API yet, but just checking the form values are correct.

@ricardoom