### PR TITLE
Back to search button

### DIFF
--- a/src/app/components/BibPage/BibPage.jsx
+++ b/src/app/components/BibPage/BibPage.jsx
@@ -35,6 +35,7 @@ const BibPage = (props) => {
       items={items}
       bibId={bibId}
       itemPage={itemPage}
+      searchKeywords={props.searchKeywords}
     /> : null;
   const marcRecord = isNYPLReCAP ? <MarcRecord bNumber={bNumber[0]} /> : null;
 

--- a/src/app/components/ElectronicDelivery/ElectronicDelivery.jsx
+++ b/src/app/components/ElectronicDelivery/ElectronicDelivery.jsx
@@ -75,7 +75,13 @@ class ElectronicDelivery extends React.Component {
       itemSource,
     } = this.state;
     const path = `${appConfig.baseUrl}/hold/confirmation/${bibId}-${itemId}`;
-    const data = _extend({ bibId, itemId, pickupLocation: 'edd', itemSource }, fields);
+    const data = _extend({
+      bibId,
+      itemId,
+      pickupLocation: 'edd',
+      itemSource,
+      searchKeywords: this.props.searchKeywords,
+    }, fields);
 
     axios
       .post(`${appConfig.baseUrl}/api/newHold`, data)
@@ -109,7 +115,6 @@ class ElectronicDelivery extends React.Component {
   }
 
   render() {
-    const searchKeywords = this.props.searchKeywords || '';
     const {
       bibId,
       itemId,
@@ -123,6 +128,7 @@ class ElectronicDelivery extends React.Component {
       this.state.patron.emails && _isArray(this.state.patron.emails)
       && this.state.patron.emails.length
       ) ? this.state.patron.emails[0] : '';
+    const searchKeywords = this.props.searchKeywords;
 
     return (
       <div id="mainContent">
@@ -209,6 +215,10 @@ ElectronicDelivery.propTypes = {
   params: PropTypes.object,
   error: PropTypes.object,
   form: PropTypes.object,
+};
+
+ElectronicDelivery.defaultProps = {
+  searchKeywords: '',
 };
 
 

--- a/src/app/components/ElectronicDelivery/ElectronicDelivery.jsx
+++ b/src/app/components/ElectronicDelivery/ElectronicDelivery.jsx
@@ -189,6 +189,7 @@ class ElectronicDelivery extends React.Component {
               error={error}
               form={form}
               defaultEmail={patronEmail}
+              searchKeywords={searchKeywords}
             />
           </div>
         </div>

--- a/src/app/components/ElectronicDelivery/ElectronicDelivery.jsx
+++ b/src/app/components/ElectronicDelivery/ElectronicDelivery.jsx
@@ -90,7 +90,7 @@ class ElectronicDelivery extends React.Component {
         } else {
           this.context.router.push(
             `${path}?pickupLocation=edd&requestId=${response.data.id}` +
-            + `&searchKeywords=${this.props.searchKeywords}`
+            `&searchKeywords=${this.props.searchKeywords}`
           );
         }
       })

--- a/src/app/components/ElectronicDelivery/ElectronicDelivery.jsx
+++ b/src/app/components/ElectronicDelivery/ElectronicDelivery.jsx
@@ -89,8 +89,8 @@ class ElectronicDelivery extends React.Component {
           this.context.router.push(`${path}?errorMessage=${response.data.error.statusText}`);
         } else {
           this.context.router.push(
-            `${path}?pickupLocation=edd&searchKeywords=${this.props.searchKeywords}` +
-            `&requestId=${response.data.id}`
+            `${path}?pickupLocation=edd&requestId=${response.data.id}` +
+            + `&searchKeywords=${this.props.searchKeywords}`
           );
         }
       })

--- a/src/app/components/ElectronicDelivery/ElectronicDelivery.jsx
+++ b/src/app/components/ElectronicDelivery/ElectronicDelivery.jsx
@@ -80,7 +80,6 @@ class ElectronicDelivery extends React.Component {
       itemId,
       pickupLocation: 'edd',
       itemSource,
-      searchKeywords: this.props.searchKeywords,
     }, fields);
 
     axios
