### PR TITLE
Note structure changes

### DIFF
--- a/src/app/components/BibPage/BibDetails.jsx
+++ b/src/app/components/BibPage/BibDetails.jsx
@@ -344,27 +344,31 @@ class BibDetails extends React.Component {
         if (note) {
           if (note.length === 1) {
             notes = (
-              <div>{note[0]}</div>
+              <span>{note[0]}</span>
             );
           } else if (typeof note[0] === 'object') {
             notes  = (
-              note.map((n, iter) => (
-                <div key={iter.toString()}>
-                  <h4>
-                    {n.noteType}
-                  </h4>
-                  <p>
-                    {n.prefLabel}
-                  </p>
-                </div>
-              ))
+              <ul>
+                {
+                  note.map((n, i) => (
+                    <li key={i.toString()}>
+                      <h4>
+                        {n.noteType}
+                      </h4>
+                      <p>
+                        {n.prefLabel}
+                      </p>
+                    </li>
+                  ))
+                }
+              </ul>
             );
           } else {
             notes  = (
               <ul>
                 {
-                  note.map((noteStr, key) => (
-                    <li key={key.toString()}>{noteStr}</li>
+                  note.map((n, i) => (
+                    <li key={i.toString()}>{n}</li>
                   ))
                 }
               </ul>

--- a/src/app/components/BibPage/BibDetails.jsx
+++ b/src/app/components/BibPage/BibDetails.jsx
@@ -57,18 +57,18 @@ class BibDetails extends React.Component {
   // Original format: ['string1', 'string2']
   // 2018 format: [ {'noteType': 'typeString', 'prefLabel': 'labelString', '@type': 'bf:Note'}, {...}]
   getNote(bib) {
-    const notes = bib.note;
-    if (!notes || !notes.length) {
+    const note = bib.note;
+    if (!note || !note.length) {
       return null;
     }
 
-    let noteObjects = notes && notes.length ? notes : null;
+    let notes = note && note.length ? note : null;
 
-    if (!noteObjects) {
+    if (!notes) {
       return null;
     }
 
-    return noteObjects;
+    return notes;
   }
 
   /*
@@ -341,34 +341,40 @@ class BibDetails extends React.Component {
       if (fieldLabel === 'Contents') {
         const note = this.getNote(this.props.bib);
         let notes;
-        if (typeof note[0] === 'object') {
-          notes  = (
-            note.map((n, iter) => (
-              <div key={iter.toString()}>
-                <h4>
-                  {n.noteType}
-                </h4>
-                <div>
-                  {n.prefLabel}
+        if (note) {
+          if (note.length === 1) {
+            notes = (
+              <div>{note[0]}</div>
+            );
+          } else if (typeof note[0] === 'object') {
+            notes  = (
+              note.map((n, iter) => (
+                <div key={iter.toString()}>
+                  <h4>
+                    {n.noteType}
+                  </h4>
+                  <p>
+                    {n.prefLabel}
+                  </p>
                 </div>
-              </div>
-            ))
-          );
-        } else {
-          notes  = (
-            <ul>
-              {
-                note.map((noteStr, x) => (
-                  <li key={x.toString()}>{noteStr}</li>
-                ))
-              }
-            </ul>
-          );
+              ))
+            );
+          } else {
+            notes  = (
+              <ul>
+                {
+                  note.map((noteStr, key) => (
+                    <li key={key.toString()}>{noteStr}</li>
+                  ))
+                }
+              </ul>
+            );
+          }
+          fieldsToRender.push({
+            term: fieldLabel,
+            definition: notes,
+          });
         }
-        fieldsToRender.push({
-          term: fieldLabel,
-          definition: notes,
-        });
       }
 
       if (fieldLabel === 'Electronic Resource' && this.props.electronicResources.length) {

--- a/src/app/components/BibPage/BibDetails.jsx
+++ b/src/app/components/BibPage/BibDetails.jsx
@@ -53,6 +53,24 @@ class BibDetails extends React.Component {
     return owner;
   }
 
+  // Parse the original and new note format.
+  // Original format: ['string1', 'string2']
+  // 2018 format: [ {'noteType': 'typeString', 'prefLabel': 'labelString', '@type': 'bf:Note'}, {...}]
+  getNote(bib) {
+    const notes = bib.note;
+    if (!notes || !notes.length) {
+      return null;
+    }
+
+    let noteObjects = notes && notes.length ? notes : null;
+
+    if (!noteObjects) {
+      return null;
+    }
+
+    return noteObjects;
+  }
+
   /*
    * getDefinitionObject(bibValues, fieldValue, fieldLinkable, fieldSelfLinkable, fieldLabel)
    * Gets a list, or one value, of data to display for a field from the API, where
@@ -317,6 +335,40 @@ class BibDetails extends React.Component {
             definition: owner,
           });
         }
+      }
+
+      // Note field rendering as array of objects instead of an array of strings.
+      if (fieldLabel === 'Contents') {
+        const note = this.getNote(this.props.bib);
+        let notes;
+        if (typeof note[0] === 'object') {
+          notes  = (
+            note.map((n, iter) => (
+              <div key={iter.toString()}>
+                <h4>
+                  {n.noteType}
+                </h4>
+                <div>
+                  {n.prefLabel}
+                </div>
+              </div>
+            ))
+          );
+        } else {
+          notes  = (
+            <ul>
+              {
+                note.map((noteStr, x) => (
+                  <li key={x.toString()}>{noteStr}</li>
+                ))
+              }
+            </ul>
+          );
+        }
+        fieldsToRender.push({
+          term: fieldLabel,
+          definition: notes,
+        });
       }
 
       if (fieldLabel === 'Electronic Resource' && this.props.electronicResources.length) {

--- a/src/app/components/BibPage/BibDetails.jsx
+++ b/src/app/components/BibPage/BibDetails.jsx
@@ -53,9 +53,11 @@ class BibDetails extends React.Component {
     return owner;
   }
 
-  // Parse the original and new note format.
-  // Original format: ['string1', 'string2']
-  // 2018 format: [ {'noteType': 'typeString', 'prefLabel': 'labelString', '@type': 'bf:Note'}, {...}]
+  /*
+   * Return note array or null.
+   * @param {object} bib
+   * @return {null|array}
+   */
   getNote(bib) {
     const note = bib.note;
     if (!note || !note.length) {
@@ -338,6 +340,13 @@ class BibDetails extends React.Component {
       }
 
       // Note field rendering as array of objects instead of an array of strings.
+      // Parse the original and new note format.
+      // Original format: ['string1', 'string2']
+      // 2018 format:
+      //    [{'noteType': 'string',
+      //     'prefLabel': 'string',
+      //     '@type': 'bf:Note'},
+      //    {...}]
       if (fieldLabel === 'Contents') {
         const note = this.getNote(this.props.bib);
         let notes;

--- a/src/app/components/BibPage/BibDetails.jsx
+++ b/src/app/components/BibPage/BibDetails.jsx
@@ -60,10 +60,6 @@ class BibDetails extends React.Component {
    */
   getNote(bib) {
     const note = bib.note;
-    if (!note || !note.length) {
-      return null;
-    }
-
     let notes = note && note.length ? note : null;
 
     if (!notes) {
@@ -351,29 +347,14 @@ class BibDetails extends React.Component {
         const note = this.getNote(this.props.bib);
         let notes;
         if (note) {
-          if (note.length === 1) {
+          if (note.length === 1 && typeof note[0] !== 'object') {
             notes = (
               <span>{note[0]}</span>
             );
           } else if (typeof note[0] === 'object') {
-            notes  = (
-              <ul>
-                {
-                  note.map((n, i) => (
-                    <li key={i.toString()}>
-                      <h4>
-                        {n.noteType}
-                      </h4>
-                      <p>
-                        {n.prefLabel}
-                      </p>
-                    </li>
-                  ))
-                }
-              </ul>
-            );
+            notes = this.noteObjectDisplay(note);
           } else {
-            notes  = (
+            notes = (
               <ul>
                 {
                   note.map((n, i) => (
@@ -436,6 +417,42 @@ class BibDetails extends React.Component {
     }); // End of the forEach loop
 
     return fieldsToRender;
+  }
+
+  /*
+   * Display for single and multivalued object arrays.
+   * @param {array} note
+   * @return {string}
+   */
+  noteObjectDisplay(note) {
+    let display;
+    if (note.length === 1) {
+      display = (
+        <div>
+          <h4>{note[0].noteType}</h4>
+          <p>{note[0].prefLabel}</p>
+        </div>
+      );
+    } else {
+      display = (
+        <ul>
+          {
+            note.map((n, i) => (
+              <li key={i.toString()}>
+                <h4>
+                  {n.noteType}
+                </h4>
+                <p>
+                  {n.prefLabel}
+                </p>
+              </li>
+            ))
+          }
+        </ul>
+      );
+    }
+
+    return display;
   }
 
   newSearch(e, query, field, value, label) {

--- a/src/app/components/BibPage/BibPage.jsx
+++ b/src/app/components/BibPage/BibPage.jsx
@@ -75,7 +75,7 @@ class BibPage extends React.Component {
       { label: 'Genre/Form', value: 'materialType' },
       { label: 'Notes', value: '' },
       { label: 'Additional Resources', value: 'supplementaryContent', selfLinkable: true },
-      { label: 'Contents', value: 'note' },
+      { label: 'Contents', value: 'React Component' },
       { label: 'Bibliography', value: '' },
       { label: 'ISBN', value: 'identifier', identifier: 'urn:isbn' },
       { label: 'ISSN', value: 'identifier', identifier: 'urn:issn' },


### PR DESCRIPTION
Changed the processing of the `note` field to a method and looping structure in BibDetails.jsx. The getNote() method initializes the note data and checks for missing or empty data and returns null. Otherwise, the note array is returned as is for output processing.

The output is set to display as a single note `<span>`, a list of stings, or, for the new structure, a list of `<h4>` and `<p>` elements. The `<h4>` contains the `noteType` string and the `<p>` tag displays the `prefLabel` string for each item in the array of objects.

See: https://jira.nypl.org/browse/SCC-320