### PR TITLE
Filter data in app

### DIFF
--- a/src/app/components/FilterPopup/FilterPopup.jsx
+++ b/src/app/components/FilterPopup/FilterPopup.jsx
@@ -145,4 +145,8 @@ FilterPopup.propTypes = {
   filters: PropTypes.array,
 };
 
+FilterPopup.defaultProps = {
+  filters: [],
+};
+
 export default FilterPopup;

--- a/src/app/components/FilterPopup/FilterPopup.jsx
+++ b/src/app/components/FilterPopup/FilterPopup.jsx
@@ -1,8 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import FocusTrap from 'focus-trap-react';
+import { findWhere as _findWhere } from 'underscore';
 
 import { trackDiscovery } from '../../utils/utils.js';
+import FieldsetDate from '../Filters/FieldsetDate';
+import FieldsetList from '../Filters/FieldsetList';
 
 class FilterPopup extends React.Component {
   constructor(props) {
@@ -93,6 +96,9 @@ class FilterPopup extends React.Component {
       >
         FILTER RESULTS
       </a>);
+    const filters = this.props.filters;
+    const materialTypeFilters = _findWhere(filters, { id: 'materialType' });
+    const languageFilters = _findWhere(filters, { id: 'language' });
 
     return (
       <div className="filter-container">
@@ -113,88 +119,19 @@ class FilterPopup extends React.Component {
           >
             <form action="" method="POST" onSubmit={() => this.onSubmitForm()}>
               <fieldset>
-                <legend>
-                  <h3>Filter Results</h3>
-                </legend>
-                <button type="button" name="Clear-Filters">Clear Filters</button>
+                <legend><h3>Filter Results</h3></legend>
 
+                <FieldsetList legend="Format" filter={materialTypeFilters} />
+
+                <FieldsetDate />
+
+                <FieldsetList legend="Language" filter={languageFilters} />
+
+                <button type="submit" name="apply-filters" >Apply Filters</button>
+                <button type="button" name="Clear-Filters">Clear Filters</button>
                 {closePopupButton}
 
-                <fieldset>
-                  <legend>Format</legend>
-                  <div className="new-checkbox">
-                    <input id="book-check-filter" className="switch-input" type="checkbox" name="format" value="Book" />
-                    <label htmlFor="book-check-filter">Book</label>
-                  </div>
-                  <div className="new-checkbox">
-                    <input id="still-image-check-filter" type="checkbox" name="format" value="Still Image" />
-                    <label htmlFor="still-image-check-filter">Still Image</label>
-                  </div>
-                  <div className="new-checkbox">
-                    <input id="audio-check-filter" type="checkbox" name="format" value="Audio" />
-                    <label htmlFor="audio-check-filter">
-                      Audio
-                    </label>
-                  </div>
-                  <div className="new-checkbox">
-                    <input id="music-check-filter" type="checkbox" name="format" value="Notated Music" />
-                    <label htmlFor="music-check-filter">Notated Music</label>
-                  </div>
-                  <div className="new-checkbox">
-                    <input id="mixed-check-filter" type="checkbox" name="format" value="Mixed Material" />
-                    <label htmlFor="mixed-check-filter">Mixed Material</label>
-                  </div>
-                </fieldset>
-                <fieldset>
-                  <legend>Date</legend>
-                  <div>
-                    <label htmlFor="start-date">Start Year
-                      <input id="start-date" name="start" className="form-text" type="number" min="1895" max="9999" step="1" />
-                    </label>
-                    <label htmlFor="end-date">End Year
-                      <input id="end-date" type="date" className="form-text" type="number" min="1895" max="9999" step="1" />
-                    </label>
-                    <span>The Start year cannot be later than the end year</span>
-                  </div>
-                </fieldset>
-                <fieldset>
-                  <legend>Language</legend>
-                  <div className="nypl-terms-checkbox new-checkbox">
-                    <input id="english-language-filter" type="checkbox" name="language" value="English" />
-                    <label htmlFor="english-language-filter">English</label>
-                  </div>
-                  <div className="nypl-terms-checkbox new-checkbox">
-                    <input id="spanish-language-filter" type="checkbox" name="language" value="Spanish" />
-                    <label htmlFor="spanish-language-filter">Spanish</label>
-                  </div>
-                  <div className="nypl-terms-checkbox new-checkbox">
-                    <input id="language-filter-0" type="checkbox" name="language" value="Language" />
-                    <label htmlFor="language-filter-0">Language</label>
-                  </div>
-                  <div className="nypl-terms-checkbox new-checkbox">
-                    <input id="language-filter-1" type="checkbox" name="language" value="Language" />
-                    <label htmlFor="language-filter-1">Language</label>
-                  </div>
-                  <div className="nypl-terms-checkbox new-checkbox">
-                    <input id="language-filter-2" type="checkbox" name="language" value="Language" />
-                    <label htmlFor="language-filter-2">Language</label>
-                  </div>
-                  <div className="nypl-terms-checkbox new-checkbox">
-                    <input id="language-filter-3" type="checkbox" name="language" value="Language" />
-                    <label htmlFor="language-filter-3">Language</label>
-                  </div>
-                  <div className="nypl-terms-checkbox new-checkbox">
-                    <input id="language-filter-4" type="checkbox" name="language" value="Language" />
-                    <label htmlFor="language-filter-4">Language</label>
-                  </div>
-                  <div className="nypl-terms-checkbox new-checkbox">
-                    <input id="language-filter-5" type="checkbox" name="language" value="Language" />
-                    <label htmlFor="language-filter-5">Language</label>
-                  </div>
-
-                </fieldset>
               </fieldset>
-              <button type="submit" name="apply-filters" >Apply Filters</button>
             </form>
           </FocusTrap>
         </div>
@@ -205,6 +142,7 @@ class FilterPopup extends React.Component {
 
 FilterPopup.propTypes = {
   location: PropTypes.object,
+  filters: PropTypes.array,
 };
 
 export default FilterPopup;

--- a/src/app/components/Filters/FieldsetDate.jsx
+++ b/src/app/components/Filters/FieldsetDate.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+class FilterPopup extends React.Component {
+  render() {
+    return (
+      <fieldset>
+        <legend>Date</legend>
+        <div>
+          <label htmlFor="start-date">Start Year
+            <input id="start-date" name="start-date" className="form-text" type="date" />
+          </label>
+          <label htmlFor="end-date">End Year
+            <input id="end-date" type="date" className="form-text" name="end-date" />
+          </label>
+          <span>The Start year cannot be later than the end year</span>
+        </div>
+      </fieldset>
+    );
+  }
+}
+
+FilterPopup.propTypes = {
+  location: PropTypes.object,
+};
+
+export default FilterPopup;

--- a/src/app/components/Filters/FieldsetList.jsx
+++ b/src/app/components/Filters/FieldsetList.jsx
@@ -1,17 +1,24 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import { isEmpty as _isEmpty } from 'underscore';
+
 class FieldsetList extends React.Component {
   render() {
     const {
       legend,
       filter,
     } = this.props;
+
+    if (_isEmpty(filter)) {
+      return null;
+    }
+
     const values = filter.values && filter.values.length ? filter.values : [];
 
     return (
       <fieldset>
-        <legend>{this.props.legend}</legend>
+        {legend && <legend>{legend}</legend>}
         <ul>
           {
             values.map((value, i) => (
@@ -37,6 +44,10 @@ class FieldsetList extends React.Component {
 FieldsetList.propTypes = {
   legend: PropTypes.string,
   filter: PropTypes.object,
+};
+
+FieldsetList.defaultProps = {
+  filter: {},
 };
 
 export default FieldsetList;

--- a/src/app/components/Filters/FieldsetList.jsx
+++ b/src/app/components/Filters/FieldsetList.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+class FieldsetList extends React.Component {
+  render() {
+    const {
+      legend,
+      filter,
+    } = this.props;
+    const values = filter.values && filter.values.length ? filter.values : [];
+
+    return (
+      <fieldset>
+        <legend>{this.props.legend}</legend>
+        <ul>
+          {
+            values.map((value, i) => (
+              <li className="nypl-terms-checkbox new-checkbox" key={i}>
+                <input
+                  id={`${value.label}-label`}
+                  type="checkbox"
+                  name="language"
+                  value={value.value}
+                />
+                <label htmlFor={`${value.label}-label`}>
+                  {value.label} ({value.count.toLocaleString()})
+                </label>
+              </li>
+            ))
+          }
+        </ul>
+      </fieldset>
+    );
+  }
+}
+
+FieldsetList.propTypes = {
+  legend: PropTypes.string,
+  filter: PropTypes.object,
+};
+
+export default FieldsetList;

--- a/src/app/components/SearchResultsPage/SearchResultsPage.jsx
+++ b/src/app/components/SearchResultsPage/SearchResultsPage.jsx
@@ -45,6 +45,7 @@ class SearchResultsPage extends React.Component {
       searchResults,
       searchKeywords,
       selectedFacets,
+      facets,
       page,
       sortBy,
       field,
@@ -76,6 +77,8 @@ class SearchResultsPage extends React.Component {
       });
     };
     const searchError = location.query && location.query.error ? location.query.error : '';
+    const filters = facets && facets.itemListElement && facets.itemListElement.length ?
+      facets.itemListElement : [];
 
     return (
       <DocumentTitle title="Search Results | Shared Collection Catalog | NYPL">
@@ -118,7 +121,9 @@ class SearchResultsPage extends React.Component {
                       />
                     )
                   }
-                  <FilterPopup />
+
+                  <FilterPopup filters={filters} />
+
                 </div>
               </div>
             </div>

--- a/src/client/styles/components/FilterPopup.scss
+++ b/src/client/styles/components/FilterPopup.scss
@@ -77,15 +77,14 @@
 
   .popup-btn-close {
     float: right;
-    color: #fff;
-    background: #776e64;
+    color: #000;
+    background: #fff;
     border: 1px solid #776e64;
     padding: 4px 10px;
     display: block;
     text-decoration: none;
   }
 }
-
 
 // Form
 fieldset > fieldset {
@@ -97,19 +96,19 @@ fieldset > fieldset > legend {
 }
 .new-checkbox input[type="checkbox"] {
   opacity: 0;
-}
-.new-checkbox label {
-  display: inline-block;
-  position: relative;
-  padding-left: 23px;
-}
-.new-checkbox label::after,
-.new-checkbox label::before {
-  content: "";
-  display: inline-block;
-  position: absolute;
-}
-.new-checkbox label::before {
+  }
+  .new-checkbox label {
+    display: inline-block;
+    position: relative;
+    padding-left: 23px;
+  }
+  .new-checkbox label::after,
+  .new-checkbox label::before {
+    content: "";
+    display: inline-block;
+    position: absolute;
+  }
+.new-checkbox label::before{
   border: 1px solid;
   height: 16px;
   left: 0;
@@ -125,15 +124,50 @@ fieldset > fieldset > legend {
   left: 4px;
   top: 3px;
 }
-/*Hide the checkmark by default*/
+      /*Hide the checkmark by default*/
 .new-checkbox input[type="checkbox"] + label::after {
-  content: none;
+    content: none;
 }
 /*Unhide on the checked state*/
+/*.new-checkbox input[type="checkbox"]:checked {
+  border-color: #d0343a;
+}*/
+.new-checkbox input[type="checkbox"]:checked + label,
+.new-checkbox input[type="checkbox"]:checked + label::before {
+  border-color: #d0343a;
+  color: #d0343a;
+}
 .new-checkbox input[type="checkbox"]:checked + label::after {
-  content: "";
+    border-color: #d0343a;
+    color: #d0343a;
+    content: "";
 }
 /*Adding focus styles on the outer-box of the fake checkbox*/
 .new-checkbox input[type="checkbox"]:focus + label::before {
-  outline: rgb(59, 153, 252) auto 2px;
+    outline: rgb(59, 153, 252) auto 2px;
+}
+.filter-container {
+  button {
+    background: #fff;
+    color: #000;
+    border: 1px solid #ddd;
+    cursor: pointer;
+    font-size: 1rem;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+  }
+  button svg {
+    background: #fff;
+    fill: #d0343a;
+    width: 1.5rem;
+    height: 1.5rem;
+  }
+  ul {
+    margin: 0;
+    padding: 0
+  }
+  ul li {
+    list-style: none;
+    margin: 0;
+  }
 }

--- a/src/server/ApiRoutes/Search.js
+++ b/src/server/ApiRoutes/Search.js
@@ -34,14 +34,14 @@ function search(searchKeywords, page, sortBy, order, field, filters, cb, errorcb
     page,
   });
 
-  // const aggregationQuery = `/aggregations?${apiQuery}`;
+  const aggregationQuery = `/aggregations?${apiQuery}`;
   const queryString = `?${apiQuery}&per_page=50`;
 
-  // Also need to make an async call to with aggregationQuery eventually...
-  // It use to be with axios.all to concurrently get both endpoints.
-  nyplApiClientCall(queryString)
-    .then((response) => {
-      cb({}, response, page);
+  // Need to get both results and aggregations before proceeding.
+  Promise.all([nyplApiClientCall(queryString), nyplApiClientCall(aggregationQuery)])
+    .then(response => {
+      const [results, aggregations] = response;
+      cb(aggregations, results, page);
     })
     .catch(error => {
       logger.error('Error making server search call in search function', error);

--- a/test/unit/FieldsetList.test.js
+++ b/test/unit/FieldsetList.test.js
@@ -1,0 +1,100 @@
+/* eslint-env mocha */
+import React from 'react';
+import { expect } from 'chai';
+import { shallow, mount } from 'enzyme';
+
+import FieldsetList from '../../src/app/components/Filters/FieldsetList';
+
+const listItemAt = (component, n) => component.find('li').at(n);
+
+describe('FilterPopup', () => {
+  // describe('Default', () => {
+  //   let component;
+  //
+  //   before(() => {
+  //     component = mount(<FieldsetList />);
+  //   });
+  //
+  //   // TODO: Enzyme doesn't seem to check when components are null ??
+  //   // it('should return null', () => {
+  //   //   expect(component.get(0)).to.equal(false);
+  //   // });
+  // });
+
+  describe('Default', () => {
+    const languageFilter = {
+      values: [
+        {
+          value: 'lang:fr',
+          label: 'French',
+          count: 145,
+        },
+        {
+          value: 'lang:en',
+          label: 'English',
+          count: 4267,
+        },
+        {
+          value: 'lang:sp',
+          label: 'Spanish',
+          count: 1245,
+        },
+      ],
+    };
+    const legend = 'Language';
+    let component;
+
+    before(() => {
+      component = mount(<FieldsetList filter={languageFilter} legend={legend} />);
+    });
+
+    it('should render a fieldset', () => {
+      expect(component.find('fieldset').length).to.equal(1);
+    });
+
+    it('should render a legend with text Language', () => {
+      expect(component.find('legend').length).to.equal(1);
+      expect(component.find('legend').text()).to.equal('Language');
+    });
+
+    it('should render a ul', () => {
+      expect(component.find('ul').length).to.equal(1);
+    });
+
+    it('should render three list items', () => {
+      expect(component.find('li').length).to.equal(3);
+    });
+
+    it('should have an input and label for each list item', () => {
+      expect(listItemAt(component, 0).find('input').length).to.equal(1);
+      expect(listItemAt(component, 0).find('label').length).to.equal(1);
+
+      expect(listItemAt(component, 1).find('input').length).to.equal(1);
+      expect(listItemAt(component, 1).find('label').length).to.equal(1);
+
+      expect(listItemAt(component, 2).find('input').length).to.equal(1);
+      expect(listItemAt(component, 2).find('label').length).to.equal(1);
+    });
+
+    it('should render the filter information for each list item', () => {
+      const firstItem = listItemAt(component, 0);
+      const secondItem = listItemAt(component, 1);
+      const thirdItem = listItemAt(component, 2);
+
+      expect(firstItem.find('input').length).to.equal(1);
+      expect(firstItem.find('input').prop('id')).to.equal('French-label');
+      expect(firstItem.find('label').length).to.equal(1);
+      expect(firstItem.find('label').text()).to.equal('French (145)');
+
+      expect(secondItem.find('input').length).to.equal(1);
+      expect(secondItem.find('input').prop('id')).to.equal('English-label');
+      expect(secondItem.find('label').length).to.equal(1);
+      expect(secondItem.find('label').text()).to.equal('English (4,267)');
+
+      expect(thirdItem.find('input').length).to.equal(1);
+      expect(thirdItem.find('input').prop('id')).to.equal('Spanish-label');
+      expect(thirdItem.find('label').length).to.equal(1);
+      expect(thirdItem.find('label').text()).to.equal('Spanish (1,245)');
+    });
+  });
+});

--- a/test/unit/FilterPopup.test.js
+++ b/test/unit/FilterPopup.test.js
@@ -1,0 +1,111 @@
+/* eslint-env mocha */
+import React from 'react';
+import { expect } from 'chai';
+import { shallow, mount } from 'enzyme';
+
+import FilterPopup from '../../src/app/components/FilterPopup/FilterPopup';
+
+describe('FilterPopup', () => {
+  describe('Default - no javascript', () => {
+    // Since this is a shallow render, the component itself is not mounted. The `js` flag
+    // becomes true when the component is mounted on the client-side so we know that
+    // javascript is enabled.
+    it('should not render a open/close buttons but <a>s instead', () => {
+      const component = shallow(<FilterPopup />);
+
+      expect(component.state('js')).to.equal(false);
+      // The Apply and Clear buttons should still be rendered:
+      expect(component.find('button').length).to.equal(2);
+      // These tests will need to be updated when the DOM structure gets updated.
+      // The second <a> element is the no-js 'cancel' element for the "smart" no-js solution.
+      expect(component.find('a').at(0).prop('className')).to.equal('popup-btn-open');
+      expect(component.find('a').at(0).prop('href')).to.equal('#popup-no-js');
+      expect(component.find('a').at(1).prop('className')).to.equal('cancel-no-js');
+      expect(component.find('a').at(2).prop('className')).to.equal('popup-btn-close');
+    });
+
+    it('should have specific "no-js" id and class', () => {
+      const component = shallow(<FilterPopup />);
+
+      expect(component.state('js')).to.equal(false);
+      expect(component.find('#popup-no-js').length).to.equal(1);
+      expect(component.find('.popup-no-js').length).to.equal(1);
+    });
+  });
+
+  describe('Default', () => {
+    let component;
+
+    before(() => {
+      component = mount(<FilterPopup />);
+    });
+
+    it('should have a .filter-container class for the wrapper', () => {
+      expect(component.find('.filter-container').length).to.equal(1);
+    });
+
+    it('should render open/close buttons', () => {
+      expect(component.state('js')).to.equal(true);
+      // All buttons should be rendered
+      expect(component.find('button').length).to.equal(4);
+      expect(component.find('button').at(0).prop('className')).to.equal('popup-btn-open');
+      expect(component.find('button').at(1).prop('name')).to.equal('apply-filters');
+      expect(component.find('button').at(2).prop('name')).to.equal('Clear-Filters');
+      expect(component.find('button').at(3).prop('className')).to.equal('popup-btn-close');
+    });
+
+    it('should not render the "no-js" <a> element', () => {
+      expect(component.find('.cancel-no-js').length).to.equal(0);
+    });
+
+    it('should have accessible open button', () => {
+      const openBtn = component.find('.popup-btn-open');
+      expect(openBtn.prop('aria-haspopup')).to.equal('true');
+      expect(openBtn.prop('aria-expanded')).to.equal(false);
+      expect(openBtn.prop('aria-controls')).to.equal('filter-popup-menu');
+    });
+
+    it('should have accessible close button', () => {
+      const openBtn = component.find('.popup-btn-close');
+      expect(openBtn.prop('aria-expanded')).to.equal(true);
+      expect(openBtn.prop('aria-controls')).to.equal('filter-popup-menu');
+    });
+
+    it('should not have specific "no-js" id and class', () => {
+      expect(component.state('js')).to.equal(true);
+      expect(component.find('#popup-no-js').length).to.equal(0);
+      expect(component.find('.popup-no-js').length).to.equal(0);
+    });
+
+    it('should have a form', () => {
+      expect(component.find('form').length).to.equal(1);
+      expect(component.find('form').prop('method')).to.equal('POST');
+    });
+  });
+
+  describe('Open/close the popup', () => {
+    let component;
+
+    before(() => {
+      component = mount(<FilterPopup />);
+    });
+
+    it('should be hidden at first', () => {
+      expect(component.find('.popup-container').hasClass('active')).to.equal(false);
+    });
+
+    // TODO: Figure out how to get the `FocusTrap` component to work with these tests:
+    // it('should display the popup when the open button is clicked', () => {
+    //   expect(component.find('.popup-container').hasClass('active')).to.equal(false);
+    //   component.find('.popup-btn-open').simulate('click');
+    //   expect(component.find('.popup-container').hasClass('active')).to.equal(true);
+    // });
+
+    // it('should hide the popup when the close button is clicked', () => {
+    //   component.setState({ showForm: true });
+    //   expect(component.find('.popup-container').hasClass('active')).to.equal(true);
+    //   component.find('.popup-btn-close').simulate('click');
+    //   expect(component.find('.popup-container').hasClass('active')).to.equal(false);
+    // });
+  });
+});


### PR DESCRIPTION
Fixes #833 

* Settles the two async calls to the results and aggregations API endpoints.
* Adds the filters to the Store in the app when making new searches.
* Populates the filter popup with the updated format (materialType) and language filters along with the count.
* This fixes half of https://jira.nypl.org/browse/DIS-156 but breaking it up because it'll get too large adding the data back AND making it all work. That being said, applying the filters doesn't work for this PR, just displaying the results from the API again.

Up on dev.