### PR TITLE
styles raised error based on toolkit

### DIFF
--- a/src/app/components/ElectronicDelivery/ElectronicDelivery.jsx
+++ b/src/app/components/ElectronicDelivery/ElectronicDelivery.jsx
@@ -142,8 +142,8 @@ class ElectronicDelivery extends React.Component {
               <h1>Electronic Delivery Request</h1>
               {
                 raiseError && (
-                  <div className="nypl-raised-error">
-                    <strong>Error</strong>
+                  <div className="nypl-form-error">
+                    <h2>Error</h2>
                     <p>Please check the following required fields and resubmit your request:</p>
                     <ul>
                       {

--- a/src/app/components/ElectronicDelivery/ElectronicDelivery.jsx
+++ b/src/app/components/ElectronicDelivery/ElectronicDelivery.jsx
@@ -140,19 +140,6 @@ class ElectronicDelivery extends React.Component {
           <div className="nypl-row">
             <div className="nypl-column-full">
               <h1>Electronic Delivery Request</h1>
-              {
-                raiseError && (
-                  <div className="nypl-form-error">
-                    <h2>Error</h2>
-                    <p>Please check the following required fields and resubmit your request:</p>
-                    <ul>
-                      {
-                        this.getRaisedErrors(raiseError)
-                      }
-                    </ul>
-                  </div>
-                )
-              }
               <h3>
                 Material request for Electronic Delivery:
                 <br />
@@ -173,6 +160,19 @@ class ElectronicDelivery extends React.Component {
 
           <div className="nypl-row">
             <div className="nypl-column-half">
+              {
+                raiseError && (
+                  <div className="nypl-form-error">
+                    <h2>Error</h2>
+                    <p>Please check the following required fields and resubmit your request:</p>
+                    <ul>
+                      {
+                        this.getRaisedErrors(raiseError)
+                      }
+                    </ul>
+                  </div>
+                )
+              }
               <ElectronicDeliveryForm
                 bibId={bibId}
                 itemId={itemId}

--- a/src/client/styles/main.scss
+++ b/src/client/styles/main.scss
@@ -117,8 +117,8 @@ button {
   height: 500px;
 }
 
-.nypl-raised-error {
-  color: red;
+.nypl-form-error li {
+  margin-left: 0.5rem;
 }
 
 // odd override for Header alert


### PR DESCRIPTION
This is for #597. I shouldn't have to add this extra shim, but the `<li>` tags do not honor what should be in the toolkit... would like to investigate but maybe will be resolved with a toolkit bump in the future. CC @ricardoom 