### PR TITLE
Classic link

### DIFF
--- a/src/app/components/ElectronicDelivery/ElectronicDelivery.jsx
+++ b/src/app/components/ElectronicDelivery/ElectronicDelivery.jsx
@@ -107,6 +107,8 @@ class ElectronicDelivery extends React.Component {
     }, fields);
     const searchKeywords = this.props.searchKeywords;
     const searchKeywordsQuery = (searchKeywords) ? `&searchKeywords=${searchKeywords}` : '';
+    const fromUrlQuery = this.props.location.query && this.props.location.query.fromUrl ?
+      `&fromUrl=${encodeURIComponent(this.props.location.query.fromUrl)}` : '';
 
     // This is to remove the error box on the top of the page on a successfull submission.
     this.setState({ raiseError: null });
@@ -116,11 +118,12 @@ class ElectronicDelivery extends React.Component {
         if (response.data.error && response.data.error.status !== 200) {
           this.context.router.push(
             `${path}?errorStatus=${response.data.error.status}` +
-            `&errorMessage=${response.data.error.statusText}${searchKeywordsQuery}`
+            `&errorMessage=${response.data.error.statusText}${searchKeywordsQuery}${fromUrlQuery}`
           );
         } else {
           this.context.router.push(
-            `${path}?pickupLocation=edd&requestId=${response.data.id}${searchKeywordsQuery}`
+            `${path}?pickupLocation=edd&requestId=${response.data.id}` +
+            `${searchKeywordsQuery}${fromUrlQuery}`
           );
         }
       })
@@ -130,7 +133,9 @@ class ElectronicDelivery extends React.Component {
           error
         );
 
-        this.context.router.push(`${path}?errorMessage=${error}${searchKeywordsQuery}`);
+        this.context.router.push(
+          `${path}?errorMessage=${error}${searchKeywordsQuery}${fromUrlQuery}`
+        );
       });
   }
 

