### PR TITLE
Adding text instructions and information regarding EDD 50 page limit …

### DIFF
--- a/src/app/components/ElectronicDelivery/ElectronicDeliveryForm.jsx
+++ b/src/app/components/ElectronicDelivery/ElectronicDeliveryForm.jsx
@@ -113,7 +113,11 @@ class ElectronicDeliveryForm extends React.Component {
                   }
                 </span>
               </div>
-              <span>You may request a maximum of 50 pages.</span>
+              <span>You may request a maximum of 50 pages.</span><br />
+              <span>
+                Read <a href="https://www.nypl.org/help/request-research-materials#EDD" target="_blank" rel="noopener noreferrer">
+                more about this service</a>.
+              </span>
               <div className={`nypl-text-field ${errorClass.startPage}`}>
                 <label htmlFor="startPage" id="startPage-label">Starting Page Number
                   <span className="nypl-required-field">&nbsp;Required</span>
@@ -259,6 +263,12 @@ class ElectronicDeliveryForm extends React.Component {
               </div>
               <div className="nypl-text-field">
                 <label htmlFor="requestNotes" id="requestNotes-label">Notes</label>
+                <p>
+                  Provide additional instructions here. In case electronic delivery is unavailable,
+                  please indicate a physical delivery location in the field below. For more
+                  information on placing an electronic delivery request, please
+                  see <a href="https://www.nypl.org/help/request-research-materials">Requesting Research Materials</a>.
+                </p>
                 <textarea
                   className="nypl-text-area"
                   id="requestNotes"

--- a/src/app/components/ElectronicDelivery/ElectronicDeliveryForm.jsx
+++ b/src/app/components/ElectronicDelivery/ElectronicDeliveryForm.jsx
@@ -261,7 +261,7 @@ class ElectronicDeliveryForm extends React.Component {
                   onChange={e => this.handleUpdate(e, 'issue')}
                 />
               </div>
-              <div className="nypl-text-field">
+              <div className="nypl-text-area-with-label">
                 <label htmlFor="requestNotes" id="requestNotes-label">Notes</label>
                 <p>
                   Provide additional instructions here. In case electronic delivery is unavailable,

--- a/src/app/components/ElectronicDelivery/ElectronicDeliveryForm.jsx
+++ b/src/app/components/ElectronicDelivery/ElectronicDeliveryForm.jsx
@@ -115,7 +115,7 @@ class ElectronicDeliveryForm extends React.Component {
               </div>
               <span>You may request a maximum of 50 pages.</span><br />
               <span>
-                Read <a href="https://www.nypl.org/help/request-research-materials#EDD" target="_blank" rel="noopener noreferrer">
+                Read <a href="https://www.nypl.org/help/request-research-materials#EDD">
                 more about this service</a>.
               </span>
               <div className={`nypl-text-field ${errorClass.startPage}`}>


### PR DESCRIPTION
…and fallback delivery location in the notes field, in case EDD fails.

Fixes [SCC-244](https://jira.nypl.org/browse/SCC-244) and [SCC-245](https://jira.nypl.org/browse/SCC-245).

On dev - http://dev-discovery.nypl.org/research/collections/shared-collection-catalog/hold/request/b10000004-i13783781/edd

@katesweeney @wlla - The link under `You may request a maximum of 50 pages.` goes to a new tab. The link in the `Notes` field opens in the same page. Please let me know which is the correct behavior that is desired.