### PR TITLE
Update edd form page error logic

### DIFF
--- a/src/app/components/ElectronicDelivery/ElectronicDeliveryForm.jsx
+++ b/src/app/components/ElectronicDelivery/ElectronicDeliveryForm.jsx
@@ -17,19 +17,19 @@ class ElectronicDeliveryForm extends React.Component {
     // empty object structure is needed.
     this.state = {
       form: !_isEmpty(this.props.form) ? this.props.form :
-      {
-        emailAddress: this.props.defaultEmail,
-        chapterTitle: '',
-        startPage: 0,
-        endPage: 0,
-      },
+        {
+          emailAddress: this.props.defaultEmail,
+          chapterTitle: '',
+          startPage: 0,
+          endPage: 0,
+        },
       error: !_isEmpty(this.props.error) ? this.props.error :
-      {
-        emailAddress: '',
-        chapterTitle: '',
-        startPage: 0,
-        endPage: 0,
-      },
+        {
+          emailAddress: '',
+          chapterTitle: '',
+          startPage: 0,
+          endPage: 0,
+        },
     };
 
     this.submit = this.submit.bind(this);
@@ -40,7 +40,7 @@ class ElectronicDeliveryForm extends React.Component {
     e.preventDefault();
 
     if (validate(this.state.form, (error) => {
-      this.setState({ error })
+      this.setState({ error });
       this.props.raiseError(error);
     })) {
       this.props.submitRequest(this.state);
@@ -65,6 +65,15 @@ class ElectronicDeliveryForm extends React.Component {
     _mapObject(this.state.form, (val, key) => {
       errorClass[key] = this.state.error[key] ? 'nypl-field-error' : '';
     });
+
+    let pageErrorMsg = 'You may request a maximum of 50 pages.';
+    let pageFieldErrorClass = '';
+
+    if (this.state.error.startPage || this.state.error.endPage) {
+      pageErrorMsg = 'Page values must be alphanumeric (no special characters). ' +
+        'You may request a maximum of 50 pages.';
+      pageFieldErrorClass = 'nypl-field-error';
+    }
 
     // A lot of this can be refactored to be in a loop but that's a later and next step.
     // I was thinking each `nypl-text-field` or `nypl-year-field` div can be
@@ -192,9 +201,7 @@ class ElectronicDeliveryForm extends React.Component {
           <h3>Select Page Number Range (Max 50 pages)</h3>
 
           <div
-            className={
-             `nypl-year-field ${(errorClass.startPage || errorClass.endPage) ? 'nypl-field-error' :''}`
-            }
+            className={`nypl-year-field ${pageFieldErrorClass}`}
           >
             <label htmlFor="start-page" id="start-page-label">Starting Page
               <span className="nypl-required-field">&nbsp;Required</span>
@@ -231,7 +238,7 @@ class ElectronicDeliveryForm extends React.Component {
               aria-live="assertive"
               aria-atomic="true"
             >
-              <span>{(this.state.error.startPage || this.state.error.startPage) ? this.state.error.startPage : 'You may request a maximum of 50 pages.'}</span>
+              <span>{pageErrorMsg}</span>
             </span>
           </div>
         </fieldset>


### PR DESCRIPTION
I was trying to update the previous EDD form PR but it got merged. So now here is the new PR!

This PR updates the logic to show the error message for page number fields. Previously each fields had their own but identical error messages and they were shown with each field's own error input. But now, based on the content updates, these two page fields will only show one error message together as long as one field has a bad input.

This PR still keeps the method to validate page number fields separately, but the results will be merged by the logic in `ElectronicDeliveryForm.jsx`

The content mock-up,
https://app.moqups.com/digitalrepository@nypl.org/55BjtB7Pm0/view/page/a7cc00da8