### PR TITLE
Adding jobId to confirmation url and using that to check against patr…

### DIFF
--- a/src/app/components/HoldRequest/HoldRequest.jsx
+++ b/src/app/components/HoldRequest/HoldRequest.jsx
@@ -96,8 +96,7 @@ class HoldRequest extends React.Component {
           this.context.router.push(`${path}?errorMessage=${response.data.error.statusText}`);
         } else {
           this.context.router.push(
-            `${path}?pickupLocation=${response.data.pickupLocation}&requestId=${response.data.id}` +
-            `&jobId=${response.data.jobId}`
+            `${path}?pickupLocation=${response.data.pickupLocation}&requestId=${response.data.id}`
           );
         }
       })

--- a/src/app/components/HoldRequest/HoldRequest.jsx
+++ b/src/app/components/HoldRequest/HoldRequest.jsx
@@ -96,7 +96,8 @@ class HoldRequest extends React.Component {
           this.context.router.push(`${path}?errorMessage=${response.data.error.statusText}`);
         } else {
           this.context.router.push(
-            `${path}?pickupLocation=${response.data.pickupLocation}&requestId=${response.data.id}`
+            `${path}?pickupLocation=${response.data.pickupLocation}&requestId=${response.data.id}` +
+            `&jobId=${response.data.jobId}`
           );
         }
       })

--- a/src/server/ApiRoutes/Hold.js
+++ b/src/server/ApiRoutes/Hold.js
@@ -154,6 +154,7 @@ function confirmRequestServer(req, res, next) {
   const jobId = req.query.jobId || '';
 
   if (!loggedIn) return false;
+  if (!jobId) return res.redirect(`${appConfig.baseUrl}/`);
 
   const accessToken = req.tokenResponse.accessToken || '';
   const patronId = req.tokenResponse.decodedPatron.sub || '';

--- a/src/server/ApiRoutes/Hold.js
+++ b/src/server/ApiRoutes/Hold.js
@@ -169,10 +169,10 @@ function confirmRequestServer(req, res, next) {
     })
     .then(response => {
       const data = response.data.data;
-      const patronIdFromJobId = data.patron;
+      const patronIdFromHoldRequest = data.patron;
 
       // The patron who is seeing the confirmation made the Hold Request
-      if (patronIdFromJobId === patronId) {
+      if (patronIdFromHoldRequest === patronId) {
         // Retrieve item
         return Bib.fetchBib(
           bibId,
@@ -225,7 +225,12 @@ function confirmRequestServer(req, res, next) {
       res.redirect(`${appConfig.baseUrl}/`);
       return false;
     })
-    .catch(requestIdError => console.log(requestIdError));
+    .catch(requestIdError => {
+      console.log(`Error fetching Hold Request from id. Error: ${requestIdError}`);
+
+      res.redirect(`${appConfig.baseUrl}/`);
+      return false;
+    });
 }
 
 /**

--- a/src/server/ApiRoutes/Hold.js
+++ b/src/server/ApiRoutes/Hold.js
@@ -151,6 +151,7 @@ function confirmRequestServer(req, res, next) {
   const bibId = req.params.bibId || '';
   const loggedIn = User.requireUser(req, res);
   const error = req.query.error ? JSON.parse(req.query.error) : {};
+  const jobId = req.query.jobId || '';
 
   if (!loggedIn) return false;
 
@@ -158,50 +159,70 @@ function confirmRequestServer(req, res, next) {
   const patronId = req.tokenResponse.decodedPatron.sub || '';
   let barcode;
 
-  // Retrieve item
-  return Bib.fetchBib(
-    bibId,
-    (bibResponseData) => {
-      barcode = LibraryItem.getItem(bibResponseData, req.params.itemId).barcode;
+  return axios
+    .get(`${apiBase}/jobs/${jobId}`)
+    .then(response => {
+      const data = response.data.data;
+      let patronIdFromJobId;
+      if (data.notices && data.notices.length) {
+        patronIdFromJobId = data.notices[0].data.patron;
+      }
 
-      getDeliveryLocations(
-        barcode,
-        patronId,
-        accessToken,
-        (deliveryLocations, isEddRequestable) => {
-          res.locals.data.Store = {
-            bib: bibResponseData,
-            searchKeywords: '',
-            error,
-            deliveryLocations,
-            isEddRequestable,
-          };
-          next();
-        },
-        (e) => {
-          console.error(`deliverylocationsbybarcode API error: ${JSON.stringify(e, null, 2)}`);
+      // The patron who is seeing the confirmation made the Hold Request
+      if (patronIdFromJobId === patronId) {
+        // Retrieve item
+        return Bib.fetchBib(
+          bibId,
+          (bibResponseData) => {
+            barcode = LibraryItem.getItem(bibResponseData, req.params.itemId).barcode;
 
-          res.locals.data.Store = {
-            bib: bibResponseData,
-            searchKeywords: '',
-            error,
-            deliveryLocations: [],
-            isEddRequestable: false,
-          };
+            getDeliveryLocations(
+              barcode,
+              patronId,
+              accessToken,
+              (deliveryLocations, isEddRequestable) => {
+                res.locals.data.Store = {
+                  bib: bibResponseData,
+                  searchKeywords: '',
+                  error,
+                  deliveryLocations,
+                  isEddRequestable,
+                };
+                next();
+              },
+              (e) => {
+                console.error(
+                  `deliverylocationsbybarcode API error: ${JSON.stringify(e, null, 2)}`
+                );
 
-          next();
-        }
-      );
-    },
-    (bibResponseError) => {
-      res.locals.data.Store = {
-        bib: {},
-        searchKeywords: '',
-        error,
-      };
-      next();
-    }
-  );
+                res.locals.data.Store = {
+                  bib: bibResponseData,
+                  searchKeywords: '',
+                  error,
+                  deliveryLocations: [],
+                  isEddRequestable: false,
+                };
+
+                next();
+              }
+            );
+          },
+          (bibResponseError) => {
+            res.locals.data.Store = {
+              bib: {},
+              searchKeywords: '',
+              error,
+            };
+            next();
+          }
+        );
+      }
+
+      // Else redirect to the homepage:
+      res.redirect(`${appConfig.baseUrl}/`);
+      return false;
+    })
+    .catch(jobIdError => console.log(jobIdError));
 }
 
 /**


### PR DESCRIPTION
…on identity.

Better fix for #564 

Instead of passing the patron's ID into the URL as a query, I'm passing the jobId into the URL as a query parameter. On the server side I'm making a request to `api/jobs/:id` and retrieving the patron's id from there. If that patron id doesn't match up with the current patron who is logged in, then they will be redirected to the homepage. Add a bit of complexity to the hold request confirmation page but it's working.

@kfriedman I'll need your approval on using the jobId in this way.