### PR TITLE
Adding a selflinkable value to the BibDetails component so that those…

### DIFF
--- a/src/app/components/BibPage/BibDetails.jsx
+++ b/src/app/components/BibPage/BibDetails.jsx
@@ -55,8 +55,9 @@ class BibDetails extends React.Component {
    * @param {array} bibValues
    * @param {string} fieldValue
    * @param {boolean} fieldLinkable
+   * @param {boolean} fieldSelfLinkable
    */
-  getDefinitionObject(bibValues, fieldValue, fieldLinkable) {
+  getDefinitionObject(bibValues, fieldValue, fieldLinkable, fieldSelfLinkable) {
     if (bibValues.length === 1) {
       const bibValue = bibValues[0];
       const url = `filters[${fieldValue}]=${bibValue['@id']}`;
@@ -69,6 +70,12 @@ class BibDetails extends React.Component {
         );
       }
 
+      if (fieldSelfLinkable) {
+        return (
+          <a href={bibValue['@id']}>{bibValue.prefLabel}</a>
+        );
+      }
+
       return <span>{bibValue.prefLabel}</span>;
     }
 
@@ -77,20 +84,19 @@ class BibDetails extends React.Component {
         {
           bibValues.map((value, i) => {
             const url = `filters[${fieldValue}]=${value['@id']}`;
-            return (
-              <li key={i}>
-                {
-                  fieldLinkable ?
-                    <Link
-                      onClick={e => this.newSearch(e, url)}
-                      to={`${appConfig.baseUrl}/search?${url}`}
-                    >
-                      {value.prefLabel}
-                    </Link>
-                    : <span>{value.prefLabel}</span>
-                }
-              </li>
-            );
+            let itemValue = fieldLinkable ?
+              <Link
+                onClick={e => this.newSearch(e, url)}
+                to={`${appConfig.baseUrl}/search?${url}`}
+              >
+                {value.prefLabel}
+              </Link>
+              : <span>{value.prefLabel}</span>;
+            if (fieldSelfLinkable) {
+              itemValue = <a href={value['@id']}>{value.prefLabel}</a>;
+            }
+
+            return (<li key={i}>{itemValue}</li>);
           })
         }
       </ul>
@@ -128,8 +134,9 @@ class BibDetails extends React.Component {
    * @param {string} fieldValue
    * @param {boolean} fieldLinkable
    * @param {string} fieldIdentifier
+   * @param {string} fieldSelfLinkable
    */
-  getDefinition(bibValues, fieldValue, fieldLinkable, fieldIdentifier) {
+  getDefinition(bibValues, fieldValue, fieldLinkable, fieldIdentifier, fieldSelfLinkable) {
     if (fieldValue === 'identifier') {
       return this.getIdentifiers(bibValues, fieldIdentifier);
     }
@@ -143,6 +150,12 @@ class BibDetails extends React.Component {
           <Link onClick={e => this.newSearch(e, url)} to={`${appConfig.baseUrl}/search?${url}`}>
             {bibValue}
           </Link>
+        );
+      }
+
+      if (fieldSelfLinkable) {
+        return (
+          <a href={bibValue}>{fieldValue}</a>
         );
       }
 
@@ -218,6 +231,7 @@ class BibDetails extends React.Component {
       const fieldLabel = field.label;
       const fieldValue = field.value;
       const fieldLinkable = field.linkable;
+      const fieldSelfLinkable = field.selfLinkable;
       const fieldIdentifier = field.identifier;
       const bibValues = bib[fieldValue];
 
@@ -230,11 +244,13 @@ class BibDetails extends React.Component {
         if (firstFieldValue['@id']) {
           fieldsToRender.push({
             term: fieldLabel,
-            definition: this.getDefinitionObject(bibValues, fieldValue, fieldLinkable),
+            definition:
+              this.getDefinitionObject(bibValues, fieldValue, fieldLinkable, fieldSelfLinkable),
           });
         } else {
-          const definition =
-            this.getDefinition(bibValues, fieldValue, fieldLinkable, fieldIdentifier);
+          const definition = this.getDefinition(
+            bibValues, fieldValue, fieldLinkable, fieldIdentifier, fieldSelfLinkable
+          );
           if (definition) {
             fieldsToRender.push({
               term: fieldLabel,

--- a/src/app/components/BibPage/BibPage.jsx
+++ b/src/app/components/BibPage/BibPage.jsx
@@ -4,7 +4,6 @@ import DocumentTitle from 'react-document-title';
 import { every as _every } from 'underscore';
 
 import Breadcrumbs from '../Breadcrumbs/Breadcrumbs';
-import Search from '../Search/Search';
 import ItemHoldings from '../Item/ItemHoldings';
 import BibDetails from './BibDetails';
 import LibraryItem from '../../utils/item';
@@ -12,7 +11,6 @@ import BackLink from './BackLink';
 import MarcRecord from './MarcRecord';
 
 import { basicQuery } from '../../utils/utils';
-import appConfig from '../../../../appConfig.js';
 
 const BibPage = (props) => {
   const createAPIQuery = basicQuery(props);
@@ -30,6 +28,9 @@ const BibPage = (props) => {
   if (props.location.pathname.indexOf('all') === -1) {
     shortenItems = false;
   }
+  // `linkable` means that those values are links inside the app.
+  // `selfLinkable` means that those values are external links and should be self-linked,
+  // e.g. the prefLabel is the label and the URL is the id.
   const topFields = [
     { label: 'Title', value: 'titleDisplay', linkable: true },
     { label: 'Author', value: 'creatorLiteral', linkable: true },
@@ -42,6 +43,7 @@ const BibPage = (props) => {
     { label: 'Subject', value: 'subjectLiteral', linkable: true },
     { label: 'Genre/Form', value: 'materialType' },
     { label: 'Notes', value: '' },
+    { label: 'Additional Resources', value: 'supplementaryContent', selfLinkable: true },
     { label: 'Contents', value: 'note' },
     { label: 'Bibliography', value: '' },
     { label: 'ISBN', value: 'identifier', identifier: 'urn:isbn' },


### PR DESCRIPTION
… values are external links and the preflabel is the link's label.

Fixes #749.

Here's the example: http://dev-discovery.nypl.org/research/collections/shared-collection-catalog/bib/b18932917

@seanredmond, I can't find other examples but if you find any, especially with multiple values, post them here to test.