### PR TITLE
Add exploding of subject literals in aggregations

### DIFF
--- a/src/app/components/Filters/FieldsetList.jsx
+++ b/src/app/components/Filters/FieldsetList.jsx
@@ -47,6 +47,8 @@ class FieldsetList extends React.Component {
     } = this.props;
     const values = this.state.values;
 
+    console.log('values: ', JSON.stringify(values, null, 4));
+
     if (!values || !values.length) {
       return null;
     }
@@ -73,7 +75,7 @@ class FieldsetList extends React.Component {
                     checked={filter.selected}
                   />
                   <label htmlFor={`${filter.label}-label`}>
-                    {filterLabel} ({filter.count.toLocaleString()})
+                    {filterLabel} {filter.count ? `(${filter.count.toLocaleString()})` : null}
                   </label>
                 </li>
               );

--- a/src/app/components/Filters/FieldsetList.jsx
+++ b/src/app/components/Filters/FieldsetList.jsx
@@ -47,8 +47,6 @@ class FieldsetList extends React.Component {
     } = this.props;
     const values = this.state.values;
 
-    console.log('values: ', JSON.stringify(values, null, 4));
-
     if (!values || !values.length) {
       return null;
     }

--- a/src/app/components/SearchResultsPage/SearchResultsPage.jsx
+++ b/src/app/components/SearchResultsPage/SearchResultsPage.jsx
@@ -117,9 +117,9 @@ class SearchResultsPage extends React.Component {
       });
     };
     const searchError = location.query && location.query.error ? location.query.error : '';
-    const apiFilters = filters && filters.itemListElement && filters.itemListElement.length ?
+    let apiFilters = filters && filters.itemListElement && filters.itemListElement.length ?
       filters.itemListElement : [];
-    subjectFilterUtil.narrowSubjectFilters(apiFilters, selectedFilters || {});
+    apiFilters = subjectFilterUtil.narrowSubjectFilters(apiFilters, selectedFilters || {});
     const dateFilterErrors = [];
     const selectedFiltersAvailable = this.checkForSelectedFilters();
 

--- a/src/app/utils/subjectFilterUtils.js
+++ b/src/app/utils/subjectFilterUtils.js
@@ -14,86 +14,19 @@ const subjectFilterUtil = {
   },
 
   /**
-    params: subjectFilterObject is an object representing a subject filter, e.g.
-    {
-      value: 'Dogs -- Painting -- Smoking',
-      label: 'Dogs -- Painting -- Smoking',
-      count: 100000000,
-    }
-    returns an array of exploded values, e.g.
-    ['Dogs', 'Dogs -- Painting', 'Dogs -- Painting -- Smoking']
-  */
-
-  explodeSubjectFilter(subjectFilterObject) {
-    const explodedValues = subjectFilterObject
-      .value
-      .replace(/\.$/, '')
-      .split(/--/g);
-    return explodedValues.map((_, i) => explodedValues.slice(0, i + 1).join('--').trim());
-  },
-
-  /**
-    params: selectedSubjectLiteralFilters is an object with a 'values' property, which
-    points to an array of filters represented by objects of the form:
-    {
-      value,
-      label,
-      count
-    }
-    e.g. the value could be 'Dogs -- Card Games -- Painting.'
-
-    explodedSubjectFilters modifies the array by replacing the values with exploded
-    versions of those values. Exploded values have no 'count' property.
-  */
-
-  explodeSubjectFilters(selectedSubjectLiteralFilters) {
-    let explodedSubjectFilters = selectedSubjectLiteralFilters
-      .values
-      .reduce((acc, subjectFilterObject) => {
-        this.explodeSubjectFilter(subjectFilterObject)
-          .forEach((explodedSubjectFilter) => {
-            acc.add(explodedSubjectFilter);
-          });
-        return acc;
-      }, new Set());
-    explodedSubjectFilters = Array.from(explodedSubjectFilters)
-      .map(explodedSubjectFilter => (
-        {
-          value: explodedSubjectFilter,
-          label: explodedSubjectFilter,
-        }
-      ),
-      );
-    selectedSubjectLiteralFilters.values = explodedSubjectFilters;
-  },
-
-  /**
     params:
       apiFilters: an object containing all the aggregations received from the api
       selectedFilters: an object containing the currently selected filters (selected in
          the Refine Search accordion)
     narrowSubjectFilters returns a new object, which is a copy of apiFilters but with only
-     the selected subjectLiteralFilters
+     the selected subjectFilters from selectedFilters
   */
