### PR TITLE
Debug initial index render

### DIFF
--- a/src/app/components/SubjectHeading/SubjectHeadingsContainer.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeadingsContainer.jsx
@@ -187,7 +187,6 @@ class SubjectHeadingsContainer extends React.Component {
             </div>
             {subjectHeadings.length > 0 ?
               <SubjectHeadingsTable
-                subjectHeadings={subjectHeadings}
                 linked={linked}
                 location={location}
                 sortBy={sortBy}

--- a/src/app/components/SubjectHeading/SubjectHeadingsTable.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeadingsTable.jsx
@@ -21,7 +21,6 @@ export default (props) => {
       <SubjectHeadingsTableHeader sortButton={sortButton}/>
       <tbody>
         <SubjectHeadingsTableBody
-          subjectHeadings={subjectHeadings}
           linked={linked}
           location={location}
           sortBy={sortBy}

--- a/src/app/components/SubjectHeading/SubjectHeadingsTableBody.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeadingsTableBody.jsx
@@ -3,6 +3,8 @@ import React from 'react';
 import { Link } from 'react-router';
 import PropTypes from 'prop-types';
 import axios from 'axios';
+import { connect } from 'react-redux';
+
 import SubjectHeading from './SubjectHeading';
 import AdditionalSubjectHeadingsButton from './AdditionalSubjectHeadingsButton';
 import Range from '../../models/Range';
@@ -160,6 +162,12 @@ class SubjectHeadingsTableBody extends React.Component {
   }
 }
 
+function mapStateToProps(state) {
+  return {
+    subjectHeadings: state.subjectHeadings,
+  }
+}
+
 SubjectHeadingsTableBody.propTypes = {
   nested: PropTypes.string,
   subjectHeadings: PropTypes.array,
@@ -169,4 +177,4 @@ SubjectHeadingsTableBody.propTypes = {
   sortBy: PropTypes.string,
 };
 
-export default SubjectHeadingsTableBody;
+export default connect(mapStateToProps)(SubjectHeadingsTableBody);

--- a/src/app/reducer.js
+++ b/src/app/reducer.js
@@ -19,8 +19,7 @@ const defaultState = {
 function reducer(state = defaultState, action) {
   switch (action.type) {
     case "UPDATE_SUBJECT_HEADINGS":
-      console.log("action", action);
-      return Object.assign({}, state, action.subjectHeadings)
+      return Object.assign({}, state, {subjectHeadings: action.subjectHeadings})
     default:
       return state
   }


### PR DESCRIPTION
This gets the initial render of the index page working. Of course a lot of the functionality is broken now, we will have to use the Store consistently (as opposed to local state or passed props) in order for everything to work. This branch removes some of the prop passing, and fixes a bug in the reducer.