### PR TITLE
Search results ajax call

### DIFF
--- a/src/app/components/SearchResultsPage/SearchResultsPage.jsx
+++ b/src/app/components/SearchResultsPage/SearchResultsPage.jsx
@@ -61,7 +61,6 @@ class SearchResultsPage extends React.Component {
       query,
     } = location;
 
-    console.log('Update: ', location.search, prevProps.location.search);
     if (search !== prevProps.location.search) {
       const qParameter = query.q;
       const urlFilters = _pick(query, (value, key) => {
@@ -77,6 +76,7 @@ class SearchResultsPage extends React.Component {
           Actions.updateSelectedFilters(selectedFilters);
           Actions.updateFilters(data.filters);
           Actions.updateSearchResults(data.searchResults);
+          Actions.updatePage(location.query.page || 1);
           if (qParameter) Actions.updateSearchKeywords(qParameter);
         }
       });


### PR DESCRIPTION
This branch solves the navigation issues with filters and pages by adding an additional ajax call when the query params change. We do not yet understand why the existing mechanisms are not already working, which is something we should look into. In addition, we need to add some logic to handle updating the page when a filter is added, and should probably do an audit of any remaining navigation issues.