### PR TITLE
Fix fiendly-errors dev dependency include

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,7 +3,6 @@ const webpack = require('webpack');
 const merge = require('webpack-merge');
 const CleanBuild = require('clean-webpack-plugin');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
-const FriendlyErrorsWebpackPlugin = require('friendly-errors-webpack-plugin');
 const sassPaths = require('@nypl/design-toolkit').includePaths
   .map(sassPath => sassPath).join('&');
 // const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
@@ -91,6 +90,9 @@ const commonSettings = {
 // Need to configure webpack-dev-server and hot-reload
 // module correctly.
 if (ENV === 'development') {
+  // Load dev depencies:
+  const FriendlyErrorsWebpackPlugin = require('friendly-errors-webpack-plugin');
+
   module.exports = merge(commonSettings, {
     devtool: 'eval',
     entry: {


### PR DESCRIPTION
Moves the inclusion of friendly-errors webpack plugin to only as needed
when NODE_ENV is development. Previously was included when building dist
for production, when it will not exist.