### PR TITLE
SCC-1761 first bug

### DIFF
--- a/src/app/components/SearchResultsPage/SearchResultsPage.jsx
+++ b/src/app/components/SearchResultsPage/SearchResultsPage.jsx
@@ -28,18 +28,18 @@ class SearchResultsPage extends React.Component {
     this.state = {
       isLoading: this.props.isLoading,
       dropdownOpen: false,
-      document: undefined,
+      // document: undefined,
     };
 
     this.updateIsLoadingState = this.updateIsLoadingState.bind(this);
     this.updateDropdownState = this.updateDropdownState.bind(this);
     this.checkForSelectedFilters = this.checkForSelectedFilters.bind(this);
-    this.focus = this.focus.bind(this);
+    // this.focus = this.focus.bind(this);
   }
 
   componentDidMount() {
-    document.getElementById('search-query').focus();
-    this.setState({ document: window.document });
+    // document.getElementById('search-query').focus();
+    // this.setState({ document: window.document });
   }
 
 
@@ -50,11 +50,11 @@ class SearchResultsPage extends React.Component {
     return false;
   }
 
-  focus() {
-    if (this.state.document) {
-      document.getElementById('filter-title').focus();
-    }
-  }
+  // focus() {
+  //   if (this.state.document) {
+  //     document.getElementById('filter-title').focus();
+  //   }
+  // }
 
   updateIsLoadingState(status) {
     this.setState({ isLoading: status });
@@ -136,7 +136,7 @@ class SearchResultsPage extends React.Component {
           <LoadingLayer
             status={this.state.isLoading}
             title="Searching"
-            focus={this.focus()}
+          
           />
           <div className="nypl-page-header">
             <div className="nypl-full-width-wrapper filter-page">

--- a/src/app/components/SearchResultsPage/SearchResultsPage.jsx
+++ b/src/app/components/SearchResultsPage/SearchResultsPage.jsx
@@ -28,19 +28,12 @@ class SearchResultsPage extends React.Component {
     this.state = {
       isLoading: this.props.isLoading,
       dropdownOpen: false,
-      // document: undefined,
     };
 
     this.updateIsLoadingState = this.updateIsLoadingState.bind(this);
     this.updateDropdownState = this.updateDropdownState.bind(this);
     this.checkForSelectedFilters = this.checkForSelectedFilters.bind(this);
-    // this.focus = this.focus.bind(this);
   }
-
-  // componentDidMount() {
-  //   document.getElementById('search-query').focus();
-  //   this.setState({ document: window.document });
-  // }
 
 
   shouldComponentUpdate() {
@@ -49,13 +42,7 @@ class SearchResultsPage extends React.Component {
     }
     return false;
   }
-
-  // focus() {
-  //   if (this.state.document) {
-  //     document.getElementById('filter-title').focus();
-  //   }
-  // }
-
+  
   updateIsLoadingState(status) {
     this.setState({ isLoading: status });
   }

--- a/src/app/components/SearchResultsPage/SearchResultsPage.jsx
+++ b/src/app/components/SearchResultsPage/SearchResultsPage.jsx
@@ -37,10 +37,10 @@ class SearchResultsPage extends React.Component {
     // this.focus = this.focus.bind(this);
   }
 
-  componentDidMount() {
-    // document.getElementById('search-query').focus();
-    // this.setState({ document: window.document });
-  }
+  // componentDidMount() {
+  //   document.getElementById('search-query').focus();
+  //   this.setState({ document: window.document });
+  // }
 
 
   shouldComponentUpdate() {
@@ -136,7 +136,7 @@ class SearchResultsPage extends React.Component {
           <LoadingLayer
             status={this.state.isLoading}
             title="Searching"
-          
+
           />
           <div className="nypl-page-header">
             <div className="nypl-full-width-wrapper filter-page">

--- a/src/app/components/SubjectHeading/BibsList.jsx
+++ b/src/app/components/SubjectHeading/BibsList.jsx
@@ -53,7 +53,7 @@ class BibsList extends React.Component {
       },
       (error) => {
         console.error(
-          'Error attempting to make an ajax request to fetch a bib record from ResultsList',
+          'Error attempting to make an ajax request to fetch a bib record from BibsList',
           error,
         );
       },

--- a/src/app/components/SubjectHeading/BibsList.jsx
+++ b/src/app/components/SubjectHeading/BibsList.jsx
@@ -76,7 +76,8 @@ class BibsList extends React.Component {
       <li key={bibId} className={`nypl-results-item ${hasRequestTable ? 'has-request' : ''}`}>
         <h3>
           <Link
-            to={`${appConfig.baseUrl}/bib/${bibId}?searchKeywords=${this.props.searchKeywords}`}
+            onClick={(e) => console.log(e)}
+            to={`${appConfig.baseUrl}/bib/${bibId}`}
             className="title"
           >
             {bibTitle}

--- a/src/app/components/SubjectHeading/BibsList.jsx
+++ b/src/app/components/SubjectHeading/BibsList.jsx
@@ -76,7 +76,6 @@ class BibsList extends React.Component {
       <li key={bibId} className={`nypl-results-item ${hasRequestTable ? 'has-request' : ''}`}>
         <h3>
           <Link
-            onClick={e => this.getBibRecord(e, bibId, bibTitle)}
             to={`${appConfig.baseUrl}/bib/${bibId}?searchKeywords=${this.props.searchKeywords}`}
             className="title"
           >


### PR DESCRIPTION
This PR fixes the navigation bug @danamansana documented on ticket [SCC-1761](https://jira.nypl.org/browse/SCC-1761)
"(Search to Bib page) Search for dogs -> Select Dogs, Dogs, Dogs -> Click the subject 'counting' -> click 'Counting wildflowers' -> press back twice. In SCC this goes back to 'Counting Wildflowers', in SHEP to a blank page."
"/src/app/components/SubjectHeading/BibsList.jsx" is mostly copied from "src/app/components/Results/ResultsList.jsx" but minus a lot of the logic from the latter to act more as a modular, frontend oriented component. There was however still a call to a function that had not been copied over.
I also checked on a branch pre and post changes from PR-1096(https://github.com/NYPL-discovery/discovery-front-end/pull/1096)
PR-1096 eliminates this warning: "Warning: unstable_flushDiscreteUpdates: Cannot flush updates when React is already rendering."