### PR TITLE
Allowing filters to persist when the keyword is updated.

### DIFF
--- a/src/app/components/ResultsCount/ResultsCount.jsx
+++ b/src/app/components/ResultsCount/ResultsCount.jsx
@@ -47,7 +47,7 @@ class ResultsCount extends React.Component {
       _mapObject(selectedFilters, (val, key) => {
         const mappedKey = keyMapping[key];
 
-        if (val[0] && val[0].value && mappedKey) {
+        if (val && val[0] && val[0].value && mappedKey) {
           result += `for ${mappedKey} "${val[0].value}"`;
         }
       });

--- a/src/app/components/Search/Search.jsx
+++ b/src/app/components/Search/Search.jsx
@@ -79,7 +79,7 @@ class Search extends React.Component {
     const searchKeywords = userSearchKeywords === '*' ? '' : userSearchKeywords;
     const apiQuery = this.props.createAPIQuery({
       field: this.state.field,
-      selectedFilters: {},
+      selectedFilters: this.props.selectedFilters,
       searchKeywords,
       page: '1',
     });
@@ -87,7 +87,7 @@ class Search extends React.Component {
     Actions.updateField(this.state.field);
     this.props.updateIsLoadingState(true);
     Actions.updateSearchKeywords(userSearchKeywords);
-    Actions.updateSelectedFilters({});
+    Actions.updateSelectedFilters(this.props.selectedFilters);
 
     ajaxCall(`${appConfig.baseUrl}/api?${apiQuery}`, (response) => {
       if (response.data.searchResults && response.data.filters) {
@@ -102,7 +102,7 @@ class Search extends React.Component {
 
       setTimeout(
         () => { this.props.updateIsLoadingState(false); },
-        500
+        500,
       );
 
       this.context.router.push(`${appConfig.baseUrl}/search?${apiQuery}`);
@@ -162,12 +162,14 @@ Search.propTypes = {
   searchKeywords: PropTypes.string,
   createAPIQuery: PropTypes.func,
   updateIsLoadingState: PropTypes.func,
+  selectedFilters: PropTypes.object,
 };
 
 Search.defaultProps = {
   field: 'all',
   searchKeywords: '',
   updateIsLoadingState: () => {},
+  selectedFilters: {},
 };
 
 Search.contextTypes = {

--- a/src/app/components/SearchResultsPage/SearchResultsPage.jsx
+++ b/src/app/components/SearchResultsPage/SearchResultsPage.jsx
@@ -115,6 +115,7 @@ class SearchResultsPage extends React.Component {
                     field={field}
                     createAPIQuery={createAPIQuery}
                     updateIsLoadingState={this.updateIsLoadingState}
+                    selectedFilters={selectedFilters}
                   />
                   <FilterPopup
                     filters={apiFilters}
@@ -218,7 +219,6 @@ SearchResultsPage.propTypes = {
   sortBy: PropTypes.string,
   field: PropTypes.string,
   isLoading: PropTypes.bool,
-  error: PropTypes.object,
   filters: PropTypes.object,
 };
 


### PR DESCRIPTION
Fixes #911  - leave filters alone when the keyword is updated.

This is up on dev right now.

**Note**: What should also be tested is whether a user changes the keyword search, has the dropdown open, clicks on `Apply filters`, and expects the keyword to also be updated (since this is now a different button...) 

@katesweeney  @ricardoom @wlla  - let me know what you think on the above note.