### PR TITLE
Updating the logic for non-recap nypl items.

### DIFF
--- a/src/app/utils/item.js
+++ b/src/app/utils/item.js
@@ -114,8 +114,8 @@ function LibraryItem() {
     // nypl-owned ReCAP
     const nyplRecap = !!((holdingLocation && !_isEmpty(holdingLocation) &&
       holdingLocation['@id'].substring(4, 6) === 'rc') && (itemSource === 'SierraNypl'));
-    const nonRecapNYPL = !!(accessMessage.prefLabel === 'USE IN LIBRARY' &&
-      (item.holdingLocation && item.holdingLocation.length));
+    const nonRecapNYPL = !!((holdingLocation && !_isEmpty(holdingLocation) &&
+      holdingLocation['@id'].substring(4, 6) !== 'rc') && (itemSource === 'SierraNypl'));
     const isRecap = nonNyplRecap || nyplRecap;
     // The identifier we need for an item now
     const identifiersArray = [{ name: 'barcode', value: 'urn:barcode:' }];


### PR DESCRIPTION
Fixes #752 

No longer using "USE IN LIBRARY" to dictate if an item is a non-ReCAP NYPL item. Checking to see that the loc code does not start with "rc".