### PR TITLE
Fixing default selected value for the field dropdown in the omnisearc…

### DIFF
--- a/src/app/components/Search/Search.jsx
+++ b/src/app/components/Search/Search.jsx
@@ -18,7 +18,7 @@ class Search extends React.Component {
 
     this.state = {
       spinning: this.props.spinning,
-      field: this.props.field,
+      field: this.props.field || 'all',
       searchKeywords: this.props.searchKeywords,
     };
 
@@ -154,7 +154,7 @@ Search.propTypes = {
 };
 
 Search.defaultProps = {
-  field: '',
+  field: 'all',
   searchKeywords: '',
   spinning: false,
 };

--- a/src/app/components/Sorter/Sorter.jsx
+++ b/src/app/components/Sorter/Sorter.jsx
@@ -83,7 +83,7 @@ class Sorter extends React.Component {
    */
   renderResultsSort() {
     return sortingOpts.map((d, i) => (
-      <option value={d.val} key={i} selected={d.val === this.state.sortValue}>
+      <option value={d.val} key={i}>
         {d.label}
       </option>
     ));

--- a/src/client/styles/components/design-toolkit-updates.scss
+++ b/src/client/styles/components/design-toolkit-updates.scss
@@ -1,6 +1,5 @@
 .nypl-omnisearch .nypl-omni-fields select {
   color: #000;
-  background: #fff;
 }
 
 a {


### PR DESCRIPTION
…h and fixing same issue for the sorter dropdown.

Fixes #630

Also updated the `Sorter` select. Note, the `selected` property appears on load and when refreshing the page, but not when selecting a new option. I noticed other dropdowns do the same thing, so I guess it's fine to not update the `selected` property every time the user updates it. Followed the [React docs](https://facebook.github.io/react/docs/forms.html).