### PR TITLE
Field context results

### DIFF
--- a/src/app/components/ResultsCount/ResultsCount.jsx
+++ b/src/app/components/ResultsCount/ResultsCount.jsx
@@ -14,18 +14,27 @@ class ResultsCount extends React.Component {
    * selections to occur.
    */
   displayContext() {
-    const { searchKeywords, selectedFacets } = this.props;
+    const {
+      searchKeywords,
+      selectedFacets,
+      field,
+    } = this.props;
     const keyMapping = {
       creatorLiteral: 'author',
       contributorLiteral: 'author',
+      contributor: 'author',
       titleDisplay: 'title',
+      title: 'title',
       subjectLiteral: 'subject',
     };
-
     let result = '';
 
     if (searchKeywords) {
-      result += `for keyword "${searchKeywords}"`;
+      if (field !== 'all') {
+        result += `for ${keyMapping[field]} "${searchKeywords}"`;
+      } else {
+        result += `for keyword "${searchKeywords}"`;
+      }
     }
 
     if (!_isEmpty(selectedFacets)) {
@@ -78,6 +87,7 @@ ResultsCount.propTypes = {
   spinning: PropTypes.bool,
   selectedFacets: PropTypes.object,
   searchKeywords: PropTypes.string,
+  field: PropTypes.string,
 };
 
 ResultsCount.defaultProps = {

--- a/src/app/components/ResultsCount/ResultsCount.jsx
+++ b/src/app/components/ResultsCount/ResultsCount.jsx
@@ -20,12 +20,14 @@ class ResultsCount extends React.Component {
       field,
     } = this.props;
     const keyMapping = {
+      // Currently from links on the bib page:
       creatorLiteral: 'author',
       contributorLiteral: 'author',
-      contributor: 'author',
-      titleDisplay: 'title',
-      title: 'title',
       subjectLiteral: 'subject',
+      titleDisplay: 'title',
+      // From the search field dropdown:
+      contributor: 'author/contributor',
+      title: 'title',
     };
     let result = '';
 

--- a/src/app/components/SearchResultsPage/SearchResultsPage.jsx
+++ b/src/app/components/SearchResultsPage/SearchResultsPage.jsx
@@ -98,6 +98,7 @@ const SearchResultsPage = (props, context) => {
                 count={totalResults}
                 selectedFacets={selectedFacets}
                 searchKeywords={searchKeywords}
+                field={field}
               />
 
               {
@@ -133,6 +134,7 @@ const SearchResultsPage = (props, context) => {
 SearchResultsPage.propTypes = {
   searchResults: PropTypes.object,
   searchKeywords: PropTypes.string,
+  selectedFacets: PropTypes.object,
   page: PropTypes.string,
   location: PropTypes.object,
   sortBy: PropTypes.string,


### PR DESCRIPTION
Fixes #683 

When selecting a value from the dropdown, the results will display the selected option.

`All fields` -> `x results for keyword ...`
`Title` -> `x results for title ...`
`Author/Contributor` -> `x results for author ...`

Currently on dev.

CC @courtneymcgee 