### PR TITLE
Fix header search results page

### DIFF
--- a/src/app/components/Results/ResultsList.jsx
+++ b/src/app/components/Results/ResultsList.jsx
@@ -97,9 +97,9 @@ class ResultsList extends React.Component {
     dateEndYear = dateEndYear === 9999 ? 'present' : dateEndYear;
 
     if (dateStartYear && dateEndYear) {
-      return (<span className="nypl-results-date">{dateStartYear}-{dateEndYear}</span>);
+      return (<li className="nypl-results-date">{dateStartYear}-{dateEndYear}</li>);
     } else if (dateStartYear) {
-      return (<span className="nypl-results-date">{dateStartYear}</span>);
+      return (<li className="nypl-results-date">{dateStartYear}</li>);
     }
     return null;
   }

--- a/src/app/components/Results/ResultsList.jsx
+++ b/src/app/components/Results/ResultsList.jsx
@@ -121,7 +121,7 @@ class ResultsList extends React.Component {
 
     return (
       <li key={i} className="nypl-results-item">
-        <h2>
+        <h3>
           <Link
             onClick={(e) => this.getBibRecord(e, bibId)}
             to={`${appConfig.baseUrl}/bib/${bibId}?searchKeywords=${this.props.searchKeywords}`}
@@ -129,17 +129,17 @@ class ResultsList extends React.Component {
           >
             {bibTitle}
           </Link>
-        </h2>
+        </h3>
         <div className="nypl-results-item-description">
-          <p>
-            <span className="nypl-results-media">{materialType}</span>
-            <span className="nypl-results-place">{placeOfPublication}</span>
-            <span className="nypl-results-publisher">{publisher}</span>
+          <ul>
+            <li className="nypl-results-media">{materialType}</li>
+            <li className="nypl-results-place">{placeOfPublication}</li>
+            <li className="nypl-results-publisher">{publisher}</li>
             {yearPublished}
-            <span className="nypl-results-info">
+            <li className="nypl-results-info">
               {totalItems} item{totalItems !== 1 ? 's' : ''}
-            </span>
-          </p>
+            </li>
+          </ul>
         </div>
         {
           (items.length === 1) &&

--- a/src/app/components/ResultsCount/ResultsCount.jsx
+++ b/src/app/components/ResultsCount/ResultsCount.jsx
@@ -65,9 +65,9 @@ class ResultsCount extends React.Component {
     }
 
     if (count !== 0) {
-      return (<p>Displaying {currentResultDisplay} of {countF} results {displayContext}</p>);
+      return (<h2>Displaying {currentResultDisplay} of {countF} results {displayContext}</h2>);
     }
-    return (<p>No results found. Please try another search.</p>);
+    return (<h2>No results found. Please try another search.</h2>);
   }
 
   render() {

--- a/src/app/components/SearchResultsPage/SearchResultsPage.jsx
+++ b/src/app/components/SearchResultsPage/SearchResultsPage.jsx
@@ -58,14 +58,21 @@ const SearchResultsPage = (props, context) => {
             <div className="nypl-row">
               <div className="nypl-column-three-quarters">
                 <Breadcrumbs query={searchKeywords} type="search" />
-                <h2 aria-label={headerLabel}>{appConfig.displayTitle}</h2>
+                <h1 aria-label={headerLabel}>Search Results</h1>
                 <Search
                   searchKeywords={searchKeywords}
                   field={field}
                   spinning={spinning}
                   createAPIQuery={createAPIQuery}
                 />
-
+                <ResultsCount
+                  spinning={spinning}
+                  count={totalResults}
+                  selectedFacets={selectedFacets}
+                  searchKeywords={searchKeywords}
+                  field={field}
+                  page={parseInt(page, 10)}
+                />
                 {
                   !!(totalResults && totalResults !== 0) && (
                     <Sorter
@@ -92,15 +99,6 @@ const SearchResultsPage = (props, context) => {
               aria-relevant="additions removals"
               aria-describedby="results-description"
             >
-              <ResultsCount
-                spinning={spinning}
-                count={totalResults}
-                selectedFacets={selectedFacets}
-                searchKeywords={searchKeywords}
-                field={field}
-                page={parseInt(page, 10)}
-              />
-
               {
                 !!(results && results.length !== 0) &&
                 (


### PR DESCRIPTION
This PR fixes the issue #674. It updates the headings on search results page. Can be viewed on dev.
http://dev-discovery.nypl.org/research/collections/shared-collection-catalog/search?q=peach

One thing I want to confirm is that the structure now of Bib details is
```
<div class="nypl-results-item-description">
  <ul>
    <liText</li>
    <li>Moskva: 1965</li>
    <li>1 item</li>
  </ul>
</div>
```
Is this correct?
Or should I remove the `<div>` and apply ` class="nypl-results-item-description"` to the  `<ul>`

