### PR TITLE
Change app config vars, documentation

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -1,0 +1,4 @@
+export SET KMS_ENV=unencrypted
+export SET PLATFORM_API_CLIENT_ID=discovery_api
+export SET PLATFORM_API_CLIENT_SECRET=[secret]
+export SET PLATFORM_API_BASE_URL=http://[fqdn]/api/v0.1

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@ nightwatch_reports
 package-lock.json
 log/*.log
 
+# Local env:
+.env
+
 # Elastic Beanstalk Files
 .elasticbeanstalk/*
 !.elasticbeanstalk/*.cfg.yml

--- a/EBSVARS.md
+++ b/EBSVARS.md
@@ -2,8 +2,14 @@
 
 As previously mentioned in the [README](README.md), we are using environment variables to make authorized requests to NYPL's API platform. In order to be secure, we are encrypting and decrypting those environment variables using AWS KMS. Please get these variables from someone in the NYPL Digital Department.
 
+ * `KMS_ENV`: Determines whether to interpret ..CLIENT_ID and ..CLIENT_SECRET variables as 'encrypted' or 'unencrypted'. Default 'encrypted'
+ * `PLATFORM_API_CLIENT_ID`: Platfrom client id. If KMS_ENV is "encrypted", this value must be encrypted.
+ * `PLATFORM_API_CLIENT_SECRET`: Platfrom client secret. If KMS_ENV is "encrypted", this value must be encrypted.
+ * `PLATFORM_API_BASE_URL`: Platform api base url (e.g. "http://example.com/api/v0.1")
+
 ### Encrypting
-There are two variables we care about: the `clientId` and the `clientSecret`. We need these variables to create an instance of the `nypl-data-api-client` npm package and make authorized requests to the NYPL Digital API endpoints. This is needed for the Discovery UI app to make requests itself to the APIs.
+
+Two variables are assumed encrypted when `KMS_ENV` is "encrypted": `PLATFORM_API_CLIENT_ID` and `PLATFORM_API_CLIENT_SECRET`. We need these variables to create an instance of the `nypl-data-api-client` npm package and make authorized requests to the NYPL Digital API endpoints. This is needed for the Discovery UI app to make requests itself to the APIs.
 
 In order to encrypt, please use the `aws` [cli tool](https://aws.amazon.com/cli/). The command to encrypt is
 
@@ -16,4 +22,5 @@ More information can be found in the [encrypt docs](http://docs.aws.amazon.com/c
 NOTE: This value is base64 encoded, so when decoding make sure to decode using base64.
 
 ### Decrypting
+
 In order to decrypt, we are using the `aws-sdk` npm module. Please check the [nyplApiClient](src/server/routes/nyplApiClient/index.js) file for more information and implementation on decryption.

--- a/README.md
+++ b/README.md
@@ -21,47 +21,44 @@ Front-end app for searching, discovering, and placing a hold on research items f
 * Express Server
 * [Travis](https://travis-ci.org/)
 
-## Client Id and Secret
-We are using environment variables to make authorized requests to NYPL's API platform. The `clientId` and `clientSecret` environment variables should be received from a developer in the NYPL Digital Department.
-
-Please check the [EBSVARS](EBSVARS.md) documentation for more information.
-
 ## Installation and running locally
 
-#### Installation
+### Installation
 To install packages run
 
     $ npm install
 
-#### Development mode with different API environments
-To run locally in development mode with the development API and with the regular unencrypted API keys, run:
+### Configuration
 
-    $ clientId=[client id] clientSecret=[client secret] npm run dev-api-start
+See `.env-sample` for supported environmental variables. Copy `.env-sample` to `.env` and replace placeholder values with your own - or obtain a prefilled version from a coworker.
 
-To run locally in production mode with the production API and with encrypted API keys, run:
+See [EBSVARS](EBSVARS.md) for more information.
 
-    $ clientId=[encrypted client id] clientSecret=[encrypted client secret] npm run prod-api-start
+### Development mode with different API environments
 
-If you would like to run in different the API environments without the special npm run scripts, run
+To run locally using config from `.env`:
 
-    $ clientId=[client id] clientSecret=[client secret] APP_ENV=[environment variable] npm start
+```
+source .env; npm run start
+```
 
-`environment variable` is the name of the particular environment, such as `development` or `production`.
+As a convenience, the following commands override some config for you:
+
+ * `source .env; npm run dev-api-start`: Use development API with *un*encrypted creds from `.env`
+ * `source .env; npm run prod-api-start`: Use production API with encrypted creds from `.env`
 
 Visit `localhost:3001` to see the UI locally.
 
-#### Production mode
-To run locally in production mode you need to run two commands:
+### Production mode
 
-    $ npm run dist
-    $ clientID=[client id] clientSecret=[client secret] NODE_ENV=production APP_ENV=production npm start
+By default, the app runs with `NODE_ENV=development`, which means a separate server is invoked to serve live updates to assets in development. Deployed instances of the app operate with `NODE_ENV=production`, indicating the app should serve pre-built assets. Sometimes it's useful to run the app in production mode locally (e.g. to test the app for NOSCRIPT visitors).
 
-or, if you'd like fewer environment variables in the command line:
+To run the app locally in production mode you need to run two commands:
 
-    $ npm run dist
-    $ clientID=[client id] clientSecret=[client secret] npm run prod-start
+ * `npm run dist`: This builds the assets.
+ * `source .env; npm run prod-start`: Start servers using production API & serve prebundled assets.
 
-and visit `localhost:3001`.
+Visit `localhost:3001` to see the UI locally.
 
 ## Contributing
 

--- a/appConfig.js
+++ b/appConfig.js
@@ -7,8 +7,8 @@ export default {
   port: 3001,
   webpackDevServerPort: 3000,
   api: {
-    development: 'https://dev-platform.nypl.org/api/v0.1',
-    production: 'https://platform.nypl.org/api/v0.1',
+    development: process.env.PLATFORM_API_BASE_URL || 'https://dev-platform.nypl.org/api/v0.1',
+    production: process.env.PLATFORM_API_BASE_URL || 'https://platform.nypl.org/api/v0.1',
   },
   loginUrl: 'https://login.nypl.org/auth/login',
   tokenUrl: 'https://isso.nypl.org/',

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "main": "index.js",
   "scripts": {
     "start": "node index",
-    "prod-start": "NODE_ENV=production APP_ENV=production node index",
-    "dev-api-start": "APP_ENV=development KMS_ENV=unencrypted node index",
-    "prod-api-start": "APP_ENV=production KMS_ENV=encrypted node index",
+    "prod-start": "NODE_ENV=production PLATFORM_API_BASE_URL=https://platform.nypl.org/api/v0.1 node index",
+    "dev-api-start": "PLATFORM_API_BASE_URL=https://dev-platform.nypl.org/api/v0.1 KMS_ENV=unencrypted node index",
+    "prod-api-start": "PLATFORM_API_BASE_URL=https://platform.nypl.org/api/v0.1 KMS_ENV=encrypted node index",
     "eb-start": "npm run dist && node index",
     "dist": "NODE_ENV=production webpack --config webpack.config.js",
     "postinstall": "npm run dist",

--- a/server.js
+++ b/server.js
@@ -90,7 +90,6 @@ app.get('/*', (req, res) => {
           appTitle: title,
           favicon: appConfig.favIconPath,
           webpackPort: WEBPACK_DEV_PORT,
-          appEnv: process.env.APP_ENV,
           path: req.url,
           isProduction,
           baseUrl: appConfig.baseUrl,

--- a/src/server/routes/nyplApiClient/index.js
+++ b/src/server/routes/nyplApiClient/index.js
@@ -32,8 +32,8 @@ if (kmsEnvironment === 'encrypted') {
   };
 }
 
-const clientId = process.env.clientId;
-const clientSecret = process.env.clientSecret;
+const clientId = process.env.clientId || process.env.PLATFORM_API_CLIENT_ID;
+const clientSecret = process.env.clientSecret || process.env.PLATFORM_API_CLIENT_SECRET;
 
 const keys = [clientId, clientSecret];
 const CACHE = {};


### PR DESCRIPTION
This changes the official config variables supported for app config:
 - Change case of clientId, clientSecret
 - Deprecates APP_ENV to just set PLATFORM_API_BASE_URL directly
 - Adds `.env-sample` and instructs use of `.env` as means to load
   config values
 - Adds simplified documentation for running with common configurations

Discussion invited. I'm trying to sand off some pain points for new users:
 1. I've found `APP_ENV` a little confusing and since it only seems to control what platform api base URL you use, I propose we just allow one to set that directly. 
 2. Also introduces use of `.env` as means to pass in env vars, which I've found much easier to use than passing them in on cmd line. Also is an opportunity to document vars in `.env-sample`