### PR TITLE
Server redirect if fetching a bib fails on the server side.

### DIFF
--- a/src/server/ApiRoutes/Bib.js
+++ b/src/server/ApiRoutes/Bib.js
@@ -1,5 +1,6 @@
 import nyplApiClient from '../routes/nyplApiClient';
 import logger from '../../../logger';
+import appConfig from '../../../appConfig.js';
 
 const nyplApiClientCall = (query) =>
   nyplApiClient().then(client => client.get(`/discovery/resources/${query}`));
@@ -20,6 +21,10 @@ function bibSearchServer(req, res, next) {
   fetchBib(
     bibId,
     (data) => {
+      if (data.status && data.status === 404) {
+        return res.redirect(`${appConfig.baseUrl}/404`);
+      }
+
       res.locals.data.Store = {
         bib: data,
         searchKeywords: req.query.searchKeywords || '',


### PR DESCRIPTION
Fixes #773.

Example:
Instead of displaying an `internal server error` message like here:
https://qa-www.nypl.org/research/collections/shared-collection-catalog/bib/b7777777

redirect to the 404 page:
http://dev-discovery.nypl.org/research/collections/shared-collection-catalog/bib/b7777777