### PR TITLE
Adding the clear all filters button/link on the search results page.

### DIFF
--- a/src/app/components/Filters/SelectedFilters.jsx
+++ b/src/app/components/Filters/SelectedFilters.jsx
@@ -14,11 +14,12 @@ import Actions from '../../actions/Actions';
 import appConfig from '../../../../appConfig';
 import { ajaxCall } from '../../utils/utils';
 
-const XCloseIcon = () => (
+const XCloseIcon = (props) => (
   <svg
     className="nypl-icon svgIcon"
     preserveAspectRatio="xMidYMid meet"
     viewBox="0 0 32 32"
+    aria-hidden={props['aria-hidden']}
   >
     <title>Remove Filter</title>
     <path
@@ -29,6 +30,10 @@ const XCloseIcon = () => (
     />
   </svg>
 );
+
+XCloseIcon.propTypes = {
+  'aria-hidden': React.PropTypes.bool,
+};
 
 class SelectedFilters extends React.Component {
   constructor(props) {
@@ -128,7 +133,7 @@ class SelectedFilters extends React.Component {
         aria-label="Clear all filters"
       >
         Clear Filters
-        <XCloseIcon />
+        <XCloseIcon aria-hidden />
       </button>
     );
 

--- a/src/app/components/Filters/SelectedFilters.jsx
+++ b/src/app/components/Filters/SelectedFilters.jsx
@@ -175,59 +175,59 @@ class SelectedFilters extends React.Component {
     }
 
     return (
-      <ul
-        className="selected-filters-container"
-        aria-live="assertive"
-        aria-atomic="true"
-        aria-relevant="additions removals"
-        aria-describedby="read-text"
-      >
-        <li id="read-text" className="visuallyHidden">
-          There are {filtersToRender.length} selected filters.
-        </li>
-        {
-          filtersToRender.map((filter, i) => {
-            let filterBtn = (
-              <button
-                className="nypl-unset-filter"
-                onClick={(e) => this.onFilterClick(e, filter)}
-                aria-controls="selected-filters-container"
-                aria-label={filter.label}
-              >
-                {filter.label}
-                <XCloseIcon />
-              </button>
-            );
-
-            if (!this.state.js) {
-              const removedSelectedFilters = JSON.parse(JSON.stringify(selectedFilters));
-              removedSelectedFilters[filter.field] =
-                _reject(selectedFilters[filter.field], (f) => (f.value === filter.value));
-
-              const apiQuery = this.props.createAPIQuery({
-                selectedFilters: removedSelectedFilters,
-              });
-
-              filterBtn = (
-                <a
+      <div>
+        <span id="read-text" className="visuallyHidden">Selected filters.</span>
+        <ul
+          id="selected-filters-container"
+          aria-live="assertive"
+          aria-atomic="true"
+          aria-relevant="additions removals"
+          aria-describedby="read-text"
+        >
+          {
+            filtersToRender.map((filter, i) => {
+              let filterBtn = (
+                <button
                   className="nypl-unset-filter"
-                  href={`${appConfig.baseUrl}/search?${apiQuery}`}
+                  onClick={(e) => this.onFilterClick(e, filter)}
                   aria-controls="selected-filters-container"
-                  aria-label={filter.label}
+                  aria-label={`${filter.label} Remove Filter`}
                 >
                   {filter.label}
                   <XCloseIcon />
-                </a>
+                </button>
               );
-            }
 
-            return (<li key={i}>{filterBtn}</li>);
-          })
-        }
-        <li>
-          {clearAllFilters}
-        </li>
-      </ul>
+              if (!this.state.js) {
+                const removedSelectedFilters = JSON.parse(JSON.stringify(selectedFilters));
+                removedSelectedFilters[filter.field] =
+                  _reject(selectedFilters[filter.field], (f) => (f.value === filter.value));
+
+                const apiQuery = this.props.createAPIQuery({
+                  selectedFilters: removedSelectedFilters,
+                });
+
+                filterBtn = (
+                  <a
+                    className="nypl-unset-filter"
+                    href={`${appConfig.baseUrl}/search?${apiQuery}`}
+                    aria-controls="selected-filters-container"
+                    aria-label={filter.label}
+                  >
+                    {filter.label}
+                    <XCloseIcon />
+                  </a>
+                );
+              }
+
+              return (<li key={i}>{filterBtn}</li>);
+            })
+          }
+          <li>
+            {clearAllFilters}
+          </li>
+        </ul>
+      </div>
     );
   }
 }

--- a/src/client/styles/components/SelectedFilters.scss
+++ b/src/client/styles/components/SelectedFilters.scss
@@ -1,4 +1,4 @@
-.selected-filters-container {
+#selected-filters-container {
   padding: 0;
   float: left;
   width: 100%;

--- a/test/unit/SelectedFilters.test.js
+++ b/test/unit/SelectedFilters.test.js
@@ -9,9 +9,9 @@ const listItemAt = (component, n) => component.find('li').at(n);
 
 describe('SelectedFilters', () => {
   describe('Default', () => {
-    it('should not render a ul', () => {
+    it('should not render a div', () => {
       const component = mount(<SelectedFilters />);
-      expect(component.find('ul').length).to.equal(0);
+      expect(component.find('div').length).to.equal(0);
     });
   });
 
@@ -38,13 +38,13 @@ describe('SelectedFilters', () => {
       expect(component.find('ul').length).to.equal(1);
     });
 
-    it('should render three list items, one text, one with data, one clear link', () => {
-      expect(component.find('li').length).to.equal(3);
+    it('should render two list items, one with data and one clear link', () => {
+      expect(component.find('li').length).to.equal(2);
     });
 
     it('should have a clear all filters link', () => {
-      expect(listItemAt(component, 2).find('a').length).to.equal(1);
-      expect(listItemAt(component, 2).find('a').render().text())
+      expect(listItemAt(component, 1).find('a').length).to.equal(1);
+      expect(listItemAt(component, 1).find('a').render().text())
         .to.equal('Clear FiltersRemove Filter');
     });
   });
@@ -78,21 +78,21 @@ describe('SelectedFilters', () => {
         expect(component.find('ul').length).to.equal(1);
       });
 
-      it('should render four list items, one text, two with data, one clear', () => {
-        expect(component.find('li').length).to.equal(4);
+      it('should render three list items, two with data, one clear', () => {
+        expect(component.find('li').length).to.equal(3);
       });
 
       it('should have one button inside each list item with the filter name', () => {
-        expect(listItemAt(component, 1).find('button').length).to.equal(1);
-        expect(listItemAt(component, 1).find('button').text()).to.equal('FrenchRemove Filter');
+        expect(listItemAt(component, 0).find('button').length).to.equal(1);
+        expect(listItemAt(component, 0).find('button').text()).to.equal('FrenchRemove Filter');
 
-        expect(listItemAt(component, 2).find('button').length).to.equal(1);
-        expect(listItemAt(component, 2).find('button').text()).to.equal('EnglishRemove Filter');
+        expect(listItemAt(component, 1).find('button').length).to.equal(1);
+        expect(listItemAt(component, 1).find('button').text()).to.equal('EnglishRemove Filter');
       });
 
       it('should have a clear all filters button', () => {
-        expect(listItemAt(component, 3).find('button').length).to.equal(1);
-        expect(listItemAt(component, 3).find('button').text())
+        expect(listItemAt(component, 2).find('button').length).to.equal(1);
+        expect(listItemAt(component, 2).find('button').text())
           .to.equal('Clear FiltersRemove Filter');
       });
     });
@@ -137,21 +137,21 @@ describe('SelectedFilters', () => {
       });
 
       it('should render five list items', () => {
-        expect(component.find('li').length).to.equal(6);
+        expect(component.find('li').length).to.equal(5);
       });
 
       it('should have one button inside each list item with the filter name', () => {
+        expect(listItemAt(component, 0).find('button').length).to.equal(1);
+        expect(listItemAt(component, 0).find('button').text()).to.equal('FrenchRemove Filter');
+
         expect(listItemAt(component, 1).find('button').length).to.equal(1);
-        expect(listItemAt(component, 1).find('button').text()).to.equal('FrenchRemove Filter');
+        expect(listItemAt(component, 1).find('button').text()).to.equal('EnglishRemove Filter');
 
         expect(listItemAt(component, 2).find('button').length).to.equal(1);
-        expect(listItemAt(component, 2).find('button').text()).to.equal('EnglishRemove Filter');
+        expect(listItemAt(component, 2).find('button').text()).to.equal('Still ImageRemove Filter');
 
         expect(listItemAt(component, 3).find('button').length).to.equal(1);
-        expect(listItemAt(component, 3).find('button').text()).to.equal('Still ImageRemove Filter');
-
-        expect(listItemAt(component, 4).find('button').length).to.equal(1);
-        expect(listItemAt(component, 4).find('button').text())
+        expect(listItemAt(component, 3).find('button').text())
           .to.equal('CartographicRemove Filter');
       });
     });
@@ -170,13 +170,13 @@ describe('SelectedFilters', () => {
           component = mount(<SelectedFilters selectedFilters={selectedFilters} />);
         });
 
-        it('should render three list items', () => {
-          expect(component.find('li').length).to.equal(3);
+        it('should render two list items', () => {
+          expect(component.find('li').length).to.equal(2);
         });
 
         it('should have one button inside each list item with the filter name', () => {
-          expect(listItemAt(component, 1).find('button').length).to.equal(1);
-          expect(listItemAt(component, 1).find('button').text()).to.equal('2010Remove Filter');
+          expect(listItemAt(component, 0).find('button').length).to.equal(1);
+          expect(listItemAt(component, 0).find('button').text()).to.equal('2010Remove Filter');
         });
       });
 
@@ -193,13 +193,13 @@ describe('SelectedFilters', () => {
           component = mount(<SelectedFilters selectedFilters={selectedFilters} />);
         });
 
-        it('should render three list items', () => {
-          expect(component.find('li').length).to.equal(3);
+        it('should render two list items', () => {
+          expect(component.find('li').length).to.equal(2);
         });
 
         it('should have one button inside each list item with the filter name', () => {
-          expect(listItemAt(component, 1).find('button').length).to.equal(1);
-          expect(listItemAt(component, 1).find('button').text()).to.equal('1999Remove Filter');
+          expect(listItemAt(component, 0).find('button').length).to.equal(1);
+          expect(listItemAt(component, 0).find('button').text()).to.equal('1999Remove Filter');
         });
       });
 
@@ -216,16 +216,16 @@ describe('SelectedFilters', () => {
           component = mount(<SelectedFilters selectedFilters={selectedFilters} />);
         });
 
-        it('should render four list items', () => {
-          expect(component.find('li').length).to.equal(4);
+        it('should render three list items', () => {
+          expect(component.find('li').length).to.equal(3);
         });
 
         it('should have one button inside each list item with the filter name', () => {
-          expect(listItemAt(component, 1).find('button').length).to.equal(1);
-          expect(listItemAt(component, 1).find('button').text()).to.equal('2010Remove Filter');
+          expect(listItemAt(component, 0).find('button').length).to.equal(1);
+          expect(listItemAt(component, 0).find('button').text()).to.equal('2010Remove Filter');
 
-          expect(listItemAt(component, 2).find('button').length).to.equal(1);
-          expect(listItemAt(component, 2).find('button').text()).to.equal('1999Remove Filter');
+          expect(listItemAt(component, 1).find('button').length).to.equal(1);
+          expect(listItemAt(component, 1).find('button').text()).to.equal('1999Remove Filter');
         });
       });
     });

--- a/test/unit/SelectedFilters.test.js
+++ b/test/unit/SelectedFilters.test.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 import React from 'react';
 import { expect } from 'chai';
-import { mount } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 
 import SelectedFilters from '../../src/app/components/Filters/SelectedFilters';
 
@@ -12,6 +12,40 @@ describe('SelectedFilters', () => {
     it('should not render a ul', () => {
       const component = mount(<SelectedFilters />);
       expect(component.find('ul').length).to.equal(0);
+    });
+  });
+
+  describe('No JS - clear all link', () => {
+    const selectedFilters = {
+      language: [
+        {
+          value: 'lang:en',
+          label: 'English',
+          count: 4267,
+        },
+      ],
+      materialType: [],
+      dateBefore: '',
+      dateAfter: '',
+    };
+    let component;
+
+    before(() => {
+      component = shallow(<SelectedFilters selectedFilters={selectedFilters} />);
+    });
+
+    it('should render a ul', () => {
+      expect(component.find('ul').length).to.equal(1);
+    });
+
+    it('should render three list items, one text, one with data, one clear link', () => {
+      expect(component.find('li').length).to.equal(3);
+    });
+
+    it('should have a clear all filters link', () => {
+      expect(listItemAt(component, 2).find('a').length).to.equal(1);
+      expect(listItemAt(component, 2).find('a').render().text())
+        .to.equal('Clear FiltersRemove Filter');
     });
   });
 
@@ -44,8 +78,8 @@ describe('SelectedFilters', () => {
         expect(component.find('ul').length).to.equal(1);
       });
 
-      it('should render three list items, one text and two with data', () => {
-        expect(component.find('li').length).to.equal(3);
+      it('should render four list items, one text, two with data, one clear', () => {
+        expect(component.find('li').length).to.equal(4);
       });
 
       it('should have one button inside each list item with the filter name', () => {
@@ -54,6 +88,12 @@ describe('SelectedFilters', () => {
 
         expect(listItemAt(component, 2).find('button').length).to.equal(1);
         expect(listItemAt(component, 2).find('button').text()).to.equal('EnglishRemove Filter');
+      });
+
+      it('should have a clear all filters button', () => {
+        expect(listItemAt(component, 3).find('button').length).to.equal(1);
+        expect(listItemAt(component, 3).find('button').text())
+          .to.equal('Clear FiltersRemove Filter');
       });
     });
 
@@ -96,8 +136,8 @@ describe('SelectedFilters', () => {
         component = mount(<SelectedFilters selectedFilters={selectedFilters} />);
       });
 
-      it('should render four list items', () => {
-        expect(component.find('li').length).to.equal(5);
+      it('should render five list items', () => {
+        expect(component.find('li').length).to.equal(6);
       });
 
       it('should have one button inside each list item with the filter name', () => {
@@ -130,8 +170,8 @@ describe('SelectedFilters', () => {
           component = mount(<SelectedFilters selectedFilters={selectedFilters} />);
         });
 
-        it('should render two list items', () => {
-          expect(component.find('li').length).to.equal(2);
+        it('should render three list items', () => {
+          expect(component.find('li').length).to.equal(3);
         });
 
         it('should have one button inside each list item with the filter name', () => {
@@ -153,8 +193,8 @@ describe('SelectedFilters', () => {
           component = mount(<SelectedFilters selectedFilters={selectedFilters} />);
         });
 
-        it('should render two list items', () => {
-          expect(component.find('li').length).to.equal(2);
+        it('should render three list items', () => {
+          expect(component.find('li').length).to.equal(3);
         });
 
         it('should have one button inside each list item with the filter name', () => {
@@ -176,8 +216,8 @@ describe('SelectedFilters', () => {
           component = mount(<SelectedFilters selectedFilters={selectedFilters} />);
         });
 
-        it('should render three list items', () => {
-          expect(component.find('li').length).to.equal(3);
+        it('should render four list items', () => {
+          expect(component.find('li').length).to.equal(4);
         });
 
         it('should have one button inside each list item with the filter name', () => {


### PR DESCRIPTION
Fixes #868

Adds a "clear filters" button in the same list as the selected filters. Clicking on it will remove all the filters and make a new search with the existing search keyword(s). Should work with and without JS.

![screen shot 2017-09-26 at 12 09 53 pm](https://user-images.githubusercontent.com/1280564/30871060-9fb32246-a2b3-11e7-984e-f8bddddd489b.png)
