### PR TITLE
Adding more and better error messages to api calling functions.

### DIFF
--- a/src/server/ApiRoutes/Bib.js
+++ b/src/server/ApiRoutes/Bib.js
@@ -9,7 +9,7 @@ function fetchBib(bibId, cb, errorcb) {
   return nyplApiClientCall(bibId)
     .then(response => cb(response))
     .catch(error => {
-      logger.error('Error attemping to fetch a Bib server side in fetchBib', error);
+      logger.error(`Error attemping to fetch a Bib server side in fetchBib, id: ${bibId}`, error);
 
       errorcb(error);
     }); /* end axios call */
@@ -33,7 +33,7 @@ function bibSearchServer(req, res, next) {
       next();
     },
     (error) => {
-      logger.error('Error in bibSearchServer API error', error);
+      logger.error(`Error in bibSearchServer API error, id: ${bibId}`, error);
       res.locals.data.Store = {
         bib: {},
         searchKeywords: req.query.searchKeywords || '',

--- a/src/server/routes/api/index.js
+++ b/src/server/routes/api/index.js
@@ -41,7 +41,8 @@ export function getPatronData(req, res, next) {
           })
           .catch((error) => {
             logger.error(
-              'Error attemping to make server side fetch call to patrons in getPatronData',
+              'Error attemping to make server side fetch call to patrons in getPatronData' +
+              `, /patrons/${userId}`,
               error
             );
             res.locals.data = {


### PR DESCRIPTION
Fixes #813 

I'm adding more information to the error messages in the log, but the app itself should not fail (or return a "internal server error") for these errors. The app should still run and the error messages will propagate to the app if applicable. I did add a better logic check for delivery locations retrieval. It seemed that one call failed because it didn't have delivery locations and it assumed there were. The endpoint for that error is also added.