### PR TITLE
Adding CSS to better render the focus style on the search button in t…

### DIFF
--- a/src/client/styles/main.scss
+++ b/src/client/styles/main.scss
@@ -143,3 +143,29 @@ li, p {
     padding: 15px 0 30px !important;
   }
 }
+
+// Override for the omnisearch div to work as a fieldset and
+// allow focus on the search button.
+div.nypl-omnisearch {
+  height: 48px;
+
+  &.nypl-spinner-field {
+    overflow: inherit;
+  }
+
+  &.spinning {
+    overflow: hidden;
+  }
+}
+
+button,
+html input[type=button],
+input[type=reset],
+input[type=submit] {
+  -moz-appearance: button;
+}
+input[type=submit]:focus {
+  outline-color: #ffb81d;
+  outline-style: solid;
+  outline-width: 3px;
+}


### PR DESCRIPTION
…he omnisearch.

Fixes #646 

Added `height` to the div so that it doesn't look broken when removing the `overflow: hidden` rule. The `Search` button should now have focus. I also added some more specific styles for that it works in Firefox too.

![screen shot 2017-08-08 at 1 05 57 pm](https://user-images.githubusercontent.com/1280564/29084548-5c3d8640-7c3a-11e7-86cc-b7e6c4e6b82c.png)
