### PR TITLE
Populate subject literal on direct link

### DIFF
--- a/src/app/components/SearchResultsPage/SearchResultsPage.jsx
+++ b/src/app/components/SearchResultsPage/SearchResultsPage.jsx
@@ -94,7 +94,7 @@ class SearchResultsPage extends React.Component {
       isLoading,
       location,
     } = this.props;
-    
+
     const totalResults = searchResults ? searchResults.totalResults : undefined;
     const totalPages = totalResults ? Math.floor(totalResults / 50) + 1 : 0;
     const results = searchResults ? searchResults.itemListElement : [];

--- a/src/app/components/SearchResultsPage/SearchResultsPage.jsx
+++ b/src/app/components/SearchResultsPage/SearchResultsPage.jsx
@@ -94,7 +94,7 @@ class SearchResultsPage extends React.Component {
       isLoading,
       location,
     } = this.props;
-
+    
     const totalResults = searchResults ? searchResults.totalResults : undefined;
     const totalPages = totalResults ? Math.floor(totalResults / 50) + 1 : 0;
     const results = searchResults ? searchResults.itemListElement : [];

--- a/src/app/utils/utils.js
+++ b/src/app/utils/utils.js
@@ -111,7 +111,7 @@ function destructureFilters(filters, apiFilters) {
         }
       }
     }
-    if (key === 'filters[subjectLiteral]') {
+    if (key.includes('filters[subjectLiteral]')) {
       selectedFilters.subjectLiteral = selectedFilters.subjectLiteral || [];
       selectedFilters.subjectLiteral.push({
         value: value,


### PR DESCRIPTION
Changes the way we find subject literal fields in the url from `===` to `includes`, so that we can recognize arrays of subject literals. This is because keyword search with an active subject literal treats the subject literal as an array with a single element. In particular, if you use browser navigation while doing keyword searches with an active subject literal, the subject literal will only sometimes appear in the filters as it currently is.