### PR TITLE
Un-encoding the search string.

### DIFF
--- a/src/server/ApiRoutes/Search.js
+++ b/src/server/ApiRoutes/Search.js
@@ -27,7 +27,7 @@ const nyplApiClientCall = (query) =>
 
 function search(searchKeywords, page, sortBy, order, field, filters, cb, errorcb) {
   const apiQuery = createAPIQuery({
-    searchKeywords: encodeURIComponent(searchKeywords),
+    searchKeywords,
     sortBy: sortBy ? `${sortBy}_${order}` : '',
     selectedFacets: filters,
     field,


### PR DESCRIPTION
Fixes #746 

Examples: 
* http://dev-discovery.nypl.org/research/collections/shared-collection-catalog/search?q=a%20life%20for%20a%20life%3A%20a%20novel
* http://dev-discovery.nypl.org/research/collections/shared-collection-catalog/search?q=aufstieg%20und%20niedergang%20der%20r%C3%B6mischen%20welt