### PR TITLE
Updated the validation for chapter title.

### DIFF
--- a/src/app/utils/formValidationUtils.js
+++ b/src/app/utils/formValidationUtils.js
@@ -114,7 +114,7 @@ function validate(form, cb) {
       errorMsg: 'Enter a valid email address. Your request will be delivered to the email address you enter above.',
     },
     chapterTitle: {
-      validate: (val) => (isNumeric('' + val) && val > 0) ? true : false,
+      validate: (val) => (val.trim().length) ? true : false,
       errorMsg: 'Indicate the title of the chapter or article you are requesting. Enter "none" if you are requesting an entire item.',
     },
     startPage: {


### PR DESCRIPTION
This PR updates the validation for chapter title in EDD form. Now the chapter title can be a string such as `chapter 4` or `IX`. @RobKelley @seanredmond @gkallenberg 

It fixes the issue #615 and [DIS-92](https://jira.nypl.org/browse/DIS-92)
On dev now