### PR TITLE
Sb/da/tree spacing

### DIFF
--- a/src/app/components/SubjectHeading/SubjectHeading.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeading.jsx
@@ -180,7 +180,7 @@ class SubjectHeading extends React.Component {
     } = this.addEmphasis(label);
 
     const positionStyle = { left: 20 * (indentation || 0) };
-
+    // changes to HTML structure here will need to be replicated in ./SubjectHeadingTableHeader
     return (
       <li data={`${subjectHeading.uuid}, ${container}`} className={`subjectHeadingRow ${ open || children ? "openSubjectHeading" : ""}`}>
         <a>

--- a/src/app/components/SubjectHeading/SubjectHeading.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeading.jsx
@@ -186,7 +186,7 @@ class SubjectHeading extends React.Component {
         <a>
           <div  className={`subjectHeadingInfo subjectHeadingRow ${ open || children ? "openSubjectHeading" : ""} ${this.props.nested ? ' nestedSubjectHeading' : ''}`} >
             <span style={positionStyle} onClick={container !== 'context' ? this.toggleOpen : () => {} } className="subjectHeadingToggle" >{desc_count > 0 ? (!open ? '+' : '-') : null}</span>
-            <span className="subjectHeadingLabelAndToggle">
+            <span className="subjectHeadingLabelContainer">
               <span className="subjectHeadingLabel" style={positionStyle} onClick={this.linkToShow}><span>{rest}</span>{rest === '' ? '' : ' -- ' }<span className='emph'>{emph}</span></span>
             </span>
             <span className="subjectHeadingAttribute titles">{`${bib_count}`}</span>

--- a/src/app/components/SubjectHeading/SubjectHeadingTableHeader.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeadingTableHeader.jsx
@@ -5,8 +5,8 @@ import PropTypes from 'prop-types';
 const SubjectHeadingTableHeader = () => {
   return (
       <div className="subjectHeadingRow tableHeadings">
-        <span className="subjectHeadingLabelAndToggle">
-          <span className="subjectHeadingToggle"></span>
+      <span className="subjectHeadingToggle"></span>
+        <span className="subjectHeadingLabelContainer">
           <span className="subjectHeadingLabel">Subject Heading</span>
         </span>
         <span className="subjectHeadingAttribute titles">Titles</span>

--- a/src/client/styles/components/SubjectHeadings.scss
+++ b/src/client/styles/components/SubjectHeadings.scss
@@ -52,7 +52,7 @@ a {
 }
 
 .subjectHeadingRow.openSubjectHeading {
-  > .subjectHeadingLabelAndToggle {
+  > .subjectHeadingLabelContainer {
     background: lightgrey;
   }
   > .subjectHeadingToggle {
@@ -76,7 +76,7 @@ a {
   color: #176e91;
 }
 
-.subjectHeadingLabelAndToggle {
+.subjectHeadingLabelContainer {
   list-style: none;
   font-weight: 500;
   width: 65%;
@@ -233,7 +233,7 @@ a {
     margin-bottom: 0;
   }
 
-  .subjectHeadingLabelAndToggle {
+  .subjectHeadingLabelContainer {
     margin-left: 0px;
   }
 
@@ -300,7 +300,7 @@ a {
   margin-left: 1%;
   margin-bottom: 1%;
 
-  .subjectHeadingLabelAndToggle > .subjectHeadingLabel {
+  .subjectHeadingLabelContainer > .subjectHeadingLabel {
     padding-left: 0px;
   }
 


### PR DESCRIPTION
Fixes the HTML structure of the table heading element and changes the now misleading className 'subjectHeadingLabelAndToggle'