### PR TITLE
Removing the electronic location check and item from the Available ta…

### DIFF
--- a/src/app/components/BibPage/BibPage.jsx
+++ b/src/app/components/BibPage/BibPage.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import DocumentTitle from 'react-document-title';
+import { every as _every } from 'underscore';
 
 import Breadcrumbs from '../Breadcrumbs/Breadcrumbs';
 import Search from '../Search/Search';
@@ -19,6 +20,7 @@ const BibPage = (props) => {
   const bibId = bib && bib['@id'] ? bib['@id'].substring(4) : '';
   const title = bib.title && bib.title.length ? bib.title[0] : '';
   const items = LibraryItem.getItems(bib);
+  const electronicItems = _every(items, (i) => i.isElectronicResource);
   const isNYPLReCAP = LibraryItem.isNYPLReCAP(bib['@id']);
   const bNumber = bib && bib.idBnum ? bib.idBnum : '';
   const searchURL = createAPIQuery({});
@@ -29,7 +31,7 @@ const BibPage = (props) => {
     shortenItems = false;
   }
 
-  const itemHoldings = items.length ?
+  const itemHoldings = items.length && !electronicItems ?
     <ItemHoldings
       shortenItems={shortenItems}
       items={items}

--- a/src/app/components/Item/ItemTable.jsx
+++ b/src/app/components/Item/ItemTable.jsx
@@ -4,7 +4,7 @@ import { isArray as _isArray } from 'underscore';
 
 import ItemTableRow from './ItemTableRow';
 
-const ItemTable = ({ items, bibId, getRecord, id, searchKeywords, }) => {
+const ItemTable = ({ items, bibId, getRecord, id, searchKeywords }) => {
   if (!_isArray(items) || !items.length) {
     return null;
   }
@@ -41,6 +41,7 @@ ItemTable.propTypes = {
   items: PropTypes.array,
   bibId: PropTypes.string,
   id: PropTypes.string,
+  searchKeywords: PropTypes.string,
   getRecord: PropTypes.func,
 };
 

--- a/src/app/components/Item/ItemTableRow.jsx
+++ b/src/app/components/Item/ItemTableRow.jsx
@@ -5,21 +5,25 @@ import { isEmpty as _isEmpty } from 'underscore';
 
 import appConfig from '../../../../appConfig.js';
 
-const createMarkup = (html) => ({ __html: html });
-
 const ItemTableRow = ({ item, bibId, getRecord, searchKeywords }) => {
   if (_isEmpty(item)) {
     return null;
   }
 
-  let itemLink = <span>{item.status.prefLabel}</span>;
-  let itemDisplay = null;
+  if (item.isElectronicResource) {
+    return null;
+  }
+
+  let itemRequestBtn = <span>{item.status.prefLabel}</span>;
+  let itemCallNumber = ' ';
 
   if (item.requestable) {
     if (item.isRecap) {
-      itemLink = item.available ?
+      itemRequestBtn = item.available ?
         (<Link
-          to={`${appConfig.baseUrl}/hold/request/${bibId}-${item.id}?searchKeywords=${searchKeywords}`}
+          to={
+            `${appConfig.baseUrl}/hold/request/${bibId}-${item.id}?searchKeywords=${searchKeywords}`
+          }
           onClick={(e) => getRecord(e, bibId, item.id)}
           tabIndex="0"
         >
@@ -28,21 +32,19 @@ const ItemTableRow = ({ item, bibId, getRecord, searchKeywords }) => {
         <span>In Use</span>;
     } else if (item.nonRecapNYPL) {
       // Not in ReCAP
-      itemLink = <span>{item.status.prefLabel}</span>;
+      itemRequestBtn = <span>{item.status.prefLabel}</span>;
     }
   }
 
   if (item.callNumber) {
-    itemDisplay = <span dangerouslySetInnerHTML={createMarkup(item.callNumber)}></span>;
-  } else if (item.isElectronicResource) {
-    itemDisplay = <span>{item.location}</span>;
+    itemCallNumber = item.callNumber;
   }
 
   return (
     <tr className={item.availability}>
       <td>{item.location}</td>
-      <td>{itemDisplay}</td>
-      <td>{itemLink}</td>
+      <td>{itemCallNumber}</td>
+      <td>{itemRequestBtn}</td>
       <td>{item.accessMessage.prefLabel}</td>
     </tr>
   );
@@ -51,6 +53,7 @@ const ItemTableRow = ({ item, bibId, getRecord, searchKeywords }) => {
 ItemTableRow.propTypes = {
   item: PropTypes.object,
   bibId: PropTypes.string,
+  searchKeywords: PropTypes.string,
   getRecord: PropTypes.func,
 };
 

--- a/src/app/utils/item.js
+++ b/src/app/utils/item.js
@@ -95,11 +95,10 @@ function LibraryItem() {
     const suppressed = item.suppressed && item.suppressed.length ? item.suppressed[0] : false;
     const isElectronicResource = this.isElectronicResource(item);
     // Taking the first status object in the array.
-    let status = item.status && item.status.length ? item.status[0] : {};
-    let availability = !_isEmpty(status) && status.prefLabel ?
+    const status = item.status && item.status.length ? item.status[0] : {};
+    const availability = !_isEmpty(status) && status.prefLabel ?
       status.prefLabel.replace(/\W/g, '').toLowerCase() : '';
     const available = availability === 'available';
-    let url = null;
     // non-NYPL ReCAP
     const nonNyplRecap = itemSource.indexOf('Recap') !== -1;
     // nypl-owned ReCAP
@@ -114,12 +113,9 @@ function LibraryItem() {
     const barcode = bibIdentifiers.barcode || '';
     const mappedItemSource = itemSourceMappings[itemSource];
     const isOffsite = this.isOffsite(holdingLocation.prefLabel.toLowerCase());
+    let url = null;
 
-    if (isElectronicResource && item.electronicLocator[0].url) {
-      status = { '@id': '', prefLabel: 'Available' };
-      availability = 'available';
-      url = item.electronicLocator[0].url;
-    } else if (availability === 'available') {
+    if (availability === 'available') {
       // For all items that we want to send to the Hold Request Form.
       url = this.getLocationHoldUrl(holdingLocation);
     }
@@ -138,8 +134,9 @@ function LibraryItem() {
       suppressed,
       barcode,
       itemSource: mappedItemSource,
-      isRecap: isRecap || isOffsite,
+      isRecap,
       nonRecapNYPL,
+      isOffsite,
     };
   };
 
@@ -242,11 +239,6 @@ function LibraryItem() {
     if (item.holdingLocation && item.holdingLocation.length) {
       location = item.holdingLocation[0];
     }
-    // this is an electronic resource
-    // else if (item.electronicLocator && item.electronicLocator.length) {
-    //   location = item.electronicLocator[0];
-    //   location['@id'] = '';
-    // }
 
     return location;
   };
@@ -257,7 +249,7 @@ function LibraryItem() {
    * @param {object} item
    * @return {boolean}
    */
-  this.isElectronicResource = (item) => item.electronicLocator && item.electronicLocator.length;
+  this.isElectronicResource = (item) => !!(item.electronicLocator && item.electronicLocator.length);
 
   /**
    * isOffsite(prefLabel)


### PR DESCRIPTION
…ble display, and updating logic to not use isOffsite as a check for ReCAP items.

Fixes #698 - Removing any check from the bib display related to an item's electronic location property. It shouldn't be used and is not displayed in the UI if it is an electronic resource.

Fixes #699 - Removing the `isOffsite` check from the requestability check for ReCAP items. If an item is "offsite", it doesn't mean that it's ReCAP.