### PR TITLE
Adding logic to update whether the Request button shows up or not.

### DIFF
--- a/src/app/utils/item.js
+++ b/src/app/utils/item.js
@@ -117,6 +117,8 @@ function LibraryItem() {
     const barcode = bibIdentifiers.barcode || '';
     const itemSource = item.idNyplSourceId ? item.idNyplSourceId['@type'] : undefined;
     const mappedItemSource = itemSourceMappings[itemSource];
+    const isOffsite = this.isOffsite(holdingLocation.prefLabel.toLowerCase());
+    const temporaryRequestable = requestable && isOffsite;
 
     if (isElectronicResource && item.electronicLocator[0].url) {
       status = { '@id': '', prefLabel: 'Available' };
@@ -154,7 +156,7 @@ function LibraryItem() {
       url,
       actionLabel,
       actionLabelHelper,
-      requestable,
+      requestable: temporaryRequestable,
       suppressed,
       barcode,
       itemSource: mappedItemSource,
@@ -284,7 +286,7 @@ function LibraryItem() {
    * @param {string} prefLabel
    * @return {boolean}
    */
-  this.isOffsite = (prefLabel = '') => prefLabel.substring(0, 7).toLowerCase() === 'offsite';
+  this.isOffsite = (prefLabel = '') => prefLabel.indexOf('offsite') !== -1;
 
   /**
    * isNYPLReCAP(bibId)

--- a/src/app/utils/item.js
+++ b/src/app/utils/item.js
@@ -118,7 +118,7 @@ function LibraryItem() {
     const itemSource = item.idNyplSourceId ? item.idNyplSourceId['@type'] : undefined;
     const mappedItemSource = itemSourceMappings[itemSource];
     const isOffsite = this.isOffsite(holdingLocation.prefLabel.toLowerCase());
-    const temporaryRequestable = requestable && isOffsite;
+    const temporaryRequestable = (requestable && (isOffsite || recap));
 
     if (isElectronicResource && item.electronicLocator[0].url) {
       status = { '@id': '', prefLabel: 'Available' };


### PR DESCRIPTION
Fixes #577 
Only displaying the "Request" button if `requestable` is true and there's `offsite` in the holding location string.

Examples:
* http://dev-discovery.nypl.org/research/collections/discovery-beta/search?q=toni%20morrison
* Appearing:
  * http://dev-discovery.nypl.org/research/collections/discovery-beta/bib/b14417507
* Not Appearing (but was before):
  * http://dev-discovery.nypl.org/research/collections/discovery-beta/bib/b15262926
  * http://dev-discovery.nypl.org/research/collections/discovery-beta/bib/b16346821