### PR TITLE
Adding scrolling to top when routing between pages. But the bib page …

### DIFF
--- a/src/client/App.jsx
+++ b/src/client/App.jsx
@@ -33,7 +33,7 @@ window.onload = () => {
   Iso.bootstrap((state, container) => {
     alt.bootstrap(state);
 
-    const appHistory = (useRouterHistory(createBrowserHistory))();
+    const appHistory = useScroll(useRouterHistory(createBrowserHistory))();
 
     ReactDOM.render(
       <Router history={appHistory}>{routes}</Router>,


### PR DESCRIPTION
…item pagination scrolls to top which may not be ideal.

Fixes #516 , however, on a bib page with item pagination, when clicking on the next/prev buttons, the page will scroll to the top and that may not be the best behavior. For example: http://dev-discovery.nypl.org/bib/b12403270

Will that be a problem @wlla ?