### PR TITLE
New pager for search results

### DIFF
--- a/src/app/components/SearchPagination/SearchPagination.jsx
+++ b/src/app/components/SearchPagination/SearchPagination.jsx
@@ -1,0 +1,129 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Link } from 'react-router';
+import {
+  LeftArrowIcon,
+  RightArrowIcon,
+} from 'dgx-svg-icons';
+import { times as _times } from 'underscore';
+
+class SearchPagination extends React.Component {
+  /*
+   * onClick()
+   * @param {string} page The next page to get results from.
+   */
+  onClick(e, page) {
+    e.preventDefault();
+    this.props.updatePage(page);
+  }
+
+  /*
+   * getPage()
+   * Get a button based on current page.
+   * @param {string} page The current page number.
+   * @param {string} type Either 'Next' or 'Previous' to indication button label.
+   */
+  getPage(page, type = 'Next') {
+    if (!page && type !== 'Number') return null;
+
+    const intPage = parseInt(page, 10);
+    const pageNum = type === 'Previous' ? intPage - 1 : intPage + 1;
+    const svg = type === 'Previous' ? <LeftArrowIcon /> : <RightArrowIcon />;
+    const apiUrl = this.props.createAPIQuery({ page: pageNum });
+    const localUrl = `${this.props.to.pathname}${pageNum}`;
+    const url = apiUrl ? { pathname: `/search?${apiUrl}` } : { pathname: localUrl };
+    let label;
+
+    if (type === 'Number') {
+      label = pageNum;
+    } else {
+      label = <div>{svg} <span>{type} Page</span></div>;
+    }
+
+    return (
+      <Link
+        to={url}
+        rel={type.toLowerCase()}
+        aria-controls={this.props.ariaControls}
+        onClick={(e) => this.onClick(e, pageNum)}
+        key={(type === 'Number') ? pageNum : type}
+      >
+        {label}
+      </Link>
+    );
+  }
+
+  /*
+   * renderPageLinks(totalPages)
+   * Renders the links to each page.
+   *
+   * @param {Number} total pages.
+   * @reruen {Array} an array contains all the links to each page.
+   */
+  renderPageLinks(totalPages) {
+    const linksArray = [];
+    let pageNum = 0;
+
+    _times(
+      totalPages,
+      () => {
+        linksArray.push(this.getPage(pageNum, 'Number'));
+        pageNum ++;
+      }
+    );
+
+    if (linksArray.length > 8) {
+      return linksArray.slice(0, 8);
+    }
+
+    return linksArray;
+  }
+
+  render() {
+    const {
+      total,
+      page,
+      perPage,
+    } = this.props;
+    if (!total) return null;
+
+    const pageFactor = parseInt(page, 10) * perPage;
+    const nextPage = (total < perPage || pageFactor > total) ? null : this.getPage(page, 'Next');
+    const prevPage = page > 1 ? this.getPage(page, 'Previous') : null;
+    const totalPages = Math.floor(total / perPage) + 1;
+
+    return (
+      <div className="nypl-results-pagination">
+        {prevPage}
+        <span
+          className={`page-count ${page === 1 ? 'first' : ''}`}
+          aria-label={`Displaying page ${page} out of ${totalPages} total pages.`}
+          tabIndex="0"
+        >
+          Page {page} of {totalPages}
+        </span>
+        {this.renderPageLinks(totalPages)}
+        {nextPage}
+      </div>
+    );
+  }
+}
+
+SearchPagination.propTypes = {
+  total: PropTypes.number,
+  page: PropTypes.number,
+  perPage: PropTypes.number,
+  ariaControls: PropTypes.string,
+  to: PropTypes.object,
+  updatePage: PropTypes.func,
+  createAPIQuery: PropTypes.func,
+};
+
+SearchPagination.defaultProps = {
+  page: 1,
+  ariaControls: 'results-region',
+  to: { pathname: '#' },
+  createAPIQuery: () => {},
+};
+
+export default SearchPagination;