-
   narrowSubjectFilters(apiFilters, selectedFilters) {
-    // deep copy the apiFilters object
     const newApiFilters = JSON.parse(JSON.stringify(apiFilters));
-    // grab the aggregated subject literal filters
     const subjectLiteralFilters = this.getSubjectLiteralFilters(newApiFilters);
-    // add the exploded subject literals if there are any
-    if (subjectLiteralFilters) {
-      this.explodeSubjectFilters(subjectLiteralFilters);
-    }
-    // get the selected subject literals
     const selectedSubjectLiteralFilters = selectedFilters.subjectLiteral || [];
-    // build a function which filters subject filters down to those in selectedSubjectLiteralFilters
-    const checkIsSelected = this.subjectFilterIsSelected(selectedSubjectLiteralFilters);
-    // remove all the unselected filters from subject literal filters
     if (subjectLiteralFilters) {
-      subjectLiteralFilters.values = subjectLiteralFilters
-        .values
-        .filter(checkIsSelected);
+      subjectLiteralFilters.values = selectedSubjectLiteralFilters;
     }
     return newApiFilters;
   },

--- a/src/app/utils/subjectFilterUtils.js
+++ b/src/app/utils/subjectFilterUtils.js
@@ -35,7 +35,9 @@ const subjectFilterUtil = {
   narrowSubjectFilters(apiFilters, selectedFilters) {
     const newApiFilters = JSON.parse(JSON.stringify(apiFilters));
     const subjectLiteralFilters = this.getSubjectLiteralFilters(newApiFilters);
-    this.explodeSubjectFilters(subjectLiteralFilters);
+    if (subjectLiteralFilters) {
+      this.explodeSubjectFilters(subjectLiteralFilters);
+    }
     const selectedSubjectLiteralFilters = selectedFilters.subjectLiteral || [];
     const checkIsSelected = this.subjectFilterIsSelected(selectedSubjectLiteralFilters);
     if (subjectLiteralFilters) {

--- a/src/app/utils/subjectFilterUtils.js
+++ b/src/app/utils/subjectFilterUtils.js
@@ -13,6 +13,17 @@ const subjectFilterUtil = {
       );
   },
 
+  /**
+    params: subjectFilterObject is an object representing a subject filter, e.g.
+    {
+      value: 'Dogs -- Painting -- Smoking',
+      label: 'Dogs -- Painting -- Smoking',
+      count: 100000000,
+    }
+    returns an array of exploded values, e.g.
+    ['Dogs', 'Dogs -- Painting', 'Dogs -- Painting -- Smoking']
+  */
+
   explodeSubjectFilter(subjectFilterObject) {
     const explodedValues = subjectFilterObject
       .value
@@ -31,23 +42,8 @@ const subjectFilterUtil = {
     }
     e.g. the value could be 'Dogs -- Card Games -- Painting.'
 
-    explodedSubjectFilters modifies the array by adding
-
-    {
-      value: X,
-      label: X,
-      count: Y
-    }
-
-    whenever
-
-    {
-      value: X -- Z,
-      label: X -- Z,
-      count: Y
-    }
-
-    is in the original array.
+    explodedSubjectFilters modifies the array by replacing the values with exploded
+    versions of those values. Exploded values have no 'count' property.
   */
 
   explodeSubjectFilters(selectedSubjectLiteralFilters) {

--- a/src/app/utils/subjectFilterUtils.js
+++ b/src/app/utils/subjectFilterUtils.js
@@ -73,12 +73,17 @@ const subjectFilterUtil = {
   narrowSubjectFilters(apiFilters, selectedFilters) {
     // deep copy the apiFilters object
     const newApiFilters = JSON.parse(JSON.stringify(apiFilters));
+    // grab the aggregated subject literal filters
     const subjectLiteralFilters = this.getSubjectLiteralFilters(newApiFilters);
+    // add the exploded subject literals if there are any
     if (subjectLiteralFilters) {
       this.explodeSubjectFilters(subjectLiteralFilters);
     }
+    // get the selected subject literals
     const selectedSubjectLiteralFilters = selectedFilters.subjectLiteral || [];
+    // build a function which filters subject filters down to those in selectedSubjectLiteralFilters
     const checkIsSelected = this.subjectFilterIsSelected(selectedSubjectLiteralFilters);
+    // remove all the unselected filters from subject literal filters
     if (subjectLiteralFilters) {
       subjectLiteralFilters.values = subjectLiteralFilters
         .values

--- a/src/app/utils/subjectFilterUtils.js
+++ b/src/app/utils/subjectFilterUtils.js
@@ -13,6 +13,35 @@ const subjectFilterUtil = {
       );
   },
 
+  /**
+    params: selectedSubjectLiteralFilters is an object with a 'values' property, which
+    points to an array of objects of the form:
+    {
+      value,
+      label,
+      count
+    }
+    e.g. the value could be 'Dogs -- Card Games -- Painting.'
+
+    explodedSubjectFilters modifies the array by adding
+
+    {
+      value: X,
+      label: X,
+      count: Y
+    }
+
+    whenever
+
+    {
+      value: X -- Z,
+      label: X -- Z,
+      count: Y
+    }
+
+    is in the original array.
+  */
+
   explodeSubjectFilters(selectedSubjectLiteralFilters) {
     selectedSubjectLiteralFilters
       .values
@@ -32,7 +61,17 @@ const subjectFilterUtil = {
       });
   },
 
+  /**
+    params:
+      apiFilters: an object containing all the aggregations received from the api
+      selectedFilters: an object containing the currently selected filters (selected in
+         the Refine Search accordion)
+    narrowSubjectFilters returns a new object, which is a copy of apiFilters but with only
+     the selected subjectLiteralFilters
+  */
+
   narrowSubjectFilters(apiFilters, selectedFilters) {
+    // deep copy the apiFilters object
     const newApiFilters = JSON.parse(JSON.stringify(apiFilters));
     const subjectLiteralFilters = this.getSubjectLiteralFilters(newApiFilters);
     if (subjectLiteralFilters) {

--- a/src/app/utils/subjectFilterUtils.js
+++ b/src/app/utils/subjectFilterUtils.js
@@ -51,7 +51,6 @@ const subjectFilterUtil = {
   */
 
   explodeSubjectFilters(selectedSubjectLiteralFilters) {
-    console.log('triggerring')
     let explodedSubjectFilters = selectedSubjectLiteralFilters
       .values
       .reduce((acc, subjectFilterObject) => {
@@ -82,7 +81,6 @@ const subjectFilterUtil = {
   */
 
   narrowSubjectFilters(apiFilters, selectedFilters) {
-    console.log('apiFilters: ', JSON.stringify(apiFilters, null, 4), '\n selectedFilters: ', JSON.stringify(selectedFilters, null, 4))
     // deep copy the apiFilters object
     const newApiFilters = JSON.parse(JSON.stringify(apiFilters));
     // grab the aggregated subject literal filters

--- a/src/app/utils/subjectFilterUtils.js
+++ b/src/app/utils/subjectFilterUtils.js
@@ -15,7 +15,7 @@ const subjectFilterUtil = {
 
   /**
     params: selectedSubjectLiteralFilters is an object with a 'values' property, which
-    points to an array of objects of the form:
+    points to an array of filters represented by objects of the form:
     {
       value,
       label,
@@ -46,11 +46,15 @@ const subjectFilterUtil = {
     selectedSubjectLiteralFilters
       .values
       .forEach((valueObject) => {
+        // get all the components of a subject filter, e.g. 'X -- Y -- Z' => ['X', 'Y', 'Z']
         let explodedValues = valueObject
           .value
           .replace(/\.$/, '')
           .split(/--/g);
+        // map all the components to the subject filter up to that point
+        // e.g. [X, Y, Z] => [X, X -- Y, X -- Y -- Z]
         explodedValues = explodedValues.map((_, i) => explodedValues.slice(0, i + 1).join('--').trim());
+        // add objects representing each exploded filter back into the list of filters
         explodedValues.forEach((explodedValue) => {
           selectedSubjectLiteralFilters.values.push({
             value: explodedValue,

--- a/src/app/utils/subjectFilterUtils.js
+++ b/src/app/utils/subjectFilterUtils.js
@@ -13,8 +13,29 @@ const subjectFilterUtil = {
       );
   },
 
+  explodeSubjectFilters(selectedSubjectLiteralFilters) {
+    selectedSubjectLiteralFilters
+      .values
+      .forEach((valueObject) => {
+        let explodedValues = valueObject
+          .value
+          .replace(/\.$/, '')
+          .split(/--/g);
+        explodedValues = explodedValues.map((_, i) => explodedValues.slice(0, i + 1).join('--').trim());
+        explodedValues.forEach((explodedValue) => {
+          selectedSubjectLiteralFilters.values.push({
+            value: explodedValue,
+            label: explodedValue,
+            count: valueObject.count, // this seems like it could cause problems when there is more than one subject
+          });
+        });
+      });
+  },
+
   narrowSubjectFilters(apiFilters, selectedFilters) {
-    const subjectLiteralFilters = this.getSubjectLiteralFilters(apiFilters);
+    const newApiFilters = JSON.parse(JSON.stringify(apiFilters));
+    const subjectLiteralFilters = this.getSubjectLiteralFilters(newApiFilters);
+    this.explodeSubjectFilters(subjectLiteralFilters);
     const selectedSubjectLiteralFilters = selectedFilters.subjectLiteral || [];
     const checkIsSelected = this.subjectFilterIsSelected(selectedSubjectLiteralFilters);
     if (subjectLiteralFilters) {
@@ -22,6 +43,7 @@ const subjectFilterUtil = {
         .values
         .filter(checkIsSelected);
     }
+    return newApiFilters;
   },
 };
 

--- a/test/unit/BibDetails.test.js
+++ b/test/unit/BibDetails.test.js
@@ -405,7 +405,7 @@ describe('BibDetails', () => {
             component.find('dd').at(2).find('li').at(ind).find('Link').at(index).prop('to')
           ).to.equal(
             '/research/collections/shared-collection-catalog/search?filters[subjectLiteral]='
-            + `${affix}.`
+            + `${affix}`
           );
         });
       });

--- a/test/unit/subjectFilterUtil.test.js
+++ b/test/unit/subjectFilterUtil.test.js
@@ -65,9 +65,8 @@ describe('subjectFilterUtil', () => {
     };
     it('should change the subjectLiteral values to only include those which are selected', () => {
       const newApiFilters = subjectFilterUtil.narrowSubjectFilters(apiFilters, selectedFilters);
-      expect(newApiFilters[0].values.length).to.equal(2);
+      expect(newApiFilters[0].values.length).to.equal(1);
       expect(newApiFilters[0].values[0].value).to.equal('puppy');
-      expect(newApiFilters[0].values[1].value).to.equal('puppy');
     });
 
     it('should change the subjectLiteral values to be empty if none are selected', () => {

--- a/test/unit/subjectFilterUtil.test.js
+++ b/test/unit/subjectFilterUtil.test.js
@@ -64,18 +64,21 @@ describe('subjectFilterUtil', () => {
       subjectLiteral: [{ value: 'puppy' }],
     };
     it('should change the subjectLiteral values to only include those which are selected', () => {
-      subjectFilterUtil.narrowSubjectFilters(apiFilters, selectedFilters);
-      expect(apiFilters[0].values.length).to.equal(1);
-      expect(apiFilters[0].values[0].value).to.equal('puppy');
+      const newApiFilters = subjectFilterUtil.narrowSubjectFilters(apiFilters, selectedFilters);
+      console.log('newApiFilters: ', JSON.stringify(newApiFilters, null, 4));
+      expect(newApiFilters[0].values.length).to.equal(2);
+      expect(newApiFilters[0].values[0].value).to.equal('puppy');
+      expect(newApiFilters[0].values[1].value).to.equal('puppy');
     });
 
     it('should change the subjectLiteral values to be empty if none are selected', () => {
-      subjectFilterUtil.narrowSubjectFilters(apiFilters, {});
-      expect(apiFilters[0].values.length).to.equal(0);
+      const newApiFilters = subjectFilterUtil.narrowSubjectFilters(apiFilters, {});
+      expect(newApiFilters[0].values.length).to.equal(0);
     });
 
     it('should leave the other filters unchanged', () => {
-      expect(apiFilters[1].values.length).to.equal(2);
+      const newApiFilters = subjectFilterUtil.narrowSubjectFilters(apiFilters, {});
+      expect(newApiFilters[1].values.length).to.equal(2);
     });
   });
 });

--- a/test/unit/subjectFilterUtil.test.js
+++ b/test/unit/subjectFilterUtil.test.js
@@ -65,7 +65,6 @@ describe('subjectFilterUtil', () => {
     };
     it('should change the subjectLiteral values to only include those which are selected', () => {
       const newApiFilters = subjectFilterUtil.narrowSubjectFilters(apiFilters, selectedFilters);
-      console.log('newApiFilters: ', JSON.stringify(newApiFilters, null, 4));
       expect(newApiFilters[0].values.length).to.equal(2);
       expect(newApiFilters[0].values[0].value).to.equal('puppy');
       expect(newApiFilters[0].values[1].value).to.equal('puppy');


### PR DESCRIPTION
This branch is meant to address the issue of partial subject literals not appearing as possible filters when a user 1) clicks on a subject on a bib page 2) clicks Refine Search  on the search results page.

This branch makes two changes:

1) It adds a method to explode the subject literals in the aggregations so that they will include a match to the partial subject literal
2) It makes the narrowSubjectFilters method return a new object rather than mutating the existing apiFilters object. This is to ensure that we do not lose filters when this method is called on the initial load.

Some issues with this PR:

1) Ideally we would use the same methods to split the subjectLiteral here as in the BibDetails component, but this seemed difficult to do

2) JSON.parse(JSON.stringify(--)) seems like a hacky way to copy an object

(But see https://stackoverflow.com/questions/122102/what-is-the-most-efficient-way-to-deep-clone-an-object-in-javascript according to which it actually has good performance compared to other methods)

3) Not sure how readable the explodeSubjectFilters method is

4) Not sure what to do about the `count` property for exploded subject literals. Right now I am just reporting the count of the parent subject literal, which is wrong, but we need to put something there or the FieldSetList will complain