### PR TITLE
Using aws kms to decrypt env vars for client id and client secret and…

### DIFF
--- a/EBSVARS.md
+++ b/EBSVARS.md
@@ -1,6 +1,6 @@
 # AWS Elastic Beanstalk Environment Variables
 
-As previously mentioned, ware environment variables to make authorized requests to NYPL's API platform. In order to be secure, we are encrypting and decrypting those environment variables using AWS KMS. Please get these variables from someone in the NYPL Digital Department.
+As previously mentioned in the [README](README.md), we are using environment variables to make authorized requests to NYPL's API platform. In order to be secure, we are encrypting and decrypting those environment variables using AWS KMS. Please get these variables from someone in the NYPL Digital Department.
 
 ### Encrypting
 There are two variables we care about: the `clientId` and the `clientSecret`. We need these variables to create an instance of the `nypl-data-api-client` npm package and make authorized requests to the NYPL Digital API endpoints. This is needed for the Discovery UI app to make requests itself to the APIs.

--- a/EBSVARS.md
+++ b/EBSVARS.md
@@ -11,6 +11,8 @@ In order to encrypt, please use the `aws` [cli tool](https://aws.amazon.com/cli/
 
 The `aws kms encrypt` commands returns and object with a `CiphertextBlob` property. Since we only want that value, we use the `--query` flag to retrieve just that. This value can be copied and pasted into the AWS EBS configuration in the UI for the app's environment.
 
+More information can be found in the [encrypt docs](http://docs.aws.amazon.com/cli/latest/reference/kms/encrypt.html).
+
 NOTE: This value is base64 encoded, so when decoding make sure to decode using base64.
 
 ### Decrypting

--- a/EBSVARS.md
+++ b/EBSVARS.md
@@ -1,0 +1,17 @@
+# AWS Elastic Beanstalk Environment Variables
+
+As previously mentioned, ware environment variables to make authorized requests to NYPL's API platform. In order to be secure, we are encrypting and decrypting those environment variables using AWS KMS. Please get these variables from someone in the NYPL Digital Department.
+
+### Encrypting
+There are two variables we care about: the `clientId` and the `clientSecret`. We need these variables to create an instance of the `nypl-data-api-client` npm package and make authorized requests to the NYPL Digital API endpoints. This is needed for the Discovery UI app to make requests itself to the APIs.
+
+In order to encrypt, please use the `aws` [cli tool](https://aws.amazon.com/cli/). The command to encrypt is
+
+    aws kms encrypt --key-id [your IAM key from AWS] --plaintext [value to encrypt] --output text --query CiphertextBlob
+
+The `aws kms encrypt` commands returns and object with a `CiphertextBlob` property. Since we only want that value, we use the `--query` flag to retrieve just that. This value can be copied and pasted into the AWS EBS configuration in the UI for the app's environment.
+
+NOTE: This value is base64 encoded, so when decoding make sure to decode using base64.
+
+### Decrypting
+In order to decrypt, we are using the `aws-sdk` npm module. Please check the [nyplApiClient](src/server/routes/nyplApiClient/index.js) file for more information and implementation on decryption.

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ and visit `localhost:3001`.
 NOTE: Currently the only working `environment variable` is `development`.
 
 ## Client Id and Secret
-We are environment variables to make authorized requests to NYPL's API platform. The `clientId` and `clientSecret` environment variables should be received from a developer in the NYPL Digital Department.
+We are using environment variables to make authorized requests to NYPL's API platform. The `clientId` and `clientSecret` environment variables should be received from a developer in the NYPL Digital Department.
 
 Please check the [EBSVARS](EBSVARS.md) documentation for more information.
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ NOTE: Currently the only working `environment variable` is `development`.
 ## Client Id and Secret
 We are environment variables to make authorized requests to NYPL's API platform. The `clientId` and `clientSecret` environment variables should be received from a developer in the NYPL Digital Department.
 
+Please check the [EBSVARS](EBSVARS.md) documentation for more information.
+
 ## Contributing
 
 Cut branches off of the `development` branch, and open pull requests against `development`.  

--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ To install packages run
 
 To run locally in development mode run
 
-    $ clientID=[client id] clientSecret=[client secret] npm run dev-start
+    $ clientId=[client id] clientSecret=[client secret] npm run dev-start
 
 If you would like to run in different the environments, run
 
-    $ clientID=[client id] clientSecret=[client secret] APP_ENV=[environment variable] npm start
+    $ clientId=[client id] clientSecret=[client secret] APP_ENV=[environment variable] npm start
 
 `environment variable` is the name of the particular environment, such as `qa`.
 

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "@nypl/dgx-header-component": "2.0.0",
     "@nypl/dgx-react-footer": "0.4.0",
     "@nypl/nypl-data-api-client": "0.2.4",
+    "aws-sdk": "2.99.0",
     "axios": "0.9.1",
     "babel-core": "6.26.0",
     "babel-loader": "6.2.3",

--- a/server.js
+++ b/server.js
@@ -19,6 +19,7 @@ import routes from './src/app/routes/routes.jsx';
 
 import initializePatronTokenAuth from './src/server/routes/auth';
 import { getPatronData } from './src/server/routes/api';
+import nyplApiClient from './src/server/routes/nyplApiClient';
 import logger from './logger';
 
 const ROOT_PATH = __dirname;
@@ -61,7 +62,9 @@ app.use('/', (req, res, next) => {
   return next();
 });
 
-// Init token and nypl data client.
+// Init the nypl data api client.
+nyplApiClient();
+
 app.use('/*', initializePatronTokenAuth, getPatronData);
 app.use('/', apiRoutes);
 

--- a/src/server/ApiRoutes/Bib.js
+++ b/src/server/ApiRoutes/Bib.js
@@ -1,8 +1,10 @@
 import nyplApiClient from '../routes/nyplApiClient';
 
+const nyplApiClientCall = (query) =>
+  nyplApiClient().then(client => client.get(`/discovery/resources/${query}`));
+
 function fetchBib(bibId, cb, errorcb) {
-  return nyplApiClient
-    .get(`/discovery/resources/${bibId}`)
+  return nyplApiClientCall(bibId)
     .then(response => cb(response))
     .catch(error => {
       console.error(`fetchBib API error: ${JSON.stringify(error, null, 2)}`);

--- a/src/server/ApiRoutes/Hold.js
+++ b/src/server/ApiRoutes/Hold.js
@@ -13,6 +13,11 @@ import LibraryItem from './../../app/utils/item.js';
 import { validate } from '../../app/utils/formValidationUtils';
 import nyplApiClient from '../routes/nyplApiClient';
 
+const nyplApiClientGet = (endpoint) =>
+  nyplApiClient().then(client => client.get(endpoint));
+
+const nyplApiClientPost = (endpoint, opts) =>
+  nyplApiClient().then(client => client.post(endpoint, opts));
 /**
  * postHoldAPI(req, pickedUpItemId, pickupLocation, cb, errorCb)
  * The function to make a POST request to the hold request API.
@@ -57,8 +62,7 @@ function postHoldAPI(
   };
   console.log('Making hold request', data);
 
-  return nyplApiClient
-    .post(holdRequestEndpoint, JSON.stringify(data))
+  return nyplApiClientPost(holdRequestEndpoint, JSON.stringify(data))
     .then(cb)
     .catch(errorCb);
 }
@@ -106,8 +110,7 @@ function getDeliveryLocations(barcode, patronId, cb, errorCb) {
   const deliveryEndpoint = `/request/deliveryLocationsByBarcode?barcodes[]=${barcode}` +
     `&patronId=${patronId}`;
 
-  return nyplApiClient
-    .get(deliveryEndpoint)
+  return nyplApiClientGet(deliveryEndpoint)
     .then(barcodeAPIresponse => {
       const eddRequestable = (barcodeAPIresponse.itemListElement[0].eddRequestable) ?
         barcodeAPIresponse.itemListElement[0].eddRequestable : false;
@@ -161,8 +164,7 @@ function confirmRequestServer(req, res, next) {
   const patronId = req.patronTokenResponse.decodedPatron.sub || '';
   let barcode;
 
-  return nyplApiClient
-    .get(`/hold-requests/${requestId}`)
+  return nyplApiClientGet(`/hold-requests/${requestId}`)
     .then(response => {
       const patronIdFromHoldRequest = response.patron;
 

--- a/src/server/ApiRoutes/Search.js
+++ b/src/server/ApiRoutes/Search.js
@@ -20,7 +20,9 @@ const createAPIQuery = basicQuery({
   field: '',
   selectedFacets: {},
 });
-const nyplApiClientCall = (query) => nyplApiClient.get(`/discovery/resources${query}`);
+
+const nyplApiClientCall = (query) =>
+  nyplApiClient().then(client => client.get(`/discovery/resources${query}`));
 
 function search(searchKeywords, page, sortBy, order, field, filters, cb, errorcb) {
   const apiQuery = createAPIQuery({

--- a/src/server/routes/api/index.js
+++ b/src/server/routes/api/index.js
@@ -8,48 +8,51 @@ export function getPatronData(req, res, next) {
   ) {
     const userId = req.patronTokenResponse.decodedPatron.sub;
 
-    return nyplApiClient
-      .get(`/patrons/${userId}`)
-      .then((response) => {
-        if (_isEmpty(response)) {
-          // Data is empty for the Patron
-          res.locals.data = {
-            PatronStore: {
-              id: '',
-              names: [],
-              barcodes: [],
-              emails: [],
-            },
-          };
-        } else {
-          // Data exists for the Patron
-          res.locals.data = {
-            PatronStore: {
-              id: response.id,
-              names: response.names,
-              barcodes: response.barCodes,
-              emails: response.emails,
-            },
-          };
-        }
+    return nyplApiClient()
+      .then(client =>
+        client.get(`/patrons/${userId}`)
+          .then((response) => {
+            if (_isEmpty(response)) {
+              // Data is empty for the Patron
+              res.locals.data = {
+                PatronStore: {
+                  id: '',
+                  names: [],
+                  barcodes: [],
+                  emails: [],
+                },
+              };
+            } else {
+              // Data exists for the Patron
+              res.locals.data = {
+                PatronStore: {
+                  id: response.id,
+                  names: response.names,
+                  barcodes: response.barCodes,
+                  emails: response.emails,
+                },
+              };
+            }
 
-        // Continue next function call
-        next();
-      })
-      .catch((error) => {
-        console.log(error);
-        res.locals.data = {
-          PatronStore: {
-            id: '',
-            names: [],
-            barcodes: [],
-            emails: [],
-          },
-        };
-        // Continue next function call
-        next();
-      });
+            // Continue next function call
+            next();
+          })
+          .catch((error) => {
+            console.log(error);
+            res.locals.data = {
+              PatronStore: {
+                id: '',
+                names: [],
+                barcodes: [],
+                emails: [],
+              },
+            };
+            // Continue next function call
+            next();
+          })
+        );
   }
+
   res.locals.data = {
     PatronStore: {
       id: '',

--- a/src/server/routes/nyplApiClient/index.js
+++ b/src/server/routes/nyplApiClient/index.js
@@ -1,13 +1,61 @@
 import NyplApiClient from '@nypl/nypl-data-api-client';
 import config from '../../../../appConfig.js';
+import aws from 'aws-sdk';
 
 const appEnvironment = process.env.APP_ENV || 'production';
 const apiBase = config.api[appEnvironment];
-const nyplApiClient = new NyplApiClient({
-  base_url: apiBase,
-  oauth_key: process.env.clientId,
-  oauth_secret: process.env.clientSecret,
-  oauth_url: config.tokenUrl,
+const kms = new aws.KMS({
+  region: 'us-east-1',
 });
 
-export default nyplApiClient;
+function decryptKMS(key) {
+  const params = {
+    CiphertextBlob: new Buffer(key, 'base64'),
+  };
+
+  return new Promise((resolve, reject) => {
+    kms.decrypt(params, (err, data) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(data.Plaintext.toString());
+      }
+    });
+  });
+}
+
+const clientId = process.env.clientId;
+const clientSecret = process.env.clientSecret;
+
+const keys = [clientId, clientSecret];
+const CACHE = {};
+
+function client() {
+  if (CACHE.nyplApiClient) {
+    return Promise.resolve(CACHE.nyplApiClient);
+  }
+
+  return new Promise((resolve, reject) => {
+    Promise.all(keys.map(decryptKMS))
+      .then(([decryptedClientId, decryptedClientSecret]) => {
+        const nyplApiClient = new NyplApiClient({
+          base_url: apiBase,
+          oauth_key: decryptedClientId,
+          oauth_secret: decryptedClientSecret,
+          oauth_url: config.tokenUrl,
+        });
+
+        CACHE.clientId = decryptedClientId;
+        CACHE.clientSecret = decryptedClientSecret;
+        CACHE.nyplApiClient = nyplApiClient;
+
+        resolve(nyplApiClient);
+      })
+      .catch(error => {
+        console.log('ERROR trying to decrypt using KMS.', error);
+        reject('ERROR trying to decrypt using KMS.', error);
+      });
+  });
+}
+
+export default client;


### PR DESCRIPTION
… passing those to the nyplDataApiClient npm package.

Fixes #719.

Adding the `aws-sdk` package in order to be able to use the `KMS` api to decrypt text. In this case, we want to decrypted environment variables for the `clientId` and `clientSecret`. Those keys were encrypted using the `aws` cli command and added to the AWS EBS configuration

![screenshot](https://user-images.githubusercontent.com/1280564/29381305-b5ae50a8-8296-11e7-95b5-e0176191f2da.png)

A few notes:
* I am using a local CACHE to store the `nyplApiClient` that we get back once we add the appropriate options. This is because decrypting is an expensive operation and we are decrypting two variables. By generating an instance and storing it in the local CACHE, we can just return that whenever the instance is called. If you console log it, after the instance gets invoked, you'll always hit the cached instance. So the keys should only be decrypted once per EBS instance.
* The AWS KMS decryption is promised based so it's a lot of promises to get the nyplDataApiClient instance, which is very annoying. I wrote a small wrapper function in each file where it gets called to return just the instance from the promise. I hope to refactor this later but I wanted to get this working properly first.