### PR TITLE
Add URL to electronic resource events

### DIFF
--- a/src/app/components/BibPage/BibDetails.jsx
+++ b/src/app/components/BibPage/BibDetails.jsx
@@ -322,7 +322,7 @@ class BibDetails extends React.Component {
               href={electronicItem.url}
               target="_blank"
               onClick={() =>
-                trackDiscovery('Bib fields', `Electronic Resource - ${electronicItem.label}`)
+                trackDiscovery('Bib fields', `Electronic Resource - ${electronicItem.label} - ${electronicItem.url}`)
               }
             >
               {electronicItem.label}
@@ -337,7 +337,7 @@ class BibDetails extends React.Component {
                       href={e.url}
                       target="_blank"
                       onClick={
-                        () => trackDiscovery('Bib fields', `Electronic Resource - ${e.label}`)
+                        () => trackDiscovery('Bib fields', `Electronic Resource - ${e.label} - ${e.url}`)
                       }
                     >
                       {e.label}


### PR DESCRIPTION
In order to better distinguish between clicks on electronic resources,
add external URL to the event data.

Since this kind of takes the "D" out of "DRY" one could argue that creation of the creation of the label (or really of the whole `<a>` element should be broken out into a function.