### PR TITLE
Fixing issue where 'no results found' does not render.

### DIFF
--- a/src/app/components/ResultsCount/ResultsCount.jsx
+++ b/src/app/components/ResultsCount/ResultsCount.jsx
@@ -13,7 +13,7 @@ class ResultsCount extends React.Component {
     if (count !== 0) {
       return (<p>{countF} results</p>);
     }
-    return (<p>No results found.</p>);
+    return (<p>No results found. Please try another search.</p>);
   }
 
   render() {

--- a/src/app/components/SearchResultsPage/SearchResultsPage.jsx
+++ b/src/app/components/SearchResultsPage/SearchResultsPage.jsx
@@ -92,10 +92,7 @@ const SearchResultsPage = (props, context) => {
               aria-relevant="additions removals"
               aria-describedby="results-description"
             >
-              {
-                !!(totalResults && totalResults !== 0) &&
-                  (<ResultsCount spinning={spinning} count={totalResults} />)
-              }
+              <ResultsCount spinning={spinning} count={totalResults} />
 
               {
                 !!(results && results.length !== 0) &&


### PR DESCRIPTION
Fixes #669. Try http://dev-discovery.nypl.org/research/collections/shared-collection-catalog/search?filters[creatorLiteral]=Yi,%20Yong-p%CA%BBil.