### PR TITLE
SCC-1763 error handling for bib page

### DIFF
--- a/src/app/components/BibPage/BibDetails.jsx
+++ b/src/app/components/BibPage/BibDetails.jsx
@@ -137,7 +137,7 @@ class BibDetails extends React.Component {
 
       return markup.length === 1
         ? markup.pop()
-        : (<ul>{markup.map(m => (<li key={m}>{m}</li>))}</ul>);
+        : (<ul>{markup.map(m => (<li key={m[0].key}>{m}</li>))}</ul>);
     }
     return null;
   }

--- a/src/app/components/BibPage/BibPage.jsx
+++ b/src/app/components/BibPage/BibPage.jsx
@@ -82,6 +82,10 @@ const BibPage = (props) => {
     { label: 'Owning Institutions', value: '' },
   ];
 
+  if (!bib['subjectHeadingData']) bottomFields.push({
+    label: 'Subject', value: 'subjectLiteral', linkable: true
+  })
+
   const itemHoldings = items.length && !isElectronicResources ? (
     <ItemHoldings
       shortenItems={shortenItems}

--- a/src/app/components/BibPage/BibPage.jsx
+++ b/src/app/components/BibPage/BibPage.jsx
@@ -82,6 +82,9 @@ const BibPage = (props) => {
     { label: 'Owning Institutions', value: '' },
   ];
 
+  // if the subject heading API call failed for some reason,
+  // we will use the subjectLiteral property from the
+  // Discovery API response instead
   if (!bib['subjectHeadingData']) bottomFields.push({
     label: 'Subject', value: 'subjectLiteral', linkable: true
   })

--- a/src/app/components/BibPage/DefinitionList.jsx
+++ b/src/app/components/BibPage/DefinitionList.jsx
@@ -12,7 +12,7 @@ const DefinitionList = ({ data, headings }) => {
       return null;
     }
 
-    if (item.term === 'Subject') return <SubjectHeadings key="subjects" headings={headings} />;
+    if (item.term === 'Subject' && headings) return <SubjectHeadings key="subjects" headings={headings} />;
 
     return ([
       (<dt key={`term-${item.term}`}>{item.term}</dt>),

--- a/src/app/components/SubjectHeading/SubjectHeading.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeading.jsx
@@ -149,7 +149,7 @@ class SubjectHeading extends React.Component {
             ),
           );
         },
-      ).catch(resp => console.log(resp));
+      ).catch(resp => console.error(resp));
   }
 
   render() {

--- a/src/server/ApiRoutes/Bib.js
+++ b/src/server/ApiRoutes/Bib.js
@@ -50,7 +50,7 @@ function bibSearchServer(req, res, next) {
         return res.redirect(`${appConfig.baseUrl}/404`);
       }
 
-      if (data.subjectLiteral.length) {
+      if (data.subjectLiteral && data.subjectLiteral.length) {
         return SubjectHeadings.shepApiCall(`/bibs/${bibId}/subject_headings`)
           .then((shepRes) => {
             console.log(shepRes.data);

--- a/src/server/ApiRoutes/Bib.js
+++ b/src/server/ApiRoutes/Bib.js
@@ -21,7 +21,6 @@ function fetchBib(bibId, cb, errorcb) {
   return Promise.all([
     nyplApiClientCall(bibId),
     nyplApiClientCall(`${bibId}.annotated-marc`),
-    SubjectHeadings.shepApiCall(`/bibs/${bibId}/subject_headings`)
   ])
     .then((response) => {
       // First response is jsonld formatting:
@@ -30,7 +29,6 @@ function fetchBib(bibId, cb, errorcb) {
       data.annotatedMarc = response[1];
       // Make sure retrieved annotated-marc document is valid:
       if (!data.annotatedMarc || !data.annotatedMarc.bib) data.annotatedMarc = null;
-      data.subjectHeadingData = response[2].data.subject_headings
 
       return data;
     })
@@ -52,12 +50,28 @@ function bibSearchServer(req, res, next) {
         return res.redirect(`${appConfig.baseUrl}/404`);
       }
 
-      res.locals.data.Store = {
-        bib: data,
-        searchKeywords: req.query.searchKeywords || '',
-        error: {},
-      };
-      next();
+      if (data.subjectLiteral.length) {
+        return SubjectHeadings.shepApiCall(`/bibs/${bibId}/subject_headings`)
+          .then((shepRes) => {
+            console.log(shepRes.data);
+            data.subjectHeadingData = shepRes.data.subject_headings;
+            res.locals.data.Store = {
+              bib: data,
+              searchKeywords: req.query.searchKeywords || '',
+              error: {},
+            };
+            next();
+          })
+          .catch((error) => {
+            logger.error(`Error in shepApiCall API error, bib_id: ${bibId}`, error);
+            res.locals.data.Store = {
+              bib: data,
+              searchKeywords: req.query.searchKeywords || '',
+              error,
+            };
+            next();
+          });
+      }
     },
     (error) => {
       logger.error(`Error in bibSearchServer API error, id: ${bibId}`, error);


### PR DESCRIPTION
This takes the SHEP API call out of the initial API call to Discovery for the bib data out of the `Promise.all`. It places it inside of a conditional in the `.then` to only make the call if the `subjectLiteral` property on the fetched bib has length. If it does and the call to SHEP API is successful, the response is stored in a `subjectHeadingData` property on the bib. In the component, if there is the `subjectHeadingData` property, it renders the subject headings with links to the SHEP show page. If that property does not exist, it falls back to the links to SearchResults with the `subjectLiteral` filter. There could be some tweaks to this logic. If that initial SHEP api call falls, there will is no re-attempt to integrating SHEP API.