### PR TITLE
Add default delivery location

### DIFF
--- a/src/app/components/HoldRequest/HoldRequest.jsx
+++ b/src/app/components/HoldRequest/HoldRequest.jsx
@@ -19,6 +19,7 @@ class HoldRequest extends React.Component {
 
     this.state = _extend({
       delivery: false,
+      checkedLocNum: 0,
     }, { patron: PatronStore.getState() });
 
     // change all the components :(
@@ -35,8 +36,11 @@ class HoldRequest extends React.Component {
     this.setState({ patron: PatronStore.getState() });
   }
 
-  onRadioSelect(e) {
-    this.setState({ delivery: e.target.value });
+  onRadioSelect(e, i) {
+    this.setState({
+      delivery: e.target.value,
+      checkedLocNum: i,
+    });
   }
 
   /**
@@ -156,7 +160,8 @@ class HoldRequest extends React.Component {
             name="delivery-location"
             id={`location${i}`}
             value={location['@id'].replace('loc:', '')}
-            onChange={this.onRadioSelect}
+            checked={i === this.state.checkedLocNum}
+            onChange={(e) => { this.onRadioSelect(e, i)}}
           />
           <span className="nypl-screenreader-only">Send to:</span>
           <span>{displayName}</span><br />

--- a/src/app/components/HoldRequest/HoldRequest.jsx
+++ b/src/app/components/HoldRequest/HoldRequest.jsx
@@ -17,10 +17,14 @@ class HoldRequest extends React.Component {
   constructor(props) {
     super(props);
 
+    const deliveryLocationsFromAPI = this.props.deliveryLocations.length;
+    const firstLocationValue = (deliveryLocationsFromAPI[0]['@id'] &&
+      typeof deliveryLocationsFromAPI[0]['@id'] === 'string') ?
+      deliveryLocationsFromAPI[0]['@id'].replace('loc:', '');
+
     this.state = _extend({
-      delivery: (this.props.deliveryLocations.length > 0) ?
-        this.props.deliveryLocations[0]['@id'].replace('loc:', '') : 'edd',
-      checkedLocNum: (this.props.deliveryLocations.length > 0) ? 0 : -1,
+      delivery: deliveryLocationsFromAPI.length ? firstLocationValue : 'edd',
+      checkedLocNum: deliveryLocationsFromAPI.length ? 0 : -1,
     }, { patron: PatronStore.getState() });
 
     // change all the components :(
@@ -154,6 +158,9 @@ class HoldRequest extends React.Component {
         location.prefLabel, location.shortName
       );
 
+      const value = (location['@id'] && typeof location['@id'] === 'string') ?
+        location['@id'].replace('loc:', '') : '';
+
       return (
         <label htmlFor={`location${i}`} id={`location${i}-label`} key={i}>
           <input
@@ -161,7 +168,7 @@ class HoldRequest extends React.Component {
             type="radio"
             name="delivery-location"
             id={`location${i}`}
-            value={location['@id'].replace('loc:', '')}
+            value
             checked={i === this.state.checkedLocNum}
             onChange={(e) => { this.onRadioSelect(e, i); }}
           />

--- a/src/app/components/HoldRequest/HoldRequest.jsx
+++ b/src/app/components/HoldRequest/HoldRequest.jsx
@@ -138,7 +138,7 @@ class HoldRequest extends React.Component {
           id="available-electronic-delivery"
           value="edd"
           checked={this.state.checkedLocNum === -1}
-          onChange={(e) => { this.onRadioSelect(e, -1); }}
+          onChange={(e) => this.onRadioSelect(e, -1)}
         />
         Have up to 50 pages scanned and sent to you via electronic mail.
       </label>
@@ -170,7 +170,7 @@ class HoldRequest extends React.Component {
             id={`location${i}`}
             value
             checked={i === this.state.checkedLocNum}
-            onChange={(e) => { this.onRadioSelect(e, i); }}
+            onChange={(e) => this.onRadioSelect(e, i)}
           />
           <span className="nypl-screenreader-only">Send to:</span>
           <span>{displayName}</span><br />

--- a/src/app/components/HoldRequest/HoldRequest.jsx
+++ b/src/app/components/HoldRequest/HoldRequest.jsx
@@ -18,7 +18,8 @@ class HoldRequest extends React.Component {
     super(props);
 
     this.state = _extend({
-      delivery: false,
+      delivery: (this.props.deliveryLocations.length > 0) ?
+        this.props.deliveryLocations[0]['@id'].replace('loc:', '') : 'edd',
       checkedLocNum: (this.props.deliveryLocations.length > 0 ) ? 0 : -1,
     }, { patron: PatronStore.getState() });
 

--- a/src/app/components/HoldRequest/HoldRequest.jsx
+++ b/src/app/components/HoldRequest/HoldRequest.jsx
@@ -19,7 +19,7 @@ class HoldRequest extends React.Component {
 
     this.state = _extend({
       delivery: false,
-      checkedLocNum: 0,
+      checkedLocNum: (this.props.deliveryLocations.length > 0 ) ? 0 : -1,
     }, { patron: PatronStore.getState() });
 
     // change all the components :(
@@ -132,7 +132,8 @@ class HoldRequest extends React.Component {
           name="delivery-location"
           id="available-electronic-delivery"
           value="edd"
-          onChange={this.onRadioSelect}
+          checked={this.state.checkedLocNum === -1}
+          onChange={(e) => { this.onRadioSelect(e, -1)}}
         />
         Have up to 50 pages scanned and sent to you via electronic mail.
       </label>

--- a/src/app/components/HoldRequest/HoldRequest.jsx
+++ b/src/app/components/HoldRequest/HoldRequest.jsx
@@ -20,7 +20,7 @@ class HoldRequest extends React.Component {
     this.state = _extend({
       delivery: (this.props.deliveryLocations.length > 0) ?
         this.props.deliveryLocations[0]['@id'].replace('loc:', '') : 'edd',
-      checkedLocNum: (this.props.deliveryLocations.length > 0 ) ? 0 : -1,
+      checkedLocNum: (this.props.deliveryLocations.length > 0) ? 0 : -1,
     }, { patron: PatronStore.getState() });
 
     // change all the components :(
@@ -134,7 +134,7 @@ class HoldRequest extends React.Component {
           id="available-electronic-delivery"
           value="edd"
           checked={this.state.checkedLocNum === -1}
-          onChange={(e) => { this.onRadioSelect(e, -1)}}
+          onChange={(e) => { this.onRadioSelect(e, -1); }}
         />
         Have up to 50 pages scanned and sent to you via electronic mail.
       </label>
@@ -163,7 +163,7 @@ class HoldRequest extends React.Component {
             id={`location${i}`}
             value={location['@id'].replace('loc:', '')}
             checked={i === this.state.checkedLocNum}
-            onChange={(e) => { this.onRadioSelect(e, i)}}
+            onChange={(e) => { this.onRadioSelect(e, i); }}
           />
           <span className="nypl-screenreader-only">Send to:</span>
           <span>{displayName}</span><br />

--- a/src/app/components/HoldRequest/HoldRequest.jsx
+++ b/src/app/components/HoldRequest/HoldRequest.jsx
@@ -17,15 +17,17 @@ class HoldRequest extends React.Component {
   constructor(props) {
     super(props);
 
-    const deliveryLocationsFromAPI = this.props.deliveryLocations.length;
-    const firstLocationValue = (deliveryLocationsFromAPI[0]['@id'] &&
+    const deliveryLocationsFromAPI = this.props.deliveryLocations;
+    const firstLocationValue = (
+      deliveryLocationsFromAPI.length &&
+      deliveryLocationsFromAPI[0]['@id'] &&
       typeof deliveryLocationsFromAPI[0]['@id'] === 'string') ?
-      deliveryLocationsFromAPI[0]['@id'].replace('loc:', '');
+      deliveryLocationsFromAPI[0]['@id'].replace('loc:', '') : '';
 
     this.state = _extend({
       // If we have any delivery locations in the array that we receive from the API,
       // set the first location as the selected option. 
-      // If there's no delivery locations, set the selected option as "-1" to
+      // If there's no delivery locations returned, set the selected option as "-1" to
       // indicate the selected option and its value is "edd".
       delivery: deliveryLocationsFromAPI.length ? firstLocationValue : 'edd',
       checkedLocNum: deliveryLocationsFromAPI.length ? 0 : -1,
@@ -172,7 +174,7 @@ class HoldRequest extends React.Component {
             type="radio"
             name="delivery-location"
             id={`location${i}`}
-            value
+            value={value}
             checked={i === this.state.checkedLocNum}
             onChange={(e) => this.onRadioSelect(e, i)}
           />

--- a/src/app/components/HoldRequest/HoldRequest.jsx
+++ b/src/app/components/HoldRequest/HoldRequest.jsx
@@ -23,6 +23,10 @@ class HoldRequest extends React.Component {
       deliveryLocationsFromAPI[0]['@id'].replace('loc:', '');
 
     this.state = _extend({
+      // If we have any delivery locations in the array that we receive from the API,
+      // set the first location as the selected option. 
+      // If there's no delivery locations, set the selected option as "-1" to
+      // indicate the selected option and its value is "edd".
       delivery: deliveryLocationsFromAPI.length ? firstLocationValue : 'edd',
       checkedLocNum: deliveryLocationsFromAPI.length ? 0 : -1,
     }, { patron: PatronStore.getState() });


### PR DESCRIPTION
This PR adds the default delivery location to the Hold Request form. The logic will be
1) If the item has physical delivery locations, the default will be the first location.
2) If the item has only EDD, the default delivery location will be EDD.

on dev now