--- a/src/app/components/HoldConfirmation/HoldConfirmation.jsx
+++ b/src/app/components/HoldConfirmation/HoldConfirmation.jsx
@@ -246,7 +246,7 @@ class HoldConfirmation extends React.Component {
 
           <h3>Electronic Delivery</h3>
           <p>
-            If you selected Electronic delivery, you will be notified via email when the
+            If you selected electronic delivery, you will be notified via email when the
             item is available.
           </p>
           {this.renderBackToClassicLink()}

--- a/src/app/components/HoldConfirmation/HoldConfirmation.jsx
+++ b/src/app/components/HoldConfirmation/HoldConfirmation.jsx
@@ -119,14 +119,42 @@ class HoldConfirmation extends React.Component {
    * @return {HTML Element}
    */
   renderStartOverLink() {
+    let buttonText = 'Start Over';
+    if (this.props.location.query.fromUrl) {
+      buttonText = 'Try the new SCC Search';
+    }
+
     return (
       <Link
         className="nypl-request-button"
         to={`${appConfig.baseUrl}/`}
         onClick={(e) => this.goRestart(e)}
       >
-        Start Over
+        {buttonText}
       </Link>
+    );
+  }
+
+  /**
+   * renderBackToClassicLink
+   * Renders the link back to the page of search results.
+   *
+   * @return {HTML Element}
+   */
+  renderBackToClassicLink() {
+    if (!this.props.location.query.fromUrl) {
+      return false;
+    }
+
+    return (
+      <span>
+        <a className="nypl-request-button" href={this.props.location.query.fromUrl}>
+          Back to Classic results
+        </a>
+        <a className="nypl-request-button" href="https://catalog.nypl.org/search">
+          New Classic Search
+        </a>
+      </span>
     );
   }
 
@@ -171,6 +199,7 @@ class HoldConfirmation extends React.Component {
           We could not process your request at this time. Please try again or contact 917-ASK-NYPL
           (<a href="tel:19172756975">917-275-6975</a>).
         </p>
+        {this.renderBackToClassicLink()}
         {this.renderBackToSearchLink()}
         {this.renderStartOverLink()}
       </div>
@@ -225,6 +254,7 @@ class HoldConfirmation extends React.Component {
             If you selected Electronic delivery, you will be notified via email when the
             item is available.
           </p>
+          {this.renderBackToClassicLink()}
           {this.renderBackToSearchLink()}
           {this.renderStartOverLink()}
         </div>

--- a/src/app/components/HoldConfirmation/HoldConfirmation.jsx
+++ b/src/app/components/HoldConfirmation/HoldConfirmation.jsx
@@ -119,19 +119,17 @@ class HoldConfirmation extends React.Component {
    * @return {HTML Element}
    */
   renderStartOverLink() {
-    let buttonText = 'Start Over';
     if (this.props.location.query.fromUrl) {
-      buttonText = 'Try the new SCC Search';
+      return (
+        <span> You may also try your search in
+          our <Link to={`${appConfig.baseUrl}/`} onClick={(e) => this.goRestart(e)}>Shared
+          Collection Catalog</Link>.
+        </span>
+      );
     }
 
     return (
-      <Link
-        className="nypl-request-button"
-        to={`${appConfig.baseUrl}/`}
-        onClick={(e) => this.goRestart(e)}
-      >
-        {buttonText}
-      </Link>
+      <Link to={`${appConfig.baseUrl}/`} onClick={(e) => this.goRestart(e)}>Start Over</Link>
     );
   }
 
@@ -148,12 +146,8 @@ class HoldConfirmation extends React.Component {
 
     return (
       <span>
-        <a className="nypl-request-button" href={this.props.location.query.fromUrl}>
-          Back to Classic results
-        </a>
-        <a className="nypl-request-button" href="https://catalog.nypl.org/search">
-          New Classic Search
-        </a>
+        <a href={this.props.location.query.fromUrl}>Go back to your search
+        results</a> or <a href="https://catalog.nypl.org/search">start a new search</a>.
       </span>
     );
   }
@@ -170,15 +164,14 @@ class HoldConfirmation extends React.Component {
     }
 
     return (
-      <Link
-        className="nypl-request-button"
+      <span><Link
         // We use this.props.location.query.searchKeywords here for the query from
         // the URL to deal with no js situation.
         to={`${appConfig.baseUrl}/search?q=${this.props.location.query.searchKeywords}`}
         onClick={(e) => this.goSearchResults(e)}
       >
         Back to results
-      </Link>
+      </Link>&nbsp;</span>
     );
   }
 

--- a/src/app/components/HoldConfirmation/HoldConfirmation.jsx
+++ b/src/app/components/HoldConfirmation/HoldConfirmation.jsx
@@ -127,10 +127,12 @@ class HoldConfirmation extends React.Component {
         </span>
       );
     }
+    let text = 'Start a new search';
+    if (this.props.location.query.searchKeywords) {
+      text = 'start a new search';
+    }
 
-    return (
-      <Link to={`${appConfig.baseUrl}/`} onClick={(e) => this.goRestart(e)}>Start Over</Link>
-    );
+    return (<Link to={`${appConfig.baseUrl}/`} onClick={(e) => this.goRestart(e)}>{text}</Link>);
   }
 
   /**
@@ -170,8 +172,8 @@ class HoldConfirmation extends React.Component {
         to={`${appConfig.baseUrl}/search?q=${this.props.location.query.searchKeywords}`}
         onClick={(e) => this.goSearchResults(e)}
       >
-        Back to results
-      </Link>&nbsp;</span>
+        Go back to your search results
+      </Link> or </span>
     );
   }
 

--- a/src/app/components/HoldRequest/HoldRequest.jsx
+++ b/src/app/components/HoldRequest/HoldRequest.jsx
@@ -88,15 +88,16 @@ class HoldRequest extends React.Component {
   submitRequest(e, bibId, itemId, itemSource) {
     e.preventDefault();
 
-    let path = `${appConfig.baseUrl}/hold/confirmation/${bibId}-${itemId}`;
     const searchKeywordsQuery =
       (this.props.searchKeywords) ? `searchKeywords=${this.props.searchKeywords}` : '';
     const searchKeywordsQueryPhysical = searchKeywordsQuery ? `&${searchKeywordsQuery}` : '';
+    const fromUrlQuery = this.props.location.query && this.props.location.query.fromUrl ?
+      `&fromUrl=${encodeURIComponent(this.props.location.query.fromUrl)}` : '';
+    let path = `${appConfig.baseUrl}/hold/confirmation/${bibId}-${itemId}`;
 
     if (this.state.delivery === 'edd') {
-      const searchKeywordsQueryEdd = searchKeywordsQuery ? `?${searchKeywordsQuery}` : '';
-
-      path = `${appConfig.baseUrl}/hold/request/${bibId}-${itemId}/edd${searchKeywordsQueryEdd}`;
+      path = `${appConfig.baseUrl}/hold/request/${bibId}-${itemId}` +
+        `/edd?${searchKeywordsQuery}${fromUrlQuery}`;
 
       this.context.router.push(path);
       return;
@@ -109,19 +110,22 @@ class HoldRequest extends React.Component {
         if (response.data.error && response.data.error.status !== 200) {
           this.context.router.push(
             `${path}?errorStatus=${response.data.error.status}` +
-            `&errorMessage=${response.data.error.statusText}${searchKeywordsQueryPhysical}`
+            `&errorMessage=${response.data.error.statusText}${searchKeywordsQueryPhysical}` +
+            `${fromUrlQuery}`
           );
         } else {
           this.context.router.push(
             `${path}?pickupLocation=${response.data.pickupLocation}&requestId=${response.data.id}` +
-            `${searchKeywordsQueryPhysical}`
+            `${searchKeywordsQueryPhysical}${fromUrlQuery}`
           );
         }
       })
       .catch(error => {
         console.error('Error attempting to make an ajax Hold Request in HoldRequest', error);
 
-        this.context.router.push(`${path}?errorMessage=${error}${searchKeywordsQueryPhysical}`);
+        this.context.router.push(
+          `${path}?errorMessage=${error}${searchKeywordsQueryPhysical}${fromUrlQuery}`
+        );
       });
   }
 


### PR DESCRIPTION
Fixes #741 

This is up on DEV and QA. QA is the place to test since the catalog links go to the Hold Request page on QA. This is using the `fromUrl` that Kevin set up in Classic to link back to Classic.

How to test:
-- From Classic:
1) Start on https://nypl-sierra-test.iii.com/search~S98/?searchtype=X&searcharg=The+Victoria+history+of+the+county+of+Sussex&searchscope=98&sortdropdown=-&SORT=DZ&extended=0&SUBMIT=Search&searchlimits=&searchorigarg=XThe+Victoria+history+of+the+county+of+Sussex%26SORT%3DDZ
2) Click on the "Request from off-site storage".
3) Submit either an EDD or a Physical request.
4) You should get a confirmation page with two links to the catalog and a link to "try" Discovery.
5) 💰 

-- From Discovery:
Starting from a search query:
1) Start on https://qa-www.nypl.org/research/collections/shared-collection-catalog/
2) Search for "Shakespeare".
3) Click on the first "Request" button.
4) Submit either an EDD or a Physical request.
5) You will see two links to go back to your search results or start a new search.

Starting directly from a bib page:
1) Start on https://qa-www.nypl.org/research/collections/shared-collection-catalog/bib/pb2405740
2) Click on the first "Request" button.
3) Submit either an EDD or a Physical request.
4) You should only see ONE link to start a new search.
