### PR TITLE
Change eb app name in sandbox to discovery-ui

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ deploy:
   access_key_id: "$AWS_ACCESS_KEY_ID_DEVELOPMENT"
   secret_access_key: "$AWS_SECRET_ACCESS_KEY_DEVELOPMENT"
   region: us-east-1
-  app: Discovery
+  app: discovery-ui
   env: discovery-ui-development
   bucket_name: elasticbeanstalk-us-east-1-224280085904
   bucket_path: discovery-ui-development


### PR DESCRIPTION
Changes the development `app` specified in .travis.yml to "discovery-ui"
for consistency with nypl-digital-dev (qa & prod deployments). This will
cause the application to be automatically deployed to the `discovery-ui`
application in nypl-sandbox when origin/development is updated.