### PR TITLE
Move ResultsCount and Sorter down

### DIFF
--- a/src/app/components/SearchResultsPage/SearchResultsPage.jsx
+++ b/src/app/components/SearchResultsPage/SearchResultsPage.jsx
@@ -123,24 +123,9 @@ class SearchResultsPage extends React.Component {
                       {searchErrorMessage}
                     </span>
                   }
-                  <ResultsCount
-                    isLoading={isLoading}
-                    count={totalResults}
-                    selectedFilters={selectedFilters}
-                    searchKeywords={searchKeywords}
-                    field={field}
-                    page={parseInt(page, 10)}
-                  />
                   {
                     !!(totalResults && totalResults !== 0) && (
                       <div>
-                        <Sorter
-                          sortBy={sortBy}
-                          page={page}
-                          searchKeywords={searchKeywords}
-                          createAPIQuery={createAPIQuery}
-                          updateIsLoadingState={this.updateIsLoadingState}
-                        />
                         <FilterPopup
                           filters={apiFilters}
                           createAPIQuery={createAPIQuery}
@@ -162,6 +147,40 @@ class SearchResultsPage extends React.Component {
                   }
 
                 </div>
+              </div>
+            </div>
+          </div>
+
+          <div className="nypl-full-width-wrapper">
+            <div className="nypl-row">
+              <div
+                className="nypl-column-three-quarters"
+                role="region"
+                id="mainContent"
+                aria-live="polite"
+                aria-atomic="true"
+                aria-relevant="additions removals"
+                aria-describedby="results-description"
+              >
+                <ResultsCount
+                  isLoading={isLoading}
+                  count={totalResults}
+                  selectedFilters={selectedFilters}
+                  searchKeywords={searchKeywords}
+                  field={field}
+                  page={parseInt(page, 10)}
+                />
+                {
+                  !!(totalResults && totalResults !== 0) && (
+                    <Sorter
+                      sortBy={sortBy}
+                      page={page}
+                      searchKeywords={searchKeywords}
+                      createAPIQuery={createAPIQuery}
+                      updateIsLoadingState={this.updateIsLoadingState}
+                    />
+                  )
+                }
               </div>
             </div>
           </div>

--- a/src/app/components/SearchResultsPage/SearchResultsPage.jsx
+++ b/src/app/components/SearchResultsPage/SearchResultsPage.jsx
@@ -153,15 +153,7 @@ class SearchResultsPage extends React.Component {
 
           <div className="nypl-full-width-wrapper">
             <div className="nypl-row">
-              <div
-                className="nypl-column-three-quarters"
-                role="region"
-                id="mainContent"
-                aria-live="polite"
-                aria-atomic="true"
-                aria-relevant="additions removals"
-                aria-describedby="results-description"
-              >
+              <div className="nypl-column-three-quarters">
                 <ResultsCount
                   isLoading={isLoading}
                   count={totalResults}

--- a/src/app/components/Sorter/Sorter.jsx
+++ b/src/app/components/Sorter/Sorter.jsx
@@ -99,6 +99,7 @@ class Sorter extends React.Component {
     return (
       <div className="nypl-results-sorting-controls">
         <div className="nypl-results-sorter">
+          <label htmlFor="sort-by-label">Sort by</label>
           <form
             action={
               `${appConfig.baseUrl}/search${searchKeywords ? `?q=${searchKeywords}` : ''}` +
@@ -107,7 +108,6 @@ class Sorter extends React.Component {
             method="POST"
           >
             <span className="nypl-omni-fields">
-              <label htmlFor="sort-by-label">Sort by</label>
               <strong>
                 <select
                   id="sort-by-label"

--- a/test/unit/SearchResultsPage.test.js
+++ b/test/unit/SearchResultsPage.test.js
@@ -138,7 +138,7 @@ describe('SearchResultsPage', () => {
     });
 
     it('should two .nypl-full-width-wrapper elements', () => {
-      expect(component.find('.nypl-full-width-wrapper')).to.have.length(2);
+      expect(component.find('.nypl-full-width-wrapper')).to.have.length(3);
     });
   });
 });


### PR DESCRIPTION
moves these components below the search results page header to it's own <div> wrapper above the ResultsList component