@@ -89,7 +88,10 @@ class ElectronicDelivery extends React.Component {
         if (response.data.error && response.data.error.status !== 200) {
           this.context.router.push(`${path}?errorMessage=${response.data.error.statusText}`);
         } else {
-          this.context.router.push(`${path}?pickupLocation=edd&requestId=${response.data.id}`);
+          this.context.router.push(
+            `${path}?pickupLocation=edd&searchKeywords=${this.props.searchKeywords}` +
+            `&requestId=${response.data.id}`
+          );
         }
       })
       .catch(error => {

--- a/src/app/components/ElectronicDelivery/ElectronicDeliveryForm.jsx
+++ b/src/app/components/ElectronicDelivery/ElectronicDeliveryForm.jsx
@@ -281,6 +281,11 @@ class ElectronicDeliveryForm extends React.Component {
         <input type="hidden" name="itemId" value={this.props.itemId} />
         <input type="hidden" name="pickupLocation" value="edd" />
         <input type="hidden" name="itemSource" value={this.props.itemSource} />
+        <input
+          type="hidden"
+          name="searchKeywords"
+          value={(this.props.searchKeywords) ? this.props.searchKeywords : ''}
+        />
 
         <button type="submit" className="nypl-request-button" onClick={this.submit} onSubmit={this.submit}>
           Submit request

--- a/src/app/components/ElectronicDelivery/ElectronicDeliveryForm.jsx
+++ b/src/app/components/ElectronicDelivery/ElectronicDeliveryForm.jsx
@@ -284,7 +284,7 @@ class ElectronicDeliveryForm extends React.Component {
         <input
           type="hidden"
           name="searchKeywords"
-          value={(this.props.searchKeywords) ? this.props.searchKeywords : ''}
+          value={this.props.searchKeywords}
         />
 
         <button
@@ -315,6 +315,7 @@ ElectronicDeliveryForm.propTypes = {
 
 ElectronicDeliveryForm.defaultProps = {
   defaultEmail: '',
+  searchKeywords: '',
 };
 
 export default ElectronicDeliveryForm;

--- a/src/app/components/ElectronicDelivery/ElectronicDeliveryForm.jsx
+++ b/src/app/components/ElectronicDelivery/ElectronicDeliveryForm.jsx
@@ -287,7 +287,12 @@ class ElectronicDeliveryForm extends React.Component {
           value={(this.props.searchKeywords) ? this.props.searchKeywords : ''}
         />
 
-        <button type="submit" className="nypl-request-button" onClick={this.submit} onSubmit={this.submit}>
+        <button
+          type="submit"
+          className="nypl-request-button"
+          onClick={this.submit}
+          onSubmit={this.submit}
+        >
           Submit request
         </button>
       </form>
@@ -305,6 +310,7 @@ ElectronicDeliveryForm.propTypes = {
   error: PropTypes.object,
   form: PropTypes.object,
   defaultEmail: PropTypes.string,
+  searchKeywords: PropTypes.string,
 };
 
 ElectronicDeliveryForm.defaultProps = {

--- a/src/app/components/HoldConfirmation/HoldConfirmation.jsx
+++ b/src/app/components/HoldConfirmation/HoldConfirmation.jsx
@@ -55,6 +55,18 @@ class HoldConfirmation extends React.Component {
   }
 
   /**
+   * goSearchResults(e)
+   * @param {event}
+   * Renders the route back to home page for single page application implementation.
+   *
+   */
+  goSearchResults(e) {
+    e.preventDefault();
+
+    this.context.router.push(`${appConfig.baseUrl}/search?${this.props.searchKeywords}`);
+  }
+
+  /**
    * modelDeliveryLocationName(prefLabel, shortName)
    * Renders the names of the radio input fields of delivery locations except EDD.
    *
@@ -109,7 +121,7 @@ class HoldConfirmation extends React.Component {
     return (
       <Link
         className="nypl-request-button"
-        to="/"
+        to={`${appConfig.baseUrl}/`}
         onClick={(e) => this.goRestart(e)}
       >
         Start Over
@@ -127,8 +139,8 @@ class HoldConfirmation extends React.Component {
     return (
       <Link
         className="nypl-request-button"
-        to="/"
-        onClick={(e) => this.goRestart(e)}
+        to={`${appConfig.baseUrl}/search?${this.props.searchKeywords}`}
+        onClick={(e) => this.goSearchResults(e)}
       >
         Back to results
       </Link>

--- a/src/app/components/HoldConfirmation/HoldConfirmation.jsx
+++ b/src/app/components/HoldConfirmation/HoldConfirmation.jsx
@@ -63,7 +63,7 @@ class HoldConfirmation extends React.Component {
   goSearchResults(e) {
     e.preventDefault();
 
-    this.context.router.push(`${appConfig.baseUrl}/search?${this.props.searchKeywords}`);
+    this.context.router.push(`${appConfig.baseUrl}/search?q=${this.props.searchKeywords}`);
   }
 
   /**
@@ -143,7 +143,7 @@ class HoldConfirmation extends React.Component {
     return (
       <Link
         className="nypl-request-button"
-        to={`${appConfig.baseUrl}/search?${this.props.searchKeywords}`}
+        to={`${appConfig.baseUrl}/search?q=${this.props.searchKeywords}`}
         onClick={(e) => this.goSearchResults(e)}
       >
         Back to results

--- a/src/app/components/HoldConfirmation/HoldConfirmation.jsx
+++ b/src/app/components/HoldConfirmation/HoldConfirmation.jsx
@@ -117,6 +117,24 @@ class HoldConfirmation extends React.Component {
     );
   }
 
+  /**
+   * renderBackToSearchLink
+   * Renders the link back to the page of search results.
+   *
+   * @return {HTML Element}
+   */
+  renderBackToSearchLink() {
+    return (
+      <Link
+        className="nypl-request-button"
+        to="/"
+        onClick={(e) => this.goRestart(e)}
+      >
+        Back to results
+      </Link>
+    );
+  }
+
   render() {
     // Need to better clarify variable names later.
     const bib = this.props.bib;
@@ -204,6 +222,7 @@ class HoldConfirmation extends React.Component {
                     If you would like to cancel your request, or if you have further questions,
                     please contact 917-ASK-NYPL (917-275-6975).
                   </p>
+                  {this.renderBackToSearchLink()}
                   {this.renderStartOverLink()}
                 </div>
               </div>

--- a/src/app/components/HoldConfirmation/HoldConfirmation.jsx
+++ b/src/app/components/HoldConfirmation/HoldConfirmation.jsx
@@ -136,14 +136,14 @@ class HoldConfirmation extends React.Component {
    * @return {HTML Element}
    */
   renderBackToSearchLink() {
-    if (!this.props.searchKeywords) {
+    if (!this.props.location.query.searchKeywords) {
       return false;
     }
 
     return (
       <Link
         className="nypl-request-button"
-        to={`${appConfig.baseUrl}/search?q=${this.props.searchKeywords}`}
+        to={`${appConfig.baseUrl}/search?q=${this.props.location.query.searchKeywords}`}
         onClick={(e) => this.goSearchResults(e)}
       >
         Back to results
@@ -184,7 +184,7 @@ class HoldConfirmation extends React.Component {
             <div className="nypl-full-width-wrapper">
               <div className="nypl-column-full">
                 <Breadcrumbs
-                  query={this.props.searchKeywords}
+                  query={this.props.location.query.searchKeywords}
                   type="confirmation"
                   bibUrl={`/bib/${bibId}`}
                   itemUrl={`/hold/request/${bibId}-${itemId}`}

--- a/src/app/components/HoldConfirmation/HoldConfirmation.jsx
+++ b/src/app/components/HoldConfirmation/HoldConfirmation.jsx
@@ -57,7 +57,7 @@ class HoldConfirmation extends React.Component {
   /**
    * goSearchResults(e)
    * @param {event}
-   * Renders the route back to home page for single page application implementation.
+   * Renders the route back to search results page.
    *
    */
   goSearchResults(e) {

--- a/src/app/components/HoldConfirmation/HoldConfirmation.jsx
+++ b/src/app/components/HoldConfirmation/HoldConfirmation.jsx
@@ -143,6 +143,8 @@ class HoldConfirmation extends React.Component {
     return (
       <Link
         className="nypl-request-button"
+        // We use this.props.location.query.searchKeywords here for the query from
+        // the URL to deal with no js situation.
         to={`${appConfig.baseUrl}/search?q=${this.props.location.query.searchKeywords}`}
         onClick={(e) => this.goSearchResults(e)}
       >

--- a/src/app/components/HoldConfirmation/HoldConfirmation.jsx
+++ b/src/app/components/HoldConfirmation/HoldConfirmation.jsx
@@ -136,6 +136,10 @@ class HoldConfirmation extends React.Component {
    * @return {HTML Element}
    */
   renderBackToSearchLink() {
+    if (!this.props.searchKeywords) {
+      return false;
+    }
+
     return (
       <Link
         className="nypl-request-button"

--- a/src/app/components/HoldRequest/HoldRequest.jsx
+++ b/src/app/components/HoldRequest/HoldRequest.jsx
@@ -240,8 +240,8 @@ class HoldRequest extends React.Component {
           }
           <input
             type="hidden"
-            name="searchKeywords"
-            value={(this.props.searchKeywords) ? this.props.searchKeywords : ''}
+            name="search-keywords"
+            value={searchKeywords}
           />
         </form>
       );

--- a/src/app/components/HoldRequest/HoldRequest.jsx
+++ b/src/app/components/HoldRequest/HoldRequest.jsx
@@ -95,8 +95,12 @@ class HoldRequest extends React.Component {
         if (response.data.error && response.data.error.status !== 200) {
           this.context.router.push(`${path}?errorMessage=${response.data.error.statusText}`);
         } else {
+          const searchKeywordsQuery = (this.props.searchKeywords) ?
+            `&searchKeywords=${this.props.searchKeywords}` : '';
+
           this.context.router.push(
-            `${path}?pickupLocation=${response.data.pickupLocation}&requestId=${response.data.id}`
+            `${path}?pickupLocation=${response.data.pickupLocation}&requestId=${response.data.id}` +
+            `${searchKeywordsQuery}`
           );
         }
       })

--- a/src/app/components/HoldRequest/HoldRequest.jsx
+++ b/src/app/components/HoldRequest/HoldRequest.jsx
@@ -238,6 +238,11 @@ class HoldRequest extends React.Component {
                 Submit request
               </button>
           }
+          <input
+            type="hidden"
+            name="searchKeywords"
+            value={(this.props.searchKeywords) ? this.props.searchKeywords : ''}
+          />
         </form>
       );
     }

--- a/src/app/components/HoldRequest/HoldRequest.jsx
+++ b/src/app/components/HoldRequest/HoldRequest.jsx
@@ -86,7 +86,7 @@ class HoldRequest extends React.Component {
     if (this.state.delivery === 'edd') {
       const searchKeywordsQueryEdd = searchKeywordsQuery ? `?${searchKeywordsQuery}` : '';
 
-      path = `${appConfig.baseUrl}/hold/request/${bibId}-${itemId}/edd`;
+      path = `${appConfig.baseUrl}/hold/request/${bibId}-${itemId}/edd${searchKeywordsQueryEdd}`;
 
       this.context.router.push(path);
       return;

--- a/src/app/components/HoldRequest/HoldRequest.jsx
+++ b/src/app/components/HoldRequest/HoldRequest.jsx
@@ -80,8 +80,12 @@ class HoldRequest extends React.Component {
     e.preventDefault();
 
     let path = `${appConfig.baseUrl}/hold/confirmation/${bibId}-${itemId}`;
+    const searchKeywordsQuery =
+      (this.props.searchKeywords) ? `searchKeywords=${this.props.searchKeywords}` : '';
 
     if (this.state.delivery === 'edd') {
+      const searchKeywordsQueryEdd = searchKeywordsQuery ? `?${searchKeywordsQuery}` : '';
+
       path = `${appConfig.baseUrl}/hold/request/${bibId}-${itemId}/edd`;
 
       this.context.router.push(path);
@@ -95,12 +99,11 @@ class HoldRequest extends React.Component {
         if (response.data.error && response.data.error.status !== 200) {
           this.context.router.push(`${path}?errorMessage=${response.data.error.statusText}`);
         } else {
-          const searchKeywordsQuery = (this.props.searchKeywords) ?
-            `&searchKeywords=${this.props.searchKeywords}` : '';
+          const searchKeywordsQueryPhysical = searchKeywordsQuery ? `&${searchKeywordsQuery}` : '';
 
           this.context.router.push(
             `${path}?pickupLocation=${response.data.pickupLocation}&requestId=${response.data.id}` +
-            `${searchKeywordsQuery}`
+            `${searchKeywordsQueryPhysical}`
           );
         }
       })

--- a/src/app/components/Item/ItemHoldings.jsx
+++ b/src/app/components/Item/ItemHoldings.jsx
@@ -99,6 +99,7 @@ class ItemHoldings extends React.Component {
           bibId={bibId}
           getRecord={this.getRecord}
           id="bib-item-table"
+          searchKeywords={this.props.searchKeywords}
         /> : null
     );
   }
@@ -189,10 +190,12 @@ ItemHoldings.propTypes = {
   itemPage: PropTypes.string,
   bibId: PropTypes.string,
   shortenItems: PropTypes.bool,
+  searchKeywords: PropTypes.string,
 };
 
 ItemHoldings.defaultProps = {
   shortenItems: false,
+  searchKeywords: '',
 };
 
 ItemHoldings.contextTypes = {

--- a/src/app/components/Item/ItemTable.jsx
+++ b/src/app/components/Item/ItemTable.jsx
@@ -4,7 +4,7 @@ import { isArray as _isArray } from 'underscore';
 
 import ItemTableRow from './ItemTableRow';
 
-const ItemTable = ({ items, bibId, getRecord, id }) => {
+const ItemTable = ({ items, bibId, getRecord, id, searchKeywords, }) => {
   if (!_isArray(items) || !items.length) {
     return null;
   }
@@ -23,7 +23,13 @@ const ItemTable = ({ items, bibId, getRecord, id }) => {
       <tbody>
         {
           items.map((item, i) =>
-            <ItemTableRow key={i} item={item} bibId={bibId} getRecord={getRecord} />
+            <ItemTableRow
+              key={i}
+              item={item}
+              bibId={bibId}
+              getRecord={getRecord}
+              searchKeywords={searchKeywords}
+            />
           )
         }
       </tbody>

--- a/src/app/components/Item/ItemTableRow.jsx
+++ b/src/app/components/Item/ItemTableRow.jsx
@@ -7,7 +7,7 @@ import appConfig from '../../../../appConfig.js';
 
 const createMarkup = (html) => ({ __html: html });
 
-const ItemTableRow = ({ item, bibId, getRecord }) => {
+const ItemTableRow = ({ item, bibId, getRecord, searchKeywords }) => {
   if (_isEmpty(item)) {
     return null;
   }
@@ -19,7 +19,7 @@ const ItemTableRow = ({ item, bibId, getRecord }) => {
     if (item.isRecap) {
       itemLink = item.available ?
         (<Link
-          to={`${appConfig.baseUrl}/hold/request/${bibId}-${item.id}`}
+          to={`${appConfig.baseUrl}/hold/request/${bibId}-${item.id}?searchKeywords=${searchKeywords}`}
           onClick={(e) => getRecord(e, bibId, item.id)}
           tabIndex="0"
         >

--- a/src/app/components/Results/ResultsList.jsx
+++ b/src/app/components/Results/ResultsList.jsx
@@ -124,7 +124,7 @@ class ResultsList extends React.Component {
         <h2>
           <Link
             onClick={(e) => this.getBibRecord(e, bibId)}
-            to={`${appConfig.baseUrl}/bib/${bibId}`}
+            to={`${appConfig.baseUrl}/bib/${bibId}?searchKeywords=${this.props.searchKeywords}`}
             className="title"
           >
             {bibTitle}
@@ -181,6 +181,7 @@ class ResultsList extends React.Component {
 ResultsList.propTypes = {
   results: PropTypes.array,
   spinning: PropTypes.bool,
+  searchKeywords: PropTypes.string,
 };
 
 ResultsList.contextTypes = {

--- a/src/app/components/Results/ResultsList.jsx
+++ b/src/app/components/Results/ResultsList.jsx
@@ -148,6 +148,7 @@ class ResultsList extends React.Component {
               bibId={bibId}
               getRecord={this.getItemRecord}
               id={null}
+              searchKeywords={this.props.searchKeywords}
             />
         }
       </li>

--- a/src/app/components/SearchResultsPage/SearchResultsPage.jsx
+++ b/src/app/components/SearchResultsPage/SearchResultsPage.jsx
@@ -99,7 +99,13 @@ const SearchResultsPage = (props, context) => {
 
               {
                 !!(results && results.length !== 0) &&
-                (<ResultList results={results} spinning={spinning} />)
+                (
+                  <ResultList
+                    results={results}
+                    spinning={spinning}
+                    searchKeywords={searchKeywords}
+                  />
+                )
               }
 
               {

--- a/src/client/styles/components/HoldConfirmation.scss
+++ b/src/client/styles/components/HoldConfirmation.scss
@@ -1,0 +1,3 @@
+.nypl-request-button {
+  margin-right: 0.75rem;
+}

--- a/src/client/styles/main.scss
+++ b/src/client/styles/main.scss
@@ -33,6 +33,7 @@ Import style rules from NYPL React module components
 @import "components/ItemTable.scss";
 @import "components/Sorter.scss";
 @import "components/design-toolkit-updates.scss";
+@import "components/HoldConfirmation.scss";
 
 @import "style-v2.scss";
 

--- a/src/server/ApiRoutes/Bib.js
+++ b/src/server/ApiRoutes/Bib.js
@@ -23,7 +23,7 @@ function bibSearchServer(req, res, next) {
     (data) => {
       res.locals.data.Store = {
         bib: data,
-        searchKeywords: '',
+        searchKeywords: req.query.searchKeywords || '',
         error: {},
       };
       next();
@@ -32,7 +32,7 @@ function bibSearchServer(req, res, next) {
       console.error(`bibSearchServer API error: ${JSON.stringify(error, null, 2)}`);
       res.locals.data.Store = {
         bib: {},
-        searchKeywords: '',
+        searchKeywords: req.query.searchKeywords || '',
         error,
       };
       next();

--- a/src/server/ApiRoutes/Hold.js
+++ b/src/server/ApiRoutes/Hold.js
@@ -408,7 +408,7 @@ function createHoldRequestServer(req, res, pickedUpBibId = '', pickedUpItemId = 
   const pickupLocation = req.body['delivery-location'];
   const docDeliveryData = (req.body.form && pickupLocation === 'edd') ? req.body.form : null;
   const searchKeywordsQuery = (req.body['search-keywords']) ?
-    `searchKeywords=${req.body['search-keywords']}` : '';
+    `&searchKeywords=${req.body['search-keywords']}` : '';
 
   if (!bibId || !itemId) {
     // Dummy redirect for now
@@ -416,7 +416,8 @@ function createHoldRequestServer(req, res, pickedUpBibId = '', pickedUpItemId = 
   }
 
   if (pickupLocation === 'edd') {
-    const eddSearchKeywordsQuery = (searchKeywordsQuery) ? `?${searchKeywordsQuery}` : '';
+    const eddSearchKeywordsQuery = (req.body['search-keywords']) ?
+      `?searchKeywords=${req.body['search-keywords']}` : '';
 
     return res.redirect(
       `${appConfig.baseUrl}/hold/request/${bibId}-${itemId}/edd${eddSearchKeywordsQuery}`

--- a/src/server/ApiRoutes/Hold.js
+++ b/src/server/ApiRoutes/Hold.js
@@ -520,8 +520,6 @@ function eddServer(req, res) {
   const {
     bibId,
     itemId,
-    pickupLocation,
-    searchKeywords,
   } = req.body;
 
   let serverErrors = {};
@@ -541,7 +539,7 @@ function eddServer(req, res) {
   // NOTE: Mocking that this workflow works correctly:
   // Just a dummy redirect that doesn't actually do anything yet with the correct valid data
   // that was submitted.
-  return createHoldRequestEdd(req, res, bibId, itemId);
+  return createHoldRequestEdd(req, res);
 }
 
 export default {

--- a/src/server/ApiRoutes/Hold.js
+++ b/src/server/ApiRoutes/Hold.js
@@ -267,7 +267,7 @@ function newHoldRequestServer(req, res, next) {
         (deliveryLocations, isEddRequestable) => {
           res.locals.data.Store = {
             bib: bibResponseData,
-            searchKeywords: '',
+            searchKeywords: req.query.searchKeywords || '',
             error,
             form,
             deliveryLocations,
@@ -281,7 +281,7 @@ function newHoldRequestServer(req, res, next) {
 
           res.locals.data.Store = {
             bib: bibResponseData,
-            searchKeywords: '',
+            searchKeywords: req.query.searchKeywords || '',
             error,
             form,
             deliveryLocations: [],
@@ -427,9 +427,13 @@ function createHoldRequestServer(req, res, pickedUpBibId = '', pickedUpItemId = 
       console.log('Hold Request Id:', response.data.data.id);
       console.log('Job Id:', response.data.data.jobId);
 
+      const searchKeywordsQuery = (req.body['search-keywords']) ?
+        `&searchKeywords=${req.body['search-keywords']}` : '';
+
       res.redirect(
         `${appConfig.baseUrl}/hold/confirmation/${bibId}-${itemId}?pickupLocation=` +
-        `${response.data.data.pickupLocation}&requestId=${response.data.data.id}`
+        `${response.data.data.pickupLocation}&requestId=${response.data.data.id}` +
+        `${searchKeywordsQuery}`
       );
     },
     (error) => {
@@ -490,9 +494,12 @@ function createHoldRequestEdd(req, res) {
     req.body,
     req.body.itemSource,
     (response) => {
+      const searchKeywordsQuery = (req.body['search-keywords']) ?
+        `&searchKeywords=${req.body['search-keywords']}` : '';
+
       res.redirect(
         `${appConfig.baseUrl}/hold/confirmation/${req.body.bibId}-${req.body.itemId}?pickupLocation=` +
-        `${req.body.pickupLocation}&requestId=${response.data.data.id}`
+        `${req.body.pickupLocation}&requestId=${response.data.data.id}${searchKeywordsQuery}`
       );
     },
     (error) => {

--- a/src/server/ApiRoutes/Hold.js
+++ b/src/server/ApiRoutes/Hold.js
@@ -53,7 +53,7 @@ function postHoldAPI(
     nyplSource: itemSource,
     requestType: (pickupLocation === 'edd') ? 'edd' : 'hold',
     recordType: 'i',
-    pickupLocation: (pickupLocation === 'edd') ? 'null' : pickupLocation,
+    pickupLocation: (pickupLocation === 'edd') ? null : pickupLocation,
     // neededBy: "2013-03-20",
     numberOfCopies: 1,
     docDeliveryData: (pickupLocation === 'edd') ? docDeliveryData : null,
@@ -495,16 +495,14 @@ function createHoldRequestEdd(req, res) {
     req,
     req.body.itemId,
     req.body.pickupLocation,
-    req.body,
+    req.body.form,
     req.body.itemSource,
     (response) => {
-      const searchKeywordsQuery = (req.body.searchKeywords) ?
-        `&searchKeywords=${req.body.searchKeywords}` : '';
-
-      res.redirect(
-        `${appConfig.baseUrl}/hold/confirmation/${req.body.bibId}-${req.body.itemId}?pickupLocation=` +
-        `${req.body.pickupLocation}&requestId=${response.data.data.id}${searchKeywordsQuery}`
-      );
+      res.json({
+        id: response.data.data.id,
+        jobId: response.data.data.jobId,
+        pickupLocation: response.data.data.pickupLocation,
+      });
     },
     (error) => {
       console.log(`Error calling Holds API : ${error.data.message}`);
@@ -537,10 +535,36 @@ function eddServer(req, res) {
       `&form=${JSON.stringify(req.body)}`);
   }
 
-  // NOTE: Mocking that this workflow works correctly:
-  // Just a dummy redirect that doesn't actually do anything yet with the correct valid data
-  // that was submitted.
-  return createHoldRequestEdd(req, res);
+  // Ensure user is logged in
+  const loggedIn = User.requireUser(req);
+
+  if (!loggedIn) return false;
+
+  return postHoldAPI(
+    req,
+    req.body.itemId,
+    req.body.pickupLocation,
+    req.body,
+    req.body.itemSource,
+    (response) => {
+      const searchKeywordsQuery = (req.body.searchKeywords) ?
+        `&searchKeywords=${req.body.searchKeywords}` : '';
+
+      res.redirect(
+        `${appConfig.baseUrl}/hold/confirmation/${req.body.bibId}-${req.body.itemId}` +
+        `?pickupLocation=${req.body.pickupLocation}&requestId=${response.data.data.id}` +
+        `${searchKeywordsQuery}`
+      );
+    },
+    (error) => {
+      console.log(`Error calling Holds API : ${error.data.message}`);
+
+      res.redirect(
+        `${appConfig.baseUrl}/hold/request/${bibId}-${itemId}/edd?error=${JSON.stringify(error)}` +
+        `&form=${JSON.stringify(req.body)}`
+      );
+    }
+  );
 }
 
 export default {


### PR DESCRIPTION
This PR creates the back to results link on confirmation page. When there's no `this.props.searchKeywords`, it won't render the link. One thing to notice and so I need your suggestions is that it is not going to work while no js, such as the link of `Search Results` in <Breadcrumbs>. The reason is that when no js, it is not a single page application anymore, so no `this.props.searchKeywords` will be passed from routes. We can pass the keywords with URL, but then we have to add one more variable to it. Any thoughts???

Btw, the styles are temporary, it should come from toolkit later.