### PR TITLE
Adding serialPublicationDates and publicationStatement (to replace…

### DIFF
--- a/src/app/components/BibPage/BibDetails.jsx
+++ b/src/app/components/BibPage/BibDetails.jsx
@@ -243,33 +243,6 @@ class BibDetails extends React.Component {
   }
 
   /**
-   * getPublication(bib)
-   * Get an object with publisher detail information.
-   * @param {object} bib
-   * @return {object}
-   */
-  getPublication(bib) {
-    const fields = ['placeOfPublication', 'publisherLiteral', 'createdString'];
-    let publicationInfo = '';
-
-    fields.forEach((field) => {
-      const fieldValue = bib[field];
-      if (fieldValue) {
-        publicationInfo += `${fieldValue} `;
-      }
-    });
-
-    if (!publicationInfo) {
-      return null;
-    }
-
-    return {
-      term: 'Publication',
-      definition: <span>{publicationInfo}</span>,
-    };
-  }
-
-  /**
    * getDisplayFields(bib)
    * Get an array of definition term/values.
    * @param {object} bib
@@ -280,7 +253,6 @@ class BibDetails extends React.Component {
     // component rather than from the bib field properties.
     const fields = this.props.fields;
     const fieldsToRender = [];
-    const publicationInfo = this.getPublication(bib);
 
     fields.forEach((field) => {
       const fieldLabel = field.label;
@@ -317,11 +289,6 @@ class BibDetails extends React.Component {
             });
           }
         }
-      }
-
-      // This is made up of three different bib property values so it's special.
-      if (fieldLabel === 'Publication' && publicationInfo) {
-        fieldsToRender.push(publicationInfo);
       }
 
       // The Owner is complicated too.

--- a/src/app/components/BibPage/BibPage.jsx
+++ b/src/app/components/BibPage/BibPage.jsx
@@ -68,7 +68,8 @@ class BibPage extends React.Component {
     ];
 
     const bottomFields = [
-      { label: 'Publication', value: 'React Component' },
+      { label: 'Publication', value: 'publicationStatement' },
+      { label: 'Publication Date', value: 'serialPublicationDates' },
       { label: 'Electronic Resource', value: 'React Component' },
       { label: 'Description', value: 'extent' },
       { label: 'Series', value: 'seriesStatement' },


### PR DESCRIPTION
…the previous publication display) to the bib details page.

Fixes #947 (and JIRA tickets [SCC-318](https://jira.nypl.org/browse/SCC-318) and [SCC-319](https://jira.nypl.org/browse/SCC-319).

Examples on dev:
* Publication Date - http://dev-discovery.nypl.org/research/collections/shared-collection-catalog/bib/b10018031
* Publication - http://dev-discovery.nypl.org/research/collections/shared-collection-catalog/bib/b20972964

CC @katesweeney @saverkamp 