### PR TITLE
Add mal17 mal23

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,9 @@ Every time the `Feedback` component has significant updates, it might lead to th
 
 ## Adding Locations
 
-Two local JSONs are critical to adding locations:
+When new Sierra locations (especially Sierra locations that are "delivery locations") are added to [NYPL-Core](https://github.com/NYPL/nypl-core), those locations will need to be added to this app. The complete set of steps for adding a location [is a documented LSP Workflow](https://github.com/NYPL/lsp_workflows/blob/5242526be2ad483c3945b94c3660f523bfdbc6bb/workflows/add_scsb_location.md#add-entries-to-nypl-core).
+
+In this repo, two local JSONs are critical to adding locations:
 
   * `./locations.js`: A JSON mapping major hub names (e.g. "schwarzman", "sibl") to data about them (e.g. "full-name", "address")
   * `./locationCodes.js`: A JSON mapping *all* sierra location codes to their `delivery_location` and relevant hub name (referencing the keys in `./locations.js`) (Note that sierra locations that act only as *delivery locations* must be entered in this hash and cite themselves as `delivery_location`.)
@@ -211,4 +213,4 @@ These files must be kept up to date with newly added locations to ensure that th
   },
 ```
 
-Changes to building hours, name, etc. may necessitate changes to `./locations.js`.
+Less frequently, when an NYPL location address changes, we should change the corresponding entry in `./locations.js`.

--- a/README.md
+++ b/README.md
@@ -195,3 +195,20 @@ Every time the `Feedback` component has significant updates, it might lead to th
  ## Alarm and Monitoring with AWS CloudWatch
 
  As one of the NYPL's services, we want to monitor its condition and receive necessary alarms if an error occurs. We set up the alarms and error filters on NYPL's [AWS CloudWatch](https://aws.amazon.com/cloudwatch/). For more details about setting up alarms and log metrics, please see NYPL engineering-general repo's [Monitoring & Alarms Instruction](https://github.com/NYPL/engineering-general/blob/master/standards/alerting.md).
+
+## Adding Locations
+
+Two local JSONs are critical to adding locations:
+
+  * `./locations.js`: A JSON mapping major hub names (e.g. "schwarzman", "sibl") to data about them (e.g. "full-name", "address")
+  * `./locationCodes.js`: A JSON mapping *all* sierra location codes to their `delivery_location` and relevant hub name (referencing the keys in `./locations.js`) (Note that sierra locations that act only as *delivery locations* must be entered in this hash and cite themselves as `delivery_location`.)
+
+These files must be kept up to date with newly added locations to ensure the delivery locations listing shown on the hold-request page show correct labels. For example, when Scholar rooms 217 and 223 were added to SASB, entries like the following needed to be added to `./locationCodes.js`:
+```
+  "mal17": {
+    "delivery_location": "mal17",
+    "location": "schwarzman"
+  },
+```
+
+Changes to building hours, name, etc. may necessitate changes to `./locations.js`.

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ Two local JSONs are critical to adding locations:
   * `./locations.js`: A JSON mapping major hub names (e.g. "schwarzman", "sibl") to data about them (e.g. "full-name", "address")
   * `./locationCodes.js`: A JSON mapping *all* sierra location codes to their `delivery_location` and relevant hub name (referencing the keys in `./locations.js`) (Note that sierra locations that act only as *delivery locations* must be entered in this hash and cite themselves as `delivery_location`.)
 
-These files must be kept up to date with newly added locations to ensure the delivery locations listing shown on the hold-request page show correct labels. For example, when Scholar rooms 217 and 223 were added to SASB, entries like the following needed to be added to `./locationCodes.js`:
+These files must be kept up to date with newly added locations to ensure that the hold-request page presents delivery locations with correct labels and building addresses. For example, when Scholar rooms 217 and 223 were added to SASB, entries like the following needed to be added to `./locationCodes.js`:
 ```
   "mal17": {
     "delivery_location": "mal17",

--- a/locationCodes.js
+++ b/locationCodes.js
@@ -622,5 +622,13 @@ export default {
   "qcmo2": {
     "delivery_location": "",
     "location": "schwarzman"
+  },
+  "mal17": {
+    "delivery_location": "mal17",
+    "location": "schwarzman"
+  },
+  "mal23": {
+    "delivery_location": "mal23",
+    "location": "schwarzman"
   }
 }


### PR DESCRIPTION
This change principally adds two new SASB scholar rooms: 217 and 223 to `./locationCodes.js`, enabling them to be labeled properly when they are presented as available delivery options for a given hold request.

This PR also includes an update to the README documenting generally how to add locations to this app.