### PR TITLE
Mobile stacked form view attempted fix

### DIFF
--- a/src/app/components/Buttons/SearchButton.jsx
+++ b/src/app/components/Buttons/SearchButton.jsx
@@ -4,11 +4,13 @@ import SearchIconReversed from './SearchIconReversed';
 
 const SearchButton = ({
   id,
+  className,
   onClick,
   value,
 }) => (
   <button
     id={id}
+    className={`${className}`}
     onClick={onClick}
     type="submit"
   >
@@ -20,6 +22,7 @@ const SearchButton = ({
 SearchButton.propTypes = {
   onClick: PropTypes.func,
   id: PropTypes.string,
+  className: PropTypes.string,
   value: PropTypes.string,
 };
 

--- a/src/app/components/Buttons/SearchButton.jsx
+++ b/src/app/components/Buttons/SearchButton.jsx
@@ -1,18 +1,21 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import SearchIconReversed from './SearchIconReversed';
 
 const SearchButton = ({
   id,
   onClick,
   value,
 }) => (
-  <input
+  <button
     id={id}
-    onSubmit={onClick}
+    className="nypl-omnisearch-button nypl-primary-button"
     onClick={onClick}
     type="submit"
-    value={value}
-  />
+  >
+    {value}
+    <SearchIconReversed />
+  </button>
 );
 
 SearchButton.propTypes = {

--- a/src/app/components/Buttons/SearchButton.jsx
+++ b/src/app/components/Buttons/SearchButton.jsx
@@ -9,7 +9,6 @@ const SearchButton = ({
 }) => (
   <button
     id={id}
-    className="nypl-omnisearch-button nypl-primary-button"
     onClick={onClick}
     type="submit"
   >

--- a/src/app/components/Buttons/SearchIconReversed.jsx
+++ b/src/app/components/Buttons/SearchIconReversed.jsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const SearchIconReversed = ({ viewBox, height, width, title, className, style, fill, ariaHidden }) => (
+  <svg
+    viewBox={viewBox}
+    width={width}
+    height={height}
+    className={`${className}`}
+    fill={fill}
+    style={style}
+    aria-hidden={ariaHidden}
+  >
+    <title>{title}</title>
+    <path d="M6.71738,25.58968a1.38782,1.38782,0,0,0,1.96268,0l3.86877-3.86822a8.53632,8.53632,0,1,0-2.07145-1.85393l-3.76,3.75948A1.38782,1.38782,0,0,0,6.71738,25.58968Zm10.401-5.31077h-.00064a5.75044,5.75044,0,1,1,.00064,0Z" />
+  </svg>
+);
+
+SearchIconReversed.propTypes = {
+  className: PropTypes.string,
+  title: PropTypes.string,
+  height: PropTypes.string,
+  width: PropTypes.string,
+  viewBox: PropTypes.string,
+  fill: PropTypes.string,
+  style: PropTypes.object,
+  ariaHidden: PropTypes.bool,
+};
+
+SearchIconReversed.defaultProps = {
+  ariaHidden: true,
+  className: 'nypl-search-icon',
+  title: 'NYPL Search SVG Icon',
+  width: '48',
+  height: '48',
+  viewBox: '0 0 32 32',
+};
+
+export default SearchIconReversed;

--- a/src/app/components/Search/Search.jsx
+++ b/src/app/components/Search/Search.jsx
@@ -168,7 +168,7 @@ class Search extends React.Component {
               />
             </span>
           </div>
-          <SearchButton onClick={this.submitSearchRequest} />
+          <SearchButton className={"nypl-omnisearch-button nypl-primary-button"} onClick={this.submitSearchRequest} />
           {inputError &&
             <span
               className="nypl-field-status"

--- a/src/app/components/Search/Search.jsx
+++ b/src/app/components/Search/Search.jsx
@@ -1,13 +1,16 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import Actions from '../../actions/Actions.js';
-import SearchButton from '../Buttons/SearchButton.jsx';
+import Actions from '../../actions/Actions';
+import SearchButton from '../Buttons/SearchButton';
 import {
   trackDiscovery,
   ajaxCall,
-} from '../../utils/utils.js';
-import appConfig from '../../../../appConfig.js';
+} from '../../utils/utils';
+import appConfig from '../../../../appConfig';
+import {
+  SearchIcon
+} from '@nypl/dgx-svg-icons';
 
 /**
  * The main container for the top Search section.
@@ -134,46 +137,55 @@ class Search extends React.Component {
         method="POST"
         className="nypl-omnisearch-form"
       >
-        <div className={`nypl-omnisearch nypl-text-field ${inputError ? 'nypl-field-error' : ''}`}>
-          <span className="nypl-omni-fields">
-            <label htmlFor="search-by-field">Search in</label>
-            <select
-              id="search-by-field"
-              onChange={this.onFieldChange}
-              value={this.state.field}
-              name="search_scope"
+        <div className="nypl-omnisearch">
+          <div className={`nypl-text-field ${inputError ? 'nypl-field-error' : ''}`}>
+            <span className="nypl-omni-fields">
+              <label htmlFor="search-by-field">Search in</label>
+              <select
+                id="search-by-field"
+                onChange={this.onFieldChange}
+                value={this.state.field}
+                name="search_scope"
+              >
+                <option value="all">All fields</option>
+                <option value="title">Title</option>
+                <option value="contributor">Author/Contributor</option>
+              </select>
+            </span>
+          </div>
+          <div className="nypl-text-field">
+            <span className="nypl-omni-fields">
+              <label htmlFor="search-query" id="search-input-label" className="visuallyhidden">
+                Search for
+              </label>
+              <input
+                type="text"
+                id="search-query"
+                aria-labelledby="search-input-label search-input-status"
+                aria-required="true"
+                placeholder="Keyword, title, or author/contributor"
+                onChange={this.inputChange}
+                value={this.state.searchKeywords}
+                name="q"
+                ref="keywords"
+              />
+            </span>
+          </div>
+          <button className="nypl-omnisearch-button nypl-primary-button">
+            <SearchButton onClick={this.submitSearchRequest} />
+            <SearchIcon />
+          </button>
+          {inputError &&
+            <span
+              className="nypl-field-status"
+              id="search-input-status"
+              aria-live="assertive"
+              aria-atomic="true"
             >
-              <option value="all">All fields</option>
-              <option value="title">Title</option>
-              <option value="contributor">Author/Contributor</option>
-            </select>
-          </span>
-          <label htmlFor="search-query" id="search-input-label" className="visuallyhidden">
-            Search for
-          </label>
-          <input
-            type="text"
-            id="search-query"
-            aria-labelledby="search-input-label search-input-status"
-            aria-required="true"
-            placeholder="Keyword, title, or author/contributor"
-            onChange={this.inputChange}
-            value={this.state.searchKeywords}
-            name="q"
-            ref="keywords"
-          />
-          <SearchButton onClick={this.submitSearchRequest} />
+              Please enter a search term.
+            </span>
+          }
         </div>
-        {inputError &&
-          <span
-            className="nypl-field-status"
-            id="search-input-status"
-            aria-live="assertive"
-            aria-atomic="true"
-          >
-            Please enter a search term.
-          </span>
-        }
       </form>
     );
   }

--- a/src/app/components/Search/Search.jsx
+++ b/src/app/components/Search/Search.jsx
@@ -8,9 +8,6 @@ import {
   ajaxCall,
 } from '../../utils/utils';
 import appConfig from '../../../../appConfig';
-import {
-  SearchIcon
-} from '@nypl/dgx-svg-icons';
 
 /**
  * The main container for the top Search section.
@@ -171,10 +168,7 @@ class Search extends React.Component {
               />
             </span>
           </div>
-          <button className="nypl-omnisearch-button nypl-primary-button">
-            <SearchButton onClick={this.submitSearchRequest} />
-            <SearchIcon />
-          </button>
+          <SearchButton onClick={this.submitSearchRequest} />
           {inputError &&
             <span
               className="nypl-field-status"

--- a/src/client/styles/components/FilterPopup.scss
+++ b/src/client/styles/components/FilterPopup.scss
@@ -30,6 +30,11 @@
     width: 100%;
     border-bottom: 0.125rem solid #d7d4d0;
   }
+  @media (max-width: $xtrasmall-breakpoint) {
+    .filter-text {
+    margin-top: 100px;
+    }
+  }
   .filter-action-buttons {
     float: left;
     width: 100%;

--- a/src/client/styles/components/Search.scss
+++ b/src/client/styles/components/Search.scss
@@ -6,12 +6,125 @@
 
   .nypl-text-field {
     input[type=text] {
-      height: 2rem;
       -webkit-box-shadow: none;
       box-shadow: none;
     }
   }
 
   .nypl-field-error {
+  }
+
+  // Larger screen collapsed version of search form elements.
+
+  .nypl-omnisearch {
+    background-color: #fff;
+    margin-left: 0.25rem;
+  }
+
+  .nypl-omnisearch .nypl-omni-fields {
+    display: block;
+    border-right: 0.08333rem solid #080807;
+    float: left;
+    width: 28%;
+  }
+
+  .nypl-omnisearch .nypl-omni-fields input[type=text] {
+    border: 0;
+    border-radius: 0.25rem;
+    font-size: 1rem;
+    padding: 0;
+    margin: 0 1%;
+    text-indent: 0.5rem;
+  }
+
+  .nypl-text-field {
+    background-color: #fff;
+    border-radius: 0.2rem;
+    box-shadow: none;
+    display: block;
+    margin: 0;
+    padding: 0;
+    position: relative;
+  }
+
+  // Button specific CSS for submit
+
+  .nypl-omnisearch-button-wrapper {
+    display: block;
+  }
+
+  .nypl-omnisearch-button {
+    font-weight: 200;
+    height: 3rem;
+    background: #1B7FA7;
+    border-left: solid 0.0625rem #080807;
+    border-radius: 0;
+    color: #fff;
+    float: right;
+    position: relative;
+    width: 8em;
+  }
+
+  .nypl-omnisearch-button input[type=submit] {
+    background: #1B7FA7;
+    height: 2.5rem;
+    border: 0;
+    color: #fff;
+    float: left;
+    width: 4em;
+  }
+
+  .nypl-omnisearch-button svg {
+    float: right;
+    fill: #fff;
+    vertical-align: middle;
+  }
+
+  .nypl-omnisearch-button .nypl-search-icon {
+    background-color: #1B7FA7;
+    speak: none;
+  }
+
+  // Small screen stacked version of search form elements.
+
+  @media (max-width: $xtrasmall-breakpoint) {
+    .nypl-search-form {
+      display: inherit;
+    }
+
+    .nypl-omnisearch {
+      display: block;
+      background-color: transparent;
+      border: 0;
+    }
+
+    .nypl-omnisearch .nypl-text-field {
+      background-color: #fff;
+      border: solid 0.0625rem #080807;
+      border-radius: 0.2rem;
+      height: 3rem;
+    }
+
+    .nypl-omnisearch input[type=text] {
+      background: #fff;
+    }
+
+    .nypl-omnisearch .nypl-omni-fields {
+      border-right: 0;
+      width: 96%;
+    }
+
+    .nypl-text-field {
+      background-color: #fff;
+      border-radius: 0.2rem;
+      box-shadow: none;
+      margin: 1rem 0;
+    }
+
+    .nypl-omnisearch-button {
+      border: solid 0.0625rem #080807;
+      border-radius: 0.2rem;
+      margin-right: 0.5em;
+    }
   }
 }

--- a/src/client/styles/components/Search.scss
+++ b/src/client/styles/components/Search.scss
@@ -21,30 +21,36 @@
     margin-left: 0.25rem;
   }
 
-  .nypl-omnisearch .nypl-omni-fields {
-    display: block;
-    border-right: 0.08333rem solid #080807;
-    float: left;
-    width: 28%;
+  .nypl-omnisearch {
+    .nypl-omni-fields {
+      display: block;
+      border-right: 0.08333rem solid #080807;
+      float: left;
+      width: 28%;
+    }
   }
 
-  .nypl-omnisearch .nypl-omni-fields input[type=text] {
-    border: 0;
-    border-radius: 0.25rem;
-    font-size: 1rem;
-    padding: 0;
-    margin: 0 1%;
-    text-indent: 0.5rem;
+  .nypl-omni-fields {
+    input[type=text] {
+      border: 0;
+      border-radius: 0.25rem;
+      font-size: 1rem;
+      padding: 0;
+      margin: 0 1%;
+      text-indent: 0.5rem;
+    }
   }
 
-  .nypl-text-field {
-    background-color: #fff;
-    border-radius: 0.2rem;
-    box-shadow: none;
-    display: block;
-    margin: 0;
-    padding: 0;
-    position: relative;
+  .nypl-omnisearch {
+    .nypl-text-field {
+      background-color: #fff;
+      border-radius: 0.2rem;
+      box-shadow: none;
+      display: block;
+      margin: 0;
+      padding: 0;
+      position: relative;
+    }
   }
 
   // Button specific CSS for submit
@@ -55,34 +61,30 @@
 
   .nypl-omnisearch-button {
     font-weight: 200;
-    height: 3rem;
     background: #1B7FA7;
     border-left: solid 0.0625rem #080807;
     border-radius: 0;
     color: #fff;
+    width: 6rem;
+    height: 3rem;
     float: right;
-    position: relative;
-    width: 8em;
+    padding-top: 0.6rem;
   }
 
-  .nypl-omnisearch-button input[type=submit] {
-    background: #1B7FA7;
-    height: 2.5rem;
-    border: 0;
-    color: #fff;
-    float: left;
-    width: 4em;
+  .nypl-omnisearch-button {
+    svg {
+      fill: #fff;
+      position: relative;
+      float: left;
+      padding-top: 0.3rem;
+    }
   }
 
-  .nypl-omnisearch-button svg {
-    float: right;
-    fill: #fff;
-    vertical-align: middle;
-  }
-
-  .nypl-omnisearch-button .nypl-search-icon {
-    background-color: #1B7FA7;
-    speak: none;
+  .nypl-omnisearch-button {
+    .nypl-search-icon {
+      background-color: #1B7FA7;
+      speak: none;
+    }
   }
 
   // Small screen stacked version of search form elements.
@@ -98,27 +100,29 @@
       border: 0;
     }
 
-    .nypl-omnisearch .nypl-text-field {
-      background-color: #fff;
-      border: solid 0.0625rem #080807;
-      border-radius: 0.2rem;
-      height: 3rem;
+    .nypl-omnisearch {
+      .nypl-text-field {
+        background-color: #fff;
+        border: solid 0.0625rem #080807;
+        border-radius: 0.2rem;
+        height: 3rem;
+        box-shadow: none;
+        margin: 1rem 0;
+      }
     }
 
-    .nypl-omnisearch input[type=text] {
-      background: #fff;
+    .nypl-omnisearch {
+      input[type=text] {
+        width: 96%;
+      }
     }
 
-    .nypl-omnisearch .nypl-omni-fields {
-      border-right: 0;
-      width: 96%;
-    }
-
-    .nypl-text-field {
-      background-color: #fff;
-      border-radius: 0.2rem;
-      box-shadow: none;
-      margin: 1rem 0;
+    .nypl-omnisearch {
+      .nypl-omni-fields {
+        background: #fff;
+        border-right: 0;
+        width: 96%;
+      }
     }
 
     .nypl-omnisearch-button {

--- a/src/client/styles/components/Search.scss
+++ b/src/client/styles/components/Search.scss
@@ -19,29 +19,23 @@
   .nypl-omnisearch {
     background-color: #fff;
     margin-left: 0.25rem;
-  }
 
-  .nypl-omnisearch {
     .nypl-omni-fields {
       display: block;
       border-right: 0.08333rem solid #080807;
       float: left;
       width: 28%;
-    }
-  }
 
-  .nypl-omni-fields {
-    input[type=text] {
-      border: 0;
-      border-radius: 0.25rem;
-      font-size: 1rem;
-      padding: 0;
-      margin: 0 1%;
-      text-indent: 0.5rem;
+      input[type=text] {
+        border: 0;
+        border-radius: 0.25rem;
+        font-size: 1rem;
+        padding: 0;
+        margin: 0 1%;
+        text-indent: 0.5rem;
+      }
     }
-  }
 
-  .nypl-omnisearch {
     .nypl-text-field {
       background-color: #fff;
       border-radius: 0.2rem;
@@ -51,39 +45,33 @@
       padding: 0;
       position: relative;
     }
-  }
 
-  // Button specific CSS for submit
+    // Button specific CSS for submit
 
-  .nypl-omnisearch-button-wrapper {
-    display: block;
-  }
+    .nypl-omnisearch-button {
+      font-weight: 200;
+      background: #1B7FA7;
+      border-left: solid 0.0625rem #080807;
+      border-radius: 0;
+      color: #fff;
+      width: 6rem;
+      height: 3rem;
+      float: right;
+      padding-top: 0.6rem;
+      padding-right: 0.8em;
+      text-indent: -1rem;
 
-  .nypl-omnisearch-button {
-    font-weight: 200;
-    background: #1B7FA7;
-    border-left: solid 0.0625rem #080807;
-    border-radius: 0;
-    color: #fff;
-    width: 6rem;
-    height: 3rem;
-    float: right;
-    padding-top: 0.6rem;
-  }
+      svg {
+        fill: #fff;
+        position: relative;
+        float: left;
+        padding-top: 0.3rem;
+      }
 
-  .nypl-omnisearch-button {
-    svg {
-      fill: #fff;
-      position: relative;
-      float: left;
-      padding-top: 0.3rem;
-    }
-  }
-
-  .nypl-omnisearch-button {
-    .nypl-search-icon {
-      background-color: #1B7FA7;
-      speak: none;
+      .nypl-search-icon {
+        background-color: #1B7FA7;
+        speak: none;
+      }
     }
   }
 
@@ -98,9 +86,7 @@
       display: block;
       background-color: transparent;
       border: 0;
-    }
 
-    .nypl-omnisearch {
       .nypl-text-field {
         background-color: #fff;
         border: solid 0.0625rem #080807;
@@ -109,26 +95,21 @@
         box-shadow: none;
         margin: 1rem 0;
       }
-    }
 
-    .nypl-omnisearch {
-      input[type=text] {
-        width: 96%;
-      }
-    }
-
-    .nypl-omnisearch {
       .nypl-omni-fields {
         background: #fff;
         border-right: 0;
         width: 96%;
       }
-    }
 
-    .nypl-omnisearch-button {
-      border: solid 0.0625rem #080807;
-      border-radius: 0.2rem;
-      margin-right: 0.5em;
+      input[type=text] {
+        width: 96%;
+      }
+
+      .nypl-omnisearch-button {
+        border: solid 0.0625rem #080807;
+        border-radius: 0.2rem;
+      }
     }
   }
 }

--- a/test/unit/Search.test.js
+++ b/test/unit/Search.test.js
@@ -58,14 +58,13 @@ describe('Search', () => {
     });
 
     it('should render an input text element', () => {
-      expect(component.find('input').length).to.equal(2);
+      expect(component.find('input').length).to.equal(1);
       expect(component.find('input').at(0).prop('type')).to.equal('text');
     });
 
-    it('should render an input submit button', () => {
-      expect(component.find('input').length).to.equal(2);
-      expect(component.find('input').at(1).prop('type')).to.equal('submit');
-      expect(component.find('input').at(1).prop('value')).to.equal('Search');
+    it('should render a submit button', () => {
+      expect(component.find('button').length).to.equal(1);
+      expect(component.find('button').at(0).prop('type')).to.equal('submit');
     });
   });
 
@@ -168,7 +167,7 @@ describe('Search', () => {
       expect(component.state('searchKeywords')).to.equal('');
 
       component.find('input').at(0).simulate('change', { target: { value: 'Dune' } });
-      component.find('input').at(1).simulate('click');
+      component.find('button').at(0).simulate('click');
 
       expect(component.state('searchKeywords')).to.equal('Dune');
       expect(submitSearchRequestSpy.callCount).to.equal(1);
@@ -178,7 +177,7 @@ describe('Search', () => {
       expect(component.state('searchKeywords')).to.equal('Dune');
 
       component.find('input').at(0).simulate('change', { target: { value: 'Harry Potter' } });
-      component.find('input').at(0).simulate('keyPress');
+      component.find('button').at(0).simulate('keyPress');
 
       expect(component.state('searchKeywords')).to.equal('Harry Potter');
       expect(triggerSubmitSpy.callCount).to.equal(1);

--- a/test/unit/SearchButton.test.js
+++ b/test/unit/SearchButton.test.js
@@ -17,12 +17,12 @@ describe('SearchButton', () => {
       expect(component.find('#nypl-omni-button').length).to.equal(1);
     });
 
-    it('should have an input element', () => {
-      expect(component.find('input')).to.have.length(1);
+    it('should have a button element', () => {
+      expect(component.find('button')).to.have.length(1);
     });
 
     it('should have a "Search" value', () => {
-      expect(component.find('input').prop('value')).to.equal('Search');
+      expect(component.find('button').prop('type')).to.equal('submit');
     });
   });
 
@@ -49,7 +49,7 @@ describe('SearchButton', () => {
     });
 
     it('should have a "Search Discovery" value', () => {
-      expect(component.find('input').prop('value')).to.equal('Search Discovery');
+      expect(component.find('button').text()).to.include('Search').and.include('Discovery');
     });
 
     it('should perform the passed function when it is clicked', () => {


### PR DESCRIPTION
Adds custom overrides for the omnisearch elements to stack the form elements when the viewport is reduced to its smallest size. Includes a stab at adjusting the form elements to inline when viewport is larger.

CSS and HTML structural changes are included as well as an addition to the new filter scss to give the "Results.." text a push down below the submit button for mobile view.