### PR TITLE
Adding links to the error box message list that, when clicked, ...

### DIFF
--- a/src/app/components/ElectronicDelivery/ElectronicDelivery.jsx
+++ b/src/app/components/ElectronicDelivery/ElectronicDelivery.jsx
@@ -74,7 +74,7 @@ class ElectronicDelivery extends React.Component {
 
     const raisedErrors = [];
     _mapObject(raiseError, (val, key) => {
-      raisedErrors.push(<li key={key}>{headlineError[key]}</li>);
+      raisedErrors.push(<li key={key}><a href={`#${key}`}>{headlineError[key]}</a></li>);
     });
 
     return raisedErrors;

--- a/src/app/components/ElectronicDelivery/ElectronicDeliveryForm.jsx
+++ b/src/app/components/ElectronicDelivery/ElectronicDeliveryForm.jsx
@@ -91,14 +91,14 @@ class ElectronicDeliveryForm extends React.Component {
               <h4>Contact Information</h4>
 
               <div className={`nypl-text-field ${errorClass.emailAddress}`}>
-                <label htmlFor="email-address" id="email-address-label">Email Address
+                <label htmlFor="emailAddress" id="emailAddress-label">Email Address
                   <span className="nypl-required-field">&nbsp;Required</span>
                 </label>
                 <input
-                  id="email-address"
+                  id="emailAddress"
                   type="text"
                   required
-                  aria-labelledby="email-address-label email-address-status"
+                  aria-labelledby="emailAddress-label emailAddress-status"
                   aria-required="true"
                   name="emailAddress"
                   value={this.state.form.emailAddress}
@@ -106,7 +106,7 @@ class ElectronicDeliveryForm extends React.Component {
                 />
                 <span
                   className="nypl-field-status"
-                  id="email-address-status"
+                  id="emailAddress-status"
                   aria-live="assertive"
                   aria-atomic="true"
                 >
@@ -127,21 +127,21 @@ class ElectronicDeliveryForm extends React.Component {
               <h4>Chapter or Article Information</h4>
 
               <div className={`nypl-text-field ${errorClass.chapterTitle}`}>
-                <label htmlFor="chapter-title" id="chapter-title-label">Chapter / Article Title
+                <label htmlFor="chapterTitle" id="chapterTitle-label">Chapter / Article Title
                   <span className="nypl-required-field">&nbsp;Required</span>
                 </label>
                 <input
-                  id="chapter-title"
+                  id="chapterTitle"
                   type="text"
                   required
-                  aria-labelledby="chapter-title-label chapter-title-status"
+                  aria-labelledby="chapterTitle-label chapterTitle-status"
                   name="chapterTitle"
                   value={this.state.form.chapterTitle}
                   onChange={(e) => this.handleUpdate(e, 'chapterTitle')}
                 />
                 <span
                   className="nypl-field-status"
-                  id="chapter-title-status"
+                  id="chapterTitle-status"
                   aria-live="assertive"
                   aria-atomic="true"
                 >
@@ -218,22 +218,22 @@ class ElectronicDeliveryForm extends React.Component {
           <div className="nypl-row">
             <div className="nypl-column-one-quarter">
               <div className={`nypl-text-field ${errorClass.startPage}`}>
-                <label htmlFor="start-page" id="start-page-label">Starting Page
+                <label htmlFor="startPage" id="startPage-label">Starting Page
                   <span className="nypl-required-field">&nbsp;Required</span>
                 </label>
                 <input
-                  id="start-page"
+                  id="startPage"
                   type="text"
                   required
                   className="form-text"
-                  aria-labelledby="start-page-label start-page-status"
+                  aria-labelledby="startPage-label startPage-status"
                   name="startPage"
                   value={this.state.form.startPage}
                   onChange={(e) => this.handleUpdate(e, 'startPage')}
                 />
                 <span
                   className="nypl-field-status"
-                  id="start-page-status"
+                  id="startPage-status"
                   aria-live="assertive"
                   aria-atomic="true"
                 >
@@ -242,22 +242,22 @@ class ElectronicDeliveryForm extends React.Component {
               </div>
 
               <div className={`nypl-text-field ${errorClass.endPage}`}>
-                <label htmlFor="end-page" id="end-page-label">Ending Page
+                <label htmlFor="endPage" id="endPage-label">Ending Page
                   <span className="nypl-required-field">&nbsp;Required</span>
                 </label>
                 <input
-                  id="end-page"
+                  id="endPage"
                   type="text"
                   required
                   className="form-text"
-                  aria-labelledby="end-page-label end-page-status"
+                  aria-labelledby="endPage-label endPage-status"
                   name="endPage"
                   value={this.state.form.endPage}
                   onChange={(e) => this.handleUpdate(e, 'endPage')}
                 />
                 <span
                   className="nypl-field-status"
-                  id="end-page-status"
+                  id="endPage-status"
                   aria-live="assertive"
                   aria-atomic="true"
                 >
@@ -266,12 +266,12 @@ class ElectronicDeliveryForm extends React.Component {
               </div>
 
               <div className="nypl-text-field">
-                <label htmlFor="request-notes" id="request-notes-label">Additional Notes</label>
+                <label htmlFor="requestNotes" id="requestNotes-label">Additional Notes</label>
                 <textarea
                   className="nypl-text-area"
-                  id="request-notes"
+                  id="requestNotes"
                   type="text"
-                  aria-labelledby="request-notes-label"
+                  aria-labelledby="requestNotes-label"
                   name="requestNotes"
                   value={this.state.form.requestNotes}
                   onChange={(e) => this.handleUpdate(e, 'requestNotes')}


### PR DESCRIPTION
... will go to the appropriate input element.

Fixes #665 

![screen shot 2017-08-07 at 12 17 09 pm](https://user-images.githubusercontent.com/1280564/29035734-b4c782be-7b6a-11e7-8534-2a6c12123773.png)

Try it out on: http://dev-discovery.nypl.org/research/collections/shared-collection-catalog/hold/request/b16295746-i15610118/edd

@wlla I noticed that the sticky header sometimes blocks the email or the author input field. That's an ongoing issue :\