### PR TITLE
Moving delivery location logic above DOM rendering logic.

### DIFF
--- a/src/app/components/HoldConfirmation/HoldConfirmation.jsx
+++ b/src/app/components/HoldConfirmation/HoldConfirmation.jsx
@@ -176,6 +176,21 @@ class HoldConfirmation extends React.Component {
       </div>
     );
 
+    if (this.props.deliveryLocations && this.props.deliveryLocations.length) {
+      if (pickupLocation !== 'edd') {
+        deliveryLocation = _findWhere(
+          this.props.deliveryLocations, { '@id': `loc:${pickupLocation}` }
+        );
+      } else {
+        deliveryLocation = {
+          id: null,
+          address: null,
+          prefLabel: 'n/a (electronic delivery)',
+          shortName: 'n/a',
+        };
+      }
+    }
+
     if (!this.props.location.query.errorStatus && !this.props.location.query.errorMessage) {
       confirmationPageTitle = 'Request Confirmation';
       confirmationInfo = (
@@ -214,21 +229,6 @@ class HoldConfirmation extends React.Component {
           {this.renderStartOverLink()}
         </div>
       );
-    }
-
-    if (this.props.deliveryLocations && this.props.deliveryLocations.length) {
-      if (pickupLocation !== 'edd') {
-        deliveryLocation = _findWhere(
-          this.props.deliveryLocations, { '@id': `loc:${pickupLocation}` }
-        );
-      } else {
-        deliveryLocation = {
-          id: null,
-          address: null,
-          prefLabel: 'n/a (electronic delivery)',
-          shortName: 'n/a',
-        };
-      }
     }
 
     return (


### PR DESCRIPTION
The delivery location logic needed to be above the html rendering logic. It was not displaying the location name before.