--- a/src/app/components/SearchPagination/SearchPagination.jsx
+++ b/src/app/components/SearchPagination/SearchPagination.jsx
@@ -62,6 +62,9 @@ class SearchPagination extends React.Component {
    */
   renderPageLinks(totalPages) {
     const linksArray = [];
+    const perPageInGroup = this.props.perPageInGroup;
+    const firstPageInGroup = (Math.ceil(this.props.page / perPageInGroup) - 1) * perPageInGroup;
+    const lastPageInGroup = firstPageInGroup + perPageInGroup;
     let pageNum = 0;
 
     _times(
@@ -72,10 +75,14 @@ class SearchPagination extends React.Component {
       }
     );
 
-    const lastPage = linksArray[(linksArray.length)-1];
+    const lastPage = ((totalPages - firstPageInGroup) > perPageInGroup) ?
+      linksArray[(linksArray.length)-1] : null;
 
     if (linksArray.length > 8) {
-      return this.renderPagerElement(linksArray.slice(0, 8), lastPage);
+      return this.renderPagerElement(
+        linksArray.slice(firstPageInGroup, lastPageInGroup),
+        lastPage
+      );
     }
 
     return linksArray;
@@ -91,7 +98,9 @@ class SearchPagination extends React.Component {
    */
   renderPagerElement(pageArray, lastPage) {
     return (
-      <div>{pageArray}<span>...</span>{lastPage}</div>
+      <div>
+        {pageArray}{(lastPage) && <span>...</span>}{lastPage}
+      </div>
     );
   }
 

--- a/src/app/components/SearchPagination/SearchPagination.jsx
+++ b/src/app/components/SearchPagination/SearchPagination.jsx
@@ -33,9 +33,12 @@ class SearchPagination extends React.Component {
     const localUrl = `${this.props.to.pathname}${pageNum}`;
     const url = apiUrl ? { pathname: `/search?${apiUrl}` } : { pathname: localUrl };
     let label;
+    const pageClass = (type === 'Number') ? 'page-number' : '';
+    let currentPageClass = '';
 
     if (type === 'Number') {
       label = pageNum;
+      currentPageClass = (pageNum === this.props.page) ? 'current-page' : '';
     } else {
       label = <div>{svg} <span>{type} Page</span></div>;
     }
@@ -47,6 +50,7 @@ class SearchPagination extends React.Component {
         aria-controls={this.props.ariaControls}
         onClick={(e) => this.onClick(e, pageNum)}
         key={(type === 'Number') ? pageNum : type}
+        className={`${pageClass} ${currentPageClass}`}
       >
         {label}
       </Link>
@@ -125,9 +129,8 @@ class SearchPagination extends React.Component {
           aria-label={`Displaying page ${page} out of ${totalPages} total pages.`}
           tabIndex="0"
         >
-          Page {page} of {totalPages}
+          {this.renderPageLinks(totalPages)}
         </span>
-        {this.renderPageLinks(totalPages)}
         {nextPage}
       </div>
     );

--- a/src/app/components/SearchPagination/SearchPagination.jsx
+++ b/src/app/components/SearchPagination/SearchPagination.jsx
@@ -80,7 +80,7 @@ class SearchPagination extends React.Component {
     );
 
     const lastPage = ((totalPages - firstPageInGroup) > perPageInGroup) ?
-      linksArray[(linksArray.length)-1] : null;
+      linksArray[(linksArray.length) - 1] : null;
 
     if (linksArray.length > 8) {
       return this.renderPagerElement(
@@ -141,6 +141,7 @@ SearchPagination.propTypes = {
   total: PropTypes.number,
   page: PropTypes.number,
   perPage: PropTypes.number,
+  perPageInGroup: PropTypes.number,
   ariaControls: PropTypes.string,
   to: PropTypes.object,
   updatePage: PropTypes.func,
@@ -149,6 +150,7 @@ SearchPagination.propTypes = {
 
 SearchPagination.defaultProps = {
   page: 1,
+  perPageInGroup: 8,
   ariaControls: 'results-region',
   to: { pathname: '#' },
   createAPIQuery: () => {},

--- a/src/app/components/SearchPagination/SearchPagination.jsx
+++ b/src/app/components/SearchPagination/SearchPagination.jsx
@@ -58,7 +58,7 @@ class SearchPagination extends React.Component {
    * Renders the links to each page.
    *
    * @param {Number} total pages.
-   * @reruen {Array} an array contains all the links to each page.
+   * @return {Array} an array contains all the links to each page.
    */
   renderPageLinks(totalPages) {
     const linksArray = [];
@@ -72,11 +72,27 @@ class SearchPagination extends React.Component {
       }
     );
 
+    const lastPage = linksArray[(linksArray.length)-1];
+
     if (linksArray.length > 8) {
-      return linksArray.slice(0, 8);
+      return this.renderPagerElement(linksArray.slice(0, 8), lastPage);
     }
 
     return linksArray;
+  }
+
+  /*
+   * renderPagerElement(pageArray, lastPage)
+   * Renders the HTML element for the pagination UI.
+   *
+   * @param {Array} pageArray
+   * @param {Object} lastPage
+   * @return {HTML Element}
+   */
+  renderPagerElement(pageArray, lastPage) {
+    return (
+      <div>{pageArray}<span>...</span>{lastPage}</div>
+    );
   }
 
   render() {

--- a/src/app/components/SearchResultsPage/SearchResultsPage.jsx
+++ b/src/app/components/SearchResultsPage/SearchResultsPage.jsx
@@ -107,6 +107,7 @@ const SearchResultsPage = (props, context) => {
                   (<SearchPagination
                     total={totalHits}
                     perPage={50}
+                    perPageInGroup={8}
                     page={parseInt(page, 10)}
                     createAPIQuery={createAPIQuery}
                     updatePage={updatePage}

--- a/src/app/components/SearchResultsPage/SearchResultsPage.jsx
+++ b/src/app/components/SearchResultsPage/SearchResultsPage.jsx
@@ -7,7 +7,7 @@ import Breadcrumbs from '../Breadcrumbs/Breadcrumbs.jsx';
 import ResultList from '../Results/ResultsList';
 import Search from '../Search/Search.jsx';
 import Sorter from '../Sorter/Sorter';
-import Pagination from '../Pagination/Pagination';
+import SearchPagination from '../SearchPagination/SearchPagination';
 
 import {
   basicQuery,
@@ -113,7 +113,7 @@ const SearchResultsPage = (props, context) => {
 
               {
                 !!(totalHits && totalHits !== 0) &&
-                  (<Pagination
+                  (<SearchPagination
                     total={totalHits}
                     perPage={50}
                     page={parseInt(page, 10)}

--- a/src/client/styles/components/SearchPagination.scss
+++ b/src/client/styles/components/SearchPagination.scss
@@ -1,0 +1,9 @@
+.nypl-results-pagination {
+  .page-number {
+    width: 10%;
+  }
+
+  .current-page {
+    font-weight: bold;
+  }
+}

--- a/src/client/styles/main.scss
+++ b/src/client/styles/main.scss
@@ -29,6 +29,7 @@ Import style rules from NYPL React module components
 @import "components/Tabs.scss";
 @import "components/ElectronicDeliveryForm.scss";
 @import "components/_forms.v2.scss";
+@import "components/SearchPagination.scss";
 
 @import "style-v2.scss";
 


### PR DESCRIPTION
This PR is to make the new pagination UI for search results page. The PR create a new class for the new pagination so we can still use the old one in another component.

The PR solves the issue of [#491](https://waffle.io/NYPL-discovery/discovery-general/cards/595e516d05733c02ea3e90b8)

The design can be seen here
https://drive.google.com/drive/folders/0B2LQIUUuUDJdR3ZZc3d6M0h1UWc

The PR mainly focus on the new functionality, so it does not fit the design 100% and also accessibility requirements. The styles are temporarily too. We will update it after we have the design for the toolkit.

@ricardoom