### PR TITLE
Dropdownfilters

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -8,5 +8,6 @@
     "react/require-default-props": 0,
     "jsx-a11y/anchor-is-valid": 0,
     "class-methods-use-this": 0,
+    "prefer-destructuring": 0,
   }
 }

--- a/src/app/components/BibPage/BibPage.jsx
+++ b/src/app/components/BibPage/BibPage.jsx
@@ -2,10 +2,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import DocumentTitle from 'react-document-title';
 import { every as _every } from 'underscore';
+import { LeftWedgeIcon } from '@nypl/dgx-svg-icons';
 
 import Breadcrumbs from '../Breadcrumbs/Breadcrumbs';
 import ItemHoldings from '../Item/ItemHoldings';
-import LoadingLayer from '../LoadingLayer/LoadingLayer.jsx';
+import LoadingLayer from '../LoadingLayer/LoadingLayer';
 import BibDetails from './BibDetails';
 import LibraryItem from '../../utils/item';
 import BackLink from './BackLink';
@@ -105,17 +106,10 @@ class BibPage extends React.Component {
                   {
                     this.props.searchKeywords && (
                       <div className="nypl-row search-control">
-                        <svg
-                          xmlns="http://www.w3.org/2000/svg"
-                          width="25" height="42"
-                          viewBox="0 0 25 42"
+                        <LeftWedgeIcon
                           preserveAspectRatio="xMidYMid meet"
-                          aria-labelledby="left-arrow"
-                          aria-hidden="true"
-                        >
-                          <title id="left-arrow">Back to Results</title>
-                          <polygon points="21.172 42.344 0 21.172 21.172 0 25.112 3.939 7.88 21.172 25.112 38.404 21.172 42.344"></polygon>
-                        </svg>
+                          title="Back to Results"
+                        />
                         <BackLink
                           searchURL={searchURL}
                           searchKeywords={this.props.searchKeywords}

--- a/src/app/components/BibPage/MarcRecord.jsx
+++ b/src/app/components/BibPage/MarcRecord.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { trackDiscovery } from '../../utils/utils.js';
+import { trackDiscovery } from '../../utils/utils';
 
 const MarcRecord = ({ bNumber }) => {
   if (!bNumber) {

--- a/src/app/components/Breadcrumbs/Breadcrumbs.jsx
+++ b/src/app/components/Breadcrumbs/Breadcrumbs.jsx
@@ -2,8 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router';
 
-import { trackDiscovery } from '../../utils/utils.js';
-import appConfig from '../../../../appConfig.js';
+import { trackDiscovery } from '../../utils/utils';
+import appConfig from '../../../../appConfig';
 
 const baseUrl = appConfig.baseUrl;
 

--- a/src/app/components/FilterPopup/FilterPopup.jsx
+++ b/src/app/components/FilterPopup/FilterPopup.jsx
@@ -94,7 +94,6 @@ class FilterPopup extends React.Component {
 
     this.openForm = this.openForm.bind(this);
     this.closeForm = this.closeForm.bind(this);
-    this.deactivateForm = this.deactivateForm.bind(this);
     this.onFilterClick = this.onFilterClick.bind(this);
     this.onDateFilterChange = this.onDateFilterChange.bind(this);
     this.validateFilterValue = this.validateFilterValue.bind(this);
@@ -226,7 +225,7 @@ class FilterPopup extends React.Component {
 
     const apiQuery = this.props.createAPIQuery({ selectedFilters: this.state.selectedFilters });
 
-    this.deactivateForm();
+    this.closeForm();
     this.props.updateIsLoadingState(true);
 
     Actions.updateSelectedFilters(this.state.selectedFilters);
@@ -279,10 +278,6 @@ class FilterPopup extends React.Component {
 
   closeForm(e) {
     e.preventDefault();
-    this.deactivateForm();
-  }
-
-  deactivateForm() {
     trackDiscovery('FilterPopup', 'Close');
     this.setState({ showForm: false });
 
@@ -299,24 +294,6 @@ class FilterPopup extends React.Component {
       filters,
     } = this.state;
 
-    const closePopupButton = js ?
-      <button
-        onClick={(e) => this.closeForm(e)}
-        aria-expanded={!showForm}
-        aria-controls="filter-popup-menu"
-        className="popup-btn-close nypl-x-close-button"
-      >
-        <span>Close</span>
-        <XCloseSVG />
-      </button>
-      : (<a
-        aria-expanded
-        href="#"
-        aria-controls="filter-popup-menu"
-        className="popup-btn-close nypl-x-close-button"
-      >
-        Close <XCloseSVG />
-      </a>);
     const openPopupButton = js ?
       (<button
         className="popup-btn-open nypl-short-button"
@@ -377,14 +354,8 @@ class FilterPopup extends React.Component {
         >
           {!js && (<a className="cancel-no-js" href="#"></a>)}
           <p id="modal-description" className="nypl-screenreader-only">Filter search results</p>
-          <FocusTrap
-            focusTrapOptions={{
-              onDeactivate: this.deactivateForm,
-              clickOutsideDeactivates: true,
-            }}
-            active={showForm}
+          <div
             id="filter-popup-menu"
-            role="menu"
             className={
               `${js ? 'popup' : 'popup-no-js'} nypl-modal-filter-form nypl-popup-filter-menu ` +
               `${showForm ? 'active' : ''}`
@@ -396,7 +367,7 @@ class FilterPopup extends React.Component {
             <form
               action={`${appConfig.baseUrl}/search?q=${searchKeywords}`}
               method="POST"
-              onSubmit={() => this.onSubmitForm()}
+              onSubmit={() => this.submitForm()}
             >
               <fieldset className="nypl-fieldset">
                 <legend><h3 id="filter-title">Filter Results</h3></legend>
@@ -426,6 +397,14 @@ class FilterPopup extends React.Component {
 
                 <div className="inner nypl-filter-button-container">
                   <button
+                    onClick={this.closeForm}
+                    aria-expanded={!showForm}
+                    aria-controls="filter-popup-menu"
+                    className="nypl-filter-button"
+                  >
+                    Close
+                  </button>
+                  <button
                     id="submit-form"
                     type="submit"
                     name="apply-filters"
@@ -437,6 +416,7 @@ class FilterPopup extends React.Component {
                       preserveAspectRatio="xMidYMid meet"
                       title="apply"
                       labelledById="apply"
+                      iconId="filterApply"
                     />
                     Apply Filters
                   </button>
@@ -452,14 +432,14 @@ class FilterPopup extends React.Component {
                       preserveAspectRatio="xMidYMid meet"
                       title="reset"
                       labelledById="reset"
+                      iconId="filterReset"
                     />
                     Clear Filters
                   </button>
                 </div>
               </fieldset>
             </form>
-          </FocusTrap>
-          {closePopupButton}
+          </div>
         </div>
       </div>
     );

--- a/src/app/components/FilterPopup/FilterPopup.jsx
+++ b/src/app/components/FilterPopup/FilterPopup.jsx
@@ -225,7 +225,7 @@ class FilterPopup extends React.Component {
 
     const apiQuery = this.props.createAPIQuery({ selectedFilters: this.state.selectedFilters });
 
-    this.closeForm();
+    this.closeForm(e);
     this.props.updateIsLoadingState(true);
 
     Actions.updateSelectedFilters(this.state.selectedFilters);
@@ -294,18 +294,47 @@ class FilterPopup extends React.Component {
       filters,
     } = this.state;
 
-    const openPopupButton = js ?
-      (<button
-        className="popup-btn-open nypl-short-button"
-        onClick={() => this.openForm()}
-        aria-haspopup="true"
-        aria-expanded={showForm}
-        aria-controls="filter-popup-menu"
-        ref="filterOpen"
+    const applyButton = showForm ? (
+      <button
+        id="submit-form"
+        type="submit"
+        name="apply-filters"
+        onClick={e => this.submitForm(e)}
+        className="nypl-filter-button"
       >
-        FILTER RESULTS <FilterIcon />
-      </button>)
-      : (<a
+        Apply Filters
+        <ApplyIcon
+          className="nypl-icon"
+          preserveAspectRatio="xMidYMid meet"
+          title="apply"
+          labelledById="apply"
+          iconId="filterApply"
+        />
+      </button>) : (
+        <button
+          className="popup-btn-open nypl-short-button"
+          onClick={() => this.openForm()}
+          aria-haspopup="true"
+          aria-expanded={showForm || null}
+          aria-controls="filter-popup-menu"
+          ref="filterOpen"
+        >
+          Add filters <FilterIcon />
+        </button>);
+    const cancelButton = (
+      <button
+        onClick={this.closeForm}
+        aria-expanded={!showForm}
+        aria-controls="filter-popup-menu"
+        className="nypl-filter-button"
+      >
+        Cancel
+      </button>
+    );
+
+
+    const openPopupButton = js ? applyButton :
+      (<a
         className="popup-btn-open nypl-short-button"
         href="#popup-no-js"
         aria-haspopup="true"
@@ -341,6 +370,7 @@ class FilterPopup extends React.Component {
 
     return (
       <div className="filter-container">
+        {showForm && cancelButton}
         {openPopupButton}
         <div
           className={
@@ -370,8 +400,6 @@ class FilterPopup extends React.Component {
               onSubmit={() => this.submitForm()}
             >
               <fieldset className="nypl-fieldset">
-                <legend><h3 id="filter-title">Filter Results</h3></legend>
-
                 <FieldsetList
                   legend="Format"
                   filterId="materialType"
@@ -397,36 +425,13 @@ class FilterPopup extends React.Component {
 
                 <div className="inner nypl-filter-button-container">
                   <button
-                    onClick={this.closeForm}
-                    aria-expanded={!showForm}
-                    aria-controls="filter-popup-menu"
-                    className="nypl-filter-button"
-                  >
-                    Close
-                  </button>
-                  <button
-                    id="submit-form"
-                    type="submit"
-                    name="apply-filters"
-                    onClick={this.submitForm}
-                    className="nypl-filter-button"
-                  >
-                    <ApplyIcon
-                      className="nypl-icon"
-                      preserveAspectRatio="xMidYMid meet"
-                      title="apply"
-                      labelledById="apply"
-                      iconId="filterApply"
-                    />
-                    Apply Filters
-                  </button>
-                  <button
                     id="clear-filters"
                     type="button"
                     name="Clear-Filters"
                     className="nypl-filter-button"
                     onClick={this.clearFilters}
                   >
+                    Clear Filters
                     <ResetIcon
                       className="nypl-icon"
                       preserveAspectRatio="xMidYMid meet"
@@ -434,8 +439,9 @@ class FilterPopup extends React.Component {
                       labelledById="reset"
                       iconId="filterReset"
                     />
-                    Clear Filters
                   </button>
+                  {cancelButton}
+                  {applyButton}
                 </div>
               </fieldset>
             </form>

--- a/src/app/components/FilterPopup/FilterPopup.jsx
+++ b/src/app/components/FilterPopup/FilterPopup.jsx
@@ -25,6 +25,17 @@ import FieldsetDate from '../Filters/FieldsetDate';
 import FieldsetList from '../Filters/FieldsetList';
 import Actions from '../../actions/Actions';
 
+const FilterResetIcon = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" width="57.69298" height="71.85359" viewBox="0 0 57.69298 71.85359">
+    <title>filter.reset.icon</title>
+    <g>
+      <path d="M22.98743,71.85359a2.82155,2.82155,0,0,1-2.82082-2.82082V38.545L.7499,17.6096A2.82138,2.82138,0,0,1,4.893,13.77872L25.80825,36.33386V69.03277A2.82155,2.82155,0,0,1,22.98743,71.85359Z"/>
+      <path d="M34.447,63.63651a2.82155,2.82155,0,0,1-2.82082-2.82082V36.35223l21.15409-23.199a2.82154,2.82154,0,0,1,4.18715,3.78313L37.26782,38.52661V60.81569A2.82155,2.82155,0,0,1,34.447,63.63651Z"/>
+      <path d="M31.17492,11.19237l7.7782-7.77814A2,2,0,0,0,36.12469.5858L28.34649,8.364,20.56829.5858a2,2,0,1,0-2.82843,2.82843l7.7782,7.77814-7.7782,7.7782A2,2,0,0,0,20.56829,21.799l7.7782-7.7782,7.7782,7.7782a2,2,0,0,0,2.82843-2.82843Z"/>
+    </g>
+  </svg>
+);
+
 class FilterPopup extends React.Component {
   constructor(props) {
     super(props);
@@ -291,12 +302,10 @@ class FilterPopup extends React.Component {
         onClick={this.clearFilters}
       >
         Clear Filters
-        <FilterIcon
+        <FilterResetIcon
           className="nypl-icon"
           preserveAspectRatio="xMidYMid meet"
           title="reset"
-          labelledById="reset"
-          iconId="filterReset"
         />
       </button>);
     const openButton = (

--- a/src/app/components/FilterPopup/FilterPopup.jsx
+++ b/src/app/components/FilterPopup/FilterPopup.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
-import FocusTrap from 'focus-trap-react';
 import {
   findWhere as _findWhere,
   reject as _reject,
@@ -10,7 +9,11 @@ import {
   isEmpty as _isEmpty,
   some as _some,
 } from 'underscore';
-import { ApplyIcon, ResetIcon } from '@nypl/dgx-svg-icons';
+import {
+  CheckSoloIcon,
+  FilterIcon,
+  ResetIcon,
+} from '@nypl/dgx-svg-icons';
 
 import {
   trackDiscovery,
@@ -21,53 +24,6 @@ import appConfig from '../../../../appConfig';
 import FieldsetDate from '../Filters/FieldsetDate';
 import FieldsetList from '../Filters/FieldsetList';
 import Actions from '../../actions/Actions';
-
-const XCloseSVG = () => (
-  <svg
-    aria-hidden="true"
-    aria-controls="filter-popup-menu"
-    className="nypl-icon"
-    preserveAspectRatio="xMidYMid meet"
-    viewBox="0 0 100 100"
-  >
-    <title>x-close-rev</title>
-    <path
-      d={'M82.07922,14.06287a48.0713,48.0713,0,1,0,0,68.01563A48.15148,48.15148,0,0,0,82.0792' +
-        '2,14.06287ZM65.06232,60.84845A2.97437,2.97437,0,1,1,60.827,65.0257L48.154,52.18756,35' +
-        '.30133,65.04022a2.97432,2.97432,0,1,1-4.20636-4.2063L43.97473,47.95416,31.27362,35.087' +
-        '46A2.97542,2.97542,0,0,1,35.509,30.90729L48.18213,43.7467,60.84149,31.0874a2.97432,2.9' +
-        '7432,0,0,1,4.2063,4.20636L52.36108,47.98047Z'}
-    />
-  </svg>
-);
-
-const FilterIcon = () => (
-  <svg
-    aria-hidden="true"
-    className="nypl-icon"
-    preserveAspectRatio="xMidYMid meet"
-    viewBox="0 0 19 22"
-  >
-    <title>filter.icon.3</title>
-    <g>
-      <circle cx="6.65947" cy="2.31986" r="1.31924" />
-      <circle cx="13.18733" cy="1.31986" r="1.31895" />
-      <circle cx="9.56477" cy="5.46901" r="1.31927" />
-      <g>
-        <path
-          d={'M7.74355,22.50683a.95047.95047,0,0,1-.95022-.95022V11.28645L.25259,4.2341' +
-          '3A.95041.95041,0,1,1,1.64824,2.94366l7.04554,7.598v11.015A.95047.95047,0,0,1,7.7435' +
-          '5,22.50683Z'}
-        />
-        <path
-          d={'M11.60384,19.73881a.95047.95047,0,0,1-.95022-.95022V10.5478l7.126-7.81485a.' +
-          '95047.95047,0,0,1,1.41049,1.27439l-6.636,7.27293v7.50832A.95047.95047,0,0,1,11.60384,' +
-          '19.73881Z'}
-        />
-      </g>
-    </g>
-  </svg>
-);
 
 class FilterPopup extends React.Component {
   constructor(props) {
@@ -294,33 +250,23 @@ class FilterPopup extends React.Component {
       filters,
     } = this.state;
 
-    const applyButton = showForm ? (
+    const applyButton = (
       <button
         id="submit-form"
         type="submit"
         name="apply-filters"
         onClick={e => this.submitForm(e)}
-        className="nypl-filter-button"
+        className="nypl-primary-button"
       >
         Apply Filters
-        <ApplyIcon
-          className="nypl-icon"
+        <CheckSoloIcon
+          className="apply-icon"
           preserveAspectRatio="xMidYMid meet"
           title="apply"
           labelledById="apply"
           iconId="filterApply"
         />
-      </button>) : (
-        <button
-          className="popup-btn-open nypl-short-button"
-          onClick={() => this.openForm()}
-          aria-haspopup="true"
-          aria-expanded={showForm || null}
-          aria-controls="filter-popup-menu"
-          ref="filterOpen"
-        >
-          Add filters <FilterIcon />
-        </button>);
+      </button>);
     const cancelButton = (
       <button
         onClick={this.closeForm}
@@ -331,9 +277,34 @@ class FilterPopup extends React.Component {
         Cancel
       </button>
     );
-
-
-    const openPopupButton = js ? applyButton :
+    const resetButton = (
+      <button
+        id="clear-filters"
+        type="button"
+        name="Clear-Filters"
+        className="nypl-basic-button"
+        onClick={this.clearFilters}
+      >
+        Clear Filters
+        <ResetIcon
+          className="nypl-icon"
+          preserveAspectRatio="xMidYMid meet"
+          title="reset"
+          labelledById="reset"
+          iconId="filterReset"
+        />
+      </button>);
+    const openPopupButton = js ?
+      (<button
+        className="popup-btn-open nypl-short-button"
+        onClick={() => this.openForm()}
+        aria-haspopup="true"
+        aria-expanded={showForm || null}
+        aria-controls="filter-popup-menu"
+        ref="filterOpen"
+      >
+        Add filters <FilterIcon />
+      </button>) :
       (<a
         className="popup-btn-open nypl-short-button"
         href="#popup-no-js"
@@ -342,7 +313,7 @@ class FilterPopup extends React.Component {
         aria-controls="filter-popup-menu"
         ref="filterOpen"
       >
-        FILTER RESULTS <FilterIcon />
+        Add filters <FilterIcon />
       </a>);
     const { searchKeywords } = this.props;
     const materialTypeFilters = _findWhere(filters, { id: 'materialType' });
@@ -388,7 +359,7 @@ class FilterPopup extends React.Component {
             id="filter-popup-menu"
             className={
               `${js ? 'popup' : 'popup-no-js'} nypl-modal-filter-form nypl-popup-filter-menu ` +
-              `${showForm ? 'active' : ''}`
+              `${showForm ? 'expand active' : 'collapse'}`
             }
           >
             {
@@ -424,24 +395,9 @@ class FilterPopup extends React.Component {
                 />
 
                 <div className="inner nypl-filter-button-container">
-                  <button
-                    id="clear-filters"
-                    type="button"
-                    name="Clear-Filters"
-                    className="nypl-filter-button"
-                    onClick={this.clearFilters}
-                  >
-                    Clear Filters
-                    <ResetIcon
-                      className="nypl-icon"
-                      preserveAspectRatio="xMidYMid meet"
-                      title="reset"
-                      labelledById="reset"
-                      iconId="filterReset"
-                    />
-                  </button>
-                  {cancelButton}
+                  {resetButton}
                   {applyButton}
+                  {cancelButton}
                 </div>
               </fieldset>
             </form>

--- a/src/app/components/FilterPopup/FilterPopup.jsx
+++ b/src/app/components/FilterPopup/FilterPopup.jsx
@@ -272,7 +272,7 @@ class FilterPopup extends React.Component {
         onClick={this.closeForm}
         aria-expanded={!showForm}
         aria-controls="filter-popup-menu"
-        className="nypl-filter-button"
+        className="nypl-filter-button cancel-button"
       >
         Cancel
       </button>

--- a/src/app/components/FilterPopup/FilterPopup.jsx
+++ b/src/app/components/FilterPopup/FilterPopup.jsx
@@ -68,8 +68,8 @@ class FilterPopup extends React.Component {
       selectedFilters: _extend({
         materialType: [],
         language: [],
-        dateAfter: {},
-        dateBefore: {},
+        dateAfter: undefined,
+        dateBefore: undefined,
       }, nextProps.selectedFilters),
       filters: nextProps.filters,
     });
@@ -135,7 +135,12 @@ class FilterPopup extends React.Component {
     }
 
     _map(errors, (val, key) => {
-      errorArray.push(<li key={key}><a href={`#${headlineError[val.name]}`}>{val.value}</a></li>);
+      if (val.name && val.value) {
+        const anchorTag = (this.state.js) ?
+          <a href={`#${headlineError[val.name]}`}>{val.value}</a> : <span>{val.value}</span>;
+
+        errorArray.push(<li key={key}>{anchorTag}</li>);
+      }
     });
 
     return errorArray;
@@ -284,11 +289,11 @@ class FilterPopup extends React.Component {
         id="clear-filters"
         type="button"
         name="Clear-Filters"
-        className="nypl-basic-button"
+        className="nypl-basic-button clear-filters-button"
         onClick={this.clearFilters}
       >
         Clear Filters
-        <ResetIcon
+        <FilterIcon
           className="nypl-icon"
           preserveAspectRatio="xMidYMid meet"
           title="reset"

--- a/src/app/components/FilterPopup/FilterPopup.jsx
+++ b/src/app/components/FilterPopup/FilterPopup.jsx
@@ -341,8 +341,14 @@ class FilterPopup extends React.Component {
 
     return (
       <div className="filter-container">
-        {showForm && cancelButton}
-        {openPopupButton}
+        <div className="filter-text">
+          <h2>Refine your search</h2>
+          <p>Add filters to narrow and define your search</p>
+        </div>
+        <div className="filter-action-buttons">
+          {showForm && cancelButton}
+          {openPopupButton}
+        </div>
         <div
           className={
             'nypl-basic-modal-container nypl-popup-container popup-container ' +

--- a/src/app/components/FilterPopup/FilterPopup.jsx
+++ b/src/app/components/FilterPopup/FilterPopup.jsx
@@ -259,11 +259,10 @@ class FilterPopup extends React.Component {
 
     const applyButton = (
       <button
-        id="submit-form"
         type="submit"
         name="apply-filters"
         onClick={e => this.submitForm(e)}
-        className="nypl-primary-button"
+        className="nypl-primary-button apply-button"
       >
         Apply Filters
         <CheckSoloIcon
@@ -286,7 +285,6 @@ class FilterPopup extends React.Component {
     );
     const resetButton = (
       <button
-        id="clear-filters"
         type="button"
         name="Clear-Filters"
         className="nypl-basic-button clear-filters-button"
@@ -301,17 +299,20 @@ class FilterPopup extends React.Component {
           iconId="filterReset"
         />
       </button>);
-    const openPopupButton = js ?
-      (<button
+    const openButton = (
+      <button
         className="popup-btn-open nypl-primary-button"
         onClick={() => this.openForm()}
         aria-haspopup="true"
         aria-expanded={showForm || null}
         aria-controls="filter-popup-menu"
-        ref="filterOpen"
       >
         Add filters <FilterIcon />
-      </button>) :
+      </button>
+    );
+    const popupOrApplyButton = showForm ? applyButton : openButton;
+    const openPopupButton = js ?
+      popupOrApplyButton :
       (<a
         className="popup-btn-open nypl-primary-button"
         href="#popup-no-js"
@@ -334,7 +335,11 @@ class FilterPopup extends React.Component {
       dateBefore: dateBeforeFilterValue,
     };
     const errorMessageBlock = (
-      <div className="nypl-form-error filter-error-box" ref="nypl-filter-error" tabIndex="0">
+      <div
+        className="nypl-form-error filter-error-box"
+        ref="nypl-filter-error"
+        tabIndex="0"
+      >
         <h2>Error</h2>
         <p>Please enter valid filter values:</p>
         <ul>
@@ -342,19 +347,19 @@ class FilterPopup extends React.Component {
         </ul>
       </div>
     );
-    const isDateInputError = _some(this.state.raisedErrors, (item) =>
-      (item.name && item.name === 'date')
-    );
+    const isDateInputError = _some(this.state.raisedErrors, item =>
+      (item.name && item.name === 'date'));
 
     return (
       <div className="filter-container">
         <div className="filter-text">
           <h2>Refine your search</h2>
-          <p>Add filters to narrow and define your search</p>
         </div>
         <div className="filter-action-buttons">
-          {showForm && cancelButton}
+          {!showForm && (<p>Add filters to narrow and define your search</p>)}
+          {showForm && resetButton}
           {openPopupButton}
+          {showForm && cancelButton}
         </div>
         <div
           className={

--- a/src/app/components/FilterPopup/FilterPopup.jsx
+++ b/src/app/components/FilterPopup/FilterPopup.jsx
@@ -275,7 +275,7 @@ class FilterPopup extends React.Component {
         onClick={e => this.submitForm(e)}
         className="nypl-primary-button apply-button"
       >
-        Apply Filters
+        Apply filters
         <CheckSoloIcon
           className="apply-icon"
           preserveAspectRatio="xMidYMid meet"
@@ -301,7 +301,7 @@ class FilterPopup extends React.Component {
         className="nypl-basic-button clear-filters-button"
         onClick={this.clearFilters}
       >
-        Clear Filters
+        Clear filters
         <FilterResetIcon
           className="nypl-icon"
           preserveAspectRatio="xMidYMid meet"

--- a/src/app/components/FilterPopup/FilterPopup.jsx
+++ b/src/app/components/FilterPopup/FilterPopup.jsx
@@ -273,12 +273,7 @@ class FilterPopup extends React.Component {
   openForm() {
     if (!this.state.showForm) {
       trackDiscovery('FilterPopup', 'Open');
-      this.setState(
-        { showForm: true },
-        () => {
-          document.body.classList.add('no-scroll');
-        }
-      );
+      this.setState({ showForm: true });
     }
   }
 
@@ -289,12 +284,7 @@ class FilterPopup extends React.Component {
 
   deactivateForm() {
     trackDiscovery('FilterPopup', 'Close');
-    this.setState(
-      { showForm: false },
-      () => {
-        document.body.classList.remove('no-scroll');
-      }
-    );
+    this.setState({ showForm: false });
 
     if (this.refs.filterOpen) {
       this.refs.filterOpen.focus();
@@ -386,93 +376,90 @@ class FilterPopup extends React.Component {
           aria-describedby="modal-description"
         >
           {!js && (<a className="cancel-no-js" href="#"></a>)}
-          <div className="nypl-modal-content">
-            <div className="nypl-popup-filter-overlay"></div>
-            <p id="modal-description" className="nypl-screenreader-only">Filter search results</p>
-            <FocusTrap
-              focusTrapOptions={{
-                onDeactivate: this.deactivateForm,
-                clickOutsideDeactivates: true,
-              }}
-              active={showForm}
-              id="filter-popup-menu"
-              role="menu"
-              className={
-                `${js ? 'popup' : 'popup-no-js'} nypl-modal-filter-form nypl-popup-filter-menu ` +
-                `${showForm ? 'active' : ''}`
-              }
+          <p id="modal-description" className="nypl-screenreader-only">Filter search results</p>
+          <FocusTrap
+            focusTrapOptions={{
+              onDeactivate: this.deactivateForm,
+              clickOutsideDeactivates: true,
+            }}
+            active={showForm}
+            id="filter-popup-menu"
+            role="menu"
+            className={
+              `${js ? 'popup' : 'popup-no-js'} nypl-modal-filter-form nypl-popup-filter-menu ` +
+              `${showForm ? 'active' : ''}`
+            }
+          >
+            {
+              this.state.raisedErrors && !_isEmpty(this.state.raisedErrors) && (errorMessageBlock)
+            }
+            <form
+              action={`${appConfig.baseUrl}/search?q=${searchKeywords}`}
+              method="POST"
+              onSubmit={() => this.onSubmitForm()}
             >
-              {
-                this.state.raisedErrors && !_isEmpty(this.state.raisedErrors) && (errorMessageBlock)
-              }
-              <form
-                action={`${appConfig.baseUrl}/search?q=${searchKeywords}`}
-                method="POST"
-                onSubmit={() => this.onSubmitForm()}
-              >
-                <fieldset className="nypl-fieldset">
-                  <legend><h3 id="filter-title">Filter Results</h3></legend>
+              <fieldset className="nypl-fieldset">
+                <legend><h3 id="filter-title">Filter Results</h3></legend>
 
-                  <FieldsetList
-                    legend="Format"
-                    filterId="materialType"
-                    filter={materialTypeFilters}
-                    selectedFilters={selectedFilters.materialType}
-                    onFilterClick={this.onFilterClick}
-                  />
+                <FieldsetList
+                  legend="Format"
+                  filterId="materialType"
+                  filter={materialTypeFilters}
+                  selectedFilters={selectedFilters.materialType}
+                  onFilterClick={this.onFilterClick}
+                />
 
-                  <FieldsetDate
-                    legend="Date"
-                    selectedFilters={dateSelectedFilters}
-                    onDateFilterChange={this.onDateFilterChange}
-                    submitError={isDateInputError}
-                  />
+                <FieldsetDate
+                  legend="Date"
+                  selectedFilters={dateSelectedFilters}
+                  onDateFilterChange={this.onDateFilterChange}
+                  submitError={isDateInputError}
+                />
 
-                  <FieldsetList
-                    legend="Language"
-                    filterId="language"
-                    filter={languageFilters}
-                    selectedFilters={selectedFilters.language}
-                    onFilterClick={this.onFilterClick}
-                  />
+                <FieldsetList
+                  legend="Language"
+                  filterId="language"
+                  filter={languageFilters}
+                  selectedFilters={selectedFilters.language}
+                  onFilterClick={this.onFilterClick}
+                />
 
-                  <div className="inner nypl-filter-button-container">
-                    <button
-                      id="submit-form"
-                      type="submit"
-                      name="apply-filters"
-                      onClick={this.submitForm}
-                      className="nypl-filter-button"
-                    >
-                      <ApplyIcon
-                        className="nypl-icon"
-                        preserveAspectRatio="xMidYMid meet"
-                        title="apply"
-                        labelledById="apply"
-                      />
-                      Apply Filters
-                    </button>
-                    <button
-                      id="clear-filters"
-                      type="button"
-                      name="Clear-Filters"
-                      className="nypl-filter-button"
-                      onClick={this.clearFilters}
-                    >
-                      <ResetIcon
-                        className="nypl-icon"
-                        preserveAspectRatio="xMidYMid meet"
-                        title="reset"
-                        labelledById="reset"
-                      />
-                      Clear Filters
-                    </button>
-                  </div>
-                </fieldset>
-              </form>
-            </FocusTrap>
-            {closePopupButton}
-          </div>
+                <div className="inner nypl-filter-button-container">
+                  <button
+                    id="submit-form"
+                    type="submit"
+                    name="apply-filters"
+                    onClick={this.submitForm}
+                    className="nypl-filter-button"
+                  >
+                    <ApplyIcon
+                      className="nypl-icon"
+                      preserveAspectRatio="xMidYMid meet"
+                      title="apply"
+                      labelledById="apply"
+                    />
+                    Apply Filters
+                  </button>
+                  <button
+                    id="clear-filters"
+                    type="button"
+                    name="Clear-Filters"
+                    className="nypl-filter-button"
+                    onClick={this.clearFilters}
+                  >
+                    <ResetIcon
+                      className="nypl-icon"
+                      preserveAspectRatio="xMidYMid meet"
+                      title="reset"
+                      labelledById="reset"
+                    />
+                    Clear Filters
+                  </button>
+                </div>
+              </fieldset>
+            </form>
+          </FocusTrap>
+          {closePopupButton}
         </div>
       </div>
     );

--- a/src/app/components/FilterPopup/FilterPopup.jsx
+++ b/src/app/components/FilterPopup/FilterPopup.jsx
@@ -367,8 +367,10 @@ class FilterPopup extends React.Component {
         <div className="filter-action-buttons">
           {!showForm && (<p>Add filters to narrow and define your search</p>)}
           {showForm && resetButton}
-          {openPopupButton}
-          {showForm && cancelButton}
+          <div className="cancel-apply-buttons">
+            {showForm && cancelButton}
+            {openPopupButton}
+          </div>
         </div>
         <div
           className={
@@ -423,8 +425,10 @@ class FilterPopup extends React.Component {
 
                 <div className="inner nypl-filter-button-container">
                   {resetButton}
-                  {applyButton}
-                  {cancelButton}
+                  <div className="cancel-apply-buttons">
+                    {cancelButton}
+                    {applyButton}
+                  </div>
                 </div>
               </fieldset>
             </form>

--- a/src/app/components/FilterPopup/FilterPopup.jsx
+++ b/src/app/components/FilterPopup/FilterPopup.jsx
@@ -229,6 +229,7 @@ class FilterPopup extends React.Component {
     if (!this.state.showForm) {
       trackDiscovery('FilterPopup', 'Open');
       this.setState({ showForm: true });
+      this.props.updateDropdownState(true);
     }
   }
 
@@ -236,6 +237,7 @@ class FilterPopup extends React.Component {
     e.preventDefault();
     trackDiscovery('FilterPopup', 'Close');
     this.setState({ showForm: false });
+    this.props.updateDropdownState(false);
 
     if (this.refs.filterOpen) {
       this.refs.filterOpen.focus();
@@ -296,7 +298,7 @@ class FilterPopup extends React.Component {
       </button>);
     const openPopupButton = js ?
       (<button
-        className="popup-btn-open nypl-short-button"
+        className="popup-btn-open nypl-primary-button"
         onClick={() => this.openForm()}
         aria-haspopup="true"
         aria-expanded={showForm || null}
@@ -306,7 +308,7 @@ class FilterPopup extends React.Component {
         Add filters <FilterIcon />
       </button>) :
       (<a
-        className="popup-btn-open nypl-short-button"
+        className="popup-btn-open nypl-primary-button"
         href="#popup-no-js"
         aria-haspopup="true"
         aria-expanded={false}
@@ -422,12 +424,14 @@ FilterPopup.propTypes = {
   selectedFilters: PropTypes.object,
   searchKeywords: PropTypes.string,
   raisedErrors: PropTypes.array,
+  updateDropdownState: PropTypes.func,
 };
 
 FilterPopup.defaultProps = {
   filters: [],
   createAPIQuery: () => {},
   updateIsLoadingState: () => {},
+  updateDropdownState: () => {},
 };
 
 FilterPopup.contextTypes = {

--- a/src/app/components/Filters/FieldsetDate.jsx
+++ b/src/app/components/Filters/FieldsetDate.jsx
@@ -69,6 +69,7 @@ class FieldsetDate extends React.Component {
               format="####"
               aria-labelledby="dateAfter-label dateInput-status"
               value={defaultValueDateAfter}
+              placeholder="YYYY"
             />
           </label>
           {/*<svg viewBox="0 0 98 98" className="nypl-icon date-hyphen" preserveAspectRatio="xMidYMid meet"  aria-hidden="true" aria-labelledby="dash" role="img">
@@ -85,6 +86,7 @@ class FieldsetDate extends React.Component {
               format="####"
               aria-labelledby="dateBefore-label dateInput-status"
               value={defaultValueDateBefore}
+              placeholder="YYYY"
             />
           </label>
           <span

--- a/src/app/components/Filters/FieldsetDate.jsx
+++ b/src/app/components/Filters/FieldsetDate.jsx
@@ -2,6 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import NumberFormat from 'react-number-format';
 
+import { DivideLineIcon } from '@nypl/dgx-svg-icons';
+
 class FieldsetDate extends React.Component {
   constructor(props) {
     super(props);
@@ -69,10 +71,11 @@ class FieldsetDate extends React.Component {
               value={defaultValueDateAfter}
             />
           </label>
-          <svg viewBox="0 0 98 98" className="nypl-icon date-hyphen" preserveAspectRatio="xMidYMid meet"  aria-hidden="true" aria-labelledby="dash" role="img">
+          {/*<svg viewBox="0 0 98 98" className="nypl-icon date-hyphen" preserveAspectRatio="xMidYMid meet"  aria-hidden="true" aria-labelledby="dash" role="img">
             <title id="dash">dash.icon</title>
             <polygon points="72.996 54.95 25.002 54.95 25.003 45.991 72.994 46.011 72.996 54.95"/>
-          </svg>
+          </svg>*/}
+          <DivideLineIcon className="date-hyphen" />
           <label htmlFor="dateBefore" id="dateBefore-label">End Year
             <NumberFormat
               id="dateBefore"

--- a/src/app/components/Filters/FieldsetDate.jsx
+++ b/src/app/components/Filters/FieldsetDate.jsx
@@ -55,8 +55,8 @@ class FieldsetDate extends React.Component {
     const defaultValueDateBefore = (this.state.dateBefore) ? this.state.dateBefore : null;
 
     return (
-      <fieldset className="nypl-fieldset inner">
-        <legend>Date</legend>
+      <fieldset className="nypl-fieldset inner date-fieldset">
+        <legend><strong>Date</strong></legend>
         <div id="input-container" className={`nypl-name-field nypl-filter-date-field ${errorClass}`}>
           <label htmlFor="dateAfter" id="dateAfter-label">Start Year
             <NumberFormat

--- a/src/app/components/Filters/FieldsetList.jsx
+++ b/src/app/components/Filters/FieldsetList.jsx
@@ -53,11 +53,8 @@ class FieldsetList extends React.Component {
 
     return (
       <fieldset className="nypl-fieldset inner">
-        {legend && <legend>{legend}</legend>}
-        <ul
-          className={`nypl-generic-checkbox ${(filterId === 'language') ?
-          'nypl-generic-columns' : ''}`}
-        >
+        {legend && <legend><strong>{legend}</strong></legend>}
+        <ul className="nypl-generic-checkbox nypl-generic-columns">
           {
             values.map((filter, i) => (
               <li className="nypl-generic-checkbox" key={i}>

--- a/src/app/components/Filters/SelectedFilters.jsx
+++ b/src/app/components/Filters/SelectedFilters.jsx
@@ -169,10 +169,11 @@ class SelectedFilters extends React.Component {
         >
           {
             filtersToRender.map((filter, i) => {
+              const dateClass = filter.field;
               let filterBtn = (
                 <button
                   className="nypl-unset-filter"
-                  onClick={(e) => this.onFilterClick(e, filter)}
+                  onClick={e => this.onFilterClick(e, filter)}
                   aria-controls="selected-filters-container"
                   aria-label={`${filter.label} Remove Filter`}
                 >
@@ -184,7 +185,10 @@ class SelectedFilters extends React.Component {
               if (!this.state.js) {
                 const removedSelectedFilters = JSON.parse(JSON.stringify(selectedFilters));
                 removedSelectedFilters[filter.field] =
-                  _reject(selectedFilters[filter.field], (f) => (f.value === filter.value));
+                  _reject(
+                    selectedFilters[filter.field],
+                    f => (f.value === filter.value),
+                  );
 
                 const apiQuery = this.props.createAPIQuery({
                   selectedFilters: removedSelectedFilters,
@@ -203,7 +207,7 @@ class SelectedFilters extends React.Component {
                 );
               }
 
-              return (<li key={i}>{filterBtn}</li>);
+              return (<li key={i} className={dateClass}>{filterBtn}</li>);
             })
           }
           <li>

--- a/src/app/components/Filters/SelectedFilters.jsx
+++ b/src/app/components/Filters/SelectedFilters.jsx
@@ -9,7 +9,10 @@ import {
   contains as _contains,
   isArray as _isArray,
 } from 'underscore';
-import { XIcon } from '@nypl/dgx-svg-icons';
+import {
+  FilterIcon,
+  XIcon,
+} from '@nypl/dgx-svg-icons';
 
 import Actions from '../../actions/Actions';
 import appConfig from '../../../../appConfig';
@@ -107,13 +110,13 @@ class SelectedFilters extends React.Component {
     const acceptedFilters = _keys(appConfig.defaultFilters);
     let clearAllFilters = (
       <button
-        className="nypl-unset-filter"
+        className="nypl-unset-filter clear-filters-button"
         onClick={this.clearFilters}
         aria-controls="selected-filters-container"
         aria-label="Clear all filters"
       >
         Clear Filters
-        <XIcon fill="#fff" ariaHidden />
+        <FilterIcon ariaHidden />
       </button>
     );
 
@@ -122,13 +125,13 @@ class SelectedFilters extends React.Component {
 
       clearAllFilters = (
         <a
-          className="nypl-unset-filter"
+          className="nypl-unset-filter clear-filters-button"
           href={`${appConfig.baseUrl}/search?${apiQuery}`}
           aria-controls="selected-filters-container"
           aria-label="Clear all filters"
         >
           Clear Filters
-          <XIcon fill="#fff" ariaHidden />
+          <FilterIcon ariaHidden />
         </a>
       );
     }

--- a/src/app/components/Filters/SelectedFilters.jsx
+++ b/src/app/components/Filters/SelectedFilters.jsx
@@ -9,31 +9,11 @@ import {
   contains as _contains,
   isArray as _isArray,
 } from 'underscore';
+import { XIcon } from '@nypl/dgx-svg-icons';
 
 import Actions from '../../actions/Actions';
 import appConfig from '../../../../appConfig';
 import { ajaxCall } from '../../utils/utils';
-
-const XCloseIcon = (props) => (
-  <svg
-    className="nypl-icon svgIcon"
-    preserveAspectRatio="xMidYMid meet"
-    viewBox="0 0 32 32"
-    aria-hidden={props['aria-hidden']}
-  >
-    <title>Remove Filter</title>
-    <path
-      d={'M17.91272,15.97339l5.65689-5.65689A1.32622,1.32622,0,0,0,21.694,8.44093L16.04938' +
-        ',14.0856l-5.65082-5.725A1.32671,1.32671,0,1,0,8.51,10.22454l5.66329,5.73712L8.4303' +
-        '8,21.7046a1.32622,1.32622,0,1,0,1.87557,1.87557l5.73088-5.73088,5.65074,5.72441a1.3' +
-        '2626,1.32626,0,1,0,1.88852-1.86261Z'}
-    />
-  </svg>
-);
-
-XCloseIcon.propTypes = {
-  'aria-hidden': React.PropTypes.bool,
-};
 
 class SelectedFilters extends React.Component {
   constructor(props) {
@@ -133,7 +113,7 @@ class SelectedFilters extends React.Component {
         aria-label="Clear all filters"
       >
         Clear Filters
-        <XCloseIcon aria-hidden />
+        <XIcon fill="#fff" ariaHidden />
       </button>
     );
 
@@ -148,7 +128,7 @@ class SelectedFilters extends React.Component {
           aria-label="Clear all filters"
         >
           Clear Filters
-          <XCloseIcon />
+          <XIcon fill="#fff" ariaHidden />
         </a>
       );
     }
@@ -194,7 +174,7 @@ class SelectedFilters extends React.Component {
                   aria-label={`${filter.label} Remove Filter`}
                 >
                   {filter.label}
-                  <XCloseIcon />
+                  <XIcon fill="#fff" ariaHidden />
                 </button>
               );
 
@@ -215,7 +195,7 @@ class SelectedFilters extends React.Component {
                     aria-label={filter.label}
                   >
                     {filter.label}
-                    <XCloseIcon />
+                    <XIcon fill="#fff" ariaHidden />
                   </a>
                 );
               }

--- a/src/app/components/Pagination/Pagination.jsx
+++ b/src/app/components/Pagination/Pagination.jsx
@@ -1,32 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router';
-import appConfig from '../../../../appConfig.js';
+import {
+  LeftWedgeIcon,
+  RightWedgeIcon,
+} from '@nypl/dgx-svg-icons';
 
-const LeftWedgeIcon = () => (
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    preserveAspectRatio="xMidYMid meet"
-    aria-hidden="true"
-    viewBox="0 0 8.97 15.125"
-  >
-    <title>Wedge Left Arrow</title>
-    <polygon
-      points="7.563 15.125 0 7.562 7.563 0 8.97 1.407 2.815 7.562 8.97 13.717 7.563 15.125"
-    />
-  </svg>
-);
-const RightWedgeIcon = () => (
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    preserveAspectRatio="xMidYMid meet"
-    aria-hidden="true"
-    viewBox="0 0 8.97 15.126"
-  >
-    <title>Wedge Right Arrow</title>
-    <polygon points="1.407 0 8.97 7.563 1.407 15.126 0 13.718 6.155 7.563 0 1.408 1.407 0" />
-  </svg>
-);
+import appConfig from '../../../../appConfig';
 
 class Pagination extends React.Component {
   /*

--- a/src/app/components/SearchResultsPage/SearchResultsPage.jsx
+++ b/src/app/components/SearchResultsPage/SearchResultsPage.jsx
@@ -2,23 +2,23 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import DocumentTitle from 'react-document-title';
 
-import ResultsCount from '../ResultsCount/ResultsCount.jsx';
-import Breadcrumbs from '../Breadcrumbs/Breadcrumbs.jsx';
+import ResultsCount from '../ResultsCount/ResultsCount';
+import Breadcrumbs from '../Breadcrumbs/Breadcrumbs';
 import ResultList from '../Results/ResultsList';
-import Search from '../Search/Search.jsx';
+import Search from '../Search/Search';
 import Sorter from '../Sorter/Sorter';
 import Pagination from '../Pagination/Pagination';
-import LoadingLayer from '../LoadingLayer/LoadingLayer.jsx';
-import FilterPopup from '../FilterPopup/FilterPopup.jsx';
-import SelectedFilters from '../Filters/SelectedFilters.jsx';
+import LoadingLayer from '../LoadingLayer/LoadingLayer';
+import FilterPopup from '../FilterPopup/FilterPopup';
+import SelectedFilters from '../Filters/SelectedFilters';
 
 import {
   basicQuery,
   ajaxCall,
   trackDiscovery,
-} from '../../utils/utils.js';
-import Actions from '../../actions/Actions.js';
-import appConfig from '../../../../appConfig.js';
+} from '../../utils/utils';
+import Actions from '../../actions/Actions';
+import appConfig from '../../../../appConfig';
 
 class SearchResultsPage extends React.Component {
   constructor(props) {

--- a/src/app/components/SearchResultsPage/SearchResultsPage.jsx
+++ b/src/app/components/SearchResultsPage/SearchResultsPage.jsx
@@ -26,9 +26,11 @@ class SearchResultsPage extends React.Component {
 
     this.state = {
       isLoading: this.props.isLoading,
+      dropdownOpen: false,
     };
 
     this.updateIsLoadingState = this.updateIsLoadingState.bind(this);
+    this.updateDropdownState = this.updateDropdownState.bind(this);
   }
 
   componentDidUpdate() {
@@ -39,6 +41,10 @@ class SearchResultsPage extends React.Component {
 
   updateIsLoadingState(status) {
     this.setState({ isLoading: status });
+  }
+
+  updateDropdownState(status) {
+    this.setState({ dropdownOpen: status });
   }
 
   render() {
@@ -133,12 +139,13 @@ class SearchResultsPage extends React.Component {
                           selectedFilters={selectedFilters}
                           searchKeywords={searchKeywords}
                           raisedErrors={dateFilterErrors}
+                          updateDropdownState={this.updateDropdownState}
                         />
                       </div>
                     )
                   }
 
-                  {
+                  {!this.state.dropdownOpen &&
                     <SelectedFilters
                       selectedFilters={selectedFilters}
                       createAPIQuery={createAPIQuery}

--- a/src/app/utils/utils.js
+++ b/src/app/utils/utils.js
@@ -143,7 +143,7 @@ const getFilterParam = (filters) => {
   if (!_isEmpty(filters)) {
     _mapObject(filters, (val, key) => {
       // Property contains an array of its selected filter values:
-      if (val.length && _isArray(val)) {
+      if (val && val.length && _isArray(val)) {
         _forEach(val, (filter, index) => {
           if (filter.value && filter.value !== '') {
             // At this time, materialType filter requires _packed for filtering (but not as data).

--- a/src/client/styles/components/BibPage.scss
+++ b/src/client/styles/components/BibPage.scss
@@ -10,3 +10,12 @@
     vertical-align: middle;
   }
 }
+
+.search-control {
+  svg {
+    height: 1.6rem;
+    width: 1.5rem;
+    top: 9px;
+    left: 0px;
+  }
+}

--- a/src/client/styles/components/FilterPopup.scss
+++ b/src/client/styles/components/FilterPopup.scss
@@ -13,16 +13,16 @@
   }
 
   .popup-container {
-    visibility: hidden;
-    display: none;
-    opacity: 0;
+    // visibility: hidden;
+    // display: none;
+    // opacity: 0;
 
-    &.active,
-    &:target {
-      visibility: visible;
-      display: block;
-      opacity: 1;
-    }
+    // &.active,
+    // &:target {
+    //   visibility: visible;
+    //   display: block;
+    //   opacity: 1;
+    // }
   }
 }
 
@@ -55,11 +55,11 @@
   }
 
   .popup {
-    display: none;
+    // display: none;
     width: 100%;
 
     &.active {
-      display: block;
+      // display: block;
       overflow: auto;
       -webkit-overflow-scrolling: touch;
     }
@@ -92,6 +92,7 @@
     cursor: pointer;
     -webkit-appearance: none;
     -moz-appearance: none;
+    margin: 2.5rem 1rem 0;
   }
   ul li {
     list-style: none;
@@ -140,8 +141,10 @@
 }
 
 .date-hyphen {
-  margin: 0 2px;
   background: #efedeb;
+  width: 25px;
+  margin: 0px 15px;
+  height: 10px;
 }
 
 .filter-error-box {
@@ -153,9 +156,34 @@
 
 
 .nypl-modal-filter-form {
+  @include transition-list(max-height .3s ease-in-out);
+  height: auto;
+
+  // Accordion rules
+  &.collapse {
+    max-height: 0;
+    visibility: hidden;
+  }
+
+  &.expand {
+    max-height: 100em;
+    visibility: visible;
+  }
+
   fieldset:last-of-type {
     border-bottom: none;
   }
+
+  .nypl-filter-button-container {
+    button {
+      float: right;
+
+      &:first-of-type {
+        float: left;
+      }
+    }
+  }
+
   .inner {
     padding: 0;
 

--- a/src/client/styles/components/FilterPopup.scss
+++ b/src/client/styles/components/FilterPopup.scss
@@ -1,7 +1,6 @@
 .filter-container {
   .popup-btn-open {
-    display: inline-block;
-    float: left;
+    float: right;
     border: 1px solid #776e64;
     display: block;
     text-decoration: none;
@@ -22,34 +21,56 @@
     padding-top: 3px;
   }
 
-  .popup-container {
-    // visibility: hidden;
-    // display: none;
-    // opacity: 0;
-
-    // &.active,
-    // &:target {
-    //   visibility: visible;
-    //   display: block;
-    //   opacity: 1;
-    // }
-  }
-
   svg {
     vertical-align: middle;
   }
 
   .filter-text {
     float: left;
+    width: 100%;
+    border-bottom: 0.125rem solid #d7d4d0;
   }
   .filter-action-buttons {
+    float: left;
+    width: 100%;
+
+    p {
+      margin: 20px 0;
+      float: left;
+      display: inline-block;
+    }
+  }
+
+  .popup-btn-open,
+  .apply-button {
     float: right;
+    background: #fff;
+    border-color: #1b7fa7;
+    color: #1b7fa7;
+
+    svg {
+      fill: #1b7fa7;
+      background: #fff;
+    }
+
+    &:hover {
+      background-color: #1b7fa7;
+      border: 0.04167rem solid #1b7fa7;
+      color: #fff;
+
+      svg {
+        fill: #fff;
+        background-color: #1b7fa7;
+      }
+    }
   }
 
   .cancel-button {
     border: none;
     background: #efedeb;
     color: #000;
+    margin: 20px;
+    float: right;
 
     &:hover {
       background: #efedeb;
@@ -129,7 +150,7 @@
   svg {
     @include transition-list(all 0.1s ease-in 0s);
   }
-  #clear-filters {
+  .clear-filters-button {
     svg {
       height: 25px;
       width: 25px;
@@ -140,20 +161,6 @@
       svg {
         fill: #fff;
         background: #d0343a;
-      }
-    }
-  }
-  #submit-form {
-    svg {
-      fill: #fff;
-      height: 25px;
-      width: 25px;
-      margin: 0 0 2px 5px;
-    }
-    &:hover {
-      svg {
-        fill: #1b7fa7;
-        background: #fff;
       }
     }
   }
@@ -241,12 +248,8 @@
   }
 
   .nypl-filter-button-container {
-    button {
-      float: right;
-
-      &:first-of-type {
-        float: left;
-      }
+    button:first-of-type {
+      float: left;
     }
   }
 

--- a/src/client/styles/components/FilterPopup.scss
+++ b/src/client/styles/components/FilterPopup.scss
@@ -51,6 +51,7 @@
     svg {
       fill: #1b7fa7;
       background: #fff;
+      margin: 0 0 3px 3px;
     }
 
     &:hover {
@@ -155,7 +156,7 @@
       height: 25px;
       width: 25px;
       padding: 0;
-      margin: 0 0 0 5px;
+      margin: 0px 0 2px 5px;
     }
     &:hover {
       svg {

--- a/src/client/styles/components/FilterPopup.scss
+++ b/src/client/styles/components/FilterPopup.scss
@@ -59,7 +59,6 @@
     padding: 20px 30px 0;
     background: #fff;
     border: 1px solid #666;
-    box-shadow: 0 0 50px rgba(0,0,0,0.5);
     float: left;
     width: auto;
     z-index: 10000;

--- a/src/client/styles/components/FilterPopup.scss
+++ b/src/client/styles/components/FilterPopup.scss
@@ -39,31 +39,28 @@
     position: fixed;
   }
 
-  .overlay {
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    position: fixed;
-    z-index: 1000;
-    background: rgba(0,0,0,0.5);
-    &.active {
-      opacity: 1;
-      visibility: visible;
-    }
-  }
+  // .overlay {
+  //   top: 0;
+  //   bottom: 0;
+  //   left: 0;
+  //   right: 0;
+  //   position: fixed;
+  //   z-index: 1000;
+  //   background: rgba(0,0,0,0.5);
+  //   &.active {
+  //     opacity: 1;
+  //     visibility: visible;
+  //   }
+  // }
 
   .popup,
   .popup-no-js {
-    margin: -1px 0 auto;
     padding: 20px 30px 0;
-    background: #fff;
-    border: 1px solid #666;
-    float: left;
+    background: #efedeb;
     width: auto;
     z-index: 10000;
-    position: relative;
-    top: -60px;
+    // position: relative;
+    // top: -60px;
 
     @include min-screen($tablet-portrait) {
       width: 42rem;
@@ -80,8 +77,7 @@
 
     &.active {
       display: block;
-      z-index: 2000;
-      overflow: scroll;
+      overflow: auto;
       -webkit-overflow-scrolling: touch;
     }
   }
@@ -93,6 +89,17 @@
 
     &.active {
       display: block;
+    }
+  }
+
+  // need to override the background color
+  .nypl-fieldset {
+    background-color: #efedeb;
+  }
+
+  .nypl-generic-checkbox {
+    label::before {
+      background: #fff;
     }
   }
 }
@@ -110,8 +117,7 @@
 
 .nypl-popup-container.active {
   .nypl-popup-filter-menu .nypl-x-close-button {
-    top: 1rem !important;
-    right: 1rem;
+    
   }
   .nypl-popup-filter-overlay {
     z-index: 1000 !important;
@@ -142,8 +148,17 @@
   -webkit-appearance: none;
 }
 
+.nypl-name-field {
+  background: #efedeb;
+
+  .nypl-field-status {
+    background: #efedeb;
+  }
+}
+
 .date-hyphen {
   margin: 0 2px;
+  background: #efedeb;
 }
 
 .filter-error-box {

--- a/src/client/styles/components/FilterPopup.scss
+++ b/src/client/styles/components/FilterPopup.scss
@@ -24,6 +24,23 @@
     //   opacity: 1;
     // }
   }
+
+  svg {
+    vertical-align: middle;
+  }
+
+  .cancel-button {
+    border: none;
+    background: #efedeb;
+    color: #000;
+
+    &:hover {
+      background: #efedeb;
+      color: #000;
+      border: none;
+      text-decoration: underline;
+    }
+  }
 }
 
 .popup-container {

--- a/src/client/styles/components/FilterPopup.scss
+++ b/src/client/styles/components/FilterPopup.scss
@@ -131,8 +131,6 @@
   }
   #clear-filters {
     svg {
-      fill: #fff;
-      background: #000;
       height: 25px;
       width: 25px;
       padding: 0;
@@ -140,8 +138,8 @@
     }
     &:hover {
       svg {
-        fill: #000;
-        background: #fff;
+        fill: #fff;
+        background: #d0343a;
       }
     }
   }

--- a/src/client/styles/components/FilterPopup.scss
+++ b/src/client/styles/components/FilterPopup.scss
@@ -41,9 +41,13 @@
     }
   }
 
+  .cancel-apply-buttons {
+    float: right;
+    display: inline-block;
+  }
+
   .popup-btn-open,
   .apply-button {
-    float: right;
     background: #fff;
     border-color: #1b7fa7;
     color: #1b7fa7;
@@ -71,7 +75,6 @@
     background: #efedeb;
     color: #000;
     margin: 20px;
-    float: right;
 
     &:hover {
       background: #efedeb;

--- a/src/client/styles/components/FilterPopup.scss
+++ b/src/client/styles/components/FilterPopup.scss
@@ -5,6 +5,17 @@
     border: 1px solid #776e64;
     display: block;
     text-decoration: none;
+
+    svg {
+      fill: #fff;
+      margin: 0 0 2px 0px;
+    }
+
+    &:hover {
+      svg {
+        fill: #1b7fa7;
+      }
+    }
   }
 
   a.popup-btn-open {
@@ -46,6 +57,10 @@
       border: none;
       text-decoration: underline;
     }
+  }
+
+  .nypl-name-field input[type=text] {
+    transition: none;
   }
 }
 
@@ -111,12 +126,18 @@
 }
 
 .filter-container {
+  svg {
+    @include transition-list(all 0.1s ease-in 0s);
+  }
   #clear-filters {
     svg {
       fill: #fff;
       background: #000;
+      height: 25px;
+      width: 25px;
+      padding: 0;
+      margin: 0 0 0 5px;
     }
-
     &:hover {
       svg {
         fill: #000;
@@ -127,6 +148,9 @@
   #submit-form {
     svg {
       fill: #fff;
+      height: 25px;
+      width: 25px;
+      margin: 0 0 2px 5px;
     }
     &:hover {
       svg {
@@ -147,9 +171,6 @@
 }
 
 .nypl-popup-container.active {
-  .nypl-popup-filter-menu .nypl-x-close-button {
-
-  }
   .nypl-popup-filter-overlay {
     z-index: 1000 !important;
   }

--- a/src/client/styles/components/FilterPopup.scss
+++ b/src/client/styles/components/FilterPopup.scss
@@ -39,28 +39,11 @@
     position: fixed;
   }
 
-  // .overlay {
-  //   top: 0;
-  //   bottom: 0;
-  //   left: 0;
-  //   right: 0;
-  //   position: fixed;
-  //   z-index: 1000;
-  //   background: rgba(0,0,0,0.5);
-  //   &.active {
-  //     opacity: 1;
-  //     visibility: visible;
-  //   }
-  // }
-
   .popup,
   .popup-no-js {
-    padding: 20px 30px 0;
     background: #efedeb;
     width: auto;
     z-index: 10000;
-    // position: relative;
-    // top: -60px;
 
     @include min-screen($tablet-portrait) {
       width: 42rem;
@@ -117,7 +100,7 @@
 
 .nypl-popup-container.active {
   .nypl-popup-filter-menu .nypl-x-close-button {
-    
+
   }
   .nypl-popup-filter-overlay {
     z-index: 1000 !important;
@@ -165,5 +148,27 @@
   margin: 0 3.125rem;
   @media (max-width: 483px) {
     margin: 0 1rem;
+  }
+}
+
+
+.nypl-modal-filter-form {
+  fieldset:last-of-type {
+    border-bottom: none;
+  }
+  .inner {
+    padding: 0;
+
+    legend {
+      padding-top: 15px;
+    }
+
+    ul {
+      margin-top: 10px;
+    }
+
+    &:last-child {
+      border-bottom: none;
+    }
   }
 }

--- a/src/client/styles/components/FilterPopup.scss
+++ b/src/client/styles/components/FilterPopup.scss
@@ -2,7 +2,6 @@
   .popup-btn-open {
     display: inline-block;
     float: left;
-    margin: 2.5rem 1rem 0;
     border: 1px solid #776e64;
     display: block;
     text-decoration: none;
@@ -27,6 +26,13 @@
 
   svg {
     vertical-align: middle;
+  }
+
+  .filter-text {
+    float: left;
+  }
+  .filter-action-buttons {
+    float: right;
   }
 
   .cancel-button {
@@ -105,11 +111,35 @@
 }
 
 .filter-container {
+  #clear-filters {
+    svg {
+      fill: #fff;
+      background: #000;
+    }
+
+    &:hover {
+      svg {
+        fill: #000;
+        background: #fff;
+      }
+    }
+  }
+  #submit-form {
+    svg {
+      fill: #fff;
+    }
+    &:hover {
+      svg {
+        fill: #1b7fa7;
+        background: #fff;
+      }
+    }
+  }
   button {
     cursor: pointer;
     -webkit-appearance: none;
     -moz-appearance: none;
-    margin: 2.5rem 1rem 0;
+    margin: 1rem 0 0;
   }
   ul li {
     list-style: none;

--- a/src/client/styles/components/FilterPopup.scss
+++ b/src/client/styles/components/FilterPopup.scss
@@ -39,6 +39,14 @@
       float: left;
       display: inline-block;
     }
+
+    .clear-filters-button {
+      display: none;
+
+      @include min-screen($xtrasmall-breakpoint) {
+        display: inline-block;
+      }
+    }
   }
 
   .cancel-apply-buttons {
@@ -75,6 +83,14 @@
     background: #efedeb;
     color: #000;
     margin: 20px;
+
+    @include min-screen(410px) {
+      margin-left: 60px;
+    }
+
+    @include min-screen($xtrasmall-breakpoint) {
+      margin-left: 20px;
+    }
 
     &:hover {
       background: #efedeb;
@@ -155,6 +171,14 @@
     @include transition-list(all 0.1s ease-in 0s);
   }
   .clear-filters-button {
+    float: right;
+    padding: 7px 16px;
+    @include border-radius(5px);
+
+    @include min-screen($xtrasmall-breakpoint) {
+      float: left;
+    }
+
     svg {
       height: 25px;
       width: 25px;
@@ -249,12 +273,6 @@
 
   fieldset:last-of-type {
     border-bottom: none;
-  }
-
-  .nypl-filter-button-container {
-    button:first-of-type {
-      float: left;
-    }
   }
 
   .inner {

--- a/src/client/styles/components/SelectedFilters.scss
+++ b/src/client/styles/components/SelectedFilters.scss
@@ -8,6 +8,21 @@
     list-style: none;
     margin: 10px 15px 0 0;
     display: inline-block;
+
+    &.dateAfter {
+      margin-right: 0;
+      button {
+        border-top-right-radius: 0;
+        border-bottom-right-radius: 0;
+      }
+    }
+
+    &.dateBefore {
+      button {
+        border-top-left-radius: 0;
+        border-bottom-left-radius: 0;
+      }
+    }
   }
 
   .nypl-unset-filter {

--- a/src/client/styles/components/SelectedFilters.scss
+++ b/src/client/styles/components/SelectedFilters.scss
@@ -9,4 +9,30 @@
     margin: 10px 15px 0 0;
     display: inline-block;
   }
+
+  .nypl-unset-filter {
+    background: #fff;
+    border: 1px solid #000;
+    color: #000;
+
+    svg {
+      fill: #000;
+      height: 25px;
+      width: 25px;
+      margin: 0 0 0 0px;
+      padding: 0;
+      float: right;
+      @include transition-list(all 0.1s ease-in 0s);
+    }
+
+    &:hover {
+      background: #000;
+      border: 1px solid #fff;
+      color: #fff;
+
+      svg {
+        fill: #fff;
+      }
+    }
+  }
 }

--- a/src/client/styles/components/SelectedFilters.scss
+++ b/src/client/styles/components/SelectedFilters.scss
@@ -35,4 +35,12 @@
       }
     }
   }
+
+  .clear-filters-button {
+    @include clear-filters-button;
+  }
+}
+
+.clear-filters-button {
+  @include clear-filters-button;
 }

--- a/src/client/styles/main.scss
+++ b/src/client/styles/main.scss
@@ -176,3 +176,13 @@ input[type=submit]:focus {
 .emailSubscription-wrapper {
   margin-top: 5px !important;
 }
+
+.nypl-results-pagination {
+  a {
+    svg {
+      height: 1.8rem;
+      width: 1.8rem;
+      margin-top: 0;
+    }
+  }
+}

--- a/src/client/styles/utils/mixins.scss
+++ b/src/client/styles/utils/mixins.scss
@@ -186,3 +186,23 @@
        -o-transition: -o-transform $values;
           transition: transform $values;
 }
+
+@mixin clear-filters-button {
+  border: 1px solid #d0343a;
+  color: #d0343a;
+  background: #fff;
+
+  svg {
+    fill: #d0343a;
+  }
+
+  &:hover {
+    border: 1px solid #fff;
+    color: #fff;
+    background: #d0343a;
+
+    svg {
+      fill: #fff;
+    }
+  }
+}

--- a/src/server/ApiRoutes/Search.js
+++ b/src/server/ApiRoutes/Search.js
@@ -34,7 +34,7 @@ function search(searchKeywords, page, sortBy, order, field, filters, cb, errorcb
     page,
   });
 
-  const aggregationQuery = `/aggregations?${apiQuery}`;
+  const aggregationQuery = `/aggregations`;
   const queryString = `?${apiQuery}&per_page=50`;
 
   // Need to get both results and aggregations before proceeding.

--- a/test/unit/FilterPopup.test.js
+++ b/test/unit/FilterPopup.test.js
@@ -53,9 +53,9 @@ describe('FilterPopup', () => {
       expect(component.find('button').at(0).prop('className'))
         .to.equal('popup-btn-open nypl-primary-button');
       expect(component.find('button').at(1).prop('name')).to.equal('Clear-Filters');
-      expect(component.find('button').at(2).prop('name')).to.equal('apply-filters');
+      expect(component.find('button').at(2).prop('className')).to.equal('nypl-filter-button cancel-button');
       expect(component.find('button').at(3).prop('className'))
-        .to.equal('nypl-filter-button cancel-button');
+        .to.equal('nypl-primary-button apply-button');
     });
 
     it('should not render the "no-js" <a> element', () => {
@@ -154,7 +154,7 @@ describe('FilterPopup', () => {
     });
 
     it('should clear all the selected filters in the state.', () => {
-      const clearFiltersButton = component.find('#clear-filters');
+      const clearFiltersButton = component.find('.clear-filters-button');
 
       clearFiltersButton.simulate('click');
       expect(component.state('selectedFilters')).to.deep.equal(emptySelectedFilters);
@@ -201,7 +201,7 @@ describe('FilterPopup', () => {
     });
 
     it('should stop submitting and the function of submitting returns false', () => {
-      const submitFormButton = component.find('#submit-form');
+      const submitFormButton = component.find('.apply-button');
 
       expect(component.find('.nypl-form-error').length).to.equal(0);
 
@@ -211,7 +211,7 @@ describe('FilterPopup', () => {
     });
 
     it('should render a div for error messages', () => {
-      const submitFormButton = component.find('#submit-form');
+      const submitFormButton = component.find('.apply-button');
 
       expect(component.find('.nypl-form-error').length).to.equal(0);
 

--- a/test/unit/FilterPopup.test.js
+++ b/test/unit/FilterPopup.test.js
@@ -15,15 +15,15 @@ describe('FilterPopup', () => {
 
       expect(component.state('js')).to.equal(false);
       // The Apply and Clear buttons should still be rendered:
-      expect(component.find('button').length).to.equal(2);
+      expect(component.find('button').length).to.equal(3);
       // These tests will need to be updated when the DOM structure gets updated.
       // The second <a> element is the no-js 'cancel' element for the "smart" no-js solution.
       expect(component.find('a').at(0).prop('className'))
-        .to.equal('popup-btn-open nypl-short-button');
+        .to.equal('popup-btn-open nypl-primary-button');
       expect(component.find('a').at(0).prop('href')).to.equal('#popup-no-js');
       expect(component.find('a').at(1).prop('className')).to.equal('cancel-no-js');
-      expect(component.find('a').at(2).prop('className'))
-        .to.equal('popup-btn-close nypl-x-close-button');
+      // expect(component.find('a').at(2).prop('className'))
+      //   .to.equal('popup-btn-close nypl-x-close-button');
     });
 
     it('should have specific "no-js" id and class', () => {
@@ -51,11 +51,11 @@ describe('FilterPopup', () => {
       // All buttons should be rendered
       expect(component.find('button').length).to.equal(4);
       expect(component.find('button').at(0).prop('className'))
-        .to.equal('popup-btn-open nypl-short-button');
-      expect(component.find('button').at(1).prop('name')).to.equal('apply-filters');
-      expect(component.find('button').at(2).prop('name')).to.equal('Clear-Filters');
+        .to.equal('popup-btn-open nypl-primary-button');
+      expect(component.find('button').at(1).prop('name')).to.equal('Clear-Filters');
+      expect(component.find('button').at(2).prop('name')).to.equal('apply-filters');
       expect(component.find('button').at(3).prop('className'))
-        .to.equal('popup-btn-close nypl-x-close-button');
+        .to.equal('nypl-filter-button cancel-button');
     });
 
     it('should not render the "no-js" <a> element', () => {
@@ -65,15 +65,15 @@ describe('FilterPopup', () => {
     it('should have accessible open button', () => {
       const openBtn = component.find('.popup-btn-open');
       expect(openBtn.prop('aria-haspopup')).to.equal('true');
-      expect(openBtn.prop('aria-expanded')).to.equal(false);
+      expect(openBtn.prop('aria-expanded')).to.equal(null);
       expect(openBtn.prop('aria-controls')).to.equal('filter-popup-menu');
     });
 
-    it('should have accessible close button', () => {
-      const openBtn = component.find('.popup-btn-close');
-      expect(openBtn.prop('aria-expanded')).to.equal(true);
-      expect(openBtn.prop('aria-controls')).to.equal('filter-popup-menu');
-    });
+    // it('should have accessible close button', () => {
+    //   const openBtn = component.find('.popup-btn-close');
+    //   expect(openBtn.prop('aria-expanded')).to.equal(true);
+    //   expect(openBtn.prop('aria-controls')).to.equal('filter-popup-menu');
+    // });
 
     it('should not have specific "no-js" id and class', () => {
       expect(component.state('js')).to.equal(true);

--- a/test/unit/Pagination.test.js
+++ b/test/unit/Pagination.test.js
@@ -66,7 +66,7 @@ describe('Pagination', () => {
     // The SVG titles should maybe not be here:
     it('should have a "next" link since there are more than 51 items', () => {
       expect(component.find('Link').children().length).to.equal(1);
-      expect(component.find('.next-link').text()).to.equal('Wedge Right Arrow Next');
+      expect(component.find('.next-link').text()).to.equal('NYPL Right Wedge SVG Icon Next');
     });
 
     it('should display what page you are on', () => {
@@ -92,8 +92,8 @@ describe('Pagination', () => {
 
     it('should have a "previous" and a "next" link', () => {
       expect(component.find('Link').children().length).to.equal(2);
-      expect(component.find('.previous-link').text()).to.equal('Wedge Left Arrow Previous');
-      expect(component.find('.next-link').text()).to.equal('Wedge Right Arrow Next');
+      expect(component.find('.previous-link').text()).to.equal('NYPL Left Wedge SVG Icon Previous');
+      expect(component.find('.next-link').text()).to.equal('NYPL Right Wedge SVG Icon Next');
     });
 
     it('should display what page you are on', () => {
@@ -115,8 +115,8 @@ describe('Pagination', () => {
 
     it('should have a "previous page" and a "next page" link', () => {
       expect(component.find('Link')).to.have.length(2);
-      expect(component.find('.previous-link').text()).to.equal('Wedge Left Arrow Previous');
-      expect(component.find('.next-link').text()).to.equal('Wedge Right Arrow Next');
+      expect(component.find('.previous-link').text()).to.equal('NYPL Left Wedge SVG Icon Previous');
+      expect(component.find('.next-link').text()).to.equal('NYPL Right Wedge SVG Icon Next');
     });
 
     it('should display what page you are on', () => {

--- a/test/unit/SelectedFilters.test.js
+++ b/test/unit/SelectedFilters.test.js
@@ -45,7 +45,7 @@ describe('SelectedFilters', () => {
     it('should have a clear all filters link', () => {
       expect(listItemAt(component, 1).find('a').length).to.equal(1);
       expect(listItemAt(component, 1).find('a').render().text())
-        .to.equal('Clear FiltersRemove Filter');
+        .to.equal('Clear FiltersNYPL Filter SVG Icon');
     });
   });
 
@@ -84,16 +84,16 @@ describe('SelectedFilters', () => {
 
       it('should have one button inside each list item with the filter name', () => {
         expect(listItemAt(component, 0).find('button').length).to.equal(1);
-        expect(listItemAt(component, 0).find('button').text()).to.equal('FrenchRemove Filter');
+        expect(listItemAt(component, 0).find('button').text()).to.equal('FrenchClose Icon');
 
         expect(listItemAt(component, 1).find('button').length).to.equal(1);
-        expect(listItemAt(component, 1).find('button').text()).to.equal('EnglishRemove Filter');
+        expect(listItemAt(component, 1).find('button').text()).to.equal('EnglishClose Icon');
       });
 
       it('should have a clear all filters button', () => {
         expect(listItemAt(component, 2).find('button').length).to.equal(1);
         expect(listItemAt(component, 2).find('button').text())
-          .to.equal('Clear FiltersRemove Filter');
+          .to.equal('Clear FiltersNYPL Filter SVG Icon');
       });
     });
 
@@ -142,17 +142,17 @@ describe('SelectedFilters', () => {
 
       it('should have one button inside each list item with the filter name', () => {
         expect(listItemAt(component, 0).find('button').length).to.equal(1);
-        expect(listItemAt(component, 0).find('button').text()).to.equal('FrenchRemove Filter');
+        expect(listItemAt(component, 0).find('button').text()).to.equal('FrenchClose Icon');
 
         expect(listItemAt(component, 1).find('button').length).to.equal(1);
-        expect(listItemAt(component, 1).find('button').text()).to.equal('EnglishRemove Filter');
+        expect(listItemAt(component, 1).find('button').text()).to.equal('EnglishClose Icon');
 
         expect(listItemAt(component, 2).find('button').length).to.equal(1);
-        expect(listItemAt(component, 2).find('button').text()).to.equal('Still ImageRemove Filter');
+        expect(listItemAt(component, 2).find('button').text()).to.equal('Still ImageClose Icon');
 
         expect(listItemAt(component, 3).find('button').length).to.equal(1);
         expect(listItemAt(component, 3).find('button').text())
-          .to.equal('CartographicRemove Filter');
+          .to.equal('CartographicClose Icon');
       });
     });
 
@@ -176,7 +176,7 @@ describe('SelectedFilters', () => {
 
         it('should have one button inside each list item with the filter name', () => {
           expect(listItemAt(component, 0).find('button').length).to.equal(1);
-          expect(listItemAt(component, 0).find('button').text()).to.equal('2010Remove Filter');
+          expect(listItemAt(component, 0).find('button').text()).to.equal('2010Close Icon');
         });
       });
 
@@ -199,7 +199,7 @@ describe('SelectedFilters', () => {
 
         it('should have one button inside each list item with the filter name', () => {
           expect(listItemAt(component, 0).find('button').length).to.equal(1);
-          expect(listItemAt(component, 0).find('button').text()).to.equal('1999Remove Filter');
+          expect(listItemAt(component, 0).find('button').text()).to.equal('1999Close Icon');
         });
       });
 
@@ -222,10 +222,10 @@ describe('SelectedFilters', () => {
 
         it('should have one button inside each list item with the filter name', () => {
           expect(listItemAt(component, 0).find('button').length).to.equal(1);
-          expect(listItemAt(component, 0).find('button').text()).to.equal('2010Remove Filter');
+          expect(listItemAt(component, 0).find('button').text()).to.equal('2010Close Icon');
 
           expect(listItemAt(component, 1).find('button').length).to.equal(1);
-          expect(listItemAt(component, 1).find('button').text()).to.equal('1999Remove Filter');
+          expect(listItemAt(component, 1).find('button').text()).to.equal('1999Close Icon');
         });
       });
     });


### PR DESCRIPTION
Lots of changes for the UI look of what was once the filter popup into the filter dropdown.

The name of the component and class names have not changed and still include "modal" in there, even though that's not correct and should eventually be updated. This is half of a rewrite to get the UI looking somewhat correct and will have to refactor this later on with @ricardoom 's help and updates to the Design Toolkit.

This is currently up on dev-discovery. Example filtered result: http://dev-discovery.nypl.org/research/collections/shared-collection-catalog/search?q=hamlet&filters[materialType][0]=resourcetypes%3Atxt&filters[dateAfter]=1000&filters[dateBefore]=2000



![screen shot 2018-01-19 at 4 28 16 pm](https://user-images.githubusercontent.com/1280564/35172455-c8302dd6-fd35-11e7-8717-7c160ce7a7b3.png)

![screen shot 2018-01-19 at 4 28 19 pm](https://user-images.githubusercontent.com/1280564/35172459-ca63c8c4-fd35-11e7-8350-57693f7b7a17.png)
