### PR TITLE
Fallbacks for not necessary edd form fields

### DIFF
--- a/src/app/components/HoldConfirmation/HoldConfirmation.jsx
+++ b/src/app/components/HoldConfirmation/HoldConfirmation.jsx
@@ -82,13 +82,21 @@ class HoldConfirmation extends React.Component {
   renderLocationInfo(loc) {
     if (!loc || _isEmpty(loc)) { return null; }
 
-    const prefLabel = this.modelDeliveryLocationName(loc.prefLabel, loc.shortName);
+    if (loc.shortName === 'n/a') {
+      return (
+        <span>
+          {loc.prefLabel}
+        </span>
+      );
+    } else {
+      const prefLabel = this.modelDeliveryLocationName(loc.prefLabel, loc.shortName);
 
-    return (
-      <span>
-        {prefLabel}
-      </span>
-    );
+      return (
+        <span>
+          {prefLabel}
+        </span>
+      );
+    }
   }
 
   /**
@@ -130,6 +138,7 @@ class HoldConfirmation extends React.Component {
           id: null,
           address: null,
           prefLabel: 'n/a (electronic delivery)',
+          shortName: 'n/a',
         };
       }
     }

--- a/src/app/components/HoldConfirmation/HoldConfirmation.jsx
+++ b/src/app/components/HoldConfirmation/HoldConfirmation.jsx
@@ -88,15 +88,15 @@ class HoldConfirmation extends React.Component {
           {loc.prefLabel}
         </span>
       );
-    } else {
-      const prefLabel = this.modelDeliveryLocationName(loc.prefLabel, loc.shortName);
-
-      return (
-        <span>
-          {prefLabel}
-        </span>
-      );
     }
+
+    const prefLabel = this.modelDeliveryLocationName(loc.prefLabel, loc.shortName);
+
+    return (
+      <span>
+        {prefLabel}
+      </span>
+    );
   }
 
   /**

--- a/src/app/utils/formValidationUtils.js
+++ b/src/app/utils/formValidationUtils.js
@@ -129,7 +129,7 @@ function validate(form, cb) {
 
   const error = {};
   _mapObject(form, (val, key) => {
-    const isValid = fieldsToCheck[key].validate(val);
+    const isValid = (fieldsToCheck[key]) ? fieldsToCheck[key].validate(val) : true;
 
     if (!isValid) {
       error[key] = fieldsToCheck[key].errorMsg;


### PR DESCRIPTION
Should fix #637 

I think the problem is we removed the validation for non-required fields so once the script in `src/app/utils/formValidationUtils.js` line 131 loop through the form, it can't find the respective key within the object `fieldsToCheck`.