### PR TITLE
Added titles to every page.

### DIFF
--- a/src/app/components/Application/Application.jsx
+++ b/src/app/components/Application/Application.jsx
@@ -84,7 +84,7 @@ class App extends React.Component {
 
   render() {
     return (
-      <DocumentTitle title="Research Catalog | NYPL">
+      <DocumentTitle title="Shared Collection Catalog | NYPL">
         <div className="app-wrapper">
           <Header navData={navConfig.current} skipNav={{ target: 'mainContent' }} />
 

--- a/src/app/components/BibPage/BibPage.jsx
+++ b/src/app/components/BibPage/BibPage.jsx
@@ -40,7 +40,7 @@ const BibPage = (props) => {
   const marcRecord = isNYPLReCAP ? <MarcRecord bNumber={bNumber[0]} /> : null;
 
   return (
-    <DocumentTitle title={`${title} | Research Catalog`}>
+    <DocumentTitle title={`${title} | Shared Collection Catalog | NYPL`}>
       <main className="main-page">
         <div className="nypl-page-header">
           <div className="nypl-full-width-wrapper">

--- a/src/app/components/BibPage/BibPage.jsx
+++ b/src/app/components/BibPage/BibPage.jsx
@@ -40,7 +40,7 @@ const BibPage = (props) => {
   const marcRecord = isNYPLReCAP ? <MarcRecord bNumber={bNumber[0]} /> : null;
 
   return (
-    <DocumentTitle title={`${title} | Shared Collection Catalog | NYPL`}>
+    <DocumentTitle title="Item Details | Shared Collection Catalog | NYPL">
       <main className="main-page">
         <div className="nypl-page-header">
           <div className="nypl-full-width-wrapper">

--- a/src/app/components/ElectronicDelivery/ElectronicDelivery.jsx
+++ b/src/app/components/ElectronicDelivery/ElectronicDelivery.jsx
@@ -9,6 +9,7 @@ import {
   extend as _extend,
   mapObject as _mapObject,
 } from 'underscore';
+import DocumentTitle from 'react-document-title';
 
 import Breadcrumbs from '../Breadcrumbs/Breadcrumbs.jsx';
 import PatronStore from '../../stores/PatronStore.js';
@@ -168,73 +169,75 @@ class ElectronicDelivery extends React.Component {
     const searchKeywords = this.props.searchKeywords;
 
     return (
-      <div id="mainContent">
-        <div className="nypl-request-page-header">
-          <div className="row">
-            <div className="content-wrapper">
-              <Breadcrumbs
-                query={searchKeywords}
-                type="edd"
-                bibUrl={`/bib/${bibId}`}
-                itemUrl={`/hold/request/${bibId}-${itemId}`}
-              />
-              <h2>{appConfig.displayTitle}</h2>
-            </div>
-          </div>
-        </div>
-        <div className="nypl-full-width-wrapper">
-          <div className="nypl-row">
-            <div className="nypl-column-three-quarters">
-              <div className="item-header">
-                <h1>Electronic Delivery Request</h1>
-              </div>
-
-              <div className="nypl-request-item-summary">
-                <h3>
-                  Material request for Electronic Delivery:
-                  <br />
-                  <Link to={`${appConfig.baseUrl}/bib/${bibId}`}>
-                    {title}
-                  </Link>
-                </h3>
-                {
-                  callNo && (
-                    <div className="call-number">
-                      <span>Call Number:</span><br />
-                      {callNo}
-                    </div>
-                  )
-                }
+      <DocumentTitle title={`${title} | Shared Collection Catalog | NYPL`}>
+        <div id="mainContent">
+          <div className="nypl-request-page-header">
+            <div className="row">
+              <div className="content-wrapper">
+                <Breadcrumbs
+                  query={searchKeywords}
+                  type="edd"
+                  bibUrl={`/bib/${bibId}`}
+                  itemUrl={`/hold/request/${bibId}-${itemId}`}
+                />
+                <h2>{appConfig.displayTitle}</h2>
               </div>
             </div>
           </div>
-
-          <div className="nypl-row">
-            {
-              raiseError && (
-                <div className="nypl-form-error" ref="nypl-form-error" tabIndex="0">
-                  <h2>Error</h2>
-                  <p>Please check the following required fields and resubmit your request:</p>
-                  <ul>
-                    {this.getRaisedErrors(raiseError)}
-                  </ul>
+          <div className="nypl-full-width-wrapper">
+            <div className="nypl-row">
+              <div className="nypl-column-three-quarters">
+                <div className="item-header">
+                  <h1>Electronic Delivery Request</h1>
                 </div>
-              )
-            }
-            <ElectronicDeliveryForm
-              bibId={bibId}
-              itemId={itemId}
-              itemSource={this.state.itemSource}
-              submitRequest={this.submitRequest}
-              raiseError={this.raiseError}
-              error={error}
-              form={form}
-              defaultEmail={patronEmail}
-              searchKeywords={searchKeywords}
-            />
+
+                <div className="nypl-request-item-summary">
+                  <h3>
+                    Material request for Electronic Delivery:
+                    <br />
+                    <Link to={`${appConfig.baseUrl}/bib/${bibId}`}>
+                      {title}
+                    </Link>
+                  </h3>
+                  {
+                    callNo && (
+                      <div className="call-number">
+                        <span>Call Number:</span><br />
+                        {callNo}
+                      </div>
+                    )
+                  }
+                </div>
+              </div>
+            </div>
+
+            <div className="nypl-row">
+              {
+                raiseError && (
+                  <div className="nypl-form-error" ref="nypl-form-error" tabIndex="0">
+                    <h2>Error</h2>
+                    <p>Please check the following required fields and resubmit your request:</p>
+                    <ul>
+                      {this.getRaisedErrors(raiseError)}
+                    </ul>
+                  </div>
+                )
+              }
+              <ElectronicDeliveryForm
+                bibId={bibId}
+                itemId={itemId}
+                itemSource={this.state.itemSource}
+                submitRequest={this.submitRequest}
+                raiseError={this.raiseError}
+                error={error}
+                form={form}
+                defaultEmail={patronEmail}
+                searchKeywords={searchKeywords}
+              />
+            </div>
           </div>
         </div>
-      </div>
+      </DocumentTitle>
     );
   }
 }

--- a/src/app/components/ElectronicDelivery/ElectronicDelivery.jsx
+++ b/src/app/components/ElectronicDelivery/ElectronicDelivery.jsx
@@ -169,7 +169,7 @@ class ElectronicDelivery extends React.Component {
     const searchKeywords = this.props.searchKeywords;
 
     return (
-      <DocumentTitle title={`${title} | Shared Collection Catalog | NYPL`}>
+      <DocumentTitle title="Electronic Delivery Request | Shared Collection Catalog | NYPL">
         <div id="mainContent">
           <div className="nypl-request-page-header">
             <div className="row">

--- a/src/app/components/HoldConfirmation/HoldConfirmation.jsx
+++ b/src/app/components/HoldConfirmation/HoldConfirmation.jsx
@@ -181,7 +181,7 @@ class HoldConfirmation extends React.Component {
     }
 
     return (
-      <DocumentTitle title={`${title} | Shared Collection Catalog | NYPL`}>
+      <DocumentTitle title="Request Confirmation | Shared Collection Catalog | NYPL">
         <main id="mainContent" className="main-page">
           <div className="nypl-request-page-header">
             <div className="row">

--- a/src/app/components/HoldConfirmation/HoldConfirmation.jsx
+++ b/src/app/components/HoldConfirmation/HoldConfirmation.jsx
@@ -8,6 +8,7 @@ import {
   isEmpty as _isEmpty,
   findWhere as _findWhere,
 } from 'underscore';
+import DocumentTitle from 'react-document-title';
 
 import Breadcrumbs from '../Breadcrumbs/Breadcrumbs.jsx';
 
@@ -180,81 +181,83 @@ class HoldConfirmation extends React.Component {
     }
 
     return (
-      <main id="mainContent" className="main-page">
-        <div className="nypl-request-page-header">
-          <div className="row">
-            <div className="nypl-full-width-wrapper">
-              <div className="nypl-column-full">
-                <Breadcrumbs
-                  query={this.props.location.query.searchKeywords}
-                  type="confirmation"
-                  bibUrl={`/bib/${bibId}`}
-                  itemUrl={`/hold/request/${bibId}-${itemId}`}
-                  edd={pickupLocation === 'edd'}
-                />
-                <h2>{appConfig.displayTitle}</h2>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <div className="nypl-full-width-wrapper">
-          <div className="nypl-row">
-            <div className="nypl-column-three-quarters">
-              <div className="item-header">
-                <h1>Request Confirmation</h1>
-              </div>
-            </div>
-          </div>
-          <div className="nypl-row">
-            <div className="nypl-column-three-quarters">
-              <div className="nypl-request-item-summary">
-                <div className="item">
-                  <h2>Submission Received</h2>
-                  <h3>Item Information</h3>
-                  <p>
-                    We've received your request for <Link to={`${appConfig.baseUrl}/bib/${bibId}`}>
-                    {title}</Link>
-                  </p>
-                  <p>
-                    Please check your library account for updates. The item will be listed as
-                    Ready under your Holds tab when it is available. You will also recieve an email
-                    confirmation after your item has arrived.
-                  </p>
-                  <p>
-                    Your item will be delivered to: {this.renderLocationInfo(deliveryLocation)}
-                  </p>
-                  <p>
-                    For off-site materials, requests made before 2:30 PM will be delivered the
-                    following business day. Requests made after 2:30 PM on Fridays or over the
-                    weekend will be delivered the following Tuesday. We will hold books for up
-                    to seven days, so you can request materials up to a week in advance.
-                  </p>
-
-                  <h3>Electronic Delivery</h3>
-                  <p>
-                    If you selected Electronic delivery, you will be notified via email when the
-                    item is available.
-                  </p>
-                  <p>
-                    If you would like to cancel your request, or if you have further questions,
-                    please contact 917-ASK-NYPL (917-275-6975).
-                  </p>
-                  {this.renderBackToSearchLink()}
-                  {this.renderStartOverLink()}
+      <DocumentTitle title={`${title} | Shared Collection Catalog | NYPL`}>
+        <main id="mainContent" className="main-page">
+          <div className="nypl-request-page-header">
+            <div className="row">
+              <div className="nypl-full-width-wrapper">
+                <div className="nypl-column-full">
+                  <Breadcrumbs
+                    query={this.props.location.query.searchKeywords}
+                    type="confirmation"
+                    bibUrl={`/bib/${bibId}`}
+                    itemUrl={`/hold/request/${bibId}-${itemId}`}
+                    edd={pickupLocation === 'edd'}
+                  />
+                  <h2>{appConfig.displayTitle}</h2>
                 </div>
               </div>
             </div>
           </div>
-          <div className="nypl-row">
-            <div className="nypl-column-three-quarters">
-              <a target="_blank" href="https://www.nypl.org/help/request-research-materials">
-                Learn more about our off-site collections.
-              </a>
+
+          <div className="nypl-full-width-wrapper">
+            <div className="nypl-row">
+              <div className="nypl-column-three-quarters">
+                <div className="item-header">
+                  <h1>Request Confirmation</h1>
+                </div>
+              </div>
+            </div>
+            <div className="nypl-row">
+              <div className="nypl-column-three-quarters">
+                <div className="nypl-request-item-summary">
+                  <div className="item">
+                    <h2>Submission Received</h2>
+                    <h3>Item Information</h3>
+                    <p>
+                      We've received your request for <Link to={`${appConfig.baseUrl}/bib/${bibId}`}>
+                      {title}</Link>
+                    </p>
+                    <p>
+                      Please check your library account for updates. The item will be listed as
+                      Ready under your Holds tab when it is available. You will also recieve an email
+                      confirmation after your item has arrived.
+                    </p>
+                    <p>
+                      Your item will be delivered to: {this.renderLocationInfo(deliveryLocation)}
+                    </p>
+                    <p>
+                      For off-site materials, requests made before 2:30 PM will be delivered the
+                      following business day. Requests made after 2:30 PM on Fridays or over the
+                      weekend will be delivered the following Tuesday. We will hold books for up
+                      to seven days, so you can request materials up to a week in advance.
+                    </p>
+
+                    <h3>Electronic Delivery</h3>
+                    <p>
+                      If you selected Electronic delivery, you will be notified via email when the
+                      item is available.
+                    </p>
+                    <p>
+                      If you would like to cancel your request, or if you have further questions,
+                      please contact 917-ASK-NYPL (917-275-6975).
+                    </p>
+                    {this.renderBackToSearchLink()}
+                    {this.renderStartOverLink()}
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div className="nypl-row">
+              <div className="nypl-column-three-quarters">
+                <a target="_blank" href="https://www.nypl.org/help/request-research-materials">
+                  Learn more about our off-site collections.
+                </a>
+              </div>
             </div>
           </div>
-        </div>
-      </main>
+        </main>
+      </DocumentTitle>
     );
   }
 }

--- a/src/app/components/HoldRequest/HoldRequest.jsx
+++ b/src/app/components/HoldRequest/HoldRequest.jsx
@@ -256,7 +256,7 @@ class HoldRequest extends React.Component {
     }
 
     return (
-      <DocumentTitle title={`${title} | Shared Collection Catalog | NYPL`}>
+      <DocumentTitle title="Item Request | Shared Collection Catalog | NYPL">
         <div id="mainContent">
           <div className="nypl-request-page-header">
             <div className="nypl-full-width-wrapper">

--- a/src/app/components/HoldRequest/HoldRequest.jsx
+++ b/src/app/components/HoldRequest/HoldRequest.jsx
@@ -7,6 +7,7 @@ import {
   isEmpty as _isEmpty,
   extend as _extend,
 } from 'underscore';
+import DocumentTitle from 'react-document-title';
 
 import Breadcrumbs from '../Breadcrumbs/Breadcrumbs.jsx';
 import PatronStore from '../../stores/PatronStore.js';
@@ -255,44 +256,46 @@ class HoldRequest extends React.Component {
     }
 
     return (
-      <div id="mainContent">
-        <div className="nypl-request-page-header">
-          <div className="nypl-full-width-wrapper">
-            <div className="row">
-              <div className="nypl-column-full">
-                <Breadcrumbs
-                  query={`q=${searchKeywords}`}
-                  bibUrl={`/bib/${bibId}`}
-                  type="hold"
-                />
-                <h2>{appConfig.displayTitle}</h2>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <div className="nypl-full-width-wrapper">
-          <div className="row">
-            <div className="nypl-column-three-quarters">
-              <div className="item-header">
-                <h3>Research item hold request</h3>
-              </div>
-
-              <div className="nypl-request-item-summary">
-                <div className="item">
-                  {!bib && <p>Something went wrong with your request</p>}
-                  <h4>
-                    <Link to={`${appConfig.baseUrl}/bib/${bibId}`}>{title}</Link>
-                  </h4>
-                  {callNo}
+      <DocumentTitle title={`${title} | Shared Collection Catalog | NYPL`}>
+        <div id="mainContent">
+          <div className="nypl-request-page-header">
+            <div className="nypl-full-width-wrapper">
+              <div className="row">
+                <div className="nypl-column-full">
+                  <Breadcrumbs
+                    query={`q=${searchKeywords}`}
+                    bibUrl={`/bib/${bibId}`}
+                    type="hold"
+                  />
+                  <h2>{appConfig.displayTitle}</h2>
                 </div>
               </div>
+            </div>
+          </div>
 
-              {form}
+          <div className="nypl-full-width-wrapper">
+            <div className="row">
+              <div className="nypl-column-three-quarters">
+                <div className="item-header">
+                  <h3>Research item hold request</h3>
+                </div>
+
+                <div className="nypl-request-item-summary">
+                  <div className="item">
+                    {!bib && <p>Something went wrong with your request</p>}
+                    <h4>
+                      <Link to={`${appConfig.baseUrl}/bib/${bibId}`}>{title}</Link>
+                    </h4>
+                    {callNo}
+                  </div>
+                </div>
+
+                {form}
+              </div>
             </div>
           </div>
         </div>
-      </div>
+      </DocumentTitle>
     );
   }
 }

--- a/src/app/components/Home/Home.jsx
+++ b/src/app/components/Home/Home.jsx
@@ -7,7 +7,7 @@ import { basicQuery } from '../../utils/utils.js';
 import appConfig from '../../../../appConfig.js';
 
 const Home = (props) => (
-  <DocumentTitle title="Research Catalog | NYPL">
+  <DocumentTitle title="Shared Collection Catalog | NYPL">
     <div className="home" id="mainContent">
 
       <div className="nypl-homepage-hero">

--- a/src/app/components/SearchResultsPage/SearchResultsPage.jsx
+++ b/src/app/components/SearchResultsPage/SearchResultsPage.jsx
@@ -50,7 +50,7 @@ const SearchResultsPage = (props, context) => {
   return (
     <DocumentTitle
       title={`${searchKeywords ? `${searchKeywords} | ` : ''} ` +
-        'Search Results | Research Catalog | NYPL'}
+        'Search Results | Shared Collection Catalog | NYPL'}
     >
       <main className="main-page">
         <div className="nypl-page-header">

--- a/src/app/components/SearchResultsPage/SearchResultsPage.jsx
+++ b/src/app/components/SearchResultsPage/SearchResultsPage.jsx
@@ -49,8 +49,7 @@ const SearchResultsPage = (props, context) => {
 
   return (
     <DocumentTitle
-      title={`${searchKeywords ? `${searchKeywords} | ` : ''} ` +
-        'Search Results | Shared Collection Catalog | NYPL'}
+      title="Search Results | Shared Collection Catalog | NYPL"
     >
       <main className="main-page">
         <div className="nypl-page-header">


### PR DESCRIPTION
This PR updates the titles and thus the titles on the browser tabs for each page. For now,
the homepage will show `Shared Collection Catalog | NYPL`, 
search result page will show `[keywords] | Search Results | Shared Collection Catalog | NYPL`,
bib page will show `[title] | Shared Collection Catalog | NYPL`,
hold request page will show `[title] | Shared Collection Catalog | NYPL`,
EDD page will show `[title] | Shared Collection Catalog | NYPL`,
confirmation page will show `[title] | Shared Collection Catalog | NYPL`.

The result can also be seen on the dev

Let me know if the contents need to be updated!!! @courtneymcgee 