### PR TITLE
Add messaging for ptype ineligibility

### DIFF
--- a/src/app/components/HoldConfirmation/HoldConfirmation.jsx
+++ b/src/app/components/HoldConfirmation/HoldConfirmation.jsx
@@ -42,7 +42,7 @@ class HoldConfirmation extends React.Component {
   }
 
   ptypeDisallowsHolds() {
-    return (<li className="errorItem">Your card does not permit placing holds.</li>);
+    return (<li className="errorItem">Your card does not permit placing holds on ReCAP materials.</li>);
   }
 
   /**

--- a/src/app/components/HoldConfirmation/HoldConfirmation.jsx
+++ b/src/app/components/HoldConfirmation/HoldConfirmation.jsx
@@ -41,6 +41,10 @@ class HoldConfirmation extends React.Component {
     return (<li className="errorItem">There is a problem with your library account</li>);
   }
 
+  ptypeDisallowsHolds() {
+    return (<li className="errorItem">Your card does not permit placing holds.</li>);
+  }
+
   /**
    * eligibilityErrorText supplies the appropriate text when a patron is ineligible to place holds.
    * @return {HTML Element}
@@ -51,13 +55,15 @@ class HoldConfirmation extends React.Component {
       const expired = errors.expired ? this.expiredMessage() : null;
       const blocked = errors.blocked ? this.blockedMessage() : null;
       const moneyOwed = errors.moneyOwed ? this.moneyOwedMessage() : null;
-      const defaultText = expired || blocked || moneyOwed ? null : 'There is a problem with your library account.';
+      const ptypeDisallowsHolds = errors.ptypeDisallowsHolds ? this.ptypeDisallowsHolds() : null;
+      const defaultText = expired || blocked || moneyOwed || ptypeDisallowsHolds  ? null : 'There is a problem with your library account.';
       return (
         <p> This is because:
           <ul>
             {moneyOwed}
             {expired}
             {blocked}
+            {ptypeDisallowsHolds}
             {defaultText}
           </ul>
           Please see a librarian or contact 917-ASK-NYPL (<a href="tel:19172756975">917-275-6975</a>) if you require assistance.
@@ -330,7 +336,8 @@ class HoldConfirmation extends React.Component {
       );
     }
 
-    if (this.props.location.query.errorStatus && this.props.location.query.errorMessage) {
+    // If running client-side, generate GA event
+    if ((typeof window !== 'undefined') && this.props.location.query.errorStatus && this.props.location.query.errorMessage) {
       trackDiscovery('Error', 'Hold Confirmation');
     }
 


### PR DESCRIPTION
This adds custom messaging for case where patron attempts to place a hold but is blocked due to having a ptype that bars holds. Without this update, the text would just read "There is a problem with your library account.". With this update, in the case of a barred ptype, the patron sees "Your card does not permit placing holds on ReCAP materials."

This also fixes a minor bug where the controller was attempting to make a google analytics call on the server side (i.e. where `window` is `undefined`), leading to a ["Internal Server Error"](https://qa-www.nypl.org/research/collections/shared-collection-catalog/hold/confirmation/pb7388405-pi6575276?errorStatus=eligibility&errorMessage={%22eligibility%22:false,%22expired%22:false,%22blocked%22:false,%22moneyOwed%22:false,%22ptypeDisallowsHolds%22:true,%22hasIssues%22:true}) . Before making the call, we now check for `window` not being `undefined`. The client-side call still succeeds if JS is enabled on the client. If the visitor navigates to (or is redirected to) the confirmation page with an `errorStatus` param like the one linked above, the GA call will simply be skipped rather than generate a 500.