### PR TITLE
Remove filters

### DIFF
--- a/src/app/components/FilterPopup/FilterPopup.jsx
+++ b/src/app/components/FilterPopup/FilterPopup.jsx
@@ -9,7 +9,6 @@ import {
 
 import {
   trackDiscovery,
-  getDefaultFacets,
   ajaxCall,
 } from '../../utils/utils.js';
 import appConfig from '../../../../appConfig';
@@ -67,13 +66,21 @@ class FilterPopup extends React.Component {
   constructor(props) {
     super(props);
 
-    const selectedFilters = this.props.selectedFilters;
+    const {
+      selectedFilters,
+      filters,
+    } = this.props;
 
     this.state = {
-      selectedFilters: _extend(getDefaultFacets(), selectedFilters),
-      filters: [],
+      selectedFilters: _extend({
+        materialType: [],
+        language: [],
+        dateAfter: {},
+        dateBefore: {},
+      }, selectedFilters),
       showForm: false,
       js: false,
+      filters,
     };
 
     this.openForm = this.openForm.bind(this);
@@ -90,7 +97,15 @@ class FilterPopup extends React.Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    this.setState({ selectedFilters: nextProps.selectedFilters });
+    this.setState({
+      selectedFilters: _extend({
+        materialType: [],
+        language: [],
+        dateAfter: {},
+        dateBefore: {},
+      }, nextProps.selectedFilters),
+      filters: nextProps.filters,
+    });
   }
 
   onFilterClick(filterId, filter) {
@@ -116,6 +131,7 @@ class FilterPopup extends React.Component {
     this.deactivateForm();
     this.props.updateIsLoadingState(true);
 
+    Actions.updateSelectedFacets(this.state.selectedFilters);
     ajaxCall(`${appConfig.baseUrl}/api?${apiQuery}`, (response) => {
       if (response.data.searchResults && response.data.facets) {
         Actions.updateSearchResults(response.data.searchResults);
@@ -158,6 +174,7 @@ class FilterPopup extends React.Component {
       showForm,
       js,
       selectedFilters,
+      filters,
     } = this.state;
     const closePopupButton = js ?
       <button
@@ -197,10 +214,7 @@ class FilterPopup extends React.Component {
       >
         FILTER RESULTS <FilterIcon />
       </a>);
-    const {
-      filters,
-      searchKeywords,
-    } = this.props;
+    const { searchKeywords } = this.props;
     const materialTypeFilters = _findWhere(filters, { id: 'materialType' });
     const languageFilters = _findWhere(filters, { id: 'language' });
 
@@ -279,6 +293,7 @@ FilterPopup.propTypes = {
   createAPIQuery: PropTypes.func,
   updateIsLoadingState: PropTypes.func,
   selectedFilters: PropTypes.object,
+  searchKeywords: PropTypes.string,
 };
 
 FilterPopup.defaultProps = {

--- a/src/app/components/Filters/FieldsetList.jsx
+++ b/src/app/components/Filters/FieldsetList.jsx
@@ -5,48 +5,35 @@ import {
   extend as _extend,
   findWhere as _findWhere,
 } from 'underscore';
+import {
+  getUpdatedFilterValues,
+} from '../../utils/utils';
 
 class FieldsetList extends React.Component {
   constructor(props) {
     super(props);
 
-    const {
-      filter,
-      selectedFilters,
-    } = this.props;
-    const filterValues = filter.values && filter.values.length ? filter.values : [];
-    // Just want to add the `selected` property here.
-    const defaultFilterValues = filterValues.map(value => _extend({ selected: false }, value));
-    let updatedFilterValues = defaultFilterValues;
-
-    // If there are selected filters, then we want to update the filter values with those
-    // filters already selected. That way, the checkboxes will be checked.
-    if (selectedFilters) {
-      updatedFilterValues = defaultFilterValues.map(defaultFilterValue => {
-        const defaultFilter = defaultFilterValue;
-        selectedFilters.forEach(selectedFilter => {
-          if (selectedFilter.value === defaultFilter.value) {
-            defaultFilter.selected = true;
-          }
-        });
-
-        return defaultFilter;
-      });
-    }
+    const updatedFilterValues = getUpdatedFilterValues(props);
 
     this.state = {
       values: updatedFilterValues,
     };
   }
 
+  componentWillReceiveProps(nextProps) {
+    const updatedFilterValues = getUpdatedFilterValues(nextProps);
+
+    this.setState({
+      values: updatedFilterValues,
+    });
+  }
+
   onFilterClick(e, filter) {
     // Find the filter we selected and toggle it's selected value.
     const match = _findWhere(this.state.values, { value: filter.value });
     if (match) {
-      match.selected = !filter.selected;
+      filter.selected = !filter.selected;
     }
-
-    this.setState({ values: this.state.values });
     this.props.onFilterClick(this.props.filterId, filter);
   }
 
@@ -74,7 +61,7 @@ class FieldsetList extends React.Component {
                   name="filters"
                   value={JSON.stringify(_extend({ field: filterId }, filter))}
                   onClick={(e) => this.onFilterClick(e, filter)}
-                  defaultChecked={filter.selected}
+                  checked={filter.selected}
                 />
                 <label htmlFor={`${filter.label}-label`}>
                   {filter.label} ({filter.count.toLocaleString()})

--- a/src/app/components/Filters/SelectedFilters.jsx
+++ b/src/app/components/Filters/SelectedFilters.jsx
@@ -13,12 +13,11 @@ import { ajaxCall } from '../../utils/utils';
 
 const XCloseIcon = () => (
   <svg
-    aria-hidden="true"
     className="nypl-icon svgIcon"
     preserveAspectRatio="xMidYMid meet"
     viewBox="0 0 32 32"
   >
-    <title>Close Icon</title>
+    <title>Remove Filter</title>
     <path
       d={'M17.91272,15.97339l5.65689-5.65689A1.32622,1.32622,0,0,0,21.694,8.44093L16.04938' +
         ',14.0856l-5.65082-5.725A1.32671,1.32671,0,1,0,8.51,10.22454l5.66329,5.73712L8.4303' +

--- a/src/app/components/Filters/SelectedFilters.jsx
+++ b/src/app/components/Filters/SelectedFilters.jsx
@@ -86,13 +86,24 @@ class SelectedFilters extends React.Component {
     }
 
     return (
-      <ul className="selected-filters-container">
+      <ul
+        className="selected-filters-container"
+        aria-live="assertive"
+        aria-atomic="true"
+        aria-relevant="additions removals"
+        aria-describedby="read-text"
+      >
+        <li id="read-text" className="visuallyHidden">
+          There are {filtersToRender.length} selected filters.
+        </li>
         {
           filtersToRender.map((filter, i) => (
             <li key={i}>
               <button
                 className="nypl-unset-filter"
                 onClick={(e) => this.onFilterClick(e, filter)}
+                aria-controls="selected-filters-container"
+                aria-label={filter.label}
               >
                 {filter.label}
                 <XCloseIcon />

--- a/src/app/components/Filters/SelectedFilters.jsx
+++ b/src/app/components/Filters/SelectedFilters.jsx
@@ -1,0 +1,123 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  isEmpty as _isEmpty,
+  mapObject as _mapObject,
+  extend as _extend,
+  reject as _reject,
+} from 'underscore';
+
+import Actions from '../../actions/Actions';
+import appConfig from '../../../../appConfig';
+import { ajaxCall } from '../../utils/utils';
+
+const XCloseIcon = () => (
+  <svg
+    aria-hidden="true"
+    className="nypl-icon svgIcon"
+    preserveAspectRatio="xMidYMid meet"
+    viewBox="0 0 32 32"
+  >
+    <title>Close Icon</title>
+    <path
+      d={'M17.91272,15.97339l5.65689-5.65689A1.32622,1.32622,0,0,0,21.694,8.44093L16.04938' +
+        ',14.0856l-5.65082-5.725A1.32671,1.32671,0,1,0,8.51,10.22454l5.66329,5.73712L8.4303' +
+        '8,21.7046a1.32622,1.32622,0,1,0,1.87557,1.87557l5.73088-5.73088,5.65074,5.72441a1.3' +
+        '2626,1.32626,0,1,0,1.88852-1.86261Z'}
+    />
+  </svg>
+);
+
+class SelectedFilters extends React.Component {
+  onFilterClick(e, filter) {
+    e.preventDefault();
+
+    const selectedFilters = this.props.selectedFilters;
+
+    selectedFilters[filter.field] =
+      _reject(
+        selectedFilters[filter.field],
+        (selectedFilter) => selectedFilter.value === filter.value
+      );
+
+    const apiQuery = this.props.createAPIQuery({ selectedFacets: selectedFilters });
+
+    this.props.updateIsLoadingState(true);
+
+    Actions.updateSelectedFacets(selectedFilters);
+    ajaxCall(`${appConfig.baseUrl}/api?${apiQuery}`, (response) => {
+      if (response.data.searchResults && response.data.facets) {
+        Actions.updateSearchResults(response.data.searchResults);
+        Actions.updateFacets(response.data.facets);
+      } else {
+        Actions.updateSearchResults({});
+        Actions.updateFacets({});
+      }
+      Actions.updateSortBy('relevance');
+      Actions.updatePage('1');
+
+      setTimeout(() => {
+        this.props.updateIsLoadingState(false);
+        this.context.router.push(`${appConfig.baseUrl}/search?${apiQuery}`);
+      }, 500);
+    });
+  }
+
+  render() {
+    const {
+      selectedFilters,
+    } = this.props;
+
+    if (_isEmpty(selectedFilters)) {
+      return null;
+    }
+
+    const filtersToRender = [];
+    _mapObject(selectedFilters, (values, key) => {
+      if (values && values.length) {
+        values.forEach(value => {
+          filtersToRender.push(_extend({ field: key }, value));
+        });
+      }
+    });
+
+    if (!filtersToRender.length) {
+      return null;
+    }
+
+    return (
+      <ul className="selected-filters-container">
+        {
+          filtersToRender.map((filter, i) => (
+            <li key={i}>
+              <button
+                className="nypl-unset-filter"
+                onClick={(e) => this.onFilterClick(e, filter)}
+              >
+                {filter.label}
+                <XCloseIcon />
+              </button>
+            </li>
+          ))
+        }
+      </ul>
+    );
+  }
+}
+
+SelectedFilters.propTypes = {
+  selectedFilters: PropTypes.object,
+  createAPIQuery: PropTypes.func,
+  updateIsLoadingState: PropTypes.func,
+};
+
+SelectedFilters.defaultProps = {
+  selectedFilters: {},
+  createAPIQuery: () => {},
+};
+
+SelectedFilters.contextTypes = {
+  router: PropTypes.object,
+};
+
+export default SelectedFilters;

--- a/src/app/components/ResultsCount/ResultsCount.jsx
+++ b/src/app/components/ResultsCount/ResultsCount.jsx
@@ -43,7 +43,7 @@ class ResultsCount extends React.Component {
       _mapObject(selectedFacets, (val, key) => {
         const mappedKey = keyMapping[key];
 
-        if (val[0] && val[0].value) {
+        if (val[0] && val[0].value && mappedKey) {
           result += `for ${mappedKey} "${val[0].value}"`;
         }
       });

--- a/src/app/components/SearchResultsPage/SearchResultsPage.jsx
+++ b/src/app/components/SearchResultsPage/SearchResultsPage.jsx
@@ -10,6 +10,7 @@ import Sorter from '../Sorter/Sorter';
 import Pagination from '../Pagination/Pagination';
 import LoadingLayer from '../LoadingLayer/LoadingLayer.jsx';
 import FilterPopup from '../FilterPopup/FilterPopup.jsx';
+import SelectedFilters from '../Filters/SelectedFilters.jsx';
 
 import {
   basicQuery,
@@ -128,6 +129,12 @@ class SearchResultsPage extends React.Component {
                     updateIsLoadingState={this.updateIsLoadingState}
                     selectedFilters={selectedFacets}
                     searchKeywords={searchKeywords}
+                  />
+
+                  <SelectedFilters
+                    selectedFilters={selectedFacets}
+                    createAPIQuery={createAPIQuery}
+                    updateIsLoadingState={this.updateIsLoadingState}
                   />
 
                 </div>

--- a/src/app/utils/utils.js
+++ b/src/app/utils/utils.js
@@ -314,6 +314,41 @@ function getAggregatedElectronicResources(items = []) {
   return _flatten(electronicResources);
 }
 
+/**
+ * getUpdatedFilterValues(props)
+ * Get an array of filter values based on one filter. If any filters are selected, they'll
+ * be `true` in their object property `selected`.
+ * @param {object} props
+ * @return {array}
+ */
+const getUpdatedFilterValues = (props) => {
+  const {
+    filter,
+    selectedFilters,
+  } = props;
+  const filterValues = filter.values && filter.values.length ? filter.values : [];
+  // Just want to add the `selected` property here.
+  const defaultFilterValues = filterValues.map(value => _extend({ selected: false }, value));
+  let updatedFilterValues = defaultFilterValues;
+
+  // If there are selected filters, then we want to update the filter values with those
+  // filters already selected. That way, the checkboxes will be checked.
+  if (selectedFilters) {
+    updatedFilterValues = defaultFilterValues.map(defaultFilterValue => {
+      const defaultFilter = defaultFilterValue;
+      selectedFilters.forEach(selectedFilter => {
+        if (selectedFilter.value === defaultFilter.value) {
+          defaultFilter.selected = true;
+        }
+      });
+
+      return defaultFilter;
+    });
+  }
+
+  return updatedFilterValues;
+};
+
 export {
   trackDiscovery,
   ajaxCall,
@@ -327,4 +362,5 @@ export {
   getReqParams,
   parseServerSelectedFilters,
   getAggregatedElectronicResources,
+  getUpdatedFilterValues,
 };

--- a/src/client/styles/components/SelectedFilters.scss
+++ b/src/client/styles/components/SelectedFilters.scss
@@ -1,0 +1,12 @@
+.selected-filters-container {
+  padding: 0;
+  float: left;
+  width: 100%;
+  margin: 10px 0;
+
+  li {
+    list-style: none;
+    margin: 10px 15px 0 0;
+    display: inline-block;
+  }
+}

--- a/src/client/styles/main.scss
+++ b/src/client/styles/main.scss
@@ -31,6 +31,7 @@ Import style rules from NYPL React module components
 @import "components/LoadingLayer.scss";
 @import "components/FilterPopup.scss";
 @import "components/Search.scss";
+@import "components/SelectedFilters.scss";
 
 @import "style-v2.scss";
 

--- a/test/unit/SelectedFilters.test.js
+++ b/test/unit/SelectedFilters.test.js
@@ -50,10 +50,10 @@ describe('SelectedFilters', () => {
 
       it('should have one button inside each list item with the filter name', () => {
         expect(listItemAt(component, 1).find('button').length).to.equal(1);
-        expect(listItemAt(component, 1).find('button').text()).to.equal('FrenchClose Icon');
+        expect(listItemAt(component, 1).find('button').text()).to.equal('FrenchRemove Filter');
 
         expect(listItemAt(component, 2).find('button').length).to.equal(1);
-        expect(listItemAt(component, 2).find('button').text()).to.equal('EnglishClose Icon');
+        expect(listItemAt(component, 2).find('button').text()).to.equal('EnglishRemove Filter');
       });
     });
 
@@ -102,16 +102,17 @@ describe('SelectedFilters', () => {
 
       it('should have one button inside each list item with the filter name', () => {
         expect(listItemAt(component, 1).find('button').length).to.equal(1);
-        expect(listItemAt(component, 1).find('button').text()).to.equal('FrenchClose Icon');
+        expect(listItemAt(component, 1).find('button').text()).to.equal('FrenchRemove Filter');
 
         expect(listItemAt(component, 2).find('button').length).to.equal(1);
-        expect(listItemAt(component, 2).find('button').text()).to.equal('EnglishClose Icon');
+        expect(listItemAt(component, 2).find('button').text()).to.equal('EnglishRemove Filter');
 
         expect(listItemAt(component, 3).find('button').length).to.equal(1);
-        expect(listItemAt(component, 3).find('button').text()).to.equal('Still ImageClose Icon');
+        expect(listItemAt(component, 3).find('button').text()).to.equal('Still ImageRemove Filter');
 
         expect(listItemAt(component, 4).find('button').length).to.equal(1);
-        expect(listItemAt(component, 4).find('button').text()).to.equal('CartographicClose Icon');
+        expect(listItemAt(component, 4).find('button').text())
+          .to.equal('CartographicRemove Filter');
       });
     });
   });

--- a/test/unit/SelectedFilters.test.js
+++ b/test/unit/SelectedFilters.test.js
@@ -1,0 +1,118 @@
+/* eslint-env mocha */
+import React from 'react';
+import { expect } from 'chai';
+import { mount } from 'enzyme';
+
+import SelectedFilters from '../../src/app/components/Filters/SelectedFilters';
+
+const listItemAt = (component, n) => component.find('li').at(n);
+
+describe('SelectedFilters', () => {
+  describe('Default', () => {
+    it('should not render a ul', () => {
+      const component = mount(<SelectedFilters />);
+      expect(component.find('ul').length).to.equal(0);
+    });
+  });
+
+  describe('With Data', () => {
+    describe('With two language filters', () => {
+      const selectedFilters = {
+        language: [
+          {
+            value: 'lang:fr',
+            label: 'French',
+            count: 145,
+          },
+          {
+            value: 'lang:en',
+            label: 'English',
+            count: 4267,
+          },
+        ],
+        materialType: [],
+        dateBefore: '',
+        dateAfter: '',
+      };
+      let component;
+
+      before(() => {
+        component = mount(<SelectedFilters selectedFilters={selectedFilters} />);
+      });
+
+      it('should render a ul', () => {
+        expect(component.find('ul').length).to.equal(1);
+      });
+
+      it('should render two list items', () => {
+        expect(component.find('li').length).to.equal(2);
+      });
+
+      it('should have one button inside each list item with the filter name', () => {
+        expect(listItemAt(component, 0).find('button').length).to.equal(1);
+        expect(listItemAt(component, 0).find('button').text()).to.equal('FrenchClose Icon');
+
+        expect(listItemAt(component, 1).find('button').length).to.equal(1);
+        expect(listItemAt(component, 1).find('button').text()).to.equal('EnglishClose Icon');
+      });
+    });
+
+    describe('With two language filters and two materialType filters', () => {
+      const selectedFilters = {
+        language: [
+          {
+            value: 'lang:fr',
+            label: 'French',
+            count: 145,
+            selected: true,
+          },
+          {
+            value: 'lang:en',
+            label: 'English',
+            count: 4267,
+            selected: true,
+          },
+        ],
+        materialType: [
+          {
+            value: 'resourcetypes:img',
+            label: 'Still Image',
+            count: 145,
+            selected: true,
+          },
+          {
+            value: 'resourcetypes:car',
+            label: 'Cartographic',
+            count: 4267,
+            selected: true,
+          },
+        ],
+        dateBefore: '',
+        dateAfter: '',
+      };
+      let component;
+
+      before(() => {
+        component = mount(<SelectedFilters selectedFilters={selectedFilters} />);
+      });
+
+      it('should render four list items', () => {
+        expect(component.find('li').length).to.equal(4);
+      });
+
+      it('should have one button inside each list item with the filter name', () => {
+        expect(listItemAt(component, 0).find('button').length).to.equal(1);
+        expect(listItemAt(component, 0).find('button').text()).to.equal('FrenchClose Icon');
+
+        expect(listItemAt(component, 1).find('button').length).to.equal(1);
+        expect(listItemAt(component, 1).find('button').text()).to.equal('EnglishClose Icon');
+
+        expect(listItemAt(component, 2).find('button').length).to.equal(1);
+        expect(listItemAt(component, 2).find('button').text()).to.equal('Still ImageClose Icon');
+
+        expect(listItemAt(component, 3).find('button').length).to.equal(1);
+        expect(listItemAt(component, 3).find('button').text()).to.equal('CartographicClose Icon');
+      });
+    });
+  });
+});

--- a/test/unit/SelectedFilters.test.js
+++ b/test/unit/SelectedFilters.test.js
@@ -44,16 +44,16 @@ describe('SelectedFilters', () => {
         expect(component.find('ul').length).to.equal(1);
       });
 
-      it('should render two list items', () => {
-        expect(component.find('li').length).to.equal(2);
+      it('should render three list items, one text and two with data', () => {
+        expect(component.find('li').length).to.equal(3);
       });
 
       it('should have one button inside each list item with the filter name', () => {
-        expect(listItemAt(component, 0).find('button').length).to.equal(1);
-        expect(listItemAt(component, 0).find('button').text()).to.equal('FrenchClose Icon');
-
         expect(listItemAt(component, 1).find('button').length).to.equal(1);
-        expect(listItemAt(component, 1).find('button').text()).to.equal('EnglishClose Icon');
+        expect(listItemAt(component, 1).find('button').text()).to.equal('FrenchClose Icon');
+
+        expect(listItemAt(component, 2).find('button').length).to.equal(1);
+        expect(listItemAt(component, 2).find('button').text()).to.equal('EnglishClose Icon');
       });
     });
 
@@ -97,21 +97,21 @@ describe('SelectedFilters', () => {
       });
 
       it('should render four list items', () => {
-        expect(component.find('li').length).to.equal(4);
+        expect(component.find('li').length).to.equal(5);
       });
 
       it('should have one button inside each list item with the filter name', () => {
-        expect(listItemAt(component, 0).find('button').length).to.equal(1);
-        expect(listItemAt(component, 0).find('button').text()).to.equal('FrenchClose Icon');
-
         expect(listItemAt(component, 1).find('button').length).to.equal(1);
-        expect(listItemAt(component, 1).find('button').text()).to.equal('EnglishClose Icon');
+        expect(listItemAt(component, 1).find('button').text()).to.equal('FrenchClose Icon');
 
         expect(listItemAt(component, 2).find('button').length).to.equal(1);
-        expect(listItemAt(component, 2).find('button').text()).to.equal('Still ImageClose Icon');
+        expect(listItemAt(component, 2).find('button').text()).to.equal('EnglishClose Icon');
 
         expect(listItemAt(component, 3).find('button').length).to.equal(1);
-        expect(listItemAt(component, 3).find('button').text()).to.equal('CartographicClose Icon');
+        expect(listItemAt(component, 3).find('button').text()).to.equal('Still ImageClose Icon');
+
+        expect(listItemAt(component, 4).find('button').length).to.equal(1);
+        expect(listItemAt(component, 4).find('button').text()).to.equal('CartographicClose Icon');
       });
     });
   });


### PR DESCRIPTION
Fixes #841 - Rendering filter buttons and removing filters when clicked.
Jira ticket [DIS-161](https://jira.nypl.org/browse/DIS-161)

Example: 
![screen shot 2017-09-15 at 4 29 03 pm](https://user-images.githubusercontent.com/1280564/30502140-04e0bc70-9a33-11e7-8d6d-dfa51f3582a1.png)

1. Go to http://dev-discovery.nypl.org/research/collections/shared-collection-catalog/search?q=war&filters[materialType]=resourcetypes%3Acar&filters[language]=lang%3Ajpn&filters[language]=lang%3Apol
2. Click on the `FILTER RESULTS` button.
3. Check out the selected filters:
![screen shot 2017-09-15 at 4 30 13 pm](https://user-images.githubusercontent.com/1280564/30502185-2ea972c2-9a33-11e7-9ecc-b67f02d03e3f.png)
4. Close the popup.
5. Click on a filter to remove it.
6. Open up the popup again and the filter should be removed.

**NOTE: This PR also fixes a few bug issues when filtering from the existing PR of #837 ** 