### PR TITLE
Trim trailing white space for matching frontend userInput and query string from api response

### DIFF
--- a/src/app/components/SubjectHeading/Search/SubjectHeadingSearch.jsx
+++ b/src/app/components/SubjectHeading/Search/SubjectHeadingSearch.jsx
@@ -40,7 +40,7 @@ class SubjectHeadingSearch extends React.Component {
     const apiCall = () => {
       if (this.state.userInput.length) return axios(`${appConfig.baseUrl}/api/subjectHeadings/autosuggest?query=${this.state.userInput}`)
         .then((res) => {
-          if (res.data.request.query === this.state.userInput) {
+          if (res.data.request.query.trim() === this.state.userInput.trim()) {
             this.setState({
               suggestions: res.data.autosuggest,
               activeSuggestion: 0,


### PR DESCRIPTION
This PR applies a small change to fix the check to make sure the autosuggest api results match the user input. The response has trailing white space removed. The `userInput` does not. Applied `.trim()` to both, just as an extra precaution.