### PR TITLE
Sorting widget v2 or something

### DIFF
--- a/src/client/styles/components/Sorter.scss
+++ b/src/client/styles/components/Sorter.scss
@@ -1,0 +1,32 @@
+// Temporary until this is in the Design Toolkit
+.nypl-results-sorter {
+  form {
+    background-color: #fff;
+    border: 0.0625rem solid #9d9ea1;
+    border-radius: 0.2rem;
+    color: #080807;
+    display: inline-block;
+    font-size: 0.85rem;
+    font-weight: normal;
+    height: auto;
+    letter-spacing: normal;
+    padding: 0.4rem 0.75rem;
+    text-decoration: none;
+    text-transform: none;
+    white-space: nowrap;
+    position: relative;
+    padding-right: 1.5rem;
+    text-align: left;
+    padding-right: 1.75rem;
+    text-transform: uppercase;
+  }
+
+  select {
+    border: none;
+    background: #fff;
+    color: #080807;
+    width: 150px;
+    padding: 0;
+    cursor: pointer;
+  }
+}

--- a/src/client/styles/main.scss
+++ b/src/client/styles/main.scss
@@ -31,6 +31,7 @@ Import style rules from NYPL React module components
 @import "components/_forms.v2.scss";
 @import "components/SearchPagination.scss";
 @import "components/ItemTable.scss";
+@import "components/Sorter.scss";
 
 @import "style-v2.scss";
 


### PR DESCRIPTION
Sort of fixes #467 
![screen shot 2017-07-25 at 3 39 35 pm](https://user-images.githubusercontent.com/1280564/28590262-8b61d124-714f-11e7-8c67-ff6db014532e.png)

Sort of because the design-toolkit has this element as a `button`/`ul` combo but it should really be a `select` element for a11y.

CC @ricardoom