### PR TITLE
Construct subject headings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## CHANGE LOG
 
+### 1.6.0
+- Updating to add more checks to see if the bib detail fields include subject headings. If so, it will then call the additional string methods to generate new texts and URLs for the link.
+
 ### 1.5.9
 - Updating the filters to include subject literal as a possible filter type
 - Fix bugs relating to browser navigation

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## Discovery
 
 ### Version
-> 1.5.9
+> 1.6.0
 
 ### Shared Collection Catalog
 [![GitHub version](https://badge.fury.io/gh/nypl-discovery%2Fdiscovery-front-end.svg)](https://badge.fury.io/gh/nypl-discovery%2Fdiscovery-front-end)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nypl-discovery",
-  "version": "1.5.2",
+  "version": "1.5.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -221,16 +221,17 @@
       }
     },
     "@nypl/dgx-header-component": {
-      "version": "2.4.11",
-      "resolved": "https://registry.npmjs.org/@nypl/dgx-header-component/-/dgx-header-component-2.4.11.tgz",
-      "integrity": "sha512-ZpD352G86cGatj/kAD/gbkFwM7X4IryHvFZ51tygnnZMTRGPc3rkOsI5dieIfFN90+PTKDOfGltwMY17nmMq9Q==",
+      "version": "2.4.19",
+      "resolved": "https://registry.npmjs.org/@nypl/dgx-header-component/-/dgx-header-component-2.4.19.tgz",
+      "integrity": "sha512-grj0TVLT9zw1sP5A8nwVf6/yIUMq21h3uyhOiZ5ORvXhk40fAAfgqDhxJVxJyCJgPaQKvMC2JYztw0+GHOFz/A==",
       "requires": {
         "@nypl/design-toolkit": "0.1.36",
         "@nypl/dgx-svg-icons": "0.3.7",
         "axios": "0.9.1",
         "classnames": "2.1.3",
-        "dgx-feature-flags": "git+https://git@bitbucket.org/NYPL/dgx-feature-flags.git#f7b1bd20f56632c71864cbe648556d03853d9f0e",
-        "dgx-skip-navigation-link": "git+https://git@bitbucket.org/NYPL/dgx-skip-navigation-link.git#d1bdcf9e5d7d54fe252c6d8a250a42908fd98a87",
+        "dgx-feature-flags": "git+https://git@bitbucket.org/NYPL/dgx-feature-flags.git#master",
+        "dgx-react-ga": "git+https://git@bitbucket.org/NYPL/dgx-react-ga.git#master",
+        "dgx-skip-navigation-link": "git+https://git@bitbucket.org/NYPL/dgx-skip-navigation-link.git#master",
         "focus-trap-react": "3.0.3",
         "moment": "2.19.3",
         "prop-types": "15.5.10",
@@ -258,34 +259,6 @@
           "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.1.3.tgz",
           "integrity": "sha1-r5skU/wUOuhUbQ5zu+6kD3S342M="
         },
-        "dgx-alt-center": {
-          "version": "git+https://bitbucket.org/NYPL/dgx-alt-center.git#b3915c1cf33ed7f70446750dcbc6fcf98faaed37",
-          "from": "dgx-alt-center@git+https://bitbucket.org/NYPL/dgx-alt-center.git#b3915c1cf33ed7f70446750dcbc6fcf98faaed37",
-          "requires": {
-            "alt": "0.18.2"
-          }
-        },
-        "dgx-feature-flags": {
-          "version": "git+https://git@bitbucket.org/NYPL/dgx-feature-flags.git#f7b1bd20f56632c71864cbe648556d03853d9f0e",
-          "from": "dgx-feature-flags@git+https://git@bitbucket.org/NYPL/dgx-feature-flags.git#f7b1bd20f56632c71864cbe648556d03853d9f0e",
-          "requires": {
-            "alt-utils": "1.0.0",
-            "dgx-alt-center": "git+https://bitbucket.org/NYPL/dgx-alt-center.git#b3915c1cf33ed7f70446750dcbc6fcf98faaed37",
-            "immutable": "3.7.6"
-          }
-        },
-        "dgx-react-ga": {
-          "version": "git+https://git@bitbucket.org/NYPL/dgx-react-ga.git#1908e78bd8704b815ec37030d0f8040f8b3cbb95",
-          "from": "git+https://git@bitbucket.org/NYPL/dgx-react-ga.git#1908e78bd8704b815ec37030d0f8040f8b3cbb95",
-          "requires": {
-            "create-react-class": "15.5.3",
-            "react-ga": "2.4.1"
-          }
-        },
-        "dgx-skip-navigation-link": {
-          "version": "git+https://git@bitbucket.org/NYPL/dgx-skip-navigation-link.git#d1bdcf9e5d7d54fe252c6d8a250a42908fd98a87",
-          "from": "dgx-skip-navigation-link@git+https://git@bitbucket.org/NYPL/dgx-skip-navigation-link.git#d1bdcf9e5d7d54fe252c6d8a250a42908fd98a87"
-        },
         "node-sass": {
           "version": "4.6.0",
           "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.6.0.tgz",
@@ -311,39 +284,6 @@
             "stdout-stream": "^1.4.0"
           }
         },
