### PR TITLE
Sib/shep accessibility

### DIFF
--- a/src/app/components/Pagination/Pagination.jsx
+++ b/src/app/components/Pagination/Pagination.jsx
@@ -30,11 +30,12 @@ class Pagination extends React.Component {
     const pageNum = type === 'Next' ? intPage + 1 : intPage - 1;
     const svg = type === 'Next' ? <RightWedgeIcon /> : <LeftWedgeIcon />;
     const { shepNavigation } = this.props
+    const subjectHeadingPage = this.props.subjectShowPage
 
     let url;
     let apiUrl;
     let localUrl;
-    if (this.props.subjectShowPage && shepNavigation) {
+    if (subjectHeadingPage && shepNavigation) {
       url = type === 'Next' ? shepNavigation.next : shepNavigation.previous
     } else {
       apiUrl = this.props.createAPIQuery({ page: pageNum });
@@ -44,13 +45,17 @@ class Pagination extends React.Component {
       : { pathname: localUrl };
     }
 
+    const linkProps = {}
+    linkProps.to = url
+    linkProps.rel = type.toLowerCase()
+    linkProps.className = `${type.toLowerCase()}-link`
+    linkProps.ariaControls = this.props.ariaControls
+
+    if (!subjectHeadingPage) linkProps.onClick = e => this.onClick(e, pageNum, type)
+
     return (
       <Link
-        to={url}
-        rel={type.toLowerCase()}
-        className={`${type.toLowerCase()}-link`}
-        aria-controls={this.props.ariaControls}
-        onClick={e => this.onClick(e, pageNum, type)}
+        {...linkProps}
       >
         {svg} {type}
       </Link>

--- a/src/app/components/Pagination/Pagination.jsx
+++ b/src/app/components/Pagination/Pagination.jsx
@@ -49,12 +49,12 @@ class Pagination extends React.Component {
     linkProps.to = url
     linkProps.rel = type.toLowerCase()
     linkProps.className = `${type.toLowerCase()}-link`
-    linkProps.ariaControls = this.props.ariaControls
 
     if (!subjectHeadingPage) linkProps.onClick = e => this.onClick(e, pageNum, type)
 
     return (
       <Link
+        aria-controls={this.props.ariaControls}
         {...linkProps}
       >
         {svg} {type}

--- a/src/app/components/SubjectHeading/AdditionalSubjectHeadingsButton.jsx
+++ b/src/app/components/SubjectHeading/AdditionalSubjectHeadingsButton.jsx
@@ -24,7 +24,7 @@ class AdditionalSubjectHeadingsButton extends React.Component {
     return (
       <tr className="subjectHeadingRow nestedSubjectHeading">
         <td colSpan="4">
-          <div
+          <button
             onClick={this.onClick}
             className={interactive ? 'seeMoreButton' : 'staticDots'}
             style={{"paddingLeft":`${40*indentation}px`}}
@@ -32,7 +32,7 @@ class AdditionalSubjectHeadingsButton extends React.Component {
             {interactive ? [previous ? '↑' : '↓', <em key='seeMoreText'>See more</em>] : null}
             {previous || !interactive ? null : <br /> }
             {previous ? null : <VerticalEllipse />}
-          </div>
+          </button>
           <div className="subjectHeadingsTableCell"></div>
           <div className="subjectHeadingsTableCell"></div>
         </td>

--- a/src/app/components/SubjectHeading/AdditionalSubjectHeadingsButton.jsx
+++ b/src/app/components/SubjectHeading/AdditionalSubjectHeadingsButton.jsx
@@ -23,18 +23,21 @@ class AdditionalSubjectHeadingsButton extends React.Component {
 
     return (
       <tr className="subjectHeadingRow nestedSubjectHeading">
-        <td colSpan="4">
-          <button
-            onClick={this.onClick}
-            className={interactive ? 'seeMoreButton' : 'staticDots'}
-            style={{"paddingLeft":`${40*indentation}px`}}
-          >
-            {interactive ? [previous ? '↑' : '↓', <em key='seeMoreText'>See more</em>] : null}
-            {previous || !interactive ? null : <br /> }
-            {previous ? null : <VerticalEllipse />}
-          </button>
-          <div className="subjectHeadingsTableCell"></div>
-          <div className="subjectHeadingsTableCell"></div>
+        <td colSpan="3">
+          <span style={{"paddingLeft":`${40*indentation}px`}}>
+          {
+            interactive ?
+            <button
+              onClick={this.onClick}
+              className='seeMoreButton'
+            >
+              {previous ? '↑' : '↓'} <em key='seeMoreText'>See more</em>
+              {previous ? null : <br /> }
+              {previous ? null : <VerticalEllipse />}
+            </button>
+            : previous ? null : <VerticalEllipse />
+            }
+          </span>
         </td>
       </tr>
     );

--- a/src/app/components/SubjectHeading/SubjectHeading.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeading.jsx
@@ -252,7 +252,7 @@ class SubjectHeading extends React.Component {
             : null
           }
         </tr>
-        { open ?
+        { open && narrower.length > 0 ?
           <SubjectHeadingsTableBody
             subjectHeadings={narrower}
             nested="true"

--- a/src/client/styles/components/SubjectHeadings.scss
+++ b/src/client/styles/components/SubjectHeadings.scss
@@ -7,7 +7,7 @@
     display: flex;
   }
 
-  > .openSubjectHeading {
+  tbody > .openSubjectHeading {
     background-color: #E8E4E3;
       &.topLevel {
         background-color: lightgray;

--- a/src/client/styles/components/SubjectHeadings.scss
+++ b/src/client/styles/components/SubjectHeadings.scss
@@ -84,6 +84,12 @@
         .subjectHeadingToggle {
           position: absolute;
           left: -20px;
+
+          &:focus {
+            outline-color: #ffb81d;
+            outline-style: solid;
+            outline-width: 0.125rem;
+          }
         }
       }
     }
@@ -411,7 +417,7 @@
   }
 }
 
-.staticDots {
+span > .verticalEllipse {
   margin-left: 40px;
 }
 

--- a/src/client/styles/components/SubjectHeadings.scss
+++ b/src/client/styles/components/SubjectHeadings.scss
@@ -93,6 +93,17 @@
   }
   .seeMoreButton {
     background-color: #E8E4E3;
+    border: none;
+    background: none;
+    padding: 0;
+    text-align: inherit;
+
+    &:focus {
+      outline-color: #ffb81d;
+      outline-style: solid;
+      outline-width: 0.125rem;
+    }
+
   }
 
   th > .subjectHeadingLabelInner {


### PR DESCRIPTION
This PR 
-fixes the bug that was introduced previously when simplifying the use of <Link> for <Pagination>
-makes the 'See more' button an HTML button (for accessibility purposes)
-And patches a bug I found with the linked index page not pre-opening because our use of props and state for the narrower/children is ... not great right now. See file `src/app/components/SubjectHeading/SubjectHeading.jsx`