### PR TITLE
Resolving the multiple definition lists in the bib page.

### DIFF
--- a/src/app/components/BibPage/BibMainInfo.jsx
+++ b/src/app/components/BibPage/BibMainInfo.jsx
@@ -7,36 +7,32 @@ import {
   findWhere as _findWhere,
   findIndex as _findIndex,
 } from 'underscore';
-import DefinitionList from './DefinitionList';
+import Definition from './Definition';
 import { ajaxCall } from '../../utils/utils';
 import Actions from '../../actions/Actions';
 
 class BibMainInfo extends React.Component {
-
   getMainInfo(bib) {
-
     const fields = [
       { label: 'Author', value: 'creatorLiteral' },
       { label: 'Additional Authors', value: 'contributorLiteral' },
     ];
+    const fieldsToRender = [];
 
-    return fields.map((field) => {
+    fields.forEach((field) => {
       const fieldLabel = field.label;
       const fieldValue = field.value;
       const bibValues = bib[fieldValue];
 
-      if (!bibValues || !bibValues.length || !_isArray(bibValues)) {
-        return false;
-      }
-
-      return {
-        term: fieldLabel,
-        definition: (
-          <span>
-            {
-              bibValues.map((value, i) => {
-                const url = `filters[${fieldValue}]=${value}`;
-                return (
+      if (bibValues && bibValues.length && _isArray(bibValues)) {
+        fieldsToRender.push({
+          term: fieldLabel,
+          definition: (
+            <span>
+              {
+                bibValues.map((value, i) => {
+                  const url = `filters[${fieldValue}]=${value}`;
+                  return (
                     <Link
                       key={i}
                       onClick={e => this.newSearch(e, url)}
@@ -44,13 +40,18 @@ class BibMainInfo extends React.Component {
                     >
                       {value}
                     </Link>
-                );
-              })
-            }
-          </span>
-        ),
-      };
+                  );
+                })
+              }
+            </span>
+          ),
+        });
+      }
+
+      return null;
     });
+
+    return fieldsToRender;
   }
 
   newSearch(e, query) {
@@ -105,11 +106,7 @@ class BibMainInfo extends React.Component {
 
     const bibMainInfo = this.getMainInfo(this.props.bib);
 
-    return (
-      <DefinitionList
-        data={bibMainInfo}
-      />
-    );
+    return (<Definition definitions={bibMainInfo} />);
   }
 }
 

--- a/src/app/components/BibPage/BibPage.jsx
+++ b/src/app/components/BibPage/BibPage.jsx
@@ -37,11 +37,11 @@ const BibPage = (props) => {
             <div className="nypl-column-three-quarters">
               <h2>New York Public Library Research Catalog</h2>
               <Search
-                  searchKeywords={props.searchKeywords}
-                  field={props.field}
-                  spinning={props.spinning}
-                  createAPIQuery={createAPIQuery}
-                />
+                searchKeywords={props.searchKeywords}
+                field={props.field}
+                spinning={props.spinning}
+                createAPIQuery={createAPIQuery}
+              />
               <div className="nypl-row search-control">
                 <svg xmlns="http://www.w3.org/2000/svg" width="25" height="42" viewBox="0 0 25 42" preserveAspectRatio="xMidYMid meet" aria-labelledby="left-arrow" aria-hidden="true">
                   <title id="left-arrow">Back to Results</title>
@@ -66,19 +66,20 @@ const BibPage = (props) => {
             >
               <div className="nypl-item-details">
                 <h1>{title}</h1>
+                <dl>
                   <BibMainInfo bib={bib} />
+
                   <ItemHoldings
                     shortenItems={shortenItems}
                     items={items}
                     bibId={bibId}
                     itemPage={itemPage}
                   />
-                  <BibDetails
-                    bib={bib}
-                    title="Bib details"
-                  />
+
+                  <BibDetails bib={bib} />
 
                   {isNYPLReCAP && <MarcRecord bNumber={bNumber[0]} />}
+                </dl>
               </div>
             </div>
           </div>

--- a/src/app/components/BibPage/Definition.jsx
+++ b/src/app/components/BibPage/Definition.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+/*
+ * Definition
+ * Expects data in the form of [{ term: '', definition: ''}, {...}, ...].
+ */
+const Definition = ({ definitions }) => {
+  const getDefinitions = (defs) => {
+    if (!defs && !defs.length) {
+      return null;
+    }
+
+    return defs.map((item) => {
+      if (!item.term && !item.definition) {
+        return null;
+      }
+      return ([
+        (<dt>{item.term}</dt>),
+        (<dd>{item.definition}</dd>),
+      ]);
+    });
+  };
+
+  if (!definitions || !definitions.length) {
+    return null;
+  }
+
+  return (<span>{getDefinitions(definitions)}</span>);
+};
+
+Definition.propTypes = {
+  definitions: PropTypes.array,
+};
+
+export default Definition;

--- a/src/app/components/BibPage/MarcRecord.jsx
+++ b/src/app/components/BibPage/MarcRecord.jsx
@@ -9,10 +9,10 @@ const MarcRecord = ({ bNumber }) => {
     `https://catalog.nypl.org/search~S1?/.b${bNumber}/.b${bNumber}/1%2C1%2C1%2CB/marc`;
 
   return (
-    <dl>
+    <span>
       <dt>MARC Record</dt>
       <dd><a href={marcRecordLink}>MARC Record</a></dd>
-    </dl>
+    </span>
   );
 };
 

--- a/src/app/components/Item/ItemHoldings.jsx
+++ b/src/app/components/Item/ItemHoldings.jsx
@@ -93,14 +93,7 @@ class ItemHoldings extends React.Component {
 
     return (
       (itemsToDisplay && _isArray(itemsToDisplay) && itemsToDisplay.length) ?
-      <dl>
-        <dt className="list-multi-control">
-          <h3>Availability</h3>
-        </dt>
-        <dd className="multi-item-list">
-          <ItemTable items={itemsToDisplay} bibId={bibId} getRecord={this.getRecord} />
-        </dd>
-      </dl> : null
+        (<ItemTable items={itemsToDisplay} bibId={bibId} getRecord={this.getRecord} />) : null
     );
   }
 
@@ -156,26 +149,35 @@ class ItemHoldings extends React.Component {
 
     const itemTable = this.getTable(items, shortenItems, this.state.showAll);
 
+    if (!items || !items.length) {
+      return null;
+    }
+
     return (
-      <div id="item-holdings" className="item-holdings">
-        {itemTable}
-        {
-          !!(shortenItems && items.length >= 20 && !this.state.showAll) &&
-            (<div className="view-all-items-container">
-              {
-                this.state.js ?
-                  (<a href="#" onClick={this.showAll}>View All Items</a>) :
-                  (<Link
-                    to={`/bib/${this.props.bibId}/all`}
-                    className="view-all-items"
-                  >
-                    View All Items
-                  </Link>)
-              }
-            </div>)
-        }
-        {pagination}
-      </div>
+      <span id="item-holdings" className="item-holdings">
+        <dt className="list-multi-control">
+          <h3>Availability</h3>
+        </dt>
+        <dd className="multi-item-list">
+          {itemTable}
+          {
+            !!(shortenItems && items.length >= 20 && !this.state.showAll) &&
+              (<div className="view-all-items-container">
+                {
+                  this.state.js ?
+                    (<a href="#" onClick={this.showAll}>View All Items</a>) :
+                    (<Link
+                      to={`/bib/${this.props.bibId}/all`}
+                      className="view-all-items"
+                    >
+                      View All Items
+                    </Link>)
+                }
+              </div>)
+          }
+          {pagination}
+        </dd>
+      </span>
     );
   }
 }


### PR DESCRIPTION
Fixes #519 

There are still three `<span>`s inside the `dl` which I don't like but it's how React is rendering the components. We can iterate on that later on. Created a new component `Definition` which is just like `DefinitionList` except it returns the definition term/definition wrapped in a `span`.