### PR TITLE
Replace positioned with width

### DIFF
--- a/src/app/components/SubjectHeading/SubjectHeading.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeading.jsx
@@ -188,7 +188,7 @@ class SubjectHeading extends React.Component {
             <span className="subjectHeadingAttribute titles">{`${bib_count}`}</span>
             <span className="subjectHeadingAttribute narrower">{`${desc_count}`}</span>
             { open && narrower.length > 1 && uuid.length > 0 && (container !== 'context' || location.pathname.includes(uuid))
-              ? <SortButtons sortBy={sortBy} handler={this.sortHandler} />
+              ? <SortButton sortBy={sortBy} handler={this.sortHandler} />
             : null
           }
           </div>

--- a/src/app/components/SubjectHeading/SubjectHeading.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeading.jsx
@@ -179,17 +179,19 @@ class SubjectHeading extends React.Component {
 
     return (
       <li data={`${subjectHeading.uuid}, ${container}`} className={`subjectHeadingRow ${ open || children ? "openSubjectHeading" : ""}`}>
-        <a  className={`subjectHeadingRow ${ open || children ? "openSubjectHeading" : ""} + ${this.props.nested ? ' nestedSubjectHeading' : ''}`} >
-          <span style={{'paddingLeft': `${20*indentation}px`}} className="subjectHeadingLabelAndToggle">
-            <span onClick={container !== 'context' ? this.toggleOpen : () => {} } className="subjectHeadingToggle" >{desc_count > 0 ? (!open ? '+' : '-') : null}</span>
-            <span className="subjectHeadingLabel" onClick={this.linkToShow}><span>{rest}</span>{rest === '' ? '' : ' -- ' }<span className='emph'>{emph}</span></span>
-          </span>
-          <span className="subjectHeadingAttribute titles">{`${bib_count}`}</span>
-          <span className="subjectHeadingAttribute narrower">{`${desc_count}`}</span>
-          { open && narrower.length > 1 && uuid.length > 0 && (container !== 'context' || location.pathname.includes(uuid))
-            ? <SortButtons sortBy={sortBy} handler={this.sortHandler} />
+        <a>
+          <div  className={`subjectHeadingInfo subjectHeadingRow ${ open || children ? "openSubjectHeading" : ""} + ${this.props.nested ? ' nestedSubjectHeading' : ''}`} >
+            <span  className="subjectHeadingLabelAndToggle">
+              <span style={{'paddingLeft': `${20*indentation}px`}} onClick={container !== 'context' ? this.toggleOpen : () => {} } className="subjectHeadingToggle" >{desc_count > 0 ? (!open ? '+' : '-') : null}</span>
+              <span className="subjectHeadingLabel" onClick={this.linkToShow}><span>{rest}</span>{rest === '' ? '' : ' -- ' }<span className='emph'>{emph}</span></span>
+            </span>
+            <span className="subjectHeadingAttribute titles">{`${bib_count}`}</span>
+            <span className="subjectHeadingAttribute narrower">{`${desc_count}`}</span>
+            { open && narrower.length > 1 && uuid.length > 0 && (container !== 'context' || location.pathname.includes(uuid))
+              ? <SortButtons sortBy={sortBy} handler={this.sortHandler} />
             : null
           }
+          </div>
         </a>
         { open
           ? <SubjectHeadingsList

--- a/src/client/styles/components/SubjectHeadings.scss
+++ b/src/client/styles/components/SubjectHeadings.scss
@@ -172,7 +172,7 @@ a {
   font-size: 1rem;
 }
 
-.subjectHeadingMainContent {
+.subjectHeadingMainContent.index {
   font-size: 0;
   max-width: 550px;
 }

--- a/src/client/styles/components/SubjectHeadings.scss
+++ b/src/client/styles/components/SubjectHeadings.scss
@@ -1,33 +1,50 @@
 .subjectHeadingRow {
   font-weight: 500;
+  width: 100%;
+  min-width: 100%;
+  min-height: 1px;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
 }
 
 .subjectHeadingRow:hover {
   color: inherit;
 }
 
+.subjectHeadingInfo {
+  // position: relative;
+  display: flex;
+}
+
 .subjectHeadingAttribute {
-  position: absolute;
+  // position: absolute;
 }
 
 .subjectHeadingAttribute.titles {
-  left: 75%;
+  // left: 100%;
 }
 
 .subjectHeadingAttribute.narrower {
-  left: 86%;
+  // left: 65%;
 }
 
 .subjectHeadingAttribute.sortButton {
-  left: 100%;
+  // left: 80%;
+  // top: 2%;
   height: 1rem;
   font-size: 0.75rem;
+  margin-top: -3px;
+  margin-left: 5px;
 }
 
 .subjectMainContentWrapper {
   position: relative;
   .subjectHeadingRow.tableHeadings {
     margin-bottom: 15px;
+    display: flex;
   }
 
   .subjectHeadingLabel {
@@ -41,7 +58,7 @@
 
 .subjectHeadingToggle {
   margin-top: -2%;
-  position: relative;
+  // position: relative;
   top: 1px;
 }
 
@@ -58,7 +75,7 @@
   list-style: none;
   margin-left: 15px;
   font-weight: 500;
-  width: 75%;
+  width: 50%;
 }
 
 .subjectHeadingLabelAndToggle > .subjectHeadingToggle {
@@ -231,7 +248,7 @@
   padding-bottom: 1%;
   margin-left: 1%;
   margin-bottom: 1%;
-  position: relative;
+  // position: relative;
 
   .subjectHeadingLabelAndToggle > .subjectHeadingLabel {
     padding-left: 0px;

--- a/src/client/styles/components/SubjectHeadings.scss
+++ b/src/client/styles/components/SubjectHeadings.scss
@@ -15,25 +15,19 @@ a {
 }
 
 .subjectHeadingInfo {
-  // position: relative;
   display: flex;
 }
 
 .subjectHeadingAttribute {
-  // position: absolute;
 }
 
 .subjectHeadingAttribute.titles {
-  // left: 100%;
 }
 
 .subjectHeadingAttribute.narrower {
-  // left: 65%;
 }
 
 .subjectHeadingAttribute.sortButton {
-  // left: 80%;
-  // top: 2%;
   height: 1rem;
   font-size: 0.75rem;
   margin-top: -3px;
@@ -58,7 +52,6 @@ a {
 
 .subjectHeadingToggle {
   margin-top: -2%;
-  // position: relative;
   top: 1px;
 }
 
@@ -109,7 +102,6 @@ a {
 
 .subjectNavButton {
   margin: 100px;
-  // border: 1px solid #104d65;
   font-size: 20px;
   text-decoration: none;
   padding: 20px;
@@ -248,7 +240,6 @@ a {
   padding-bottom: 1%;
   margin-left: 1%;
   margin-bottom: 1%;
-  // position: relative;
 
   .subjectHeadingLabelAndToggle > .subjectHeadingLabel {
     padding-left: 0px;

--- a/src/client/styles/components/SubjectHeadings.scss
+++ b/src/client/styles/components/SubjectHeadings.scss
@@ -172,7 +172,10 @@ a {
   font-size: 1rem;
 }
 
-.subjectHeadingMainContent { font-size: 0;}
+.subjectHeadingMainContent {
+  font-size: 0;
+  max-width: 550px;
+}
 
 .subjectHeadingList {font-size: 0;}
 

--- a/src/client/styles/components/SubjectHeadings.scss
+++ b/src/client/styles/components/SubjectHeadings.scss
@@ -5,6 +5,10 @@
   min-height: 1px;
 }
 
+.subjectHeadingRow.tableHeadings {
+  display: flex;
+}
+
 a {
   color: inherit;
   text-decoration: none;


### PR DESCRIPTION
Changes the styling to set width attributes rather than position attributes. This seems to work better with very long titles. I also hope it will 1) be less brittle and 2) produce less unexpected behavior.
Note there are still some issues with very long titles, see e.g. http://localhost:3001/research/collections/shared-collection-catalog/subject_headings?fromLabel=%22Orchestrated+by+Ernest+Gold%2C+April+25%2C+1959.%22--The+life+and+music+of+George+Antheil%2C+1900-1959+%2F+by+Linda+Whitesitt.+Ann+Arbor%2C+Michigan+%3A+UPI+Research+Press%2C+c1983+%28Item+104%29&fromComparator=after and navigate to "Plast" orhaniza︠t︡si︠i︡a ukraïnsʹkoï molodi -- History -- Sources -- Bibliography -- Catalogs
