### PR TITLE
Updating message for when there are no results with filters and without filters.

### DIFF
--- a/src/app/components/FilterPopup/FilterPopup.jsx
+++ b/src/app/components/FilterPopup/FilterPopup.jsx
@@ -166,7 +166,9 @@ class FilterPopup extends React.Component {
     trackDiscovery('FilterPopup', 'Close');
     this.setState({ showForm: false });
 
-    this.refs.filterOpen.focus();
+    if (this.refs.filterOpen) {
+      this.refs.filterOpen.focus();
+    }
   }
 
   render() {

--- a/src/app/components/Filters/SelectedFilters.jsx
+++ b/src/app/components/Filters/SelectedFilters.jsx
@@ -13,12 +13,11 @@ import { ajaxCall } from '../../utils/utils';
 
 const XCloseIcon = () => (
   <svg
-    aria-hidden="true"
     className="nypl-icon svgIcon"
     preserveAspectRatio="xMidYMid meet"
     viewBox="0 0 32 32"
   >
-    <title>Close Icon</title>
+    <title>Remove Filter</title>
     <path
       d={'M17.91272,15.97339l5.65689-5.65689A1.32622,1.32622,0,0,0,21.694,8.44093L16.04938' +
         ',14.0856l-5.65082-5.725A1.32671,1.32671,0,1,0,8.51,10.22454l5.66329,5.73712L8.4303' +

--- a/src/app/components/ResultsCount/ResultsCount.jsx
+++ b/src/app/components/ResultsCount/ResultsCount.jsx
@@ -52,8 +52,29 @@ class ResultsCount extends React.Component {
     return result;
   }
 
+  /*
+   * checkSelectedFilters()
+   * Returns true if there are any selected format or language filters. TODO: add Date.
+   */
+  checkSelectedFilters() {
+    const selectedFilters = this.props.selectedFacets;
+
+    if ((selectedFilters.materialType && selectedFilters.materialType.length) ||
+      (selectedFilters.language && selectedFilters.language.length)) {
+      return true;
+    }
+
+    // Eventually need to add check for date.
+    return false;
+  }
+
   displayCount() {
-    const { count, isLoading, page } = this.props;
+    const {
+      count,
+      isLoading,
+      page,
+      searchKeywords,
+    } = this.props;
     const countF = count ? count.toLocaleString() : '';
     const displayContext = this.displayContext();
     const start = (page - 1) * 50 + 1;
@@ -67,7 +88,16 @@ class ResultsCount extends React.Component {
     if (count !== 0) {
       return (<h2>Displaying {currentResultDisplay} of {countF} results {displayContext}</h2>);
     }
-    return (<h2>No results found. Please try another search.</h2>);
+
+    if (this.checkSelectedFilters()) {
+      return (
+        <h2>No results for the keyword "{searchKeywords}" with the chosen filters. Try
+          a different search or different filters.
+        </h2>
+      );
+    }
+
+    return (<h2>No results for the keyword "{searchKeywords}". Try a different search.</h2>);
   }
 
   render() {
@@ -100,6 +130,12 @@ ResultsCount.defaultProps = {
   count: 0,
   isLoading: false,
   page: 1,
+  selectedFacets: {
+    materialType: [],
+    language: [],
+    dateAfter: {},
+    dateBefore: {},
+  },
 };
 
 export default ResultsCount;

--- a/src/app/components/ResultsCount/ResultsCount.jsx
+++ b/src/app/components/ResultsCount/ResultsCount.jsx
@@ -35,7 +35,11 @@ class ResultsCount extends React.Component {
       if (field && field !== 'all') {
         result += `for ${keyMapping[field]} "${searchKeywords}"`;
       } else {
-        result += `for keyword "${searchKeywords}"`;
+        if (searchKeywords.indexOf(' ') !== -1) {
+          result += `for keywords "${searchKeywords}"`;
+        } else {
+          result += `for keyword "${searchKeywords}"`;
+        }
       }
     }
 
@@ -80,6 +84,7 @@ class ResultsCount extends React.Component {
     const start = (page - 1) * 50 + 1;
     const end = (page) * 50 > count ? count : (page * 50);
     const currentResultDisplay = `${start}-${end}`;
+    const plural = (searchKeywords && searchKeywords.indexOf(' ') !== -1) ? 's' : '';
 
     if (isLoading) {
       return (<p>Loading...</p>);
@@ -91,13 +96,17 @@ class ResultsCount extends React.Component {
 
     if (this.checkSelectedFilters()) {
       return (
-        <h2>No results for the keyword "{searchKeywords}" with the chosen filters. Try
+        <h2>No results for the keyword{plural} "{searchKeywords}" with the chosen filters. Try
           a different search or different filters.
         </h2>
       );
     }
 
-    return (<h2>No results for the keyword "{searchKeywords}". Try a different search.</h2>);
+    return (
+      <h2>
+        No results for the keyword{plural} "{searchKeywords}". Try a different search.
+      </h2>
+    );
   }
 
   render() {

--- a/src/app/components/SearchResultsPage/SearchResultsPage.jsx
+++ b/src/app/components/SearchResultsPage/SearchResultsPage.jsx
@@ -113,29 +113,32 @@ class SearchResultsPage extends React.Component {
                   />
                   {
                     !!(totalResults && totalResults !== 0) && (
-                      <Sorter
-                        sortBy={sortBy}
-                        page={page}
-                        searchKeywords={searchKeywords}
-                        createAPIQuery={createAPIQuery}
-                        updateIsLoadingState={this.updateIsLoadingState}
-                      />
+                      <div>
+                        <Sorter
+                          sortBy={sortBy}
+                          page={page}
+                          searchKeywords={searchKeywords}
+                          createAPIQuery={createAPIQuery}
+                          updateIsLoadingState={this.updateIsLoadingState}
+                        />
+                        <FilterPopup
+                          filters={filters}
+                          createAPIQuery={createAPIQuery}
+                          updateIsLoadingState={this.updateIsLoadingState}
+                          selectedFilters={selectedFacets}
+                          searchKeywords={searchKeywords}
+                        />
+                      </div>
                     )
                   }
 
-                  <FilterPopup
-                    filters={filters}
-                    createAPIQuery={createAPIQuery}
-                    updateIsLoadingState={this.updateIsLoadingState}
-                    selectedFilters={selectedFacets}
-                    searchKeywords={searchKeywords}
-                  />
-
-                  <SelectedFilters
-                    selectedFilters={selectedFacets}
-                    createAPIQuery={createAPIQuery}
-                    updateIsLoadingState={this.updateIsLoadingState}
-                  />
+                  {
+                    <SelectedFilters
+                      selectedFilters={selectedFacets}
+                      createAPIQuery={createAPIQuery}
+                      updateIsLoadingState={this.updateIsLoadingState}
+                    />
+                  }
 
                 </div>
               </div>

--- a/src/app/stores/Store.js
+++ b/src/app/stores/Store.js
@@ -26,7 +26,12 @@ class Store {
       bib: {},
       searchKeywords: '',
       facets: {},
-      selectedFacets: {},
+      selectedFacets: {
+        materialType: [],
+        language: [],
+        dateAfter: {},
+        dateBefore: {},
+      },
       page: '1',
       sortBy: 'relevance',
       isLoading: false,

--- a/src/app/utils/utils.js
+++ b/src/app/utils/utils.js
@@ -265,7 +265,7 @@ function parseServerSelectedFilters(filters, dateAfter, dateBefore) {
     dateAfter: {},
     dateBefore: {},
   };
-  // console.log(filters);
+
   if (_isArray(filters) && filters.length && !_isEmpty(filters[0])) {
     _chain(filters)
       // Each incoming filter is in JSON string format so it needs to be parsed first.

--- a/src/app/utils/utils.js
+++ b/src/app/utils/utils.js
@@ -259,7 +259,12 @@ function getReqParams(query = {}) {
  * @return {object}
  */
 function parseServerSelectedFilters(filters, dateAfter, dateBefore) {
-  const selectedFacets = {};
+  const selectedFacets = {
+    materialType: [],
+    language: [],
+    dateAfter: {},
+    dateBefore: {},
+  };
   // console.log(filters);
   if (_isArray(filters) && filters.length && !_isEmpty(filters[0])) {
     _chain(filters)

--- a/src/server/ApiRoutes/Search.js
+++ b/src/server/ApiRoutes/Search.js
@@ -114,7 +114,12 @@ function searchServer(req, res, next) {
     fieldQuery,
     filters,
     (facets, data, pageQuery) => {
-      const selectedFacets = {};
+      const selectedFacets = {
+        materialType: [],
+        language: [],
+        dateAfter: {},
+        dateBefore: {},
+      };
 
       if (!_isEmpty(filters)) {
         _mapObject(filters, (value, key) => {
@@ -176,7 +181,12 @@ function searchServer(req, res, next) {
       logger.error('Error retrieving search data in searchServer', error);
       res.locals.data.Store = {
         searchResults: {},
-        selectedFacets: {},
+        selectedFacets: {
+          materialType: [],
+          language: [],
+          dateAfter: {},
+          dateBefore: {},
+        },
         searchKeywords: '',
         facets: {},
         page: '1',

--- a/test/unit/ResultsCount.test.js
+++ b/test/unit/ResultsCount.test.js
@@ -35,7 +35,7 @@ describe('ResultsCount', () => {
       it('should output that no results were found', () => {
         expect(component.find('h2').length).to.equal(1);
         expect(component.find('h2').text())
-          .to.equal('No results found. Please try another search.');
+          .to.equal('No results for the keyword "". Try a different search.');
       });
     });
 
@@ -49,7 +49,7 @@ describe('ResultsCount', () => {
       it('should output that no results were found', () => {
         expect(component.find('h2').length).to.equal(1);
         expect(component.find('h2').text())
-          .to.equal('No results found. Please try another search.');
+          .to.equal('No results for the keyword "locofocos". Try a different search.');
       });
     });
   });

--- a/test/unit/ResultsCount.test.js
+++ b/test/unit/ResultsCount.test.js
@@ -52,6 +52,20 @@ describe('ResultsCount', () => {
           .to.equal('No results for the keyword "locofocos". Try a different search.');
       });
     });
+
+    describe('No result count with multiple search keywords', () => {
+      let component;
+
+      before(() => {
+        component = shallow(<ResultsCount searchKeywords="harry potter" count={0} />);
+      });
+
+      it('should output that no results were found', () => {
+        expect(component.find('h2').length).to.equal(1);
+        expect(component.find('h2').text())
+          .to.equal('No results for the keywords "harry potter". Try a different search.');
+      });
+    });
   });
 
   describe('Loading display', () => {
@@ -87,6 +101,25 @@ describe('ResultsCount', () => {
           expect(component.find('h2').length).to.equal(1);
           expect(component.find('h2').text())
             .to.equal('Displaying 1-50 of 2,345 results for keyword "hamlet"');
+        });
+      });
+
+      describe('Multiple search keyword', () => {
+        let component;
+
+        before(() => {
+          component = shallow(
+            <ResultsCount
+              searchKeywords="harry potter"
+              count={2345}
+            />
+          );
+        });
+
+        it('should output that no results were found', () => {
+          expect(component.find('h2').length).to.equal(1);
+          expect(component.find('h2').text())
+            .to.equal('Displaying 1-50 of 2,345 results for keywords "harry potter"');
         });
       });
 

--- a/test/unit/SelectedFilters.test.js
+++ b/test/unit/SelectedFilters.test.js
@@ -50,10 +50,10 @@ describe('SelectedFilters', () => {
 
       it('should have one button inside each list item with the filter name', () => {
         expect(listItemAt(component, 1).find('button').length).to.equal(1);
-        expect(listItemAt(component, 1).find('button').text()).to.equal('FrenchClose Icon');
+        expect(listItemAt(component, 1).find('button').text()).to.equal('FrenchRemove Filter');
 
         expect(listItemAt(component, 2).find('button').length).to.equal(1);
-        expect(listItemAt(component, 2).find('button').text()).to.equal('EnglishClose Icon');
+        expect(listItemAt(component, 2).find('button').text()).to.equal('EnglishRemove Filter');
       });
     });
 
@@ -102,16 +102,17 @@ describe('SelectedFilters', () => {
 
       it('should have one button inside each list item with the filter name', () => {
         expect(listItemAt(component, 1).find('button').length).to.equal(1);
-        expect(listItemAt(component, 1).find('button').text()).to.equal('FrenchClose Icon');
+        expect(listItemAt(component, 1).find('button').text()).to.equal('FrenchRemove Filter');
 
         expect(listItemAt(component, 2).find('button').length).to.equal(1);
-        expect(listItemAt(component, 2).find('button').text()).to.equal('EnglishClose Icon');
+        expect(listItemAt(component, 2).find('button').text()).to.equal('EnglishRemove Filter');
 
         expect(listItemAt(component, 3).find('button').length).to.equal(1);
-        expect(listItemAt(component, 3).find('button').text()).to.equal('Still ImageClose Icon');
+        expect(listItemAt(component, 3).find('button').text()).to.equal('Still ImageRemove Filter');
 
         expect(listItemAt(component, 4).find('button').length).to.equal(1);
-        expect(listItemAt(component, 4).find('button').text()).to.equal('CartographicClose Icon');
+        expect(listItemAt(component, 4).find('button').text())
+          .to.equal('CartographicRemove Filter');
       });
     });
   });


### PR DESCRIPTION
Fixes #844 and #846

1) Displays a warning specific to just using a search keyword:
* Search for `bike banana beans`
![screen shot 2017-09-19 at 3 18 57 pm](https://user-images.githubusercontent.com/1280564/30610948-ee277406-9d4d-11e7-8c7b-a84b873a8d9e.png)

2) Displays a warning with a search keyword AND selected filters: 
* Search for `hamlet` and then select `Cartographic` and `Portuguese`.
![screen shot 2017-09-19 at 3 18 52 pm](https://user-images.githubusercontent.com/1280564/30610953-f08fd01c-9d4d-11e7-8289-a2e4e8d0c0c9.png)
