### PR TITLE
Focus check

### DIFF
--- a/src/app/components/BibPage/BibPage.jsx
+++ b/src/app/components/BibPage/BibPage.jsx
@@ -1,3 +1,4 @@
+/* globals document */
 import React from 'react';
 import PropTypes from 'prop-types';
 import DocumentTitle from 'react-document-title';
@@ -27,6 +28,10 @@ class BibPage extends React.Component {
     };
 
     this.updateIsLoadingState = this.updateIsLoadingState.bind(this);
+  }
+
+  componentDidMount() {
+    document.getElementById('bib-title').focus();
   }
 
   updateIsLoadingState(status) {
@@ -95,13 +100,16 @@ class BibPage extends React.Component {
     return (
       <DocumentTitle title="Item Details | Shared Collection Catalog | NYPL">
         <main className="main-page">
-          <LoadingLayer status={this.state.isLoading} title="Searching" />
+          <LoadingLayer
+            status={this.state.isLoading}
+            title="Searching"
+          />
           <div className="nypl-page-header">
             <div className="nypl-full-width-wrapper">
               <div className="nypl-row">
                 <div className="nypl-column-three-quarters">
                   <Breadcrumbs type="bib" query={searchURL} />
-                  <h1>Item Details</h1>
+                  <h1 id="bib-title" tabIndex="0">Item Details</h1>
                   <h2>{title}</h2>
                   {
                     this.props.searchKeywords && (

--- a/src/app/components/ElectronicDelivery/ElectronicDelivery.jsx
+++ b/src/app/components/ElectronicDelivery/ElectronicDelivery.jsx
@@ -51,7 +51,7 @@ class ElectronicDelivery extends React.Component {
   componentDidMount() {
     this.requireUser();
 
-    document.getElementById('edd-request').focus();
+    document.getElementById('edd-request-title').focus();
   }
 
   /*
@@ -62,10 +62,6 @@ class ElectronicDelivery extends React.Component {
    * idea of what is wrong.
    */
   componentDidUpdate(prevProps, prevState) {
-    if (this.loadingLayer) {
-      this.loadingLayer.focus();
-    }
-
     if (prevState.raiseError !== this.state.raiseError) {
       if (this.refs['nypl-form-error']) {
         ReactDOM.findDOMNode(this.refs['nypl-form-error']).focus();
@@ -231,7 +227,7 @@ class ElectronicDelivery extends React.Component {
                   bibUrl={`/bib/${bibId}`}
                   itemUrl={`/hold/request/${bibId}-${itemId}`}
                 />
-                <h1>Electronic Delivery Request</h1>
+                <h1 id="edd-request-title" tabIndex="0">Electronic Delivery Request</h1>
               </div>
             </div>
           </div>

--- a/src/app/components/ElectronicDelivery/ElectronicDelivery.jsx
+++ b/src/app/components/ElectronicDelivery/ElectronicDelivery.jsx
@@ -1,4 +1,4 @@
-/* global window */
+/* global window document */
 import React from 'react';
 import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
@@ -50,6 +50,8 @@ class ElectronicDelivery extends React.Component {
 
   componentDidMount() {
     this.requireUser();
+
+    document.getElementById('edd-request').focus();
   }
 
   /*
@@ -219,7 +221,6 @@ class ElectronicDelivery extends React.Component {
           <LoadingLayer
             status={this.state.isLoading}
             title="Requesting"
-            childRef={(c) => { this.loadingLayer = c; }}
           />
           <div className="nypl-request-page-header">
             <div className="row">

--- a/src/app/components/ElectronicDelivery/ElectronicDeliveryForm.jsx
+++ b/src/app/components/ElectronicDelivery/ElectronicDeliveryForm.jsx
@@ -80,8 +80,6 @@ class ElectronicDeliveryForm extends React.Component {
         action={`${appConfig.baseUrl}/edd`}
         method="POST"
         onSubmit={e => this.submit(e)}
-        id="edd-request"
-        tabIndex="0"
       >
         <fieldset className="nypl-fieldset">
           <legend>

--- a/src/app/components/ElectronicDelivery/ElectronicDeliveryForm.jsx
+++ b/src/app/components/ElectronicDelivery/ElectronicDeliveryForm.jsx
@@ -81,6 +81,7 @@ class ElectronicDeliveryForm extends React.Component {
         method="POST"
         onSubmit={e => this.submit(e)}
         id="edd-request"
+        tabIndex="0"
       >
         <fieldset className="nypl-fieldset">
           <legend>

--- a/src/app/components/FilterPopup/FilterPopup.jsx
+++ b/src/app/components/FilterPopup/FilterPopup.jsx
@@ -481,7 +481,7 @@ class FilterPopup extends React.Component {
           <div className="nypl-row">
             <div className="nypl-column-full">
               <div className="filter-text">
-                <h2 id="filter-title">Refine your search</h2>
+                <h2 id="filter-title" tabIndex="0">Refine your search</h2>
                 <p>Toggle filters to narrow and define your search</p>
               </div>
               {(!showForm && !!(totalResults && totalResults !== 0)) && openPopupButton}

--- a/src/app/components/HoldConfirmation/HoldConfirmation.jsx
+++ b/src/app/components/HoldConfirmation/HoldConfirmation.jsx
@@ -1,4 +1,4 @@
-/* global window */
+/* global window document */
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router';
@@ -25,6 +25,8 @@ class HoldConfirmation extends React.Component {
 
   componentDidMount() {
     this.requireUser();
+
+    document.getElementById('confirmation-title').focus();
   }
 
   /**
@@ -303,7 +305,7 @@ class HoldConfirmation extends React.Component {
                     itemUrl={`/hold/request/${bibId}-${itemId}`}
                     edd={pickupLocation === 'edd'}
                   />
-                  <h1>{confirmationPageTitle}</h1>
+                  <h1 id="confirmation-title" tabIndex="0">{confirmationPageTitle}</h1>
                 </div>
               </div>
             </div>

--- a/src/app/components/HoldRequest/HoldRequest.jsx
+++ b/src/app/components/HoldRequest/HoldRequest.jsx
@@ -56,7 +56,7 @@ class HoldRequest extends React.Component {
   componentDidMount() {
     this.requireUser();
 
-    document.getElementById('item-link').focus();
+    document.getElementById('item-title').focus();
   }
 
   onChange() {
@@ -271,7 +271,6 @@ class HoldRequest extends React.Component {
     const bibLink = (bibId && title) ?
       (<h2>
         <Link
-          id="item-link"
           to={`${appConfig.baseUrl}/bib/${bibId}`}
           onClick={() => trackDiscovery('Hold Request - Bib', title)}
         >
@@ -346,7 +345,7 @@ class HoldRequest extends React.Component {
                     bibUrl={`/bib/${bibId}`}
                     type="hold"
                   />
-                  <h1 id="item-title">Item Request</h1>
+                  <h1 id="item-title" tabIndex="0">Item Request</h1>
                 </div>
               </div>
             </div>

--- a/src/app/components/HoldRequest/HoldRequest.jsx
+++ b/src/app/components/HoldRequest/HoldRequest.jsx
@@ -271,6 +271,7 @@ class HoldRequest extends React.Component {
     const bibLink = (bibId && title) ?
       (<h2>
         <Link
+          id="item-link"
           to={`${appConfig.baseUrl}/bib/${bibId}`}
           onClick={() => trackDiscovery('Hold Request - Bib', title)}
         >

--- a/src/app/components/HoldRequest/HoldRequest.jsx
+++ b/src/app/components/HoldRequest/HoldRequest.jsx
@@ -1,4 +1,4 @@
-/* globals window */
+/* globals window document */
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router';
@@ -55,12 +55,8 @@ class HoldRequest extends React.Component {
 
   componentDidMount() {
     this.requireUser();
-  }
 
-  componentDidUpdate() {
-    if (this.loadingLayer) {
-      this.loadingLayer.focus();
-    }
+    document.getElementById('item-link').focus();
   }
 
   onChange() {
@@ -340,7 +336,6 @@ class HoldRequest extends React.Component {
           <LoadingLayer
             status={this.state.isLoading}
             title="Requesting"
-            childRef={(c) => { this.loadingLayer = c; }}
           />
           <div className="nypl-request-page-header">
             <div className="nypl-full-width-wrapper">
@@ -351,7 +346,7 @@ class HoldRequest extends React.Component {
                     bibUrl={`/bib/${bibId}`}
                     type="hold"
                   />
-                  <h1>Item Request</h1>
+                  <h1 id="item-title">Item Request</h1>
                 </div>
               </div>
             </div>

--- a/src/app/components/Home/Home.jsx
+++ b/src/app/components/Home/Home.jsx
@@ -21,12 +21,6 @@ class Home extends React.Component {
     this.updateIsLoadingState = this.updateIsLoadingState.bind(this);
   }
 
-  componentDidUpdate() {
-    if (this.loadingLayer) {
-      this.loadingLayer.focus();
-    }
-  }
-
   updateIsLoadingState(status) {
     this.setState({ isLoading: status });
   }
@@ -38,7 +32,6 @@ class Home extends React.Component {
           <LoadingLayer
             status={this.state.isLoading}
             title="Searching"
-            childRef={(c) => { this.loadingLayer = c; }}
           />
           <div className="nypl-homepage-hero">
             <div className="nypl-full-width-wrapper">

--- a/src/app/components/LoadingLayer/LoadingLayer.jsx
+++ b/src/app/components/LoadingLayer/LoadingLayer.jsx
@@ -2,52 +2,48 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import FocusTrap from 'focus-trap-react';
 
-class LoadingLayer extends React.Component {
-  render() {
-    if (this.props.status === false) {
-      return null;
-    }
+const LoadingLayer = ({ status, title }) => {
+  if (status === false) {
+    return null;
+  }
 
-    return (
-      <FocusTrap className="focus-trap">
-        <div
-          className="loadingLayer"
-          role="alertdialog"
-          aria-labelledby="loading-animation"
-          aria-describedby="loading-description"
-          aria-live="assertive"
-          aria-atomic="true"
-          ref={this.props.childRef}
-          tabIndex={0}
-        >
-          <div className="loadingLayer-layer" />
-          <div className="loadingLayer-texts">
-            <span id="loading-animation" className="loadingLayer-texts-loadingWord">
-              Loading...
-            </span>
-            <span
-              id="loading-description"
-              className="loadingLayer-texts-title"
-            >
-              {this.props.title}
-            </span>
-            <div className="loadingDots">
-              <span />
-              <span />
-              <span />
-              <span />
-            </div>
+  return (
+    <FocusTrap className="focus-trap">
+      <div
+        className="loadingLayer"
+        role="alertdialog"
+        aria-labelledby="loading-animation"
+        aria-describedby="loading-description"
+        aria-live="assertive"
+        aria-atomic="true"
+        tabIndex="0"
+      >
+        <div className="loadingLayer-layer" />
+        <div className="loadingLayer-texts">
+          <span id="loading-animation" className="loadingLayer-texts-loadingWord">
+            Loading...
+          </span>
+          <span
+            id="loading-description"
+            className="loadingLayer-texts-title"
+          >
+            {title}
+          </span>
+          <div className="loadingDots">
+            <span />
+            <span />
+            <span />
+            <span />
           </div>
         </div>
-      </FocusTrap>
-    );
-  }
-}
+      </div>
+    </FocusTrap>
+  );
+};
 
 LoadingLayer.propTypes = {
   status: PropTypes.bool,
   title: PropTypes.string,
-  childRef: PropTypes.func,
 };
 
 LoadingLayer.defaultProps = {

--- a/src/app/components/SearchResultsPage/SearchResultsPage.jsx
+++ b/src/app/components/SearchResultsPage/SearchResultsPage.jsx
@@ -1,3 +1,4 @@
+/* globals document */
 import React from 'react';
 import PropTypes from 'prop-types';
 import DocumentTitle from 'react-document-title';
@@ -34,10 +35,12 @@ class SearchResultsPage extends React.Component {
     this.checkForSelectedFilters = this.checkForSelectedFilters.bind(this);
   }
 
+  componentDidMount() {
+    document.getElementById('search-query').focus();
+  }
+
   componentDidUpdate() {
-    if (this.loadingLayer) {
-      this.loadingLayer.focus();
-    }
+    document.getElementById('filter-title').focus();
   }
 
   updateIsLoadingState(status) {
@@ -119,15 +122,15 @@ class SearchResultsPage extends React.Component {
           <LoadingLayer
             status={this.state.isLoading}
             title="Searching"
-            childRef={(c) => { this.loadingLayer = c; }}
-            tabIndex={0}
           />
           <div className="nypl-page-header">
             <div className="nypl-full-width-wrapper filter-page">
               <div className="nypl-row">
                 <div className="nypl-column-full">
                   <Breadcrumbs query={searchKeywords} type="search" />
-                  <h1 aria-label={headerLabel}>Search Results</h1>
+                  <h1 aria-label={headerLabel} tabIndex="0">
+                    Search Results
+                  </h1>
                   <Search
                     searchKeywords={searchKeywords}
                     field={field}

--- a/src/app/components/SearchResultsPage/SearchResultsPage.jsx
+++ b/src/app/components/SearchResultsPage/SearchResultsPage.jsx
@@ -36,7 +36,7 @@ class SearchResultsPage extends React.Component {
   }
 
   componentDidMount() {
-    document.getElementById('search-query').focus();
+    document.getElementById('filter-title').focus();
   }
 
   componentDidUpdate() {

--- a/test/unit/HoldConfirmation.test.js
+++ b/test/unit/HoldConfirmation.test.js
@@ -22,7 +22,7 @@ describe('HoldConfirmation', () => {
 
     before(() => {
       requireUser = sinon.spy(HoldConfirmation.prototype, 'requireUser');
-      component = mount(<HoldConfirmation location={location} />);
+      component = mount(<HoldConfirmation location={location} />, { attachTo: document.body });
     });
 
     after(() => {
@@ -48,7 +48,7 @@ describe('HoldConfirmation', () => {
     before(() => {
       Actions.updatePatronData({});
       requireUser = sinon.spy(HoldConfirmation.prototype, 'requireUser');
-      component = mount(<HoldConfirmation location={location} />);
+      component = mount(<HoldConfirmation location={location} />, { attachTo: document.body });
     });
 
     after(() => {
@@ -82,7 +82,7 @@ describe('HoldConfirmation', () => {
           barcodes: ['162402680435300'],
         });
         requireUser = sinon.spy(HoldConfirmation.prototype, 'requireUser');
-        component = mount(<HoldConfirmation location={location} />);
+        component = mount(<HoldConfirmation location={location} />, { attachTo: document.body });
       });
 
       after(() => {
@@ -159,7 +159,10 @@ describe('HoldConfirmation', () => {
           bib={bib}
           deliveryLocations={deliveryLocations}
         />,
-        { context: { router: { createHref: () => {}, push: pushSpy } } },
+        {
+          context: { router: { createHref: () => {}, push: pushSpy } },
+          attachTo: document.body,
+        },
       );
     });
 
@@ -177,7 +180,9 @@ describe('HoldConfirmation', () => {
       expect(pageHeader).to.have.length(1);
       expect(pageHeader.find('h1')).to.have.length(1);
       expect(pageHeader.find('h1').text()).to.equal('Request Confirmation');
-      expect(pageHeader.contains(<h1>Request Confirmation</h1>)).to.equal(true);
+      expect(
+        pageHeader.contains(<h1 id="confirmation-title" tabIndex="0">Request Confirmation</h1>)
+      ).to.equal(true);
     });
 
     it('should display the layout of request confirmation page\'s contents.', () => {
@@ -254,7 +259,8 @@ describe('HoldConfirmation', () => {
         'modelDeliveryLocationName',
       );
       component = mount(
-        <HoldConfirmation location={location} deliveryLocations={deliveryLocations} />
+        <HoldConfirmation location={location} deliveryLocations={deliveryLocations} />,
+        { attachTo: document.body }
       );
     });
 
@@ -314,7 +320,8 @@ describe('HoldConfirmation', () => {
           location={location}
           bib={bib}
           deliveryLocations={deliveryLocations}
-        />);
+        />,
+        { attachTo: document.body });
     });
 
     after(() => {
@@ -358,7 +365,8 @@ describe('HoldConfirmation', () => {
         barcodes: ['162402680435300'],
       });
       requireUser = sinon.spy(HoldConfirmation.prototype, 'requireUser');
-      component = mount(<HoldConfirmation location={location} bib={bib} />);
+      component =
+        mount(<HoldConfirmation location={location} bib={bib} />, { attachTo: document.body });
     });
 
     after(() => {
@@ -429,6 +437,7 @@ describe('HoldConfirmation', () => {
           bib={bib}
           deliveryLocations={deliveryLocations}
         />,
+        { attachTo: document.body }
       );
     });
 
@@ -459,7 +468,8 @@ describe('HoldConfirmation', () => {
     };
 
     before(() => {
-      component = mount(<HoldConfirmation location={location} bib={bib} />);
+      component =
+        mount(<HoldConfirmation location={location} bib={bib} />, { attachTo: document.body });
     });
 
     after(() => {
@@ -492,7 +502,10 @@ describe('HoldConfirmation', () => {
       pushSpy = sinon.spy();
       component = mount(
         <HoldConfirmation location={location} bib={bib} searchKeywords="Bryant" />,
-        { context: { router: { createHref: () => {}, push: pushSpy } } },
+        {
+          context: { router: { createHref: () => {}, push: pushSpy } },
+          attachTo: document.body,
+        },
       );
     });
 
@@ -535,7 +548,8 @@ describe('HoldConfirmation', () => {
 
     before(() => {
       renderBackToClassicLink = sinon.spy(HoldConfirmation.prototype, 'renderBackToClassicLink');
-      component = mount(<HoldConfirmation location={location} bib={bib} />);
+      component =
+        mount(<HoldConfirmation location={location} bib={bib} />, { attachTo: document.body });
     });
 
     after(() => {
@@ -575,7 +589,8 @@ describe('HoldConfirmation', () => {
       };
 
       before(() => {
-        component = mount(<HoldConfirmation location={location} bib={bib} />);
+        component =
+          mount(<HoldConfirmation location={location} bib={bib} />, { attachTo: document.body });
       });
 
       after(() => {

--- a/test/unit/HoldRequest.test.js
+++ b/test/unit/HoldRequest.test.js
@@ -72,7 +72,7 @@ describe('HoldRequest', () => {
 
     before(() => {
       requireUser = sinon.spy(HoldRequest.prototype, 'requireUser');
-      component = mount(<HoldRequest />);
+      component = mount(<HoldRequest />, { attachTo: document.body });
     });
 
     after(() => {
@@ -93,7 +93,7 @@ describe('HoldRequest', () => {
     before(() => {
       Actions.updatePatronData({});
       requireUser = sinon.spy(HoldRequest.prototype, 'requireUser');
-      component = mount(<HoldRequest />);
+      component = mount(<HoldRequest />, { attachTo: document.body });
     });
 
     after(() => {
@@ -112,7 +112,7 @@ describe('HoldRequest', () => {
       let component;
 
       before(() => {
-        component = mount(<HoldRequest />);
+        component = mount(<HoldRequest />, { attachTo: document.body });
       });
 
       after(() => {
@@ -150,7 +150,7 @@ describe('HoldRequest', () => {
     };
 
     before(() => {
-      component = mount(<HoldRequest bib={bib} params={{ itemId: 'i10000003' }} />);
+      component = mount(<HoldRequest bib={bib} params={{ itemId: 'i10000003' }} />, { attachTo: document.body });
     });
 
     after(() => {
@@ -213,7 +213,8 @@ describe('HoldRequest', () => {
           bib={bib}
           deliveryLocations={deliveryLocations}
           params={{ itemId: 'i10000003' }}
-        />
+        />,
+        { attachTo: document.body }
       );
     });
 
@@ -318,7 +319,8 @@ describe('HoldRequest', () => {
           deliveryLocations={deliveryLocations}
           isEddRequestable
           params={{ itemId: 'i10000003' }}
-        />
+        />,
+        { attachTo: document.body }
       );
     });
 

--- a/test/unit/SearchResultsPage.test.js
+++ b/test/unit/SearchResultsPage.test.js
@@ -33,7 +33,8 @@ describe('SearchResultsPage', () => {
         <SearchResultsPage
           searchResults={{}}
           location={{ search: '' }}
-        />
+        />,
+        { attachTo: document.body }
       );
     });
 
@@ -82,6 +83,7 @@ describe('SearchResultsPage', () => {
           searchResults={searchResults}
           location={{ search: '' }}
         />,
+        { attachTo: document.body }
       );
     });
 
@@ -117,6 +119,7 @@ describe('SearchResultsPage', () => {
           searchResults={searchResults}
           location={{ search: '' }}
         />,
+        { attachTo: document.body }
       );
     });
 


### PR DESCRIPTION
This helps fix #938 by focusing on every `h1` on a new page when transitioning. When running a new search, the "Refine Search" title will be focused after the loading screen.

This is currently up on dev.