### PR TITLE
Top level open heading grey extends to right edge

### DIFF
--- a/src/app/components/SubjectHeading/AdditionalSubjectHeadingsButton.jsx
+++ b/src/app/components/SubjectHeading/AdditionalSubjectHeadingsButton.jsx
@@ -22,7 +22,7 @@ class AdditionalSubjectHeadingsButton extends React.Component {
     const previous = this.props.button === 'previous';
 
     return (
-      <div onClick={this.onClick} className={interactive ? 'seeMoreButton' : ''} style={{"paddingLeft":`${20*indentation}px`}}>
+      <div onClick={this.onClick} className={interactive ? 'seeMoreButton' : 'staticDots'} style={{"paddingLeft":`${20*indentation}px`}}>
           {interactive ? `${previous ? '↑' : '↓'} See more` : null}
           {previous || !interactive ? null : <br /> }
           {previous ? null : <VerticalEllipse />}

--- a/src/client/styles/components/SubjectHeadings.scss
+++ b/src/client/styles/components/SubjectHeadings.scss
@@ -57,7 +57,7 @@ a {
   background: #E8E4E3;
 }
 
-.subjectHeadingRow.openSubjectHeading {
+div.subjectHeadingRow.openSubjectHeading {
   border-bottom: 2px solid #E8E4E3;
 
   > .subjectHeadingLabelAndToggle {
@@ -493,4 +493,8 @@ span.subjectHeadingToggle {
   &:hover {
     text-decoration: none;
   }
+}
+
+.subjectHeadingRow.openSubjectHeading:not(.nestedSubjectHeading) {
+  background: lightgray;
 }

--- a/src/client/styles/components/SubjectHeadings.scss
+++ b/src/client/styles/components/SubjectHeadings.scss
@@ -245,6 +245,7 @@ div.subjectHeadingRow.openSubjectHeading {
 
 .nestedSubjectHeadingList {
   background-color: #E8E4E3;
+  padding-bottom: 3px;
 
   li {
     margin-bottom: 0;
@@ -455,6 +456,10 @@ div.subjectHeadingRow.openSubjectHeading {
     width: 125px;
     height: 25px;
   }
+}
+
+.staticDots {
+  margin-left: 20px;
 }
 
 .verticalEllipse {


### PR DESCRIPTION
tweaks upon tweaks. Particularly- open top level headings have the slightly darker grey extend to the right edge as depicted in Figma. Also made the selector slightly more specific for the `border-bottom` styling.