### PR TITLE
Updating the omnisearch to not allow empty search except with *, and …

### DIFF
--- a/src/app/components/Search/Search.jsx
+++ b/src/app/components/Search/Search.jsx
@@ -19,7 +19,7 @@ class Search extends React.Component {
     this.state = {
       field: this.props.field || 'all',
       searchKeywords: this.props.searchKeywords,
-      inputError: false,
+      inputError: this.props.searchError === 'true',
     };
 
     this.inputChange = this.inputChange.bind(this);
@@ -181,11 +181,13 @@ Search.propTypes = {
   searchKeywords: PropTypes.string,
   createAPIQuery: PropTypes.func,
   updateIsLoadingState: PropTypes.func,
+  searchError: PropTypes.string,
 };
 
 Search.defaultProps = {
   field: 'all',
   searchKeywords: '',
+  searchError: 'false',
   updateIsLoadingState: () => {},
 };
 

--- a/src/app/components/Search/Search.jsx
+++ b/src/app/components/Search/Search.jsx
@@ -32,12 +32,6 @@ class Search extends React.Component {
     this.setState(nextProps);
   }
 
-  // componentDidUpdate() {
-  //   if (this.refs.keywords) {
-  //     this.refs.keywords.focus();
-  //   }
-  // }
-
   /**
    * onFieldChange(e)
    * Listen to the select dropdown for field searching.

--- a/src/app/components/SearchResultsPage/SearchResultsPage.jsx
+++ b/src/app/components/SearchResultsPage/SearchResultsPage.jsx
@@ -48,6 +48,7 @@ class SearchResultsPage extends React.Component {
       sortBy,
       field,
       isLoading,
+      location,
     } = this.props;
 
     const totalResults = searchResults ? searchResults.totalResults : undefined;
@@ -74,6 +75,7 @@ class SearchResultsPage extends React.Component {
         this.context.router.push(`${appConfig.baseUrl}/search?${apiQuery}`);
       });
     };
+    const searchError = location.query && location.query.error ? location.query.error : '';
 
     return (
       <DocumentTitle title="Search Results | Shared Collection Catalog | NYPL">
@@ -95,6 +97,7 @@ class SearchResultsPage extends React.Component {
                     field={field}
                     createAPIQuery={createAPIQuery}
                     updateIsLoadingState={this.updateIsLoadingState}
+                    searchError={searchError}
                   />
                   <ResultsCount
                     isLoading={isLoading}

--- a/src/client/styles/components/Search.scss
+++ b/src/client/styles/components/Search.scss
@@ -1,0 +1,17 @@
+.nypl-omnisearch-form {
+  .nypl-field-status {
+    color: #d0343a;
+    background: #efedeb;
+  }
+
+  .nypl-text-field {
+    input[type=text] {
+      height: 2rem;
+      -webkit-box-shadow: none;
+      box-shadow: none;
+    }
+  }
+
+  .nypl-field-error {
+  }
+}

--- a/src/client/styles/main.scss
+++ b/src/client/styles/main.scss
@@ -34,6 +34,7 @@ Import style rules from NYPL React module components
 @import "components/design-toolkit-updates.scss";
 @import "components/HoldConfirmation.scss";
 @import "components/LoadingLayer.scss";
+@import "components/Search.scss";
 
 @import "style-v2.scss";
 

--- a/src/server/ApiRoutes/Search.js
+++ b/src/server/ApiRoutes/Search.js
@@ -78,6 +78,13 @@ function searchServerPost(req, res) {
   if (req.query.q) {
     searchKeywords = req.query.q;
   }
+
+  if (!searchKeywords) {
+    return res.redirect(`${appConfig.baseUrl}/search?error=true`);
+  }
+
+  const updatedSearchKeywords = searchKeywords === '*' ? '' : searchKeywords;
+
   if (req.query.search_scope) {
     field = req.query.search_scope;
   }
@@ -86,13 +93,13 @@ function searchServerPost(req, res) {
   }
 
   const apiQuery = createAPIQuery({
-    searchKeywords: encodeURIComponent(searchKeywords),
+    searchKeywords: encodeURIComponent(updatedSearchKeywords),
     selectedFacets,
     field,
     sortBy,
   });
 
-  res.redirect(`${appConfig.baseUrl}/search?${apiQuery}`);
+  return res.redirect(`${appConfig.baseUrl}/search?${apiQuery}`);
 }
 
 function searchServer(req, res, next) {


### PR DESCRIPTION
…displaying an error message.

First part of "Empty searching".

Try it on dev:
1. I did not include the `required` label. Leaving the design for @ricardoom .
2. If you make an empty search and submit, you should see a red `Please enter a search term.` below the omnisearch.
3. If you submit by pressing enter, the default behavior is to stay focused on the input field. If you click on "Search" the focus will go to the input field (similar to the feedback widget).
4. Has `aria-required`.
5. All search is now `*`.
6. @ricardoom styles would need to be updated for `nypl-field-error` because I added it but the `.nypl-omnisearch input[type=text]` class is not allow the `nypl-field-error` styles to show.