-        "react-ga": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/react-ga/-/react-ga-2.4.1.tgz",
-          "integrity": "sha512-hjn2SRdhB3JrdWvodNVegjxLi6xiQyCEELVTvutSB/g57GmfGqSxIvKmxgEN3c6Rjp21rxOYou6TrwzTE288Ig==",
-          "requires": {
-            "prop-types": "^15.6.0",
-            "react": "^15.6.2 || ^16.0"
-          },
-          "dependencies": {
-            "prop-types": {
-              "version": "15.6.2",
-              "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
-              "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
-              "optional": true,
-              "requires": {
-                "loose-envify": "^1.3.1",
-                "object-assign": "^4.1.1"
-              }
-            },
-            "react": {
-              "version": "16.5.2",
-              "resolved": "https://registry.npmjs.org/react/-/react-16.5.2.tgz",
-              "integrity": "sha512-FDCSVd3DjVTmbEAjUNX6FgfAmQ+ypJfHUsqUJOYNCBUp1h8lqmtC+0mXJ+JjsWx4KAVTkk1vKd1hLQPvEviSuw==",
-              "optional": true,
-              "requires": {
-                "loose-envify": "^1.1.0",
-                "object-assign": "^4.1.1",
-                "prop-types": "^15.6.2",
-                "schedule": "^0.5.0"
-              }
-            }
-          }
-        },
         "react-tappable": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/react-tappable/-/react-tappable-1.0.0.tgz",
@@ -352,9 +292,9 @@
       }
     },
     "@nypl/dgx-react-footer": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@nypl/dgx-react-footer/-/dgx-react-footer-0.5.1.tgz",
-      "integrity": "sha512-5+HJ9H2Qr/JEsBmLukLQztpoLVldU1FyLn2UVBritIQB0LpFR1MKsh9uRubXxqCdkes5ser5iDFcIk0q7z9f2g==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@nypl/dgx-react-footer/-/dgx-react-footer-0.5.2.tgz",
+      "integrity": "sha512-ItzXH3eJGygszWhI94T4/7EgqVe3lZ00QCNYHkSeVg6wuAPoKvvyFGG4VKy3EWxtPeQPXu3TYVc9X2aKC7ZrZA==",
       "requires": {
         "@nypl/dgx-svg-icons": "0.3.8"
       },
@@ -3288,6 +3228,22 @@
       "integrity": "sha1-ogM8CcyOFY03dI+951B4Mr1s4Sc=",
       "dev": true
     },
+    "dgx-alt-center": {
+      "version": "git+https://bitbucket.org/NYPL/dgx-alt-center.git#b3915c1cf33ed7f70446750dcbc6fcf98faaed37",
+      "from": "git+https://bitbucket.org/NYPL/dgx-alt-center.git#master",
+      "requires": {
+        "alt": "0.18.2"
+      }
+    },
+    "dgx-feature-flags": {
+      "version": "git+https://git@bitbucket.org/NYPL/dgx-feature-flags.git#f7b1bd20f56632c71864cbe648556d03853d9f0e",
+      "from": "git+https://git@bitbucket.org/NYPL/dgx-feature-flags.git#master",
+      "requires": {
+        "alt-utils": "1.0.0",
+        "dgx-alt-center": "git+https://bitbucket.org/NYPL/dgx-alt-center.git#master",
+        "immutable": "3.7.6"
+      }
+    },
     "dgx-react-ga": {
       "version": "git+https://git@bitbucket.org/NYPL/dgx-react-ga.git#1908e78bd8704b815ec37030d0f8040f8b3cbb95",
       "from": "git+https://git@bitbucket.org/NYPL/dgx-react-ga.git#master",
@@ -3328,6 +3284,10 @@
           }
         }
       }
