### PR TITLE
Adding aria-attributes to feedback button and making it static on mob…

### DIFF
--- a/src/app/components/Feedback/Feedback.jsx
+++ b/src/app/components/Feedback/Feedback.jsx
@@ -43,6 +43,8 @@ class Feedback extends React.Component {
         <button
           className={`feedback-button ${!showForm ? 'hidden' : ''}`}
           onClick={() => this.closeForm()}
+          aria-expanded={!showForm}
+          aria-controls="feedback-menu"
         >
           Cancel
         </button>

--- a/src/app/components/Feedback/Feedback.jsx
+++ b/src/app/components/Feedback/Feedback.jsx
@@ -20,7 +20,8 @@ class Feedback extends React.Component {
     this.refs.commentText.value = '';
   }
 
-  closeForm() {
+  closeForm(e) {
+    e.preventDefault();
     this.setState({ showForm: false });
     this.refs.commentText.value = '';
   }
@@ -39,14 +40,6 @@ class Feedback extends React.Component {
           aria-controls="feedback-menu"
         >
           Feedback
-        </button>
-        <button
-          className={`feedback-button ${!showForm ? 'hidden' : ''}`}
-          onClick={() => this.closeForm()}
-          aria-expanded={!showForm}
-          aria-controls="feedback-menu"
-        >
-          Cancel
         </button>
         <div
           id="feedback-menu"
@@ -70,15 +63,12 @@ class Feedback extends React.Component {
                 name="entry.148983317"
                 rows="5"
                 ref="commentText"
-                required
+                aria-required="true"
               />
             </div>
             <div>
-              <label htmlFor="feedback-input-email">
-                Email Address
-                <span className="nypl-required-field">&nbsp;Required</span>
-              </label>
-              <input id="feedback-input-email" name="entry.503620384" type="email" required />
+              <label htmlFor="feedback-input-email">Email Address</label>
+              <input id="feedback-input-email" name="entry.503620384" type="email" />
             </div>
             <input
               id="feedback-input-url"
@@ -87,6 +77,15 @@ class Feedback extends React.Component {
               type="hidden"
             />
             <input name="fvv" value="1" type="hidden" />
+
+            <button
+              className={`cancel-button ${!showForm ? 'hidden' : ''}`}
+              onClick={(e) => this.closeForm(e)}
+              aria-expanded={!showForm}
+              aria-controls="feedback-menu"
+            >
+              Cancel
+            </button>
 
             <button type="submit" className="large">Submit</button>
           </form>

--- a/src/app/components/Feedback/Feedback.jsx
+++ b/src/app/components/Feedback/Feedback.jsx
@@ -15,10 +15,13 @@ class Feedback extends React.Component {
     alert('Thank you, your feedback has been submitted.');
   }
 
-  toggleForm() {
-    this.setState({
-      showForm: !this.state.showForm,
-    });
+  openForm() {
+    this.setState({ showForm: true });
+    this.refs.commentText.value = '';
+  }
+
+  closeForm() {
+    this.setState({ showForm: false });
     this.refs.commentText.value = '';
   }
 
@@ -28,12 +31,29 @@ class Feedback extends React.Component {
 
     return (
       <div className="feedback">
-        <button className="feedback-button" onClick={() => this.toggleForm()}>
+        <button
+          className="feedback-button"
+          onClick={() => this.openForm()}
+          aria-haspopup="true"
+          aria-expanded={showForm}
+          aria-controls="feedback-menu"
+        >
           Feedback
         </button>
-        <div className={`feedback-form-container${showForm ? ' active' : ''}`}>
+        <button
+          className={`feedback-button ${!showForm ? 'hidden' : ''}`}
+          onClick={() => this.closeForm()}
+        >
+          Cancel
+        </button>
+        <div
+          id="feedback-menu"
+          role="menu"
+          className={`feedback-form-container${showForm ? ' active' : ''}`}
+        >
           <form
-            action="https://docs.google.com/a/nypl.org/forms/d/e/1FAIpQLScnoQV5OjAP-Y9BOJ1PO9YpMdLjMyWn7VOTFSrDhCAP5ZN5Dw/formResponse"
+            action={'https://docs.google.com/a/nypl.org/forms/d/e/1FAIpQLScnoQV5OjAP-Y9BOJ1PO9' +
+              'YpMdLjMyWn7VOTFSrDhCAP5ZN5Dw/formResponse'}
             target="hidden_feedback_iframe"
             method="POST"
             onSubmit={() => this.onSubmitForm()}

--- a/src/app/components/Feedback/Feedback.jsx
+++ b/src/app/components/Feedback/Feedback.jsx
@@ -11,8 +11,12 @@ class Feedback extends React.Component {
   }
 
   onSubmitForm() {
-    this.setState({ showForm: false });
-    alert('Thank you, your feedback has been submitted.');
+    if (!this.refs.commentText.value) {
+      this.refs.commentText.focus();
+    } else {
+      this.setState({ showForm: false });
+      alert('Thank you, your feedback has been submitted.');
+    }
   }
 
   openForm() {

--- a/src/client/styles/components/Feedback.scss
+++ b/src/client/styles/components/Feedback.scss
@@ -25,7 +25,6 @@
   text-align: center;
   font-size: 1rem;
   position: relative;
-  margin-left: 2px;
 
   &:hover {
     background: #FFF;
@@ -33,6 +32,20 @@
     color: #d0343a;
   }
 }
+
+.cancel-button {
+  background: #d0343a;
+  display: inline-block;
+  color: #FFF;
+  cursor: pointer;
+  box-sizing: border-box;
+  border: 1px solid #d0343a;
+  text-align: center;
+  font-size: 1rem;
+  position: relative;
+  margin-right: 15px;
+}
+
 
 .feedback-form-container {
   display: none;

--- a/src/client/styles/components/Feedback.scss
+++ b/src/client/styles/components/Feedback.scss
@@ -1,10 +1,17 @@
 .feedback {
-  position: fixed;
-  max-width: 400px;
+  position: static;
   bottom: 0;
   right: 0;
   z-index: 100;
   text-align: right;
+  background: #54514A;
+  color: #000;
+
+  @include min-screen($tablet-portrait) {
+    position: fixed;
+    background: inherit;
+    max-width: 400px;
+  }
 }
 
 .feedback-button {
@@ -14,9 +21,11 @@
   cursor: pointer;
   box-sizing: border-box;
   padding: 0.5rem 1rem;
-  border: 0;
+  border: 1px solid #d0343a;
   text-align: center;
   font-size: 1rem;
+  position: relative;
+  margin-left: 2px;
 
   &:hover {
     background: #FFF;


### PR DESCRIPTION
…ile view.

Fixes #779 and #647 

CSS for the feedback form on mobile.
Added the appropriate aria attributes and a "cancel" button. @seanredmond , you mentioned focus should be trapped in the "modal" so you can't tab out of it, but didn't we go against that pattern in the header?