### PR TITLE
Adding more context for search results by displaying the number of re…

### DIFF
--- a/src/app/components/ResultsCount/ResultsCount.jsx
+++ b/src/app/components/ResultsCount/ResultsCount.jsx
@@ -53,16 +53,19 @@ class ResultsCount extends React.Component {
   }
 
   displayCount() {
-    const { count, spinning } = this.props;
+    const { count, spinning, page } = this.props;
     const countF = count ? count.toLocaleString() : '';
     const displayContext = this.displayContext();
+    const start = (page - 1) * 50 + 1;
+    const end = (page) * 50 > count ? count : (page * 50);
+    const currentResultDisplay = `${start} - ${end}`;
 
     if (spinning) {
       return (<p>Loading…</p>);
     }
 
     if (count !== 0) {
-      return (<p>{countF} results {displayContext}</p>);
+      return (<p>Display {currentResultDisplay} of {countF} results {displayContext}</p>);
     }
     return (<p>No results found. Please try another search.</p>);
   }
@@ -86,6 +89,7 @@ class ResultsCount extends React.Component {
 
 ResultsCount.propTypes = {
   count: PropTypes.number,
+  page: PropTypes.string,
   spinning: PropTypes.bool,
   selectedFacets: PropTypes.object,
   searchKeywords: PropTypes.string,

--- a/src/app/components/ResultsCount/ResultsCount.jsx
+++ b/src/app/components/ResultsCount/ResultsCount.jsx
@@ -58,7 +58,7 @@ class ResultsCount extends React.Component {
     const displayContext = this.displayContext();
     const start = (page - 1) * 50 + 1;
     const end = (page) * 50 > count ? count : (page * 50);
-    const currentResultDisplay = `${start} - ${end}`;
+    const currentResultDisplay = `${start}-${end}`;
 
     if (spinning) {
       return (<p>Loading…</p>);

--- a/src/app/components/ResultsCount/ResultsCount.jsx
+++ b/src/app/components/ResultsCount/ResultsCount.jsx
@@ -89,7 +89,7 @@ class ResultsCount extends React.Component {
 
 ResultsCount.propTypes = {
   count: PropTypes.number,
-  page: PropTypes.string,
+  page: PropTypes.number,
   spinning: PropTypes.bool,
   selectedFacets: PropTypes.object,
   searchKeywords: PropTypes.string,
@@ -99,6 +99,7 @@ ResultsCount.propTypes = {
 ResultsCount.defaultProps = {
   count: 0,
   spinning: false,
+  page: 1,
 };
 
 export default ResultsCount;

--- a/src/app/components/ResultsCount/ResultsCount.jsx
+++ b/src/app/components/ResultsCount/ResultsCount.jsx
@@ -65,7 +65,7 @@ class ResultsCount extends React.Component {
     }
 
     if (count !== 0) {
-      return (<p>Display {currentResultDisplay} of {countF} results {displayContext}</p>);
+      return (<p>Displaying {currentResultDisplay} of {countF} results {displayContext}</p>);
     }
     return (<p>No results found. Please try another search.</p>);
   }

--- a/src/app/components/ResultsCount/ResultsCount.jsx
+++ b/src/app/components/ResultsCount/ResultsCount.jsx
@@ -32,7 +32,7 @@ class ResultsCount extends React.Component {
     let result = '';
 
     if (searchKeywords) {
-      if (field !== 'all') {
+      if (field && field !== 'all') {
         result += `for ${keyMapping[field]} "${searchKeywords}"`;
       } else {
         result += `for keyword "${searchKeywords}"`;

--- a/src/app/components/SearchResultsPage/SearchResultsPage.jsx
+++ b/src/app/components/SearchResultsPage/SearchResultsPage.jsx
@@ -98,7 +98,7 @@ const SearchResultsPage = (props, context) => {
                 selectedFacets={selectedFacets}
                 searchKeywords={searchKeywords}
                 field={field}
-                page={page}
+                page={parseInt(page, 10)}
               />
 
               {

--- a/src/app/components/SearchResultsPage/SearchResultsPage.jsx
+++ b/src/app/components/SearchResultsPage/SearchResultsPage.jsx
@@ -98,6 +98,7 @@ const SearchResultsPage = (props, context) => {
                 selectedFacets={selectedFacets}
                 searchKeywords={searchKeywords}
                 field={field}
+                page={page}
               />
 
               {


### PR DESCRIPTION
Fixes #706 

This PR is based of #687 so please review that first. This add to that previous PR by displaying `Displaying 1-50 of 4,000 results [...]`.

Currently on dev:
* http://dev-discovery.nypl.org/research/collections/shared-collection-catalog/search?q=hamlet&search_scope=contributor&page=3
* http://dev-discovery.nypl.org/research/collections/shared-collection-catalog/search?q=seaweed&page=2
* 