+    },
+    "dgx-skip-navigation-link": {
+      "version": "git+https://git@bitbucket.org/NYPL/dgx-skip-navigation-link.git#d1bdcf9e5d7d54fe252c6d8a250a42908fd98a87",
+      "from": "git+https://git@bitbucket.org/NYPL/dgx-skip-navigation-link.git#master"
     },
     "diff": {
       "version": "3.5.0",
@@ -4734,7 +4694,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4752,11 +4713,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4769,15 +4732,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4880,7 +4846,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4890,6 +4857,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4902,17 +4870,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -4929,6 +4900,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5001,7 +4973,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5011,6 +4984,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5086,7 +5060,8 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5116,6 +5091,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5133,6 +5109,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5171,11 +5148,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },
@@ -8007,6 +7986,7 @@
           "version": "0.1.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -8339,7 +8319,8 @@
         "is-buffer": {
           "version": "1.1.6",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "is-builtin-module": {
           "version": "1.0.0",
@@ -8438,6 +8419,7 @@
           "version": "3.2.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -8475,7 +8457,8 @@
         "longest": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "lru-cache": {
           "version": "4.1.3",
@@ -8676,7 +8659,8 @@
         "repeat-string": {
           "version": "1.6.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "require-directory": {
           "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nypl-discovery",
-  "version": "1.5.9",
+  "version": "1.6.0",
   "description": "Isomorphic React App for NYPL Research Catalog.",
   "main": "index.js",
   "scripts": {

--- a/src/app/components/BibPage/BibDetails.jsx
+++ b/src/app/components/BibPage/BibDetails.jsx
@@ -270,10 +270,10 @@ class BibDetails extends React.Component {
       const fieldLinkable = field.linkable;
       const fieldSelfLinkable = field.selfLinkable;
       const fieldIdentifier = field.identifier;
-      const bibValues = bib[fieldValue];
+      let bibValues = bib[fieldValue];
 
       if (fieldValue === 'subjectLiteral') {
-        bib[fieldValue] = this.compressSubjectLiteral(bib[fieldValue]);
+        bibValues = this.compressSubjectLiteral(bib[fieldValue]);
       }
 
       // skip absent fields

--- a/src/app/components/BibPage/BibDetails.jsx
+++ b/src/app/components/BibPage/BibDetails.jsx
@@ -189,7 +189,7 @@ class BibDetails extends React.Component {
     const linkArray = singleSubjectHeadingArray.map((heading, index) => {
       return(
         <Link
-          onClick={e => this.newSearch(e, url, fieldValue, bibValue, fieldLabel)}
+          onClick={e => this.newSearch(e, urlArray[index], fieldValue, bibValue, fieldLabel)}
           to={`${appConfig.baseUrl}/search?${urlArray[index]}.`}
           key={index}
         >

--- a/src/app/components/BibPage/BibDetails.jsx
+++ b/src/app/components/BibPage/BibDetails.jsx
@@ -174,10 +174,48 @@ class BibDetails extends React.Component {
     );
   }
 
+  constructSubjectHeading(bibValue, url, fieldValue, fieldLabel) {
+    let currentArrayString = '';
+    const singleSubjectHeadingArray = bibValue.split(' > ');
+    const returnArray = [];
+
+    const urlArray = url.split(' > ').map((urlString, index) => {
+      const dashDivided = (index !== 0) ? ' -- ' : '';
+      currentArrayString = `${currentArrayString}${dashDivided}${urlString}`;
+
+      return currentArrayString;
+    });
+
+    const linkArray = singleSubjectHeadingArray.map((heading, index) => {
+      return(
+        <Link
+          onClick={e => this.newSearch(e, url, fieldValue, bibValue, fieldLabel)}
+          to={`${appConfig.baseUrl}/search?${urlArray[index]}.`}
+          key={index}
+        >
+          {heading}
+        </Link>
+      );
+    });
+
+    linkArray.forEach((linkElement, index) => {
+      returnArray.push(linkElement);
+      if (index < linkArray.length - 1) {
+        returnArray.push(<span key={`divider-${index}`}> > </span>);
+      }
+    });
+
+    return(returnArray);
+  }
+
   getDefinitionOneItem (
     bibValue, url, bibValues, fieldValue, fieldLinkable, fieldIdentifier,
     fieldSelfLinkable, fieldLabel
   ) {
+
+    if (fieldValue === 'subjectLiteral') {
+      return this.constructSubjectHeading(bibValue, url, fieldValue, fieldLabel);
+    }
 
     if (fieldLinkable) {
       return (
@@ -204,14 +242,22 @@ class BibDetails extends React.Component {
     return <span>{bibValue}</span>;
   }
 
+  compressSubjectLiteral(subjectLiteralArray) {
+    if (Array.isArray(subjectLiteralArray) && subjectLiteralArray.length) {
+      subjectLiteralArray = subjectLiteralArray.map((item) => {
+        return item.replace(/\.$/, '').replace(/--/g, '>');
+      });
+    }
+
+    return subjectLiteralArray;
+  }
+
   /**
    * getDisplayFields(bib)
    * Get an array of definition term/values.
    * @param {object} bib
    * @return {array}
    */
-
-
   getDisplayFields(bib) {
     // A value of 'React Component' just means that we are getting it from a
     // component rather than from the bib field properties.
@@ -225,6 +271,10 @@ class BibDetails extends React.Component {
       const fieldSelfLinkable = field.selfLinkable;
       const fieldIdentifier = field.identifier;
       const bibValues = bib[fieldValue];
+
+      if (fieldValue === 'subjectLiteral') {
+        bib[fieldValue] = this.compressSubjectLiteral(bib[fieldValue]);
+      }
 
       // skip absent fields
       if (bibValues && bibValues.length && _isArray(bibValues)) {

--- a/src/app/components/BibPage/BibDetails.jsx
+++ b/src/app/components/BibPage/BibDetails.jsx
@@ -27,8 +27,9 @@ class BibDetails extends React.Component {
     this.owner = getOwner(this.props.bib);
   }
 
-  /*
+  /**
    * Return note array or null.
+   *
    * @param {object} bib
    * @return {null|array}
    */
@@ -43,15 +44,17 @@ class BibDetails extends React.Component {
     return notes;
   }
 
-  /*
+  /**
    * getDefinitionObject(bibValues, fieldValue, fieldLinkable, fieldSelfLinkable, fieldLabel)
    * Gets a list, or one value, of data to display for a field from the API, where
    * the data is an object in the array.
-   * @param {array} bibValues
-   * @param {string} fieldValue
-   * @param {boolean} fieldLinkable
-   * @param {boolean} fieldSelfLinkable
-   * @param {string} fieldLabel
+   *
+   * @param {array} bibValues - the value(s) of the current field
+   * @param {string} fieldValue - the name of the current field
+   * @param {boolean} fieldLinkable - flags true if the field should be clickable
+   * @param {boolean} fieldSelfLinkable - flags true if the Bib field already has a URL
+   * @param {string} fieldLabel - offers the type of search keywords
+   * @return {HTML element}
    */
   getDefinitionObject(bibValues, fieldValue, fieldLinkable, fieldSelfLinkable, fieldLabel) {
     // If there's only one value, we just want that value and not a list.
@@ -137,16 +140,18 @@ class BibDetails extends React.Component {
     return null;
   }
 
-  /*
+  /**
    * getDefinition(bibValues, fieldValue, fieldLinkable, fieldIdentifier,
    * fieldSelfLinkable, fieldLabel)
    * Gets a list, or one value, of data to display for a field from the API.
-   * @param {array} bibValues
-   * @param {string} fieldValue
-   * @param {boolean} fieldLinkable
+   *
+   * @param {array} bibValues - the value(s) of the current field
+   * @param {string} fieldValue - the name of the current field
+   * @param {boolean} fieldLinkable  - flags true if the field should be clickable
    * @param {string} fieldIdentifier
-   * @param {string} fieldSelfLinkable
-   * @param {string} fieldLabel
+   * @param {string} fieldSelfLinkable - flags true if the Bib field already has a URL
+   * @param {string} fieldLabel - offers the type of search keywords
+   * @return {HTML element}
    */
   getDefinition(
     bibValues, fieldValue, fieldLinkable, fieldIdentifier,
@@ -174,25 +179,37 @@ class BibDetails extends React.Component {
     );
   }
 
+  /**
+   * constructSubjectHeading(bibValue, url, fieldValue, fieldLabel)
+   * Constructs the link elements of subject headings.
+   *
+   * @param {string} bibValue - for constructing the texts of link elements
+   * @param {string} url - for constructing the query values of the URLs
+   * @param {string} fieldValue - offers the values of search keywords
+   * @param {string} fieldLabel - offers the type of search keywords
+   * @return {HTML element}
+   */
   constructSubjectHeading(bibValue, url, fieldValue, fieldLabel) {
     let currentArrayString = '';
+    const filterQueryForSubjectHeading = 'filters[subjectLiteral]=';
     const singleSubjectHeadingArray = bibValue.split(' > ');
     const returnArray = [];
 
-    const urlArray = url.split(' > ').map((urlString, index) => {
-      const dashDivided = (index !== 0) ? ' -- ' : '';
-      currentArrayString = `${currentArrayString}${dashDivided}${urlString}`;
+    const urlArray = url.replace(filterQueryForSubjectHeading, '').split(' > ')
+      .map((urlString, index) => {
+        const dashDivided = (index !== 0) ? ' -- ' : '';
+        currentArrayString = `${currentArrayString}${dashDivided}${urlString}`;
 
-      return currentArrayString;
-    });
+        return currentArrayString;
+      });
 
     const linkArray = singleSubjectHeadingArray.map((heading, index) => {
-      const searchQueryValue = urlArray[index].replace('filters[subjectLiteral]=', '');
+      const urlWithFilterQuery = `${filterQueryForSubjectHeading}${urlArray[index]}`;
 
       return(
         <Link
-          onClick={e => this.newSearch(e, urlArray[index], fieldValue, searchQueryValue, fieldLabel)}
-          to={`${appConfig.baseUrl}/search?${urlArray[index]}.`}
+          onClick={e => this.newSearch(e, urlWithFilterQuery, fieldValue, urlArray[index], fieldLabel)}
+          to={`${appConfig.baseUrl}/search?${urlWithFilterQuery}.`}
           key={index}
         >
           {heading}
@@ -210,11 +227,25 @@ class BibDetails extends React.Component {
     return returnArray;
   }
 
+  /**
+   * getDefinitionOneItem (bibValue, url, bibValues, fieldValue, fieldLinkable, fieldIdentifier,
+   * fieldSelfLinkable, fieldLabel)
+   * Gets the value for a single Bib detail field.
+   *
+   * @param {string} bibValue - the value for the current field
+   * @param {string} url - for constructing the query values of the URLs
+   * @param {string} bibValues
+   * @param {string} fieldValue - the name of the current field
+   * @param {boolean} fieldLinkable - if the field should be clickable
+   * @param {string} fieldIdentifier
+   * @param {boolean} fieldSelfLinkable - if the Bib field already has a URL
+   * @param {string} fieldLabel - offers the type of search keywords
+   * @return {HTML element}
+   */
   getDefinitionOneItem (
     bibValue, url, bibValues, fieldValue, fieldLinkable, fieldIdentifier,
     fieldSelfLinkable, fieldLabel
   ) {
-
     if (fieldValue === 'subjectLiteral') {
       return this.constructSubjectHeading(bibValue, url, fieldValue, fieldLabel);
     }
@@ -244,6 +275,13 @@ class BibDetails extends React.Component {
     return <span>{bibValue}</span>;
   }
 
+  /**
+   * compressSubjectLiteral(subjectLiteralArray)
+   * Updates the string structure of subject literals.
+   *
+   * @param {array} subjectLiteralArray
+   * @return {array}
+   */
   compressSubjectLiteral(subjectLiteralArray) {
     if (Array.isArray(subjectLiteralArray) && subjectLiteralArray.length) {
       subjectLiteralArray = subjectLiteralArray.map((item) => {
@@ -257,6 +295,7 @@ class BibDetails extends React.Component {
   /**
    * getDisplayFields(bib)
    * Get an array of definition term/values.
+   *
    * @param {object} bib
    * @return {array}
    */
@@ -407,7 +446,7 @@ class BibDetails extends React.Component {
     return fieldsToRender;
   }
 
-  /*
+  /**
    * Display for single and multivalued object arrays.
    * @param {array} note
    * @return {string}
@@ -443,6 +482,17 @@ class BibDetails extends React.Component {
     return display;
   }
 
+  /**
+   * newSearch(e, query, field, value, label)
+   * The method that passed as a callback to a Link element for handling onClick events.
+   *
+   * @param e {event} - onClick event
+   * @param {string} query - the search query that is attached to the search endpoint
+   * @param {string} field - the type of the search query
+   * @param {string} value - the search keyword of the search. It will be used for the filter button
+   * @param {string} label - the type of the search keyword. It will be used for
+   * the search instruction
+   */
   newSearch(e, query, field, value, label) {
     e.preventDefault();
     this.props.updateIsLoadingState(true);

--- a/src/app/components/BibPage/BibDetails.jsx
+++ b/src/app/components/BibPage/BibDetails.jsx
@@ -7,7 +7,6 @@ import {
   isEmpty as _isEmpty,
   findWhere as _findWhere,
   findIndex as _findIndex,
-  every as _every,
 } from 'underscore';
 
 import Actions from '../../actions/Actions';
@@ -21,7 +20,6 @@ import getOwner from '../../utils/getOwner';
 import LibraryItem from '../../utils/item';
 
 class BibDetails extends React.Component {
-
   constructor(props) {
     super(props);
     this.owner = getOwner(this.props.bib);
@@ -35,7 +33,7 @@ class BibDetails extends React.Component {
    */
   getNote(bib) {
     const note = bib.note;
-    let notes = note && note.length ? note : null;
+    const notes = note && note.length ? note : null;
 
     if (!notes) {
       return null;
@@ -88,26 +86,29 @@ class BibDetails extends React.Component {
     }
 
     return (
-      <ul className={'additionalDetails'}>
+      <ul className="additionalDetails">
         {
           bibValues.map((value, i) => {
             const url = `filters[${fieldValue}]=${value['@id']}`;
             let itemValue = fieldLinkable ?
-              (<Link
-                onClick={e => this.newSearch(e, url, fieldValue, value['@id'], fieldLabel)}
-                to={`${appConfig.baseUrl}/search?${url}`}
-              >
-                {value.prefLabel}
-              </Link>)
+              (
+                <Link
+                  onClick={e => this.newSearch(e, url, fieldValue, value['@id'], fieldLabel)}
+                  to={`${appConfig.baseUrl}/search?${url}`}
+                >
+                  {value.prefLabel}
+                </Link>
+              )
               : <span>{value.prefLabel}</span>;
             if (fieldSelfLinkable) {
-              itemValue =
-                (<a
+              itemValue = (
+                <a
                   href={value['@id']}
                   onClick={() => trackDiscovery('Bib fields', `${fieldLabel} - ${value.prefLabel}`)}
                 >
                   {value.prefLabel}
-                </a>);
+                </a>
+              );
             }
 
             return (<li key={i}>{itemValue}</li>);
@@ -164,7 +165,16 @@ class BibDetails extends React.Component {
     if (bibValues.length === 1) {
       const bibValue = bibValues[0];
       const url = `filters[${fieldValue}]=${bibValue}`;
-      return this.getDefinitionOneItem(bibValue, url, bibValues, fieldValue, fieldLinkable, fieldIdentifier, fieldSelfLinkable, fieldLabel)
+      return this.getDefinitionOneItem(
+        bibValue,
+        url,
+        bibValues,
+        fieldValue,
+        fieldLinkable,
+        fieldIdentifier,
+        fieldSelfLinkable,
+        fieldLabel,
+      );
     }
 
     return (
@@ -177,54 +187,6 @@ class BibDetails extends React.Component {
         }
       </ul>
     );
-  }
-
-  /**
-   * constructSubjectHeading(bibValue, url, fieldValue, fieldLabel)
-   * Constructs the link elements of subject headings.
-   *
-   * @param {string} bibValue - for constructing the texts of link elements
-   * @param {string} url - for constructing the query values of the URLs
-   * @param {string} fieldValue - offers the values of search keywords
-   * @param {string} fieldLabel - offers the type of search keywords
-   * @return {HTML element}
-   */
-  constructSubjectHeading(bibValue, url, fieldValue, fieldLabel) {
-    let currentArrayString = '';
-    const filterQueryForSubjectHeading = 'filters[subjectLiteral]=';
-    const singleSubjectHeadingArray = bibValue.split(' > ');
-    const returnArray = [];
-
-    const urlArray = url.replace(filterQueryForSubjectHeading, '').split(' > ')
-      .map((urlString, index) => {
-        const dashDivided = (index !== 0) ? ' -- ' : '';
-        currentArrayString = `${currentArrayString}${dashDivided}${urlString}`;
-
-        return currentArrayString;
-      });
-
-    singleSubjectHeadingArray.forEach((heading, index) => {
-      const urlWithFilterQuery = `${filterQueryForSubjectHeading}${urlArray[index]}`;
-
-      const subjectHeadingLink = (
-        <Link
-          onClick={e => this.newSearch(e, urlWithFilterQuery, fieldValue, urlArray[index], fieldLabel)}
-          to={`${appConfig.baseUrl}/search?${urlWithFilterQuery}.`}
-          key={index}
-        >
-          {heading}
-        </Link>
-      );
-
-      returnArray.push(subjectHeadingLink);
-
-      // Push a divider in between the link elements
-      if (index < singleSubjectHeadingArray.length - 1) {
-        returnArray.push(<span key={`divider-${index}`}> > </span>);
-      }
-    });
-
-    return returnArray;
   }
 
   /**
@@ -242,9 +204,9 @@ class BibDetails extends React.Component {
    * @param {string} fieldLabel - offers the type of search keywords
    * @return {HTML element}
    */
-  getDefinitionOneItem (
+  getDefinitionOneItem(
     bibValue, url, bibValues, fieldValue, fieldLinkable, fieldIdentifier,
-    fieldSelfLinkable, fieldLabel
+    fieldSelfLinkable, fieldLabel,
   ) {
     if (fieldValue === 'subjectLiteral') {
       return this.constructSubjectHeading(bibValue, url, fieldValue, fieldLabel);
@@ -273,23 +235,6 @@ class BibDetails extends React.Component {
     }
 
     return <span>{bibValue}</span>;
-  }
-
-  /**
-   * compressSubjectLiteral(subjectLiteralArray)
-   * Updates the string structure of subject literals.
-   *
-   * @param {array} subjectLiteralArray
-   * @return {array}
-   */
-  compressSubjectLiteral(subjectLiteralArray) {
-    if (Array.isArray(subjectLiteralArray) && subjectLiteralArray.length) {
-      subjectLiteralArray = subjectLiteralArray.map((item) => {
-        return item.replace(/\.$/, '').replace(/--/g, '>');
-      });
-    }
-
-    return subjectLiteralArray;
   }
 
   /**
@@ -418,8 +363,8 @@ class BibDetails extends React.Component {
           electronicElem = (
             <ul>
               {
-                electronicResources.map((e, i) => (
-                  <li key={i}>
+                electronicResources.map(e => (
+                  <li key={e.label}>
                     <a
                       href={e.url}
                       target="_blank"
@@ -444,6 +389,73 @@ class BibDetails extends React.Component {
     }); // End of the forEach loop
 
     return fieldsToRender;
+  }
+
+  /**
+   * compressSubjectLiteral(subjectLiteralArray)
+   * Updates the string structure of subject literals.
+   *
+   * @param {array} subjectLiteralArray
+   * @return {array}
+   */
+  compressSubjectLiteral(subjectLiteralArray) {
+    if (Array.isArray(subjectLiteralArray) && subjectLiteralArray.length) {
+      subjectLiteralArray = subjectLiteralArray.map(item =>
+        item.replace(/\.$/, '').replace(/--/g, '>'),
+      );
+    }
+
+    return subjectLiteralArray;
+  }
+
+  /**
+   * constructSubjectHeading(bibValue, url, fieldValue, fieldLabel)
+   * Constructs the link elements of subject headings.
+   *
+   * @param {string} bibValue - for constructing the texts of link elements
+   * @param {string} url - for constructing the query values of the URLs
+   * @param {string} fieldValue - offers the values of search keywords
+   * @param {string} fieldLabel - offers the type of search keywords
+   * @return {HTML element}
+   */
+  constructSubjectHeading(bibValue, url, fieldValue, fieldLabel) {
+    let currentArrayString = '';
+    const filterQueryForSubjectHeading = 'filters[subjectLiteral]=';
+    const singleSubjectHeadingArray = bibValue.split(' > ');
+    const returnArray = [];
+
+    const urlArray = url.replace(filterQueryForSubjectHeading, '').split(' > ')
+      .map((urlString, index) => {
+        const dashDivided = (index !== 0) ? ' -- ' : '';
+        currentArrayString = `${currentArrayString}${dashDivided}${urlString}`;
+
+        return currentArrayString;
+      });
+
+    singleSubjectHeadingArray.forEach((heading, index) => {
+      const urlWithFilterQuery = `${filterQueryForSubjectHeading}${urlArray[index]}`;
+
+      const subjectHeadingLink = (
+        <Link
+          onClick={
+            e => this.newSearch(e, urlWithFilterQuery, fieldValue, urlArray[index], fieldLabel)
+          }
+          to={`${appConfig.baseUrl}/search?${urlWithFilterQuery}.`}
+          key={index}
+        >
+          {heading}
+        </Link>
+      );
+
+      returnArray.push(subjectHeadingLink);
+
+      // Push a divider in between the link elements
+      if (index < singleSubjectHeadingArray.length - 1) {
+        returnArray.push(<span key={`divider-${index}`}> &gt; </span>);
+      }
+    });
+
+    return returnArray;
   }
 
   /**

--- a/src/app/components/BibPage/BibDetails.jsx
+++ b/src/app/components/BibPage/BibDetails.jsx
@@ -187,9 +187,11 @@ class BibDetails extends React.Component {
     });
 
     const linkArray = singleSubjectHeadingArray.map((heading, index) => {
+      const searchQueryValue = urlArray[index].replace('filters[subjectLiteral]=', '');
+
       return(
         <Link
-          onClick={e => this.newSearch(e, urlArray[index], fieldValue, bibValue, fieldLabel)}
+          onClick={e => this.newSearch(e, urlArray[index], fieldValue, searchQueryValue, fieldLabel)}
           to={`${appConfig.baseUrl}/search?${urlArray[index]}.`}
           key={index}
         >
@@ -205,7 +207,7 @@ class BibDetails extends React.Component {
       }
     });
 
-    return(returnArray);
+    return returnArray;
   }
 
   getDefinitionOneItem (

--- a/src/app/components/BibPage/BibDetails.jsx
+++ b/src/app/components/BibPage/BibDetails.jsx
@@ -203,10 +203,10 @@ class BibDetails extends React.Component {
         return currentArrayString;
       });
 
-    const linkArray = singleSubjectHeadingArray.map((heading, index) => {
+    singleSubjectHeadingArray.forEach((heading, index) => {
       const urlWithFilterQuery = `${filterQueryForSubjectHeading}${urlArray[index]}`;
 
-      return(
+      const subjectHeadingLink = (
         <Link
           onClick={e => this.newSearch(e, urlWithFilterQuery, fieldValue, urlArray[index], fieldLabel)}
           to={`${appConfig.baseUrl}/search?${urlWithFilterQuery}.`}
@@ -215,11 +215,11 @@ class BibDetails extends React.Component {
           {heading}
         </Link>
       );
-    });
 
-    linkArray.forEach((linkElement, index) => {
-      returnArray.push(linkElement);
-      if (index < linkArray.length - 1) {
+      returnArray.push(subjectHeadingLink);
+
+      // Push a divider in between the link elements
+      if (index < singleSubjectHeadingArray.length - 1) {
         returnArray.push(<span key={`divider-${index}`}> > </span>);
       }
     });

--- a/src/app/components/BibPage/DefinitionList.jsx
+++ b/src/app/components/BibPage/DefinitionList.jsx
@@ -8,13 +8,14 @@ import PropTypes from 'prop-types';
 const DefinitionList = ({ data }) => {
   const getDefinitions = (definitions) => {
 
-    return definitions.map((item) => {
+    return definitions.map((item, i) => {
       if (!item || (!item.term && !item.definition)) {
         return null;
       }
+
       return ([
-        (<dt key={item.term}>{item.term}</dt>),
-        (<dd key={item.definition}>{item.definition}</dd>),
+        (<dt key={`term-${i}`}>{item.term}</dt>),
+        (<dd key={`definition-${i}`}>{item.definition}</dd>),
       ]);
     });
   };

--- a/test/unit/BibDetails.test.js
+++ b/test/unit/BibDetails.test.js
@@ -335,7 +335,7 @@ describe('BibDetails', () => {
     });
   });
 
-  describe.only('Subject headings', () => {
+  describe('Subject headings', () => {
     const fields = [
       { label: 'Publication', value: 'publicationStatement' },
       { label: 'Publication Date', value: 'serialPublicationDates' },

--- a/test/unit/BibDetails.test.js
+++ b/test/unit/BibDetails.test.js
@@ -318,14 +318,6 @@ describe('BibDetails', () => {
         expect(component.find('dt')).to.have.lengthOf(8);
         expect(component.find('dd').at(0).text()).to.equal(bibs[0].publicationStatement[0]);
         expect(component.find('dd').at(1).text()).to.equal(bibs[0].extent[0]);
-        // Expect 4 specific subjectLiterals:
-        expect(component.find('dd').at(2).find('li')).to.have.lengthOf(4);
-        bibs[0].subjectLiteral.forEach((subjectLiteral, ind) => {
-          expect(
-            component.find('dd').at(2).find('li').at(ind)
-              .text(),
-          ).to.equal(subjectLiteral);
-        });
         // Note with noteType=Bibliography:
         expect(component.find('dd').at(3).text()).to.equal(bibs[0].note[0].prefLabel);
         expect(component.find('dd').at(4).text()).to.equal(bibs[0].shelfMark[0]);
@@ -339,6 +331,52 @@ describe('BibDetails', () => {
         // Lccn:
         const lccn = bibs[0].identifier.filter(ident => ident['@type'] === 'bf:Lccn').pop();
         expect(component.find('dd').at(6).text()).to.equal(lccn['@value']);
+      });
+    });
+  });
+
+  describe.only('Subject headings', () => {
+    const fields = [
+      { label: 'Publication', value: 'publicationStatement' },
+      { label: 'Publication Date', value: 'serialPublicationDates' },
+      { label: 'Electronic Resource', value: 'React Component' },
+      { label: 'Description', value: 'extent' },
+      { label: 'Series Statement', value: 'seriesStatement' },
+      { label: 'Uniform Title', value: 'uniformTitle' },
+      { label: 'Alternative Title', value: 'titleAlt' },
+      { label: 'Former Title', value: 'formerTitle' },
+      { label: 'Subject', value: 'subjectLiteral', linkable: true },
+      { label: 'Genre/Form', value: 'genreForm' },
+      { label: 'Notes', value: 'React Component' },
+      { label: 'Additional Resources', value: 'supplementaryContent', selfLinkable: true },
+      { label: 'Contents', value: 'tableOfContents' },
+      { label: 'Bibliography', value: '' },
+      { label: 'Call Number', value: 'identifier', identifier: 'bf:ShelfMark' },
+      { label: 'ISBN', value: 'identifier', identifier: 'bf:Isbn' },
+      { label: 'ISSN', value: 'identifier', identifier: 'bf:Issn' },
+      { label: 'LCCN', value: 'identifier', identifier: 'bf:Lccn' },
+      { label: 'OCLC', value: 'identifier', identifier: 'nypl:Oclc' },
+      { label: 'GPO', value: '' },
+      { label: 'Other Titles', value: '' },
+      { label: 'Owning Institutions', value: '' },
+    ];
+    let component;
+    const expectSubjectLiterals = [
+      'Editing > History > 18th century',
+      'Malone, Edmond, 1741-1812',
+      'Shakespeare, William, 1564-1616 > Criticism, Textual',
+      'Shakespeare, William, 1564-1616',
+    ];
+
+    it('should render proper texts and link(s) for each subject heading', () => {
+      component = mount(React.createElement(BibDetails, { bib: bibs[0], fields }));
+
+      // Expect 4 specific subjectLiterals:
+      expect(component.find('dd').at(2).find('li')).to.have.lengthOf(4);
+      expectSubjectLiterals.forEach((subjectLiteral, ind) => {
+        expect(
+          component.find('dd').at(2).find('li').at(ind).text(),
+        ).to.equal(subjectLiteral);
       });
     });
   });

--- a/test/unit/BibDetails.test.js
+++ b/test/unit/BibDetails.test.js
@@ -362,21 +362,52 @@ describe('BibDetails', () => {
     ];
     let component;
     const expectSubjectLiterals = [
-      'Editing > History > 18th century',
-      'Malone, Edmond, 1741-1812',
-      'Shakespeare, William, 1564-1616 > Criticism, Textual',
-      'Shakespeare, William, 1564-1616',
+      { text: 'Editing > History > 18th century',
+        linksAffixes: [
+          'Editing',
+          'Editing -- History',
+          'Editing -- History -- 18th century',
+        ],
+      },
+      { text: 'Malone, Edmond, 1741-1812',
+        linksAffixes: [
+          'Malone, Edmond, 1741-1812',
+        ],
+      },
+      { text: 'Shakespeare, William, 1564-1616 > Criticism, Textual',
+        linksAffixes: [
+          'Shakespeare, William, 1564-1616',
+          'Shakespeare, William, 1564-1616 -- Criticism, Textual',
+        ],
+      },
+      { text: 'Shakespeare, William, 1564-1616',
+        linksAffixes: [
+          'Shakespeare, William, 1564-1616',
+        ],
+      },
     ];
 
     it('should render proper texts and link(s) for each subject heading', () => {
-      component = mount(React.createElement(BibDetails, { bib: bibs[0], fields }));
+      component = mount(
+        React.createElement(
+          BibDetails, { bib: bibs[0], fields }
+        )
+      );
 
       // Expect 4 specific subjectLiterals:
       expect(component.find('dd').at(2).find('li')).to.have.lengthOf(4);
       expectSubjectLiterals.forEach((subjectLiteral, ind) => {
         expect(
           component.find('dd').at(2).find('li').at(ind).text(),
-        ).to.equal(subjectLiteral);
+        ).to.equal(subjectLiteral.text);
+        subjectLiteral.linksAffixes.forEach((affix, index) => {
+          expect(
+            component.find('dd').at(2).find('li').at(ind).find('Link').at(index).prop('to')
+          ).to.equal(
+            '/research/collections/shared-collection-catalog/search?filters[subjectLiteral]='
+            + `${affix}.`
+          );
+        });
       });
     });
   });


### PR DESCRIPTION
This PR basically adds two condition checks to see if the bib detail field is subject headings. If so, it will calls the addiontal string methods to generate new texts and URLs for the link.

Can be tested here locally,
http://local.nypl.org:3001/research/collections/shared-collection-catalog/bib/b21160519

Now the subject headings should look like
```
Amateur journalism > Australia > Periodicals
Amateur journalism
Australian Amateur Journalists' Association > Periodicals
Golden Hours Corresponding Club > Periodicals
```

And the filter values should be (as the example of the first subject heading)
```
Amateur journalism. > Amateur journalism -- Australia. > Amateur journalism -- Australia -- Periodicals.
```