### PR TITLE
Fix ga event action and label for item requests

### DIFF
--- a/src/app/components/Item/ItemHoldings.jsx
+++ b/src/app/components/Item/ItemHoldings.jsx
@@ -66,7 +66,7 @@ class ItemHoldings extends React.Component {
     e.preventDefault();
     this.props.updateIsLoadingState(true);
 
-    trackDiscovery('Bib Item Request', `Item Details - ${itemId}`);
+    trackDiscovery('Item Request', `Item Details`);
     // Search for the bib? Just pass the data.
     axios
       .get(`${appConfig.baseUrl}/api/hold/request/${bibId}-${itemId}`)

--- a/src/app/components/Item/ItemHoldings.jsx
+++ b/src/app/components/Item/ItemHoldings.jsx
@@ -66,7 +66,7 @@ class ItemHoldings extends React.Component {
     e.preventDefault();
     this.props.updateIsLoadingState(true);
 
-    trackDiscovery('Item Request', `Item Details`);
+    trackDiscovery('Item Request', 'Item Details');
     // Search for the bib? Just pass the data.
     axios
       .get(`${appConfig.baseUrl}/api/hold/request/${bibId}-${itemId}`)

--- a/src/app/components/Results/ResultsList.jsx
+++ b/src/app/components/Results/ResultsList.jsx
@@ -71,7 +71,7 @@ class ResultsList extends React.Component {
 
     this.props.updateIsLoadingState(true);
 
-    trackDiscovery('Item Request', `Search Results`);
+    trackDiscovery('Item Request', 'Search Results');
     ajaxCall(`${appConfig.baseUrl}/api/hold/request/${bibId}-${itemId}`,
       (response) => {
         Actions.updateBib(response.data.bib);

--- a/src/app/components/Results/ResultsList.jsx
+++ b/src/app/components/Results/ResultsList.jsx
@@ -71,7 +71,7 @@ class ResultsList extends React.Component {
 
     this.props.updateIsLoadingState(true);
 
-    trackDiscovery('Bib Item Request', `Search Results - ${itemId}`);
+    trackDiscovery('Item Request', `Search Results`);
     ajaxCall(`${appConfig.baseUrl}/api/hold/request/${bibId}-${itemId}`,
       (response) => {
         Actions.updateBib(response.data.bib);


### PR DESCRIPTION
This branch just changes a the action and label of a couple of ga events. First, it changes the action from "Bib Item Request", which was viewed as confusing, to simply "Item Request". Second, it changes the label by dropping the item id. This is to allow easier comparison of the number of events triggered from the search results page vs. the item details page. It was decided that the loss of information was acceptable because currently no one is looking at the richer information anyway.