### PR TITLE
Block submitting when no results

### DIFF
--- a/src/app/components/HoldRequest/HoldRequest.jsx
+++ b/src/app/components/HoldRequest/HoldRequest.jsx
@@ -208,9 +208,8 @@ class HoldRequest extends React.Component {
     const isEddRequestable = this.props.isEddRequestable;
     let deliveryLocationInstruction =
       (!deliveryLocations.length && !isEddRequestable) ?
-      'Delivery options for this item are currently unavailable. ' +
-      'Please try again later or contact 917-ASK-NYPL (917-275-6975).' :
-      'Choose a delivery option or location';
+      <h4>Delivery options for this item are currently unavailable. Please try again later or contact 917-ASK-NYPL (<a href="tel:917-275-6975">917-275-6975</a>).</h4> :
+      <h4>Choose a delivery option or location</h4>;
     let form = null;
 
     if (bib) {
@@ -221,7 +220,7 @@ class HoldRequest extends React.Component {
           method="POST"
           onSubmit={(e) => this.submitRequest(e, bibId, itemId, itemSource)}
         >
-          <h4>{deliveryLocationInstruction}</h4>
+          {deliveryLocationInstruction}
           <div className="nypl-request-radiobutton-field">
             <fieldset>
               <legend className="visuallyHidden" id="radiobutton-group1">

--- a/src/app/components/HoldRequest/HoldRequest.jsx
+++ b/src/app/components/HoldRequest/HoldRequest.jsx
@@ -208,7 +208,9 @@ class HoldRequest extends React.Component {
     const isEddRequestable = this.props.isEddRequestable;
     let deliveryLocationInstruction =
       (!deliveryLocations.length && !isEddRequestable) ?
-      'No delivery option is available' : 'Choose a delivery option or location';
+      'Delivery options for this item are currently unavailable. ' +
+      'Please try again later or contact 917-ASK-NYPL (917-275-6975).' :
+      'Choose a delivery option or location';
     let form = null;
 
     if (bib) {

--- a/src/app/components/HoldRequest/HoldRequest.jsx
+++ b/src/app/components/HoldRequest/HoldRequest.jsx
@@ -26,7 +26,7 @@ class HoldRequest extends React.Component {
 
     this.state = _extend({
       // If we have any delivery locations in the array that we receive from the API,
-      // set the first location as the selected option. 
+      // set the first location as the selected option.
       // If there's no delivery locations returned, set the selected option as "-1" to
       // indicate the selected option and its value is "edd".
       delivery: deliveryLocationsFromAPI.length ? firstLocationValue : 'edd',
@@ -206,7 +206,8 @@ class HoldRequest extends React.Component {
     const itemSource = selectedItem.itemSource;
     const deliveryLocations = this.props.deliveryLocations;
     const isEddRequestable = this.props.isEddRequestable;
-    const deliveryLocationInstruction = (!deliveryLocations.length && !isEddRequestable) ?
+    let deliveryLocationInstruction =
+      (!deliveryLocations.length && !isEddRequestable) ?
       'No delivery option is available' : 'Choose a delivery option or location';
     let form = null;
 
@@ -230,9 +231,12 @@ class HoldRequest extends React.Component {
 
             <input type="hidden" name="pickupLocation" value="test" />
           </div>
-          <button type="submit" className="nypl-request-button">
-            Submit request
-          </button>
+          {
+            (deliveryLocations.length || isEddRequestable) &&
+              <button type="submit" className="nypl-request-button">
+                Submit request
+              </button>
+          }
         </form>
       );
     }

--- a/src/app/components/HoldRequest/HoldRequest.jsx
+++ b/src/app/components/HoldRequest/HoldRequest.jsx
@@ -204,6 +204,10 @@ class HoldRequest extends React.Component {
         </div>
       ) : null;
     const itemSource = selectedItem.itemSource;
+    const deliveryLocations = this.props.deliveryLocations;
+    const isEddRequestable = this.props.isEddRequestable;
+    const deliveryLocationInstruction = (!deliveryLocations.length && !isEddRequestable) ?
+      'No delivery option is available' : 'Choose a delivery option or location';
     let form = null;
 
     if (bib) {
@@ -214,7 +218,7 @@ class HoldRequest extends React.Component {
           method="POST"
           onSubmit={(e) => this.submitRequest(e, bibId, itemId, itemSource)}
         >
-          <h4>Choose a delivery option or location</h4>
+          <h4>{deliveryLocationInstruction}</h4>
           <div className="nypl-request-radiobutton-field">
             <fieldset>
               <legend className="visuallyHidden" id="radiobutton-group1">


### PR DESCRIPTION
This PR adds the logic to skip rendering submit request button on Hold Request page if for some reason the patron doesn't get any delivery locations back from the API and also no EDD available. The content for the no delivery location is temporary and needs to be created.