### PR TITLE
remove extra "/" from shep request url

### DIFF
--- a/src/server/ApiRoutes/SubjectHeadings.js
+++ b/src/server/ApiRoutes/SubjectHeadings.js
@@ -54,7 +54,7 @@ const shepApiCall = (path, queryParams) => {
 
   return axios({
     method: 'GET',
-    url: `${appConfig.shepApi}/${path}`,
+    url: `${appConfig.shepApi}${path}`,
     params: queryParams,
   }).then((response) => {
     if (/\/bibs$/.test(path)) {


### PR DESCRIPTION
Not a breaking typo. But there was an extra "/" in all shep API calls