### PR TITLE
Electronic locator display

### DIFF
--- a/src/app/components/BibPage/BibDetails.jsx
+++ b/src/app/components/BibPage/BibDetails.jsx
@@ -282,13 +282,29 @@ class BibDetails extends React.Component {
         }
       }
 
-      if (fieldLabel === 'Electronic Resource') {
+      if (fieldLabel === 'Electronic Resource' && this.props.electronicResources.length) {
         const electronicResources = this.props.electronicResources;
+        let electronicElem;
+
+        if (electronicResources.length === 1) {
+          const electronicItem = electronicResources[0];
+          electronicElem =
+            <a href={electronicItem.url} target="_blank">{electronicItem.prefLabel}</a>;
+        } else {
+          electronicElem = (
+            <ul>
+              {
+                electronicResources.map((e, i) => (
+                  <li key={i}><a href={e.url} target="_blank">{e.prefLabel}</a></li>
+                ))
+              }
+            </ul>
+          );
+        }
+
         fieldsToRender.push({
           term: fieldLabel,
-          definition: electronicResources.map((e, i) => (
-            <a key={i} href={e.url} target="_blank">{e.prefLabel}</a>
-          )),
+          definition: electronicElem,
         });
       }
     }); // End of the forEach loop

--- a/src/app/components/BibPage/BibDetails.jsx
+++ b/src/app/components/BibPage/BibDetails.jsx
@@ -281,6 +281,16 @@ class BibDetails extends React.Component {
           });
         }
       }
+
+      if (fieldLabel === 'Electronic Resource') {
+        const electronicResources = this.props.electronicResources;
+        fieldsToRender.push({
+          term: fieldLabel,
+          definition: electronicResources.map((e, i) => (
+            <a key={i} href={e.url} target="_blank">{e.prefLabel}</a>
+          )),
+        });
+      }
     }); // End of the forEach loop
 
     return fieldsToRender;
