### PR TITLE
Added start over button and related routes.

### DIFF
--- a/src/app/components/HoldConfirmation/HoldConfirmation.jsx
+++ b/src/app/components/HoldConfirmation/HoldConfirmation.jsx
@@ -44,6 +44,18 @@ class HoldConfirmation extends React.Component {
   }
 
   /**
+   * goRestart(e)
+   * @param {event}
+   * Renders the route back to home page for single page application implement.
+   *
+   */
+  goRestart(e) {
+    e.preventDefault();
+
+    this.context.router.push('/');
+  }
+
+  /**
    * renderLocationInfo()
    * Renders the location information.
    *
@@ -64,6 +76,24 @@ class HoldConfirmation extends React.Component {
         {address}<br />
         {prefLabel}
       </p>
+    );
+  }
+
+  /**
+   * renderStartOverLink
+   * Renders the link back to homepage.
+   *
+   * @return {HTML Element}
+   */
+  renderStartOverLink() {
+    return (
+      <Link
+        to="/"
+        onClick={(e) => this.goRestart(e)}
+        tabIndex="0"
+      >
+        Start Over
+      </Link>
     );
   }
 
@@ -127,6 +157,11 @@ class HoldConfirmation extends React.Component {
               {this.renderLocationInfo(deliveryLocation)}
             </div>
           </div>
+          <div className="start-over-container">
+            <div className="third">
+              {this.renderStartOverLink()}
+            </div>
+          </div>
         </div>
       </div>
     );
@@ -147,6 +182,10 @@ HoldConfirmation.defaultProps = {
   searchKeywords: '',
   params: {},
   deliveryLocations: [],
+};
+
+HoldConfirmation.contextTypes = {
+  router: PropTypes.object,
 };
 
 export default HoldConfirmation;

--- a/src/app/components/HoldConfirmation/HoldConfirmation.jsx
+++ b/src/app/components/HoldConfirmation/HoldConfirmation.jsx
@@ -46,7 +46,7 @@ class HoldConfirmation extends React.Component {
   /**
    * goRestart(e)
    * @param {event}
-   * Renders the route back to home page for single page application implement.
+   * Renders the route back to home page for single page application implementation.
    *
    */
   goRestart(e) {
@@ -90,7 +90,6 @@ class HoldConfirmation extends React.Component {
       <Link
         to="/"
         onClick={(e) => this.goRestart(e)}
-        tabIndex="0"
       >
         Start Over
       </Link>
@@ -158,7 +157,7 @@ class HoldConfirmation extends React.Component {
             </div>
           </div>
           <div className="start-over-container">
-            <div className="third">
+            <div>
               {this.renderStartOverLink()}
             </div>
           </div>


### PR DESCRIPTION
This PR adds a new start over button on the confirmation page based on the mockup.
https://app.moqups.com/digitalrepository@nypl.org/55BjtB7Pm0/view/page/a0f66a95b

can be tested on dev now.