### PR TITLE
Bumped footer version to v0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 ## CHANGE LOG
 
+### 1.5.8
+- Updating @nypl/dgx-react-footer to 0.5.2.
+
 ### 1.5.7
-- Updating @nypl/dgx-header-component to 2.4.19
+- Updating @nypl/dgx-header-component to 2.4.19.
 
 ### 1.5.6
 - Updating @nypl/dgx-header-component to 2.4.15 and checking for QA in APP_ENV.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## Discovery
 
 ### Version
-> 1.5.7
+> 1.5.8
 
 ### Shared Collection Catalog
 [![GitHub version](https://badge.fury.io/gh/nypl-discovery%2Fdiscovery-front-end.svg)](https://badge.fury.io/gh/nypl-discovery%2Fdiscovery-front-end)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nypl-discovery",
-  "version": "1.5.7",
+  "version": "1.5.8",
   "description": "Isomorphic React App for NYPL Research Catalog.",
   "main": "index.js",
   "scripts": {
@@ -77,7 +77,7 @@
   "dependencies": {
     "@nypl/design-toolkit": "0.1.35",
     "@nypl/dgx-header-component": "2.4.19",
-    "@nypl/dgx-react-footer": "0.5.1",
+    "@nypl/dgx-react-footer": "0.5.2",
     "@nypl/dgx-svg-icons": "0.2.5",
     "@nypl/nypl-data-api-client": "0.2.5",
     "aws-sdk": "2.99.0",


### PR DESCRIPTION
This PR updates footer to v0.5.2 to add non-profit status information

https://jira.nypl.org/browse/SCC-1309