### PR TITLE
Add eb https config for development

### DIFF
--- a/.ebextensions/01_loadbalancer-terminatehttps.config
+++ b/.ebextensions/01_loadbalancer-terminatehttps.config
@@ -1,6 +1,6 @@
 option_settings:
   aws:elb:listener:443:
     ListenerProtocol: HTTPS
-    SSLCertificateId: arn:aws:acm:us-east-1:946183545209:certificate/aee40806-85d9-4e4f-973d-4430105a0369
+    SSLCertificateId: arn:aws:acm:us-east-1:224280085904:certificate/81061d9f-0a08-4440-bdc0-016e4d40b423
     InstancePort: 80
     InstanceProtocol: HTTP


### PR DESCRIPTION
Adding elasticbeanstalk https config with nypl-sandbox cert arn. This is
commit 1 of a 3-commit fix to register the correct cert arn in
development and qa:

 1. commit nypl-sandbox cert arn into development
 2. merge development into qa
 3. commit nypl-digital-dev cert arn into qa

Because the nypl-digital-dev cert arn is also correct for master, when
qa is merged into master (i.e. production), our production will retain
the correct cert arn. Provided no new commits change the cert arn in
development after this process, future feature promotion merges should
preserve the correct cert arn in each of the three deploy branches.