### PR TITLE
Adding SCSS rules to better style the filter popup with no js.

### DIFF
--- a/src/app/components/FilterPopup/FilterPopup.jsx
+++ b/src/app/components/FilterPopup/FilterPopup.jsx
@@ -314,7 +314,8 @@ class FilterPopup extends React.Component {
         aria-controls="filter-popup-menu"
         className="popup-btn-close nypl-x-close-button"
       >
-        Close <XCloseSVG />
+        <span>Close</span>
+        <XCloseSVG />
       </button>
       : (<a
         aria-expanded

--- a/src/client/styles/components/FilterPopup.scss
+++ b/src/client/styles/components/FilterPopup.scss
@@ -56,7 +56,7 @@
   .popup,
   .popup-no-js {
     margin: -1px 0 auto;
-    padding: 20px 0 0 0;
+    padding: 20px 30px 0;
     background: #fff;
     border: 1px solid #666;
     box-shadow: 0 0 50px rgba(0,0,0,0.5);
@@ -64,6 +64,15 @@
     width: auto;
     z-index: 10000;
     position: relative;
+    top: -60px;
+
+    @include min-screen($tablet-portrait) {
+      width: 42rem;
+    }
+
+    @include min-screen(966px) {
+      width: 52rem;
+    }
   }
 
   .popup {


### PR DESCRIPTION
Fixes #878
Fixes the close button not displaying correctly on mobile and minor styling to the popup when js is turned off.

Hard to replicate what's on the design-toolkit because of the difference in DOM structure.