### PR TITLE
adds logic to link specifically the author field

### DIFF
--- a/src/app/components/BibPage/BibMainInfo.jsx
+++ b/src/app/components/BibPage/BibMainInfo.jsx
@@ -49,6 +49,29 @@ class BibMainInfo extends React.Component {
             </ul>
           ),
         };
+      } else if (fieldLabel == 'Author'){
+        return {
+          term: fieldLabel,
+          definition: (
+            <span>
+              {
+                bibValues.map((value, i) => {
+                  const url = `filters[${fieldValue}]=${value}`;
+                  return (
+                      <Link
+                        key={i}
+                        onClick={e => this.newSearch(e, url)}
+                        title={`Make a new search for ${fieldLabel}: "${value}"`}
+                        to={`/search?${url}`}
+                      >
+                        {value}
+                      </Link>
+                  );
+                })
+              }
+            </span>
+          ),
+        };
       }
 
       return {


### PR DESCRIPTION
Whoops -- did this on a branch named for something else -- but does as described. Links author to match the mockup.