### PR TITLE
Winston logging

### DIFF
--- a/.ebextensions/02_cloudwatch_agent_config.config
+++ b/.ebextensions/02_cloudwatch_agent_config.config
@@ -1,0 +1,14 @@
+files:
+  '/etc/awslogs/config/application_log.conf' :
+    mode: "000444"
+    owner: root
+    group: root
+    content: |
+      [application_log]
+      file = /var/app/current/log/discovery-ui.log*
+      log_group_name = `{"Fn::Join":["/", ["/aws/elasticbeanstalk", { "Ref":"AWSEBEnvironmentName" }, "var/app/current/log/discovery-ui.log"]]}`
+      log_stream_name = {instance_id}
+
+commands:
+  restart_awslogs:
+    command: service awslogs restart

--- a/.ebextensions/03_enable_log_streaming.config
+++ b/.ebextensions/03_enable_log_streaming.config
@@ -1,0 +1,5 @@
+option_settings:
+  aws:elasticbeanstalk:cloudwatch:logs:
+    StreamLogs: true
+    DeleteOnTerminate: false
+    RetentionInDays: 180

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ bin/*
 selenium-debug.log
 nightwatch_reports
 package-lock.json
+log/*.log
 
 # Elastic Beanstalk Files
 .elasticbeanstalk/*

--- a/logger.js
+++ b/logger.js
@@ -1,0 +1,43 @@
+import winston from 'winston';
+winston.emitErrs = false;
+
+const logLevel = (process.env.NODE_ENV === 'production') ? 'info' : 'debug';
+
+const loggerTransports = [
+  new winston.transports.File({
+    level: logLevel,
+    filename: './log/discovery-ui.log',
+    handleExceptions: true,
+    maxsize: 5242880, // 5MB
+    maxFiles: 5,
+    colorize: false,
+    json: false,
+    formatter: (options) => {
+      const outputObject = {
+        level: options.level.toUpperCase(),
+        message: options.message,
+        timestamp: new Date().toISOString(),
+      };
+
+      return JSON.stringify(Object.assign(outputObject, options.meta));
+    },
+  }),
+];
+
+// spewing logs while running tests is annoying
+if (process.env.NODE_ENV !== 'test') {
+  loggerTransports.push(new winston.transports.Console({
+    level: logLevel,
+    handleExceptions: true,
+    json: true,
+    stringify: true,
+    colorize: true,
+  }));
+}
+
+const logger = new winston.Logger({
+  transports: loggerTransports,
+  exitOnError: false,
+});
+
+export default logger;

--- a/logger.js
+++ b/logger.js
@@ -1,41 +1,101 @@
 import winston from 'winston';
+// Supress error handling
 winston.emitErrs = false;
+// Set default NYPL agreed upon log levels
+const nyplLogLevels = {
+  levels: {
+    emergency: 0,
+    alert: 1,
+    critical: 2,
+    error: 3,
+    warning: 4,
+    notice: 5,
+    info: 6,
+    debug: 7,
+  },
+};
 
-const logLevel = (process.env.NODE_ENV === 'production') ? 'info' : 'debug';
+const getLogLevelCode = (levelString) => {
+  switch (levelString) {
+    case 'emergency':
+      return 0;
+    case 'alert':
+      return 1;
+    case 'critical':
+      return 2;
+    case 'error':
+      return 3;
+    case 'warning':
+      return 4;
+    case 'notice':
+      return 5;
+    case 'info':
+      return 6;
+    case 'debug':
+      return 7;
+    default:
+      return 'n/a';
+  }
+};
+
+// const logLevel = (process.env.NODE_ENV === 'production') ? 'info' : 'debug';
+const timestamp = () => new Date().toISOString();
+const formatter = (options) => {
+  const result = {
+    timestamp: options.timestamp(),
+    levelCode: getLogLevelCode(options.level),
+    level: options.level.toUpperCase(),
+  };
+
+  if (process.pid) {
+    result.pid = process.pid.toString();
+  }
+
+  if (options.message) {
+    result.message = options.message;
+  }
+
+  if (options.meta && Object.keys(options.meta).length) {
+    if (options.meta.holdRequestId) {
+      result.holdRequestId = options.meta.holdRequestId;
+      delete options.meta.holdRequestId;
+    }
+
+    if (options.meta && Object.keys(options.meta).length) {
+      result.meta = JSON.stringify(options.meta);
+    }
+  }
+
+  return JSON.stringify(result);
+};
 
 const loggerTransports = [
   new winston.transports.File({
-    level: logLevel,
     filename: './log/discovery-ui.log',
     handleExceptions: true,
     maxsize: 5242880, // 5MB
     maxFiles: 5,
     colorize: false,
     json: false,
-    formatter: (options) => {
-      const outputObject = {
-        level: options.level.toUpperCase(),
-        message: options.message,
-        timestamp: new Date().toISOString(),
-      };
-
-      return JSON.stringify(Object.assign(outputObject, options.meta));
-    },
+    timestamp,
+    formatter,
   }),
 ];
 
 // spewing logs while running tests is annoying
 if (process.env.NODE_ENV !== 'test') {
   loggerTransports.push(new winston.transports.Console({
-    level: logLevel,
     handleExceptions: true,
     json: true,
     stringify: true,
     colorize: true,
+    timestamp,
+    formatter,
   }));
 }
 
 const logger = new winston.Logger({
+  levels: nyplLogLevels.levels,
   transports: loggerTransports,
   exitOnError: false,
 });

--- a/logger.js
+++ b/logger.js
@@ -86,7 +86,7 @@ const loggerTransports = [
 if (process.env.NODE_ENV !== 'test') {
   loggerTransports.push(new winston.transports.Console({
     handleExceptions: true,
-    json: true,
+    json: false,
     stringify: true,
     colorize: true,
     timestamp,

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "@nypl/design-toolkit": "0.1.22",
     "@nypl/dgx-header-component": "2.0.0",
     "@nypl/dgx-react-footer": "0.4.0",
-    "dgx-alt-center": "git+https://bitbucket.org/NYPL/dgx-alt-center.git#master",
     "axios": "0.9.1",
     "babel-core": "6.5.2",
     "babel-loader": "6.2.3",
@@ -75,10 +74,10 @@
     "chai": "3.5.0",
     "classnames": "2.1.3",
     "clean-webpack-plugin": "0.1.3",
-    "colors": "1.1.2",
     "compression": "1.5.2",
     "cookie-parser": "1.4.3",
     "css-loader": "0.23.1",
+    "dgx-alt-center": "git+https://bitbucket.org/NYPL/dgx-alt-center.git#master",
     "dgx-feature-flags": "git+https://bitbucket.org/NYPL/dgx-feature-flags.git#master",
     "dgx-react-ga": "git+https://git@bitbucket.org/NYPL/dgx-react-ga.git#master",
     "dgx-svg-icons": "git+https://git@bitbucket.org/NYPL/dgx-svg-icons.git#master",
@@ -117,6 +116,7 @@
     "validator": "7.2.0",
     "webpack": "1.12.14",
     "webpack-dev-server": "1.10.1",
-    "webpack-merge": "0.8.4"
+    "webpack-merge": "0.8.4",
+    "winston": "2.3.1"
   }
 }

--- a/server.js
+++ b/server.js
@@ -1,27 +1,24 @@
 import path from 'path';
 import express from 'express';
 import compress from 'compression';
-import colors from 'colors';
 import DocumentTitle from 'react-document-title';
 import React from 'react';
 import ReactDOMServer from 'react-dom/server';
 import { match, RouterContext } from 'react-router';
-
 import Iso from 'iso';
-import alt from './src/app/alt.js';
-
-import appConfig from './appConfig.js';
 import webpack from 'webpack';
+import cookieParser from 'cookie-parser';
+import bodyParser from 'body-parser';
+
+import alt from './src/app/alt.js';
+import appConfig from './appConfig.js';
 import WebpackDevServer from 'webpack-dev-server';
 import webpackConfig from './webpack.config.js';
-
 import apiRoutes from './src/server/ApiRoutes/ApiRoutes.js';
 import routes from './src/app/routes/routes.jsx';
-
-import cookieParser from 'cookie-parser';
 import { initializeTokenAuth } from './src/server/routes/auth';
 import { getPatronData } from './src/server/routes/api';
-import bodyParser from 'body-parser';
+import logger from './logger';
 
 const ROOT_PATH = __dirname;
 const INDEX_PATH = path.resolve(ROOT_PATH, 'src/client');
@@ -102,27 +99,23 @@ app.get('/*', (req, res) => {
 
 const server = app.listen(app.get('port'), (error) => {
   if (error) {
-    console.log(colors.red(error));
+    logger.error(error);
   }
 
-  console.log(colors.yellow.underline(appConfig.appName));
-  console.log(
-    colors.green('Express server is listening at'),
-    colors.cyan(`localhost: ${app.get('port')}`)
-  );
+  logger.info(`App - Express server is listening at localhost: ${app.get('port')}.`);
 });
 
 // This function is called when you want the server to die gracefully
 // i.e. wait for existing connections
 const gracefulShutdown = () => {
-  console.log('Received kill signal, shutting down gracefully.');
+  logger.info('Received kill signal, shutting down gracefully.');
   server.close(() => {
-    console.log('Closed out remaining connections.');
+    logger.info('Closed out remaining connections.');
     process.exit(0);
   });
   // if after
   setTimeout(() => {
-    console.error('Could not close connections in time, forcefully shutting down');
+    logger.error('Could not close connections in time, forcefully shutting down');
     process.exit();
   }, 1000);
 };
@@ -148,8 +141,8 @@ if (!isProduction) {
     },
   }).listen(WEBPACK_DEV_PORT, 'localhost', (error) => {
     if (error) {
-      console.log(colors.red(error));
+      logger.error(error);
     }
-    console.log(colors.magenta('Webpack Dev Server listening at'), colors.cyan(`localhost: ${WEBPACK_DEV_PORT}`));
+    logger.info(`Webpack Dev Server listening at localhost: ${WEBPACK_DEV_PORT}.`);
   });
 }


### PR DESCRIPTION
Fixes #708 .

Adding the `winston` npm package and set up eb config files and a logger instance file - all based on the work in the [discovery-api](https://github.com/NYPL-discovery/discovery-api). This PR just sets up the logging but there are still lots of `console.log` and `console.error` messages in the app. I wanted to get feedback on what has been done so far and if any AWS configs need to be updated.

I deployed it to dev and this is what the log has in cloudwatch in `/aws/elasticbeanstalk/discovery-ui-dev/var/log/nodejs/nodejs.log`:

![screen shot 2017-08-14 at 6 50 13 pm](https://user-images.githubusercontent.com/1280564/29295391-2e62b078-8122-11e7-94bc-94d0f8d92117.png)

I need to work with @ricardoom to remove a lot of the debug messages from the [design-toolkit](https://www.npmjs.com/package/@nypl/design-toolkit) npm package (but should be a different issue).