### PR TITLE
Test header server login

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   },
   "dependencies": {
     "@nypl/design-toolkit": "0.1.26.1",
-    "@nypl/dgx-header-component": "2.0.0",
+    "@nypl/dgx-header-component": "git+https://git@bitbucket.org/NYPL/dgx-header-component.git#server-side-login",
     "@nypl/dgx-react-footer": "0.4.0",
     "@nypl/nypl-data-api-client": "0.2.5",
     "aws-sdk": "2.99.0",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   },
   "dependencies": {
     "@nypl/design-toolkit": "0.1.26.1",
-    "@nypl/dgx-header-component": "git+https://git@bitbucket.org/NYPL/dgx-header-component.git#server-side-login",
+    "@nypl/dgx-header-component": "2.1.0",
     "@nypl/dgx-react-footer": "0.4.0",
     "@nypl/nypl-data-api-client": "0.2.5",
     "aws-sdk": "2.99.0",

--- a/src/app/components/Application/Application.jsx
+++ b/src/app/components/Application/Application.jsx
@@ -83,7 +83,11 @@ class App extends React.Component {
     return (
       <DocumentTitle title="Shared Collection Catalog | NYPL">
         <div className="app-wrapper">
-          <Header navData={navConfig.current} skipNav={{ target: 'mainContent' }} />
+          <Header
+            navData={navConfig.current}
+            skipNav={{ target: 'mainContent' }}
+            patron={this.state.patron}
+          />
 
           {React.cloneElement(this.props.children, this.state.data)}
 

--- a/src/app/stores/PatronStore.js
+++ b/src/app/stores/PatronStore.js
@@ -12,6 +12,7 @@ class PatronStore {
       names: [],
       barcodes: [],
       emails: [],
+      loggedIn: false,
     };
   }
 
@@ -21,6 +22,7 @@ class PatronStore {
       names: data.names,
       barcodes: data.barcodes,
       emails: data.emails,
+      loggedIn: true,
     });
   }
 }

--- a/src/server/routes/api/index.js
+++ b/src/server/routes/api/index.js
@@ -22,6 +22,7 @@ export function getPatronData(req, res, next) {
                   names: [],
                   barcodes: [],
                   emails: [],
+                  loggedIn: false,
                 },
               };
             } else {
@@ -32,6 +33,7 @@ export function getPatronData(req, res, next) {
                   names: response.names,
                   barcodes: response.barCodes,
                   emails: response.emails,
+                  loggedIn: true,
                 },
               };
             }
@@ -51,6 +53,7 @@ export function getPatronData(req, res, next) {
                 names: [],
                 barcodes: [],
                 emails: [],
+                loggedIn: false,
               },
             };
             // Continue next function call
@@ -65,6 +68,7 @@ export function getPatronData(req, res, next) {
       names: [],
       barcodes: [],
       emails: [],
+      loggedIn: false,
     },
   };
   return next();


### PR DESCRIPTION
Hey, so this is a WIP. The Header component doesn't have a new npm version yet but this is what would be needed to simply pass the props to the `<Header>` component so it can render the patron's info on the server-side.

Each React app itself would need to have the `jwt` related npm packages and code to fetch a Patron's information so it can be handled correctly in the header. Otherwise, the header will simply fetch the Patron's data itself like always.