### PR TITLE
Highlight main no children

### DIFF
--- a/src/app/components/SubjectHeading/SubjectHeading.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeading.jsx
@@ -15,13 +15,16 @@ class SubjectHeading extends React.Component {
       subjectHeading,
       container,
       sortBy,
+      linked,
+      location,
     } = this.props;
     const {
       children,
       range,
+      uuid,
     } = subjectHeading;
     this.state = {
-      open: !!children,
+      open: !!children || this.isMain(),
       narrower: (children || []),
       sortBy: sortBy || "alphabetical",
       range: range || Range.default(),
@@ -52,6 +55,15 @@ class SubjectHeading extends React.Component {
 
   updateSubjectHeading(properties) {
     this.setState(properties);
+  }
+
+  isMain() {
+    const {
+      subjectHeading: { uuid },
+      location: { pathname },
+      linked,
+    } = this.props;
+    return linked === uuid || pathname.includes(uuid);
   }
 
   toggleOpen() {
@@ -190,7 +202,7 @@ class SubjectHeading extends React.Component {
           <div  className={`subjectHeadingInfo subjectHeadingRow ${ open || children ? "openSubjectHeading" : ""} ${this.props.nested ? ' nestedSubjectHeading' : ''}`} >
             <span style={positionStyle} onClick={container !== 'context' ? this.toggleOpen : () => {} } className="subjectHeadingToggle" >{desc_count > 0 ? (!open ? '+' : '-') : null}</span>
             <span className="subjectHeadingLabelContainer">
-              <span className="subjectHeadingLabel" style={positionStyle} onClick={this.linkToShow}><span>{rest}</span>{rest === '' ? '' : ' -- ' }<span className='emph'>{emph}</span></span>
+              <span className={`subjectHeadingLabel ${this.isMain() ? 'mainLabel' : ''}`} style={positionStyle} onClick={this.linkToShow}><span>{rest}</span>{rest === '' ? '' : ' -- ' }<span className='emph'>{emph}</span></span>
             </span>
             <span className="subjectHeadingAttribute titles">{`${bib_count}`}</span>
             <span className="subjectHeadingAttribute narrower">{`${desc_count || '-'}`}</span>

--- a/src/app/components/SubjectHeading/SubjectHeading.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeading.jsx
@@ -188,15 +188,16 @@ class SubjectHeading extends React.Component {
     } = this.addEmphasis(label);
 
     const positionStyle = { left: 20 * (indentation || 0) };
+    const noChildren = this.isMain() && narrower.length === 0 ? 'noChildren' : '';
     // changes to HTML structure here will need to be replicated in ./SubjectHeadingTableHeader
     return (
-      <li data={`${subjectHeading.uuid}, ${container}`} className={`subjectHeadingRow ${ open || children ? "openSubjectHeading" : ""}`}>
+      <li data={`${subjectHeading.uuid}, ${container}`} className={`subjectHeadingRow ${ open || children ? "openSubjectHeading" : ""} ${noChildren}`}>
       {container === 'narrower' ?
         <hr className="relatedHeadingsBoundary"/>
         : null
       }
         <a>
-          <div  className={`subjectHeadingInfo subjectHeadingRow ${ open || children ? "openSubjectHeading" : ""} ${this.props.nested ? ' nestedSubjectHeading' : ''}`} >
+          <div  className={`subjectHeadingInfo subjectHeadingRow ${ open || children ? "openSubjectHeading" : ""} ${this.props.nested ? ' nestedSubjectHeading' : ''} ${noChildren}`} >
             <span style={positionStyle} onClick={container !== 'context' ? this.toggleOpen : () => {} } className="subjectHeadingToggle" >{desc_count > 0 ? (!open ? '+' : '-') : null}</span>
             <span className="subjectHeadingLabelContainer">
               <span className={`subjectHeadingLabel ${this.isMain() ? 'mainLabel' : ''}`} style={positionStyle} onClick={this.linkToShow}><span>{rest}</span>{rest === '' ? '' : ' -- ' }<span className='emph'>{emph}</span></span>

--- a/src/app/components/SubjectHeading/SubjectHeading.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeading.jsx
@@ -15,13 +15,10 @@ class SubjectHeading extends React.Component {
       subjectHeading,
       container,
       sortBy,
-      linked,
-      location,
     } = this.props;
     const {
       children,
       range,
-      uuid,
     } = subjectHeading;
     this.state = {
       open: !!children || this.isMain(),

--- a/src/app/components/SubjectHeading/SubjectHeading.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeading.jsx
@@ -209,7 +209,7 @@ class SubjectHeading extends React.Component {
             : null
           }
         </a>
-        { open ?
+        { open && narrower.length > 0 ?
           <SubjectHeadingsList
             subjectHeadings={narrower}
             nested="true"

--- a/src/app/components/SubjectHeading/SubjectHeadingsList.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeadingsList.jsx
@@ -122,6 +122,7 @@ class SubjectHeadingsList extends React.Component {
       location,
       container,
       sortBy,
+      linked,
     } = this.props;
 
     const {
@@ -153,6 +154,7 @@ class SubjectHeadingsList extends React.Component {
               location={location}
               container={container}
               sortBy={sortBy}
+              linked={linked}
             />
           )) :
           null

--- a/src/client/styles/components/SubjectHeadings.scss
+++ b/src/client/styles/components/SubjectHeadings.scss
@@ -552,3 +552,7 @@ span.subjectHeadingToggle {
     margin: 0 auto;
   }
 }
+
+.subjectHeadingLabel.mainLabel {
+  font-style: italic;
+}

--- a/src/client/styles/components/SubjectHeadings.scss
+++ b/src/client/styles/components/SubjectHeadings.scss
@@ -61,7 +61,9 @@ a {
 }
 
 div.subjectHeadingRow.openSubjectHeading {
-  border-bottom: 2px solid #E8E4E3;
+  &:not(.noChildren) {
+    border-bottom: 2px solid #E8E4E3;
+  }
 
   > .subjectHeadingLabelContainer {
     background: lightgrey;


### PR DESCRIPTION
Adds some extra logic and styling to make sure that the main subject heading (either linked or on the show page) is highlighted and italicized, even if it has no children.