### PR TITLE
Da/filtered loading

### DIFF
--- a/src/app/components/LoadingLayer/LoadingLayer.jsx
+++ b/src/app/components/LoadingLayer/LoadingLayer.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import FocusTrap from 'focus-trap-react';
 
 const LoadingLayer = ({ status, title, focus }) => {
-  console.log('LoadingLayer status ', status, title)
   if (status === false) {
     return null;
   }

--- a/src/app/components/LoadingLayer/LoadingLayer.jsx
+++ b/src/app/components/LoadingLayer/LoadingLayer.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import FocusTrap from 'focus-trap-react';
 
 const LoadingLayer = ({ status, title, focus }) => {
+  console.log('LoadingLayer status ', status, title)
   if (status === false) {
     return null;
   }

--- a/src/app/components/ShepContainer/ShepContainer.jsx
+++ b/src/app/components/ShepContainer/ShepContainer.jsx
@@ -1,53 +1,82 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import Store from '@Store';
 import Breadcrumbs from '../Breadcrumbs/Breadcrumbs';
 import LoadingLayer from '../LoadingLayer/LoadingLayer';
 
-import Store from '../../stores/Store';
+// import Store from '../../stores/Store';
 
-const ShepContainer = (props) => {
-  return (
-    <main className="main-page shepcontainer">
-      <LoadingLayer
-        status={Store.state.isLoading}
-        title={props.loadingLayerText}
-      />
-      <div className="header-wrapper container-header">
-        <div className="header-topWrapper filter-page">
-          <div className="nypl-row container-row">
-            <div className="nypl-column-full">
-              <Breadcrumbs type={props.breadcrumbsType} />
-              { props.extraBannerElement }
-              <h1
-                aria-label={props.bannerOptions.ariaLabel || props.bannerOptions.text}
-              >
-                { props.bannerOptions.text }
-              </h1>
+class ShepContainer extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      isLoading: Store.state.isLoading,
+    };
+    this.onChange = this.onChange.bind(this);
+    Store.listen(this.onChange);
+  }
+
+  onChange() {
+    this.setState({ isLoading: Store.state.isLoading });
+  }
+
+  render() {
+    const {
+      mainContent,
+      extraBannerElement,
+      secondaryExtraBannerElement,
+      extraRow,
+      loadingLayerText,
+      breadcrumbsType,
+      bannerOptions,
+    } = this.props;
+    const {
+      isLoading,
+    } = this.state;
+
+    return (
+      <main className="main-page shepcontainer">
+        <LoadingLayer
+          status={isLoading}
+          title={loadingLayerText}
+        />
+        <div className="header-wrapper container-header">
+          <div className="header-topWrapper filter-page">
+            <div className="nypl-row container-row">
+              <div className="nypl-column-full">
+                <Breadcrumbs type={breadcrumbsType} />
+                { extraBannerElement }
+                <h1
+                  aria-label={bannerOptions.ariaLabel || bannerOptions.text}
+                >
+                  { bannerOptions.text }
+                </h1>
+              </div>
+            </div>
+          </div>
+          { secondaryExtraBannerElement }
+        </div>
+        { extraRow }
+        <div className="header-wrapper">
+          <div className="header-topWrapper">
+            <div className="nypl-row container-row">
+              <div className="nypl-column-full">
+                { mainContent }
+              </div>
             </div>
           </div>
         </div>
-        { props.secondaryExtraBannerElement }
-      </div>
-      { props.extraRow }
-      <div className="header-wrapper">
-        <div className="header-topWrapper">
-          <div className="nypl-row container-row">
-            <div className="nypl-column-full">
-              { props.mainContent }
-            </div>
-          </div>
-        </div>
-      </div>
-      { props.secondaryExtraBannerElement }
+        { secondaryExtraBannerElement }
 
-      { props.extraRow }
-      <div className="nypl-full-width-wrapper">
-        { null && props.mainContent }
-      </div>
-    </main>
-  );
-};
+        { extraRow }
+        <div className="nypl-full-width-wrapper">
+          { null && mainContent }
+        </div>
+      </main>
+    );
+  }
+}
 
 ShepContainer.propTypes = {
   mainContent: PropTypes.element,
@@ -62,7 +91,7 @@ ShepContainer.propTypes = {
 ShepContainer.defaultProps = {
   mainContent: null,
   extraBannerElement: null,
-  loadingLayerText: "Loading",
+  loadingLayerText: 'Loading',
 };
 
 export default ShepContainer;

--- a/src/app/components/ShepContainer/ShepContainer.jsx
+++ b/src/app/components/ShepContainer/ShepContainer.jsx
@@ -5,8 +5,6 @@ import Store from '@Store';
 import Breadcrumbs from '../Breadcrumbs/Breadcrumbs';
 import LoadingLayer from '../LoadingLayer/LoadingLayer';
 
-// import Store from '../../stores/Store';
-
 class ShepContainer extends React.Component {
   constructor(props) {
     super(props);

--- a/src/app/components/ShepContainer/ShepContainer.jsx
+++ b/src/app/components/ShepContainer/ShepContainer.jsx
@@ -9,14 +9,14 @@ class ShepContainer extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      isLoading: Store.state.isLoading,
+      isLoading: Store.getState().isLoading,
     };
     this.onChange = this.onChange.bind(this);
     Store.listen(this.onChange);
   }
 
   onChange() {
-    this.setState({ isLoading: Store.state.isLoading });
+    this.setState({ isLoading: Store.getState().isLoading });
   }
 
   render() {

--- a/src/app/components/SubjectHeading/SubjectHeadingsContainer.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeadingsContainer.jsx
@@ -8,7 +8,6 @@ import AlphabeticalPagination from '@AlphabeticalPagination';
 import SubjectHeadingsTable from './SubjectHeadingsTable';
 import SortButton from './SortButton';
 import appConfig from '../../data/appConfig';
-import Store from '@Store';
 
 
 class SubjectHeadingsContainer extends React.Component {

--- a/src/app/components/SubjectHeading/SubjectHeadingsContainer.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeadingsContainer.jsx
@@ -3,10 +3,12 @@ import PropTypes from 'prop-types';
 import axios from 'axios';
 
 import Pagination from '@Pagination';
+import Actions from '@Actions';
 import AlphabeticalPagination from '@AlphabeticalPagination';
 import SubjectHeadingsTable from './SubjectHeadingsTable';
 import SortButton from './SortButton';
 import appConfig from '../../data/appConfig';
+import Store from '@Store';
 
 
 class SubjectHeadingsContainer extends React.Component {
@@ -50,21 +52,27 @@ class SubjectHeadingsContainer extends React.Component {
       .join('&');
 
     const url = `${appConfig.baseUrl}/api/subjectHeadings/subject_headings?${apiParamString}`;
+    console.log('container did mount ', filter)
+    if (filter) {
+      console.log('loading');
+      Actions.updateLoadingStatus(true);
+    }
     axios(url)
       .then(
         (res) => {
+          console.log('store is loading ', Store.state.isLoading);
           this.setState({
             previousUrl: res.data.previous_url,
             nextUrl: res.data.next_url,
             subjectHeadings: res.data.subject_headings,
             error: res.data.subject_headings.length === 0,
-          });
+          }, () => (filter ? Actions.updateLoadingStatus(false) : null));
         },
       ).catch(
         (err) => {
           console.error('error: ', err);
           if (!this.state.subjectHeadings || this.state.subjectHeadings.length === 0) {
-            this.setState({ error: true });
+            this.setState({ error: true }, (() => filter ? Actions.updateLoadingStatus(false) : null));
           }
         },
       );

--- a/src/app/components/SubjectHeading/SubjectHeadingsContainer.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeadingsContainer.jsx
@@ -52,15 +52,12 @@ class SubjectHeadingsContainer extends React.Component {
       .join('&');
 
     const url = `${appConfig.baseUrl}/api/subjectHeadings/subject_headings?${apiParamString}`;
-    console.log('container did mount ', filter)
     if (filter) {
-      console.log('loading');
       Actions.updateLoadingStatus(true);
     }
     axios(url)
       .then(
         (res) => {
-          console.log('store is loading ', Store.state.isLoading);
           this.setState({
             previousUrl: res.data.previous_url,
             nextUrl: res.data.next_url,

--- a/src/app/pages/SubjectHeadingsIndex.jsx
+++ b/src/app/pages/SubjectHeadingsIndex.jsx
@@ -26,7 +26,7 @@ const SubjectHeadingsIndex = (props) => {
         }
       }
       extraBannerElement={<SubjectHeadingSearch />}
-      loadingLayerText="Subject Headings"
+      loadingLayerText={`Subject Headings ${filter ? `containing ${filter}` : ''}`}
       breadcrumbsType="subjectHeadings"
       key={componentKey}
     />


### PR DESCRIPTION
Addresses SCC-1801

Adds a loading layer to the filtered index page. This is basically a small change of calling some actions to change the `isLoading` slice of the Store before and after making the api calls on the filtered page. However, in order to get the ShepContainer listening properly to the Store, it needs to be a class component (it looks like this could also be done with hooks if we had react-redux 7 or above).

 Needed to put the call to `Store.listen` in the constructor, because the component doesn't finish mounting until after the axios call returns. This doesn't seem like standard practice, so we should discuss with Edwin and Crystal.