### PR TITLE
Search results context

### DIFF
--- a/src/app/components/BibPage/BibDetails.jsx
+++ b/src/app/components/BibPage/BibDetails.jsx
@@ -308,9 +308,8 @@ class BibDetails extends React.Component {
   }
 
   newSearch(e, query) {
-
     e.preventDefault();
-// console.log(query);
+
     Actions.updateSpinner(true);
     ajaxCall(`${appConfig.baseUrl}/api?${query}`, (response) => {
       const closingBracketIndex = query.indexOf(']');

--- a/src/app/components/ResultsCount/ResultsCount.jsx
+++ b/src/app/components/ResultsCount/ResultsCount.jsx
@@ -16,16 +16,16 @@ class ResultsCount extends React.Component {
   displayContext() {
     const { searchKeywords, selectedFacets } = this.props;
     const keyMapping = {
-      creatorLiteral: 'Author',
-      contributorLiteral: 'Author',
-      titleDisplay: 'Title',
-      subjectLiteral: 'Subject',
+      creatorLiteral: 'author',
+      contributorLiteral: 'author',
+      titleDisplay: 'title',
+      subjectLiteral: 'subject',
     };
 
     let result = '';
 
     if (searchKeywords) {
-      result += `for search keyword ${searchKeywords}`;
+      result += `for keyword '${searchKeywords}'`;
     }
 
     if (!_isEmpty(selectedFacets)) {
@@ -33,11 +33,9 @@ class ResultsCount extends React.Component {
         const mappedKey = keyMapping[key];
 
         if (val[0] && val[0].value) {
-          result += `for ${mappedKey} ${val[0].value}`;
+          result += `for ${mappedKey} '${val[0].value}'`;
         }
       });
-    } else {
-      result += '.';
     }
 
     return result;

--- a/src/app/components/ResultsCount/ResultsCount.jsx
+++ b/src/app/components/ResultsCount/ResultsCount.jsx
@@ -1,17 +1,49 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import {
+  isEmpty as _isEmpty,
+  mapObject as _mapObject,
+} from 'underscore';
+
 class ResultsCount extends React.Component {
+  displayContext() {
+    const { searchKeywords, selectedFacets } = this.props;
+    const keyMapping = {
+      creatorLiteral: 'Author',
+      contributorLiteral: 'Author',
+      titleDisplay: 'Title',
+      subjectLiteral: 'Subject',
+    };
+
+    let result = '';
+
+    if (searchKeywords) {
+      result += `for search keyword ${searchKeywords}`;
+    }
+
+    if (!_isEmpty(selectedFacets)) {
+      _mapObject(selectedFacets, (val, key) => {
+        const mappedKey = keyMapping[key];
+        result += `for ${mappedKey} ${val[0].value}`;
+      });
+    }
+
+    result += '.';
+    return result;
+  }
+
   displayCount() {
     const { count, spinning } = this.props;
     const countF = count ? count.toLocaleString() : '';
+    const displayContext = this.displayContext();
 
     if (spinning) {
       return (<p>Loading…</p>);
     }
 
     if (count !== 0) {
-      return (<p>{countF} results</p>);
+      return (<p>{countF} results {displayContext}</p>);
     }
     return (<p>No results found.</p>);
   }
@@ -36,6 +68,8 @@ class ResultsCount extends React.Component {
 ResultsCount.propTypes = {
   count: PropTypes.number,
   spinning: PropTypes.bool,
+  selectedFacets: PropTypes.object,
+  searchKeywords: PropTypes.string,
 };
 
 ResultsCount.defaultProps = {

--- a/src/app/components/ResultsCount/ResultsCount.jsx
+++ b/src/app/components/ResultsCount/ResultsCount.jsx
@@ -7,6 +7,12 @@ import {
 } from 'underscore';
 
 class ResultsCount extends React.Component {
+  /*
+   * displayContext()
+   * Displays where the results are coming from. This currently only allows for one
+   * option at a time due to constraints on the front end not allowing for multiple
+   * selections to occur.
+   */
   displayContext() {
     const { searchKeywords, selectedFacets } = this.props;
     const keyMapping = {

--- a/src/app/components/ResultsCount/ResultsCount.jsx
+++ b/src/app/components/ResultsCount/ResultsCount.jsx
@@ -25,7 +25,7 @@ class ResultsCount extends React.Component {
     let result = '';
 
     if (searchKeywords) {
-      result += `for keyword '${searchKeywords}'`;
+      result += `for keyword "${searchKeywords}"`;
     }
 
     if (!_isEmpty(selectedFacets)) {
@@ -33,7 +33,7 @@ class ResultsCount extends React.Component {
         const mappedKey = keyMapping[key];
 
         if (val[0] && val[0].value) {
-          result += `for ${mappedKey} '${val[0].value}'`;
+          result += `for ${mappedKey} "${val[0].value}"`;
         }
       });
     }

--- a/src/app/components/ResultsCount/ResultsCount.jsx
+++ b/src/app/components/ResultsCount/ResultsCount.jsx
@@ -25,11 +25,15 @@ class ResultsCount extends React.Component {
     if (!_isEmpty(selectedFacets)) {
       _mapObject(selectedFacets, (val, key) => {
         const mappedKey = keyMapping[key];
-        result += `for ${mappedKey} ${val[0].value}`;
+
+        if (val[0] && val[0].value) {
+          result += `for ${mappedKey} ${val[0].value}`;
+        }
       });
+    } else {
+      result += '.';
     }
 
-    result += '.';
     return result;
   }
 

--- a/src/app/components/SearchResultsPage/SearchResultsPage.jsx
+++ b/src/app/components/SearchResultsPage/SearchResultsPage.jsx
@@ -20,6 +20,7 @@ const SearchResultsPage = (props, context) => {
   const {
     searchResults,
     searchKeywords,
+    selectedFacets,
     page,
     sortBy,
     field,
@@ -94,7 +95,12 @@ const SearchResultsPage = (props, context) => {
             >
               {
                 !!(totalResults && totalResults !== 0) &&
-                  (<ResultsCount spinning={spinning} count={totalResults} />)
+                  (<ResultsCount
+                    spinning={spinning}
+                    count={totalResults}
+                    selectedFacets={selectedFacets}
+                    searchKeywords={searchKeywords}
+                  />)
               }
 
               {


### PR DESCRIPTION
Fixes #668 .

Displays "x results for ....".
Examples:
1) Search Keyword `hamlet`: `2,320 results for search keyword hamlet.` http://dev-discovery.nypl.org/research/collections/shared-collection-catalog/search?q=hamlet
2) Author: `3,209 results for Author Shakespeare, William, 1564-1616.` http://dev-discovery.nypl.org/research/collections/shared-collection-catalog/search?filters[creatorLiteral]=Shakespeare,%20William,%201564-1616.
3) Title: `8,017,731 results for Title Cymbeline : complete and unabridged / the text conforming to the latest scholarly edition.`
4) Subject: `8 results for Subject Brel, Jacques.` http://dev-discovery.nypl.org/research/collections/shared-collection-catalog/search?filters[subjectLiteral]=Brel,%20Jacques.

NOTE: Title seems to be a bit buggy but may be API related.

@courtneymcgee , what do you think of `for search keyword ...`, `for Author ...`, `for Title ...`, and `for Subject ...`?