### PR TITLE
Remove componentDidMount from BibPage

### DIFF
--- a/src/app/components/BibPage/BibPage.jsx
+++ b/src/app/components/BibPage/BibPage.jsx
@@ -33,12 +33,6 @@ class BibPage extends React.Component {
     this.updateIsLoadingState = this.updateIsLoadingState.bind(this);
   }
 
-  componentDidMount() {
-    if(!this.props.location.hash){
-      document.getElementById('bib-title').focus();
-    }
-  }
-
   updateIsLoadingState(status) {
     this.setState({ isLoading: status });
   }


### PR DESCRIPTION
Previously BibPage had a componentDidMount method to focus on an html element with id bib-title. This no longer exists. As a result, componentDidMount in Application.jsx (which depends on componentDidMount in all its children, including BibPage), was erroring, and not telling Application to listen to the Store as it was supposed to. Removing componentDidMount from BibPage now removes this error. As a result, delivery locations are fetched from the Store.