### PR TITLE
Kms local

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ Front-end app for searching, discovering, and placing a hold on research items f
 * Express Server
 * [Travis](https://travis-ci.org/)
 
+## Client Id and Secret
+We are using environment variables to make authorized requests to NYPL's API platform. The `clientId` and `clientSecret` environment variables should be received from a developer in the NYPL Digital Department.
+
+Please check the [EBSVARS](EBSVARS.md) documentation for more information.
+
 ## Installation and running locally
 
 #### Installation
@@ -57,11 +62,6 @@ or, if you'd like fewer environment variables in the command line:
     $ clientID=[client id] clientSecret=[client secret] npm run prod-start
 
 and visit `localhost:3001`.
-
-## Client Id and Secret
-We are using environment variables to make authorized requests to NYPL's API platform. The `clientId` and `clientSecret` environment variables should be received from a developer in the NYPL Digital Department.
-
-Please check the [EBSVARS](EBSVARS.md) documentation for more information.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -29,13 +29,13 @@ To install packages run
     $ npm install
 
 #### Development mode with different API environments
-To run locally in development mode with the development API run
+To run locally in development mode with the development API and with the regular unencrypted API keys, run:
 
     $ clientId=[client id] clientSecret=[client secret] npm run dev-api-start
 
-To run locally in development mode with the production API run
+To run locally in production mode with the production API and with encrypted API keys, run:
 
-    $ clientId=[client id] clientSecret=[client secret] npm run prod-api-start
+    $ clientId=[encrypted client id] clientSecret=[encrypted client secret] npm run prod-api-start
 
 If you would like to run in different the API environments without the special npm run scripts, run
 

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "start": "node index",
     "prod-start": "NODE_ENV=production APP_ENV=production node index",
-    "dev-api-start": "APP_ENV=development node index",
-    "prod-api-start": "APP_ENV=production node index",
+    "dev-api-start": "APP_ENV=development KMS_ENV=unencrypted node index",
+    "prod-api-start": "APP_ENV=production KMS_ENV=encrypted node index",
     "eb-start": "npm run dist && node index",
     "dist": "NODE_ENV=production webpack --config webpack.config.js",
     "postinstall": "npm run dist",

--- a/src/server/routes/nyplApiClient/index.js
+++ b/src/server/routes/nyplApiClient/index.js
@@ -5,11 +5,12 @@ import config from '../../../../appConfig.js';
 import logger from '../../../../logger.js';
 
 const appEnvironment = process.env.APP_ENV || 'production';
+const kmsEnvironment = process.env.KMS_ENV || 'encrypted';
 const apiBase = config.api[appEnvironment];
 let decryptKMS;
 let kms;
 
-if (appEnvironment === 'production') {
+if (kmsEnvironment === 'encrypted') {
   kms = new aws.KMS({
     region: 'us-east-1',
   });
@@ -42,7 +43,7 @@ function client() {
     return Promise.resolve(CACHE.nyplApiClient);
   }
 
-  if (appEnvironment !== 'production') {
+  if (kmsEnvironment !== 'encrypted') {
     const nyplApiClient = new NyplApiClient({
       base_url: apiBase,
       oauth_key: clientId,

--- a/src/server/routes/nyplApiClient/index.js
+++ b/src/server/routes/nyplApiClient/index.js
@@ -1,27 +1,34 @@
 import NyplApiClient from '@nypl/nypl-data-api-client';
-import config from '../../../../appConfig.js';
 import aws from 'aws-sdk';
+
+import config from '../../../../appConfig.js';
+import logger from '../../../../logger.js';
 
 const appEnvironment = process.env.APP_ENV || 'production';
 const apiBase = config.api[appEnvironment];
-const kms = new aws.KMS({
-  region: 'us-east-1',
-});
+let decryptKMS;
+let kms;
 
-function decryptKMS(key) {
-  const params = {
-    CiphertextBlob: new Buffer(key, 'base64'),
-  };
-
-  return new Promise((resolve, reject) => {
-    kms.decrypt(params, (err, data) => {
-      if (err) {
-        reject(err);
-      } else {
-        resolve(data.Plaintext.toString());
-      }
-    });
+if (appEnvironment === 'production') {
+  kms = new aws.KMS({
+    region: 'us-east-1',
   });
+
+  decryptKMS = (key) => {
+    const params = {
+      CiphertextBlob: new Buffer(key, 'base64'),
+    };
+
+    return new Promise((resolve, reject) => {
+      kms.decrypt(params, (err, data) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(data.Plaintext.toString());
+        }
+      });
+    });
+  };
 }
 
 const clientId = process.env.clientId;
@@ -33,6 +40,21 @@ const CACHE = {};
 function client() {
   if (CACHE.nyplApiClient) {
     return Promise.resolve(CACHE.nyplApiClient);
+  }
+
+  if (appEnvironment !== 'production') {
+    const nyplApiClient = new NyplApiClient({
+      base_url: apiBase,
+      oauth_key: clientId,
+      oauth_secret: clientSecret,
+      oauth_url: config.tokenUrl,
+    });
+
+    CACHE.clientId = clientId;
+    CACHE.clientSecret = clientSecret;
+    CACHE.nyplApiClient = nyplApiClient;
+
+    return Promise.resolve(nyplApiClient);
   }
 
   return new Promise((resolve, reject) => {
@@ -52,7 +74,7 @@ function client() {
         resolve(nyplApiClient);
       })
       .catch(error => {
-        console.log('ERROR trying to decrypt using KMS.', error);
+        logger.error('ERROR trying to decrypt using KMS.', error);
         reject('ERROR trying to decrypt using KMS.', error);
       });
   });


### PR DESCRIPTION
Fixes #756.

I added a new `KMS_ENV` variable to keep track of whether we want encrypted or unencrypted env variables. In local development server, `KMS_ENV` is set to `unencrypted` and in the AWS servers it will be set to `encrypted`.

Like it says in the updated readme, to run locally with unencrypted keys, use:
`clientId=[client id] clientSecret=[client secret] npm run dev-api-start`

To run with encrypted keys, use:
`clientId=[encrypted client id] clientSecret=[encrypted client secret] npm run prod-api-start`