@@ -344,6 +354,11 @@ class BibDetails extends React.Component {
 BibDetails.propTypes = {
   bib: PropTypes.object,
   fields: PropTypes.array,
+  electronicResources: PropTypes.array,
+};
+
+BibDetails.defaultProps = {
+  electronicResources: [],
 };
 
 BibDetails.contextTypes = {

--- a/src/app/components/BibPage/BibPage.jsx
+++ b/src/app/components/BibPage/BibPage.jsx
@@ -10,7 +10,10 @@ import LibraryItem from '../../utils/item';
 import BackLink from './BackLink';
 import MarcRecord from './MarcRecord';
 
-import { basicQuery } from '../../utils/utils';
+import {
+  basicQuery,
+  getAggregatedElectronicResources,
+} from '../../utils/utils';
 
 const BibPage = (props) => {
   const createAPIQuery = basicQuery(props);
@@ -18,11 +21,12 @@ const BibPage = (props) => {
   const bibId = bib && bib['@id'] ? bib['@id'].substring(4) : '';
   const title = bib.title && bib.title.length ? bib.title[0] : '';
   const items = LibraryItem.getItems(bib);
-  const electronicItems = _every(items, (i) => i.isElectronicResource);
+  const isElectronicResources = _every(items, (i) => i.isElectronicResource);
   const isNYPLReCAP = LibraryItem.isNYPLReCAP(bib['@id']);
   const bNumber = bib && bib.idBnum ? bib.idBnum : '';
   const searchURL = createAPIQuery({});
   const itemPage = props.location.search;
+  const aggregatedElectronicResources = getAggregatedElectronicResources(items);
   let shortenItems = true;
 
   if (props.location.pathname.indexOf('all') === -1) {
@@ -38,7 +42,7 @@ const BibPage = (props) => {
   ];
   const bottomFields = [
     { label: 'Publication', value: 'React Component' },
-    { label: 'Electronic Resource', value: '' },
+    { label: 'Electronic Resource', value: 'React Component' },
     { label: 'Description', value: 'extent' },
     { label: 'Subject', value: 'subjectLiteral', linkable: true },
     { label: 'Genre/Form', value: 'materialType' },
@@ -54,7 +58,7 @@ const BibPage = (props) => {
     { label: 'Owning Institutions', value: '' },
   ];
 
-  const itemHoldings = items.length && !electronicItems ?
+  const itemHoldings = items.length && !isElectronicResources ?
     <ItemHoldings
       shortenItems={shortenItems}
       items={items}
@@ -111,6 +115,7 @@ const BibPage = (props) => {
                 <BibDetails
                   bib={bib}
                   fields={bottomFields}
+                  electronicResources={aggregatedElectronicResources}
                 />
                 {marcRecord}
               </div>

--- a/src/app/utils/item.js
+++ b/src/app/utils/item.js
@@ -85,6 +85,19 @@ function LibraryItem() {
   };
 
   /**
+   * getElectronicResources(item)
+   * @param {object} items The item to get an electronic resource from.
+   * @return {array}
+   */
+  this.getElectronicResources = (item = {}) => {
+    if (item.electronicLocator) {
+      return item.electronicLocator;
+    }
+
+    return [];
+  };
+
+  /**
    * mapItem(item, title)
    * Massage data and update an item's properties.
    * @param {object} item The item to update the data for.
@@ -103,6 +116,7 @@ function LibraryItem() {
     // Taking the first value in the array;
     const suppressed = item.suppressed && item.suppressed.length ? item.suppressed[0] : false;
     const isElectronicResource = this.isElectronicResource(item);
+    const electronicResources = isElectronicResource ? this.getElectronicResources(item) : null;
     // Taking the first status object in the array.
     const status = item.status && item.status.length ? item.status[0] : {};
     const availability = !_isEmpty(status) && status.prefLabel ?
@@ -137,6 +151,7 @@ function LibraryItem() {
       available,
       accessMessage,
       isElectronicResource,
+      electronicResources,
       location: holdingLocation.prefLabel,
       callNumber,
       url,

--- a/src/app/utils/utils.js
+++ b/src/app/utils/utils.js
@@ -13,6 +13,7 @@ import {
   isArray as _isArray,
   extend as _extend,
   chain as _chain,
+  flatten as _flatten,
 } from 'underscore';
 
 import appConfig from '../../../appConfig.js';
@@ -400,6 +401,28 @@ function parseServerSelectedFilters(filters, dateAfter, dateBefore) {
   return selectedFacets;
 }
 
+/**
+ * getAggregatedElectronicResources(items)
+ * Get an aggregated array of electronic items from each item if available.
+ * @param {array} items
+ * @return {object}
+ */
+function getAggregatedElectronicResources(items = []) {
+  if (!items && !items.length) {
+    return [];
+  }
+
+  const electronicResources = [];
+
+  _forEach(items, item => {
+    if (item.isElectronicResource) {
+      electronicResources.push(item.electronicResources);
+    }
+  });
+
+  return _flatten(electronicResources);
+}
+
 export {
   collapse,
   trackDiscovery,
@@ -414,4 +437,5 @@ export {
   basicQuery,
   getReqParams,
   parseServerSelectedFilters,
+  getAggregatedElectronicResources,
 };


### PR DESCRIPTION
Fixes #784 

NOTE: This PR is the logic/data part. @ricardoom , let me know where it should be located, how it should look, or any other changes. I think you mentioned to make the link open in new pages so I did that.
This PR is:
1) Extracting each item's `electronicLocator` array.
2) If there are multiple items with multiple `electronicLocator` array, it will aggregate them all into one single array.
3) It will render that list of links (or a single link) in the Bib page.

Examples:
* http://dev-discovery.nypl.org/research/collections/shared-collection-catalog/bib/b12170263
* http://dev-discovery.nypl.org/research/collections/shared-collection-catalog/bib/b17997741
* http://dev-discovery.nypl.org/research/collections/shared-collection-catalog/bib/b14924644
* http://dev-discovery.nypl.org/research/collections/shared-collection-catalog/bib/b16099314
