### PR TITLE
Adding logic to display owner for partner bibs if items have that pro…

### DIFF
--- a/src/app/components/BibPage/BibDetails.jsx
+++ b/src/app/components/BibPage/BibDetails.jsx
@@ -6,6 +6,8 @@ import {
   isEmpty as _isEmpty,
   findWhere as _findWhere,
   findIndex as _findIndex,
+  contains as _contains,
+  every as _every,
 } from 'underscore';
 
 import { ajaxCall } from '../../utils/utils';
@@ -70,6 +72,32 @@ const getDefinitionObject = (bibValues, fieldValue, fieldLinkable) => {
       }
     </ul>
   );
+};
+
+const getOwner = (bib) => {
+  const items = bib.items;
+  const ownerArr = [];
+  let owner;
+
+  if (!items || !items.length) {
+    return null;
+  }
+
+  items.forEach(item => {
+    const ownerObj = item.owner && item.owner.length ?
+      item.owner[0].prefLabel : undefined;
+
+    ownerArr.push(ownerObj);
+  });
+
+  if (_every(ownerArr, (o) => (o === ownerArr[0]))) {
+    if ((ownerArr[0] === 'Princeton University Library') ||
+      (ownerArr[0] === 'Columbia University Libraries')) {
+      owner = ownerArr[0];
+    }
+  }
+
+  return owner;
 };
 
 const getDefinition = (bibValues, fieldValue, fieldLinkable, fieldIdentifier) => {
@@ -201,6 +229,16 @@ class BibDetails extends React.Component {
               definition,
             });
           }
+        }
+      }
+
+      if (fieldLabel === 'Owning Institutions') {
+        const owner = getOwner(this.props.bib);
+        if (owner) {
+          fieldsToRender.push({
+            term: fieldLabel,
+            definition: owner,
+          });
         }
       }
     }); // End of the forEach loop

--- a/src/app/components/BibPage/BibDetails.jsx
+++ b/src/app/components/BibPage/BibDetails.jsx
@@ -74,6 +74,14 @@ const getDefinitionObject = (bibValues, fieldValue, fieldLinkable) => {
   );
 };
 
+/*
+ * getOwner(bib)
+ * This is currently only for non-NYPL partner items. If it's NYPL, it should return undefined.
+ * Requirement: Look at all the owners of all the items and if they were all the same and
+ * not NYPL, show that as the owning institution and otherwise show nothing.
+ * @param {object} bibId
+ * @return {string}
+ */
 const getOwner = (bib) => {
   const items = bib.items;
   const ownerArr = [];


### PR DESCRIPTION
…perty.

Fixes #566 

@seanredmond I think most non-nypl partner bibs have only one item. Haven't come across an example with multiple items to fully test, but it should be working.