### PR TITLE
Added missing / to get to the homepage from the 404 page.

### DIFF
--- a/src/app/components/NotFound404/NotFound404.jsx
+++ b/src/app/components/NotFound404/NotFound404.jsx
@@ -15,7 +15,7 @@ const NotFound404 = () => (
             <p>We're sorry...</p>
             <p>The page you were looking for doesn't exist.</p>
             <p>
-              Search the <Link to={`${appConfig.baseUrl}`}>
+              Search the <Link to={`${appConfig.baseUrl}/`}>
               Shared Collection Catalog</Link> or our classic <a href="http://catalog.nypl.org/">
               Research Catalog</a> for research materials.</p>
           </div>


### PR DESCRIPTION
Fixes #822 
Forgot a `/` 😓 

Check it out on dev: http://dev-discovery.nypl.org/research/collections/shared-collection-catalog/404

@gkallenberg 