### PR TITLE
Adding scss to override DT to put the sorter on the right side.

### DIFF
--- a/src/client/styles/components/Sorter.scss
+++ b/src/client/styles/components/Sorter.scss
@@ -1,10 +1,19 @@
 // Temporary until this is in the Design Toolkit
-.nypl-results-sorting-controls {
+.nypl-results-summary {
   display: inline-block;
   float: left;
+  max-width: 65%;
+}
+
+.nypl-results-sorting-controls {
+  display: inline-block;
+  float: right;
+  margin: 1rem 0;
 }
 
 .nypl-results-sorter {
+  margin-right: 0;
+
   form {
     background-color: #fff;
     border: 0.0625rem solid #9d9ea1;


### PR DESCRIPTION
Fixes #895 - moving the sorter dropdown to the right side of the page. A few overrides to the Design Toolkit but we'll get there in the next iteration/refactor.

Up on dev-discovery.nypl.org