### PR TITLE
Hold confirmation error

### DIFF
--- a/src/app/components/ElectronicDelivery/ElectronicDelivery.jsx
+++ b/src/app/components/ElectronicDelivery/ElectronicDelivery.jsx
@@ -126,7 +126,8 @@ class ElectronicDelivery extends React.Component {
       })
       .catch(error => {
         console.log(error);
-        this.context.router.push(`${path}?errorMessage=${error}`);
+
+        this.context.router.push(`${path}?errorMessage=${error}${searchKeywordsQuery}`);
       });
   }
 

--- a/src/app/components/ElectronicDelivery/ElectronicDelivery.jsx
+++ b/src/app/components/ElectronicDelivery/ElectronicDelivery.jsx
@@ -105,6 +105,8 @@ class ElectronicDelivery extends React.Component {
       pickupLocation: 'edd',
       itemSource,
     }, fields);
+    const searchKeywords = this.props.searchKeywords;
+    const searchKeywordsQuery = (searchKeywords) ? `&searchKeywords=${searchKeywords}` : '';
 
     // This is to remove the error box on the top of the page on a successfull submission.
     this.setState({ raiseError: null });
@@ -112,11 +114,13 @@ class ElectronicDelivery extends React.Component {
       .post(`${appConfig.baseUrl}/api/newHold`, data)
       .then(response => {
         if (response.data.error && response.data.error.status !== 200) {
-          this.context.router.push(`${path}?errorMessage=${response.data.error.statusText}`);
+          this.context.router.push(
+            `${path}?errorStatus=${response.data.error.status}` +
+            `&errorMessage=${response.data.error.statusText}${searchKeywordsQuery}`
+          );
         } else {
           this.context.router.push(
-            `${path}?pickupLocation=edd&requestId=${response.data.id}` +
-            `&searchKeywords=${this.props.searchKeywords}`
+            `${path}?pickupLocation=edd&requestId=${response.data.id}${searchKeywordsQuery}`
           );
         }
       })

--- a/src/app/components/HoldConfirmation/HoldConfirmation.jsx
+++ b/src/app/components/HoldConfirmation/HoldConfirmation.jsx
@@ -164,7 +164,6 @@ class HoldConfirmation extends React.Component {
     const itemId = this.props.params.itemId;
     const pickupLocation = this.props.location.query.pickupLocation;
     let deliveryLocation = null;
-    let confirmationTabTitle = 'Submission Error';
     let confirmationPageTitle = 'Submission Error';
     let confirmationInfo = (
       <div className="item">
@@ -178,7 +177,6 @@ class HoldConfirmation extends React.Component {
     );
 
     if (!this.props.location.query.errorStatus && !this.props.location.query.errorMessage) {
-      confirmationTabTitle = 'Request Confirmation';
       confirmationPageTitle = 'Request Confirmation';
       confirmationInfo = (
       <div className="item">
@@ -234,7 +232,7 @@ class HoldConfirmation extends React.Component {
     }
 
     return (
-      <DocumentTitle title={`${confirmationTabTitle} | Shared Collection Catalog | NYPL`}>
+      <DocumentTitle title={`${confirmationPageTitle} | Shared Collection Catalog | NYPL`}>
         <main id="mainContent" className="main-page">
           <div className="nypl-request-page-header">
             <div className="row">

--- a/src/app/components/HoldConfirmation/HoldConfirmation.jsx
+++ b/src/app/components/HoldConfirmation/HoldConfirmation.jsx
@@ -165,56 +165,57 @@ class HoldConfirmation extends React.Component {
     const pickupLocation = this.props.location.query.pickupLocation;
     let deliveryLocation = null;
 
-    const item = !this.props.location.query.errorStatus ? (
-      <div className="item">
-        <h2>Submission Received</h2>
-        <h3>Item Information</h3>
-        <p>
-          We've received your request for <Link to={`${appConfig.baseUrl}/bib/${bibId}`}>
-          {title}</Link>
-        </p>
-        <p>
-          Please check your library account for updates. The item will be listed as
-          Ready under your Holds tab when it is available. You will also recieve an email
-          confirmation after your item has arrived.
-        </p>
-        <p>
-          Your item will be delivered to: {this.renderLocationInfo(deliveryLocation)}
-        </p>
-        <p>
-          For off-site materials, requests made before 2:30 PM will be delivered the
-          following business day. Requests made after 2:30 PM on Fridays or over the
-          weekend will be delivered the following Tuesday. We will hold books for up
-          to seven days, so you can request materials up to a week in advance.
-        </p>
+    const item = (!this.props.location.query.errorStatus && !this.props.location.query.errorMessage)
+      ? (
+        <div className="item">
+          <h2>Submission Received</h2>
+          <h3>Item Information</h3>
+          <p>
+            We've received your request for <Link to={`${appConfig.baseUrl}/bib/${bibId}`}>
+            {title}</Link>
+          </p>
+          <p>
+            Please check your library account for updates. The item will be listed as
+            Ready under your Holds tab when it is available. You will also recieve an email
+            confirmation after your item has arrived.
+          </p>
+          <p>
+            Your item will be delivered to: {this.renderLocationInfo(deliveryLocation)}
+          </p>
+          <p>
+            For off-site materials, requests made before 2:30 PM will be delivered the
+            following business day. Requests made after 2:30 PM on Fridays or over the
+            weekend will be delivered the following Tuesday. We will hold books for up
+            to seven days, so you can request materials up to a week in advance.
+          </p>
 
-        <h3>Electronic Delivery</h3>
-        <p>
-          If you selected Electronic delivery, you will be notified via email when the
-          item is available.
-        </p>
-        <p>
-          If you would like to cancel your request, or if you have further questions,
-          please contact 917-ASK-NYPL (<a href="tel:19172756975">917-275-6975</a>).
-        </p>
-        {this.renderBackToSearchLink()}
-        {this.renderStartOverLink()}
-      </div>
-    ) : (
-      <div className="item">
-        <h2>Submission Error</h2>
-        <h3>Item Information</h3>
-        <p>
-          Something is wrong with your request.
-        </p>
-        <p>
-          Please contact 917-ASK-NYPL (<a href="tel:19172756975">917-275-6975</a>) for further
-          information.
-        </p>
-        {this.renderBackToSearchLink()}
-        {this.renderStartOverLink()}
-      </div>
-    );
+          <h3>Electronic Delivery</h3>
+          <p>
+            If you selected Electronic delivery, you will be notified via email when the
+            item is available.
+          </p>
+          <p>
+            If you would like to cancel your request, or if you have further questions,
+            please contact 917-ASK-NYPL (<a href="tel:19172756975">917-275-6975</a>).
+          </p>
+          {this.renderBackToSearchLink()}
+          {this.renderStartOverLink()}
+        </div>
+      ) : (
+        <div className="item">
+          <h2>Submission Error</h2>
+          <h3>Item Information</h3>
+          <p>
+            Something is wrong with your request.
+          </p>
+          <p>
+            Please contact 917-ASK-NYPL (<a href="tel:19172756975">917-275-6975</a>) for further
+            information.
+          </p>
+          {this.renderBackToSearchLink()}
+          {this.renderStartOverLink()}
+        </div>
+      );
 
     if (this.props.deliveryLocations && this.props.deliveryLocations.length) {
       if (pickupLocation !== 'edd') {

--- a/src/app/components/HoldConfirmation/HoldConfirmation.jsx
+++ b/src/app/components/HoldConfirmation/HoldConfirmation.jsx
@@ -164,9 +164,21 @@ class HoldConfirmation extends React.Component {
     const itemId = this.props.params.itemId;
     const pickupLocation = this.props.location.query.pickupLocation;
     let deliveryLocation = null;
+    let confirmationPageTitle = 'Submission Error';
+    let confirmationInfo = (
+      <div className="item">
+        <p>
+          We could not process your request at this time. Please try again or contact 917-ASK-NYPL
+          (<a href="tel:19172756975">917-275-6975</a>).
+        </p>
+        {this.renderBackToSearchLink()}
+        {this.renderStartOverLink()}
+      </div>
+    );
 
-    const confirmationInfo = (!this.props.location.query.errorStatus && !this.props.location.query.errorMessage)
-      ? (
+    if (!this.props.location.query.errorStatus && !this.props.location.query.errorMessage) {
+      confirmationPageTitle = 'Request Confirmation';
+      confirmationInfo = (
       <div className="item">
         <h2>Submission Received</h2>
         <h3>Item Information</h3>
@@ -201,18 +213,8 @@ class HoldConfirmation extends React.Component {
         {this.renderBackToSearchLink()}
         {this.renderStartOverLink()}
       </div>
-    ) : (
-      <div className="item">
-        <h2>Submission Error</h2>
-        <h3>Item Information</h3>
-        <p>
-          We could not process your request at this time. Please try again or contact 917-ASK-NYPL
-          (<a href="tel:19172756975">917-275-6975</a>).
-        </p>
-        {this.renderBackToSearchLink()}
-        {this.renderStartOverLink()}
-      </div>
     );
+    }
 
     if (this.props.deliveryLocations && this.props.deliveryLocations.length) {
       if (pickupLocation !== 'edd') {
@@ -253,7 +255,7 @@ class HoldConfirmation extends React.Component {
             <div className="nypl-row">
               <div className="nypl-column-three-quarters">
                 <div className="item-header">
-                  <h1>Request Confirmation</h1>
+                  <h1>{confirmationPageTitle}</h1>
                 </div>
               </div>
             </div>

--- a/src/app/components/HoldConfirmation/HoldConfirmation.jsx
+++ b/src/app/components/HoldConfirmation/HoldConfirmation.jsx
@@ -167,55 +167,55 @@ class HoldConfirmation extends React.Component {
 
     const item = (!this.props.location.query.errorStatus && !this.props.location.query.errorMessage)
       ? (
-        <div className="item">
-          <h2>Submission Received</h2>
-          <h3>Item Information</h3>
-          <p>
-            We've received your request for <Link to={`${appConfig.baseUrl}/bib/${bibId}`}>
-            {title}</Link>
-          </p>
-          <p>
-            Please check your library account for updates. The item will be listed as
-            Ready under your Holds tab when it is available. You will also recieve an email
-            confirmation after your item has arrived.
-          </p>
-          <p>
-            Your item will be delivered to: {this.renderLocationInfo(deliveryLocation)}
-          </p>
-          <p>
-            For off-site materials, requests made before 2:30 PM will be delivered the
-            following business day. Requests made after 2:30 PM on Fridays or over the
-            weekend will be delivered the following Tuesday. We will hold books for up
-            to seven days, so you can request materials up to a week in advance.
-          </p>
+      <div className="item">
+        <h2>Submission Received</h2>
+        <h3>Item Information</h3>
+        <p>
+          We've received your request for <Link to={`${appConfig.baseUrl}/bib/${bibId}`}>
+          {title}</Link>
+        </p>
+        <p>
+          Please check your library account for updates. The item will be listed as
+          Ready under your Holds tab when it is available. You will also recieve an email
+          confirmation after your item has arrived.
+        </p>
+        <p>
+          Your item will be delivered to: {this.renderLocationInfo(deliveryLocation)}
+        </p>
+        <p>
+          For off-site materials, requests made before 2:30 PM will be delivered the
+          following business day. Requests made after 2:30 PM on Fridays or over the
+          weekend will be delivered the following Tuesday. We will hold books for up
+          to seven days, so you can request materials up to a week in advance.
+        </p>
 
-          <h3>Electronic Delivery</h3>
-          <p>
-            If you selected Electronic delivery, you will be notified via email when the
-            item is available.
-          </p>
-          <p>
-            If you would like to cancel your request, or if you have further questions,
-            please contact 917-ASK-NYPL (<a href="tel:19172756975">917-275-6975</a>).
-          </p>
-          {this.renderBackToSearchLink()}
-          {this.renderStartOverLink()}
-        </div>
-      ) : (
-        <div className="item">
-          <h2>Submission Error</h2>
-          <h3>Item Information</h3>
-          <p>
-            Something is wrong with your request.
-          </p>
-          <p>
-            Please contact 917-ASK-NYPL (<a href="tel:19172756975">917-275-6975</a>) for further
-            information.
-          </p>
-          {this.renderBackToSearchLink()}
-          {this.renderStartOverLink()}
-        </div>
-      );
+        <h3>Electronic Delivery</h3>
+        <p>
+          If you selected Electronic delivery, you will be notified via email when the
+          item is available.
+        </p>
+        <p>
+          If you would like to cancel your request, or if you have further questions,
+          please contact 917-ASK-NYPL (<a href="tel:19172756975">917-275-6975</a>).
+        </p>
+        {this.renderBackToSearchLink()}
+        {this.renderStartOverLink()}
+      </div>
+    ) : (
+      <div className="item">
+        <h2>Submission Error</h2>
+        <h3>Item Information</h3>
+        <p>
+          Something is wrong with your request.
+        </p>
+        <p>
+          Please contact 917-ASK-NYPL (<a href="tel:19172756975">917-275-6975</a>) for further
+          information.
+        </p>
+        {this.renderBackToSearchLink()}
+        {this.renderStartOverLink()}
+      </div>
+    );
 
     if (this.props.deliveryLocations && this.props.deliveryLocations.length) {
       if (pickupLocation !== 'edd') {

--- a/src/app/components/HoldConfirmation/HoldConfirmation.jsx
+++ b/src/app/components/HoldConfirmation/HoldConfirmation.jsx
@@ -165,6 +165,57 @@ class HoldConfirmation extends React.Component {
     const pickupLocation = this.props.location.query.pickupLocation;
     let deliveryLocation = null;
 
+    const item = !this.props.location.query.errorStatus ? (
+      <div className="item">
+        <h2>Submission Received</h2>
+        <h3>Item Information</h3>
+        <p>
+          We've received your request for <Link to={`${appConfig.baseUrl}/bib/${bibId}`}>
+          {title}</Link>
+        </p>
+        <p>
+          Please check your library account for updates. The item will be listed as
+          Ready under your Holds tab when it is available. You will also recieve an email
+          confirmation after your item has arrived.
+        </p>
+        <p>
+          Your item will be delivered to: {this.renderLocationInfo(deliveryLocation)}
+        </p>
+        <p>
+          For off-site materials, requests made before 2:30 PM will be delivered the
+          following business day. Requests made after 2:30 PM on Fridays or over the
+          weekend will be delivered the following Tuesday. We will hold books for up
+          to seven days, so you can request materials up to a week in advance.
+        </p>
+
+        <h3>Electronic Delivery</h3>
+        <p>
+          If you selected Electronic delivery, you will be notified via email when the
+          item is available.
+        </p>
+        <p>
+          If you would like to cancel your request, or if you have further questions,
+          please contact 917-ASK-NYPL (<a href="tel:19172756975">917-275-6975</a>).
+        </p>
+        {this.renderBackToSearchLink()}
+        {this.renderStartOverLink()}
+      </div>
+    ) : (
+      <div className="item">
+        <h2>Submission Error</h2>
+        <h3>Item Information</h3>
+        <p>
+          Something is wrong with your request.
+        </p>
+        <p>
+          Please contact 917-ASK-NYPL (<a href="tel:19172756975">917-275-6975</a>) for further
+          information.
+        </p>
+        {this.renderBackToSearchLink()}
+        {this.renderStartOverLink()}
+      </div>
+    );
+
     if (this.props.deliveryLocations && this.props.deliveryLocations.length) {
       if (pickupLocation !== 'edd') {
         deliveryLocation = _findWhere(
@@ -211,40 +262,7 @@ class HoldConfirmation extends React.Component {
             <div className="nypl-row">
               <div className="nypl-column-three-quarters">
                 <div className="nypl-request-item-summary">
-                  <div className="item">
-                    <h2>Submission Received</h2>
-                    <h3>Item Information</h3>
-                    <p>
-                      We've received your request for <Link to={`${appConfig.baseUrl}/bib/${bibId}`}>
-                      {title}</Link>
-                    </p>
-                    <p>
-                      Please check your library account for updates. The item will be listed as
-                      Ready under your Holds tab when it is available. You will also recieve an email
-                      confirmation after your item has arrived.
-                    </p>
-                    <p>
-                      Your item will be delivered to: {this.renderLocationInfo(deliveryLocation)}
-                    </p>
-                    <p>
-                      For off-site materials, requests made before 2:30 PM will be delivered the
-                      following business day. Requests made after 2:30 PM on Fridays or over the
-                      weekend will be delivered the following Tuesday. We will hold books for up
-                      to seven days, so you can request materials up to a week in advance.
-                    </p>
-
-                    <h3>Electronic Delivery</h3>
-                    <p>
-                      If you selected Electronic delivery, you will be notified via email when the
-                      item is available.
-                    </p>
-                    <p>
-                      If you would like to cancel your request, or if you have further questions,
-                      please contact 917-ASK-NYPL (<a href="tel:19172756975">917-275-6975</a>).
-                    </p>
-                    {this.renderBackToSearchLink()}
-                    {this.renderStartOverLink()}
-                  </div>
+                  {item}
                 </div>
               </div>
             </div>

--- a/src/app/components/HoldConfirmation/HoldConfirmation.jsx
+++ b/src/app/components/HoldConfirmation/HoldConfirmation.jsx
@@ -165,7 +165,7 @@ class HoldConfirmation extends React.Component {
     const pickupLocation = this.props.location.query.pickupLocation;
     let deliveryLocation = null;
 
-    const item = (!this.props.location.query.errorStatus && !this.props.location.query.errorMessage)
+    const confirmationInfo = (!this.props.location.query.errorStatus && !this.props.location.query.errorMessage)
       ? (
       <div className="item">
         <h2>Submission Received</h2>
@@ -260,7 +260,7 @@ class HoldConfirmation extends React.Component {
             <div className="nypl-row">
               <div className="nypl-column-three-quarters">
                 <div className="nypl-request-item-summary">
-                  {item}
+                  {confirmationInfo}
                 </div>
               </div>
             </div>

--- a/src/app/components/HoldConfirmation/HoldConfirmation.jsx
+++ b/src/app/components/HoldConfirmation/HoldConfirmation.jsx
@@ -206,11 +206,8 @@ class HoldConfirmation extends React.Component {
         <h2>Submission Error</h2>
         <h3>Item Information</h3>
         <p>
-          Something is wrong with your request.
-        </p>
-        <p>
-          Please contact 917-ASK-NYPL (<a href="tel:19172756975">917-275-6975</a>) for further
-          information.
+          We could not process your request at this time. Please try again or contact 917-ASK-NYPL
+          (<a href="tel:19172756975">917-275-6975</a>).
         </p>
         {this.renderBackToSearchLink()}
         {this.renderStartOverLink()}

--- a/src/app/components/HoldConfirmation/HoldConfirmation.jsx
+++ b/src/app/components/HoldConfirmation/HoldConfirmation.jsx
@@ -164,6 +164,7 @@ class HoldConfirmation extends React.Component {
     const itemId = this.props.params.itemId;
     const pickupLocation = this.props.location.query.pickupLocation;
     let deliveryLocation = null;
+    let confirmationTabTitle = 'Submission Error';
     let confirmationPageTitle = 'Submission Error';
     let confirmationInfo = (
       <div className="item">
@@ -177,6 +178,7 @@ class HoldConfirmation extends React.Component {
     );
 
     if (!this.props.location.query.errorStatus && !this.props.location.query.errorMessage) {
+      confirmationTabTitle = 'Request Confirmation';
       confirmationPageTitle = 'Request Confirmation';
       confirmationInfo = (
       <div className="item">
@@ -232,7 +234,7 @@ class HoldConfirmation extends React.Component {
     }
 
     return (
-      <DocumentTitle title="Request Confirmation | Shared Collection Catalog | NYPL">
+      <DocumentTitle title={`${confirmationTabTitle} | Shared Collection Catalog | NYPL`}>
         <main id="mainContent" className="main-page">
           <div className="nypl-request-page-header">
             <div className="row">

--- a/src/app/components/HoldRequest/HoldRequest.jsx
+++ b/src/app/components/HoldRequest/HoldRequest.jsx
@@ -91,6 +91,7 @@ class HoldRequest extends React.Component {
     let path = `${appConfig.baseUrl}/hold/confirmation/${bibId}-${itemId}`;
     const searchKeywordsQuery =
       (this.props.searchKeywords) ? `searchKeywords=${this.props.searchKeywords}` : '';
+    const searchKeywordsQueryPhysical = searchKeywordsQuery ? `&${searchKeywordsQuery}` : '';
 
     if (this.state.delivery === 'edd') {
       const searchKeywordsQueryEdd = searchKeywordsQuery ? `?${searchKeywordsQuery}` : '';
@@ -106,10 +107,11 @@ class HoldRequest extends React.Component {
         `${this.state.delivery}&itemSource=${itemSource}`)
       .then(response => {
         if (response.data.error && response.data.error.status !== 200) {
-          this.context.router.push(`${path}?errorMessage=${response.data.error.statusText}`);
+          this.context.router.push(
+            `${path}?errorStatus=${response.data.error.status}` +
+            `&errorMessage=${response.data.error.statusText}${searchKeywordsQueryPhysical}`
+          );
         } else {
-          const searchKeywordsQueryPhysical = searchKeywordsQuery ? `&${searchKeywordsQuery}` : '';
-
           this.context.router.push(
             `${path}?pickupLocation=${response.data.pickupLocation}&requestId=${response.data.id}` +
             `${searchKeywordsQueryPhysical}`

--- a/src/app/components/HoldRequest/HoldRequest.jsx
+++ b/src/app/components/HoldRequest/HoldRequest.jsx
@@ -120,7 +120,8 @@ class HoldRequest extends React.Component {
       })
       .catch(error => {
         console.log(error);
-        this.context.router.push(`${path}?errorMessage=${error}`);
+
+        this.context.router.push(`${path}?errorMessage=${error}${searchKeywordsQueryPhysical}`);
       });
   }
 

--- a/src/server/ApiRoutes/Hold.js
+++ b/src/server/ApiRoutes/Hold.js
@@ -41,7 +41,7 @@ function postHoldAPI(
   // retrieve access token and patron info
   const accessToken = req.tokenResponse.accessToken;
   const patronId = req.tokenResponse.decodedPatron.sub;
-  const patronHoldsApi = `${appConfig.api.development}/hold-requestsTest`;
+  const patronHoldsApi = `${appConfig.api.development}/hold-requests`;
 
   // get item id and pickup location
   // NOTE: pickedUpItemId and pickedUpBibId are coming from the EDD form function below:

--- a/src/server/ApiRoutes/Hold.js
+++ b/src/server/ApiRoutes/Hold.js
@@ -212,7 +212,7 @@ function confirmRequestServer(req, res, next) {
               },
               (deliveryLocationError) => {
                 console.error(
-                  `deliverylocationsbybarcode API error: ` +
+                  `deliveryLocationsByBarcode API error: ` +
                   `${JSON.stringify(deliveryLocationError, null, 2)}`
                 );
 

--- a/src/server/ApiRoutes/Hold.js
+++ b/src/server/ApiRoutes/Hold.js
@@ -155,7 +155,7 @@ function confirmRequestServer(req, res, next) {
   const searchKeywords = req.query.searchKeywords || '';
   const errorStatus = req.query.errorStatus ? req.query.errorStatus : null;
   const errorMessage = req.query.errorMessage ? req.query.errorMessage : null;
-  const error = _extend({}, {errorStatus, errorMessage});
+  const error = _extend({}, { errorStatus, errorMessage });
 
   if (!loggedIn) return false;
 
@@ -212,7 +212,8 @@ function confirmRequestServer(req, res, next) {
               },
               (deliveryLocationError) => {
                 console.error(
-                  `deliverylocationsbybarcode API error: ${JSON.stringify(e, null, 2)}`
+                  `deliverylocationsbybarcode API error: ` +
+                  `${JSON.stringify(deliveryLocationError, null, 2)}`
                 );
 
                 res.locals.data.Store = {

--- a/src/server/ApiRoutes/Hold.js
+++ b/src/server/ApiRoutes/Hold.js
@@ -162,7 +162,7 @@ function confirmRequestServer(req, res, next) {
   if (!requestId) {
     res.locals.data.Store = {
       bib: {},
-      searchKeywords: searchKeywords,
+      searchKeywords,
       error,
       deliveryLocations: [],
     };
@@ -203,7 +203,7 @@ function confirmRequestServer(req, res, next) {
               (deliveryLocations, isEddRequestable) => {
                 res.locals.data.Store = {
                   bib: bibResponseData,
-                  searchKeywords: searchKeywords,
+                  searchKeywords,
                   error,
                   deliveryLocations,
                   isEddRequestable,
@@ -218,7 +218,7 @@ function confirmRequestServer(req, res, next) {
 
                 res.locals.data.Store = {
                   bib: bibResponseData,
-                  searchKeywords: searchKeywords,
+                  searchKeywords,
                   error,
                   deliveryLocations: [],
                   isEddRequestable: false,
@@ -230,7 +230,7 @@ function confirmRequestServer(req, res, next) {
           (bibResponseError) => {
             res.locals.data.Store = {
               bib: {},
-              searchKeywords: searchKeywords,
+              searchKeywords,
               error,
               deliveryLocations: [],
             };
@@ -246,7 +246,7 @@ function confirmRequestServer(req, res, next) {
 
       res.locals.data.Store = {
         bib: {},
-        searchKeywords: searchKeywords,
+        searchKeywords,
         error,
         deliveryLocations: [],
       };


### PR DESCRIPTION
This PR handles the error after submitting a hold request to the API. It renders a general error message on the page, also offers the link to search results again or start all over.

![screencapture-local-nypl-org-3001-research-collections-shared-collection-catalog-hold-confirmation-b10722566-i11995945-1502746236527](https://user-images.githubusercontent.com/3506922/29292797-87ef2dbc-8116-11e7-8fe8-209374d7d6cb.png)
