### PR TITLE
Updating the bib page again. Removing the table from the definition l…

### DIFF
--- a/log/discovery-ui.log
+++ b/log/discovery-ui.log
@@ -1,3 +1,0 @@
-{"timestamp":"2017-08-15T15:38:26.987Z","levelCode":6,"level":"INFO","pid":"22441","message":"App - Express server is listening at localhost: 3001."}
-{"timestamp":"2017-08-15T15:38:26.993Z","levelCode":6,"level":"INFO","pid":"22441","message":"Webpack Dev Server listening at localhost: 3000."}
-{"timestamp":"2017-08-15T15:39:17.777Z","levelCode":6,"level":"INFO","pid":"22441","message":"Received kill signal, shutting down gracefully."}

--- a/src/app/components/BibPage/BibDetails.jsx
+++ b/src/app/components/BibPage/BibDetails.jsx
@@ -210,27 +210,7 @@ class BibDetails extends React.Component {
   getDisplayFields(bib) {
     // A value of 'React Component' just means that we are getting it from a
     // component rather than from the bib field properties.
-    const fields = [
-      { label: 'Title', value: 'titleDisplay', linkable: true },
-      { label: 'Author', value: 'creatorLiteral', linkable: true },
-      { label: 'Additional Authors', value: 'contributorLiteral', linkable: true },
-      { label: 'Availability', value: 'React Component' },
-      { label: 'Publisher', value: 'React Component' },
-      { label: 'Electronic Resource', value: '' },
-      { label: 'Description', value: 'extent' },
-      { label: 'Subject', value: 'subjectLiteral', linkable: true },
-      { label: 'Genre/Form', value: 'materialType' },
-      { label: 'Notes', value: '' },
-      { label: 'Contents', value: 'note' },
-      { label: 'Bibliography', value: '' },
-      { label: 'ISBN', value: 'identifier', identifier: 'urn:isbn' },
-      { label: 'ISSN', value: 'identifier', identifier: 'urn:issn' },
-      { label: 'LCC', value: 'identifier', identifier: 'urn:lcc' },
-      { label: 'GPO', value: '' },
-      { label: 'Other Titles', value: '' },
-      { label: 'Owning Institutions', value: '' },
-      { label: 'MARC Record', value: 'React Component' },
-    ];
+    const fields = this.props.fields;
     const fieldsToRender = [];
     const publisherInfo = this.getPublisher(bib);
 
@@ -261,19 +241,6 @@ class BibDetails extends React.Component {
               definition,
             });
           }
-        }
-      }
-
-      // If it's not a field from the bib, then it's probably a React Component or a more
-      // complicated field. There are unique classes needed for the dt/dd elements.
-      if (fieldLabel === 'Availability') {
-        if (this.props.itemHoldings) {
-          fieldsToRender.push({
-            term: <h3>Availability</h3>,
-            definition: this.props.itemHoldings,
-            termClass: 'list-multi-control',
-            definitionClass: 'multi-item-list',
-          });
         }
       }
 
@@ -372,8 +339,8 @@ class BibDetails extends React.Component {
 
 BibDetails.propTypes = {
   bib: PropTypes.object,
-  itemHoldings: PropTypes.object,
   marcRecord: PropTypes.object,
+  fields: PropTypes.array,
 };
 
 BibDetails.contextTypes = {

--- a/src/app/components/BibPage/BibPage.jsx
+++ b/src/app/components/BibPage/BibPage.jsx
@@ -30,6 +30,28 @@ const BibPage = (props) => {
   if (props.location.pathname.indexOf('all') === -1) {
     shortenItems = false;
   }
+  const topFields = [
+    { label: 'Title', value: 'titleDisplay', linkable: true },
+    { label: 'Author', value: 'creatorLiteral', linkable: true },
+    { label: 'Additional Authors', value: 'contributorLiteral', linkable: true },
+  ];
+  const bottomFields = [
+    { label: 'Publisher', value: 'React Component' },
+    { label: 'Electronic Resource', value: '' },
+    { label: 'Description', value: 'extent' },
+    { label: 'Subject', value: 'subjectLiteral', linkable: true },
+    { label: 'Genre/Form', value: 'materialType' },
+    { label: 'Notes', value: '' },
+    { label: 'Contents', value: 'note' },
+    { label: 'Bibliography', value: '' },
+    { label: 'ISBN', value: 'identifier', identifier: 'urn:isbn' },
+    { label: 'ISSN', value: 'identifier', identifier: 'urn:issn' },
+    { label: 'LCC', value: 'identifier', identifier: 'urn:lcc' },
+    { label: 'GPO', value: '' },
+    { label: 'Other Titles', value: '' },
+    { label: 'Owning Institutions', value: '' },
+    { label: 'MARC Record', value: 'React Component' },
+  ];
 
   const itemHoldings = items.length && !electronicItems ?
     <ItemHoldings
@@ -85,8 +107,17 @@ const BibPage = (props) => {
                 <h1>{title}</h1>
                 <BibDetails
                   bib={bib}
-                  itemHoldings={itemHoldings}
                   marcRecord={marcRecord}
+                  fields={topFields}
+                />
+
+                {itemHoldings}
+
+                <h3>Additional details</h3>
+                <BibDetails
+                  bib={bib}
+                  marcRecord={marcRecord}
+                  fields={bottomFields}
                 />
               </div>
             </div>

--- a/src/app/components/BibPage/DefinitionList.jsx
+++ b/src/app/components/BibPage/DefinitionList.jsx
@@ -3,10 +3,7 @@ import PropTypes from 'prop-types';
 
 /*
  * DefinitionList
- * Expects data in the form of [
- *  { term: '', definition: '', termClass: '', definitionClass: ''},
- *  {...}, {...}, ...].
- * termClass and definitionClass are optional properties.
+ * Expects data in the form of [{ term: '', definition: '' }, {...}, ...].
  */
 const DefinitionList = ({ data }) => {
   const getDefinitions = (definitions) => {
@@ -19,8 +16,8 @@ const DefinitionList = ({ data }) => {
         return null;
       }
       return ([
-        (<dt className={item.termClass || null}>{item.term}</dt>),
-        (<dd className={item.definitionClass || null}>{item.definition}</dd>),
+        (<dt>{item.term}</dt>),
+        (<dd>{item.definition}</dd>),
       ]);
     });
   };

--- a/src/app/components/Item/ItemHoldings.jsx
+++ b/src/app/components/Item/ItemHoldings.jsx
@@ -162,7 +162,8 @@ class ItemHoldings extends React.Component {
     }
 
     return (
-      <span>
+      <div className="nypl-results-item">
+        <h3>Availability</h3>
         {itemTable}
         {
           !!(shortenItems && items.length >= 20 && !this.state.showAll) &&
@@ -180,7 +181,7 @@ class ItemHoldings extends React.Component {
             </div>)
         }
         {pagination}
-      </span>
+      </div>
     );
   }
 }


### PR DESCRIPTION
…ist and break apart the large definition list into two lists.

Fixes #724 

Breaks apart the big `dl` on the bib page into two lists. Had to refactor the `BibDetails` component so it doesn't render the table in a term/definition anymore.