### PR TITLE
Da/bib title bug

### DIFF
--- a/src/app/components/Results/ResultsList.jsx
+++ b/src/app/components/Results/ResultsList.jsx
@@ -179,7 +179,7 @@ class ResultsList extends React.Component {
   }
 
   render() {
-    const results = this.props.results.filter(result => result['@id']);
+    const results = this.props.results;
     let resultsElm = null;
 
     if (!results || !_isArray(results) || !results.length) {

--- a/src/app/components/Results/ResultsList.jsx
+++ b/src/app/components/Results/ResultsList.jsx
@@ -179,7 +179,7 @@ class ResultsList extends React.Component {
   }
 
   render() {
-    const results = this.props.results;
+    const results = this.props.results.filter(result => result['@id']);
     let resultsElm = null;
 
     if (!results || !_isArray(results) || !results.length) {

--- a/src/app/components/SubjectHeading/SubjectHeadingShow.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeadingShow.jsx
@@ -54,8 +54,9 @@ class SubjectHeadingShow extends React.Component {
       url: `${appConfig.baseUrl}/api/subjectHeadings/subject_headings/${uuid}/bibs`,
     })
       .then((res) => {
+        console.log('show resp ', res.data.bibs)
         this.setState({
-          shepBibs: res.data.bibs,
+          shepBibs: res.data.bibs.filter(bib => bib['@id']),
           bibsNextUrl: res.data.next_url,
         });
       })

--- a/src/app/components/SubjectHeading/SubjectHeadingShow.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeadingShow.jsx
@@ -54,7 +54,6 @@ class SubjectHeadingShow extends React.Component {
       url: `${appConfig.baseUrl}/api/subjectHeadings/subject_headings/${uuid}/bibs`,
     })
       .then((res) => {
-        console.log('show resp ', res.data.bibs)
         this.setState({
           shepBibs: res.data.bibs.filter(bib => bib['@id']),
           bibsNextUrl: res.data.next_url,


### PR DESCRIPTION
Addresses single letter titles, see SCC-1794. It looks like the error is coming from `convertShepBibsToDiscoveryBibs` in `ApiRoutes/SubjectHeadings`. When this method fails to match a bib in shep to a bib in discovery, it returns the shep bib. Unfortunately, it seems the bib ids it returns are broken. For now, I've added some logic to filter these out. In the future, we should look into why these mismatches occur and what we want to do with them.