### PR TITLE
Updating name to Research Discovery (beta)

### DIFF
--- a/src/app/components/BibPage/BibPage.jsx
+++ b/src/app/components/BibPage/BibPage.jsx
@@ -32,11 +32,11 @@ const BibPage = (props) => {
   return (
     <DocumentTitle title={`${title} | Research Catalog`}>
       <main className="main-page">
-        <div className="nypl-homepage-hero">
+        <div className="nypl-page-header">
           <div className="nypl-full-width-wrapper">
             <div className="nypl-row">
               <div className="nypl-column-three-quarters">
-                <h1>Research Discovery (beta)</h1>
+                <h2>Research Discovery (beta)</h2>
                 <Search
                   searchKeywords={props.searchKeywords}
                   field={props.field}

--- a/src/app/components/BibPage/BibPage.jsx
+++ b/src/app/components/BibPage/BibPage.jsx
@@ -32,11 +32,11 @@ const BibPage = (props) => {
   return (
     <DocumentTitle title={`${title} | Research Catalog`}>
       <main className="main-page">
-        <div className="nypl-page-header">
+        <div className="nypl-homepage-hero">
           <div className="nypl-full-width-wrapper">
             <div className="nypl-row">
               <div className="nypl-column-three-quarters">
-                <h2>New York Public Library Research Catalog</h2>
+                <h1>Research Discovery (beta)</h1>
                 <Search
                   searchKeywords={props.searchKeywords}
                   field={props.field}

--- a/src/app/components/SearchResultsPage/SearchResultsPage.jsx
+++ b/src/app/components/SearchResultsPage/SearchResultsPage.jsx
@@ -56,12 +56,12 @@ const SearchResultsPage = (props, context) => {
         'Search Results | Research Catalog | NYPL'}
     >
       <main className="main-page">
-        <div className="nypl-homepage-hero">
+        <div className="nypl-page-header">
           <div className="nypl-full-width-wrapper">
             <div className="nypl-row">
               <div className="nypl-column-three-quarters">
                 {breadcrumbs}
-                <h1 aria-label={headerLabel}>Research Discovery (beta)</h1>
+                <h2 aria-label={headerLabel}>Research Discovery (beta)</h2>
                 <Search
                   searchKeywords={searchKeywords}
                   field={field}

--- a/src/app/components/SearchResultsPage/SearchResultsPage.jsx
+++ b/src/app/components/SearchResultsPage/SearchResultsPage.jsx
@@ -33,9 +33,9 @@ const SearchResultsPage = (props, context) => {
     <Breadcrumbs query={searchKeywords} type="search" />
   );
   const createAPIQuery = basicQuery(props);
-  const h1searchKeywordsLabel = searchKeywords ? `for ${searchKeywords}` : '';
-  const h1pageLabel = totalPages ? `page ${page} of ${totalPages}` : '';
-  const h2Label = `Search results ${h1searchKeywordsLabel} ${h1pageLabel}`;
+  const searchKeywordsLabel = searchKeywords ? `for ${searchKeywords}` : '';
+  const pageLabel = totalPages ? `page ${page} of ${totalPages}` : '';
+  const headerLabel = `Search results ${searchKeywordsLabel} ${pageLabel}`;
   const updatePage = (nextPage) => {
     Actions.updateSpinner(true);
     // Temporary. Need to check cross-browser and if it's needed at all.
@@ -56,14 +56,12 @@ const SearchResultsPage = (props, context) => {
         'Search Results | Research Catalog | NYPL'}
     >
       <main className="main-page">
-        <div className="nypl-page-header">
+        <div className="nypl-homepage-hero">
           <div className="nypl-full-width-wrapper">
             <div className="nypl-row">
               <div className="nypl-column-three-quarters">
                 {breadcrumbs}
-                <h2 aria-label={h2Label}>
-                  New York Public Library Research Catalog
-                </h2>
+                <h1 aria-label={headerLabel}>Research Discovery (beta)</h1>
                 <Search
                   searchKeywords={searchKeywords}
                   field={field}


### PR DESCRIPTION
Fixes #585 - for the most part. Other pages are being worked on and they should update the title to "Research Discovery (beta)" ( @ktp242 for the pages you're working on)

@wlla , do you think we still need the aria-label for the page h1 header on the Search Results page that says "Search results for Hamlet page 1 of 20" (for example)?