### PR TITLE
Making the placeholder text darker for the omnisearch input field.

### DIFF
--- a/src/client/styles/components/_forms.v2.scss
+++ b/src/client/styles/components/_forms.v2.scss
@@ -50,3 +50,28 @@
     margin-left: 1rem;
   }
 }
+
+.nypl-omnisearch {
+  input[type=text] {
+    &::placeholder {
+      opacity: 1;
+      color: #000;
+    }
+    &::-webkit-input-placeholder { /* Chrome/Opera/Safari */
+      opacity: 1;
+      color: #000;
+    }
+    &::-moz-placeholder { /* Firefox 19+ */
+      opacity: 1;
+      color: #000;
+    }
+    &:-ms-input-placeholder { /* IE 10+ */
+      opacity: 1;
+      color: #000;
+    }
+    &:-moz-placeholder { /* Firefox 18- */
+      opacity: 1;
+      color: #000;
+    }
+  }
+}

--- a/src/client/styles/style-v2.scss
+++ b/src/client/styles/style-v2.scss
@@ -1,4 +1,3 @@
-
 #skip a {
   background-color: $nypl-white;
   border: 0;


### PR DESCRIPTION
Fixes #648 

It's so odd that I couldn't put the styles together or else it wouldn't work. I tried:
```
&::placeholder,
&::-webkit-input-placeholder,
... etc
```
So, it seems like they have to be in separate rules to work. Got the pseudo classes/elements from this recent article:
https://css-tricks.com/almanac/selectors/p/placeholder/