### PR TITLE
SCC-1839 use glob import for component style sheets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3457,6 +3457,15 @@
       "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
       "dev": true
     },
+    "camel-case": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
+      "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
+      "requires": {
+        "no-case": "^2.2.0",
+        "upper-case": "^1.1.1"
+      }
+    },
     "camelcase": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
@@ -3545,6 +3554,31 @@
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
         "supports-color": "^5.3.0"
+      }
+    },
+    "change-case": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/change-case/-/change-case-3.1.0.tgz",
+      "integrity": "sha512-2AZp7uJZbYEzRPsFoa+ijKdvp9zsrnnt6+yFokfwEpeJm0xuJDVoxiRCAaTzyJND8GJkofo2IcKWaUZ/OECVzw==",
+      "requires": {
+        "camel-case": "^3.0.0",
+        "constant-case": "^2.0.0",
+        "dot-case": "^2.1.0",
+        "header-case": "^1.0.0",
+        "is-lower-case": "^1.1.0",
+        "is-upper-case": "^1.1.0",
+        "lower-case": "^1.1.1",
+        "lower-case-first": "^1.0.0",
+        "no-case": "^2.3.2",
+        "param-case": "^2.1.0",
+        "pascal-case": "^2.0.0",
+        "path-case": "^2.1.0",
+        "sentence-case": "^2.1.0",
+        "snake-case": "^2.1.0",
+        "swap-case": "^1.1.0",
+        "title-case": "^2.1.0",
+        "upper-case": "^1.1.1",
+        "upper-case-first": "^1.1.0"
       }
     },
     "chardet": {
@@ -4026,6 +4060,15 @@
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
     },
+    "constant-case": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-2.0.0.tgz",
+      "integrity": "sha1-QXV2TTidP6nI7NKRhu1gBSQ7akY=",
+      "requires": {
+        "snake-case": "^2.1.0",
+        "upper-case": "^1.1.1"
+      }
+    },
     "constants-browserify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
@@ -4245,6 +4288,32 @@
         "source-list-map": "^2.0.0"
       }
     },
+    "css-node-extract": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/css-node-extract/-/css-node-extract-2.1.3.tgz",
+      "integrity": "sha512-E7CzbC0I4uAs2dI8mPCVe+K37xuja5kjIugOotpwICFL7vzhmFMAPHvS/MF9gFrmv8DDUANsxrgyT/I3OLukcw==",
+      "requires": {
+        "change-case": "^3.0.1",
+        "postcss": "^6.0.14"
+      },
+      "dependencies": {
+        "postcss": {
+          "version": "6.0.23",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+          "requires": {
+            "chalk": "^2.4.1",
+            "source-map": "^0.6.1",
+            "supports-color": "^5.4.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        }
+      }
+    },
     "css-select": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
@@ -4255,6 +4324,31 @@
         "css-what": "2.1",
         "domutils": "1.5.1",
         "nth-check": "~1.0.1"
+      }
+    },
+    "css-selector-extract": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/css-selector-extract/-/css-selector-extract-3.3.6.tgz",
+      "integrity": "sha512-bBI8ZJKKyR9iHvxXb4t3E6WTMkis94eINopVg7y2FmmMjLXUVduD7mPEcADi4i9FX4wOypFMFpySX+0keuefxg==",
+      "requires": {
+        "postcss": "^6.0.14"
+      },
+      "dependencies": {
+        "postcss": {
+          "version": "6.0.23",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+          "requires": {
+            "chalk": "^2.4.1",
+            "source-map": "^0.6.1",
+            "supports-color": "^5.4.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        }
       }
     },
     "css-selector-tokenizer": {
@@ -4605,8 +4699,7 @@
     "detect-file": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
-      "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=",
-      "dev": true
+      "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc="
     },
     "detect-indent": {
       "version": "4.0.0",
@@ -4782,6 +4875,14 @@
       "requires": {
         "dom-serializer": "0",
         "domelementtype": "1"
+      }
+    },
+    "dot-case": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-2.1.1.tgz",
+      "integrity": "sha1-NNzzf1Co6TwrO8qLt/uRVcfaO+4=",
+      "requires": {
+        "no-case": "^2.2.0"
       }
     },
     "dotenv": {
@@ -5768,7 +5869,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
       "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
-      "dev": true,
       "requires": {
         "homedir-polyfill": "^1.0.1"
       }
@@ -6087,7 +6187,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-3.0.0.tgz",
       "integrity": "sha512-YbffarhcicEhOrm4CtrwdKBdCuz576RLdhJDsIfvNtxUuhdRet1qZcsMjqbePtAseKdAnDyM/IyXbu7PRPRLYg==",
-      "dev": true,
       "requires": {
         "detect-file": "^1.0.0",
         "is-glob": "^4.0.0",
@@ -6098,20 +6197,17 @@
         "arr-diff": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
-          "dev": true
+          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
         },
         "array-unique": {
           "version": "0.3.2",
           "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
-          "dev": true
+          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
         },
         "braces": {
           "version": "2.3.2",
           "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
           "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-          "dev": true,
           "requires": {
             "arr-flatten": "^1.1.0",
             "array-unique": "^0.3.2",
@@ -6129,7 +6225,6 @@
               "version": "2.0.1",
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true,
               "requires": {
                 "is-extendable": "^0.1.0"
               }
@@ -6140,7 +6235,6 @@
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -6149,7 +6243,6 @@
           "version": "2.1.4",
           "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
           "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
-          "dev": true,
           "requires": {
             "debug": "^2.3.3",
             "define-property": "^0.2.5",
@@ -6164,7 +6257,6 @@
               "version": "0.2.5",
               "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-              "dev": true,
               "requires": {
                 "is-descriptor": "^0.1.0"
               }
@@ -6173,7 +6265,6 @@
               "version": "2.0.1",
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true,
               "requires": {
                 "is-extendable": "^0.1.0"
               }
@@ -6182,7 +6273,6 @@
               "version": "0.1.6",
               "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
               "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-              "dev": true,
               "requires": {
                 "kind-of": "^3.0.2"
               },
@@ -6191,7 +6281,6 @@
                   "version": "3.2.2",
                   "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                  "dev": true,
                   "requires": {
                     "is-buffer": "^1.1.5"
                   }
@@ -6202,7 +6291,6 @@
               "version": "0.1.4",
               "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
               "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-              "dev": true,
               "requires": {
                 "kind-of": "^3.0.2"
               },
@@ -6211,7 +6299,6 @@
                   "version": "3.2.2",
                   "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                  "dev": true,
                   "requires": {
                     "is-buffer": "^1.1.5"
                   }
@@ -6222,7 +6309,6 @@
               "version": "0.1.6",
               "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
               "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-              "dev": true,
               "requires": {
                 "is-accessor-descriptor": "^0.1.6",
                 "is-data-descriptor": "^0.1.4",
@@ -6232,8 +6318,7 @@
             "kind-of": {
               "version": "5.1.0",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-              "dev": true
+              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
             }
           }
         },
@@ -6241,7 +6326,6 @@
           "version": "2.0.4",
           "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
           "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
-          "dev": true,
           "requires": {
             "array-unique": "^0.3.2",
             "define-property": "^1.0.0",
@@ -6257,7 +6341,6 @@
               "version": "1.0.0",
               "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-              "dev": true,
               "requires": {
                 "is-descriptor": "^1.0.0"
               }
@@ -6266,7 +6349,6 @@
               "version": "2.0.1",
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true,
               "requires": {
                 "is-extendable": "^0.1.0"
               }
@@ -6277,7 +6359,6 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-          "dev": true,
           "requires": {
             "extend-shallow": "^2.0.1",
             "is-number": "^3.0.0",
@@ -6289,7 +6370,6 @@
               "version": "2.0.1",
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true,
               "requires": {
                 "is-extendable": "^0.1.0"
               }
@@ -6300,7 +6380,6 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-          "dev": true,
           "requires": {
             "kind-of": "^6.0.0"
           }
@@ -6309,7 +6388,6 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-          "dev": true,
           "requires": {
             "kind-of": "^6.0.0"
           }
@@ -6318,7 +6396,6 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-          "dev": true,
           "requires": {
             "is-accessor-descriptor": "^1.0.0",
             "is-data-descriptor": "^1.0.0",
@@ -6328,14 +6405,12 @@
         "is-extglob": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-          "dev": true
+          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
         },
         "is-glob": {
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
           "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
-          "dev": true,
           "requires": {
             "is-extglob": "^2.1.1"
           }
@@ -6344,7 +6419,6 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
           },
@@ -6353,7 +6427,6 @@
               "version": "3.2.2",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
               "requires": {
                 "is-buffer": "^1.1.5"
               }
@@ -6363,20 +6436,17 @@
         "isobject": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
         },
         "kind-of": {
           "version": "6.0.3",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
-          "dev": true
+          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
         },
         "micromatch": {
           "version": "3.1.10",
           "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
           "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-          "dev": true,
           "requires": {
             "arr-diff": "^4.0.0",
             "array-unique": "^0.3.2",
@@ -6396,8 +6466,7 @@
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
     },
@@ -7332,7 +7401,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
       "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
-      "dev": true,
       "requires": {
         "expand-tilde": "^2.0.2",
         "homedir-polyfill": "^1.0.1",
@@ -7544,6 +7612,15 @@
       "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
       "dev": true
     },
+    "header-case": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/header-case/-/header-case-1.0.1.tgz",
+      "integrity": "sha1-lTWXMZfBRLCWE81l0xfvGZY70C0=",
+      "requires": {
+        "no-case": "^2.2.0",
+        "upper-case": "^1.1.3"
+      }
+    },
     "history": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/history/-/history-3.3.0.tgz",
@@ -7588,7 +7665,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
       "integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
-      "dev": true,
       "requires": {
         "parse-passwd": "^1.0.0"
       }
@@ -8054,8 +8130,7 @@
     "ini": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
-      "dev": true
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
     },
     "inquirer": {
       "version": "3.3.0",
@@ -8296,6 +8371,14 @@
       "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
       "dev": true
     },
+    "is-lower-case": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/is-lower-case/-/is-lower-case-1.1.3.tgz",
+      "integrity": "sha1-fhR75HaNxGbbO/shzGCzHmrWk5M=",
+      "requires": {
+        "lower-case": "^1.1.0"
+      }
+    },
     "is-my-ip-valid": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
@@ -8444,6 +8527,14 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+    },
+    "is-upper-case": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-upper-case/-/is-upper-case-1.1.2.tgz",
+      "integrity": "sha1-jQsfp+eTOh5YSDYA7H2WYcuvdW8=",
+      "requires": {
+        "upper-case": "^1.1.0"
+      }
     },
     "is-utf8": {
       "version": "0.2.1",
@@ -9164,6 +9255,19 @@
       "requires": {
         "currently-unhandled": "^0.4.1",
         "signal-exit": "^3.0.0"
+      }
+    },
+    "lower-case": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
+      "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw="
+    },
+    "lower-case-first": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/lower-case-first/-/lower-case-first-1.0.2.tgz",
+      "integrity": "sha1-5dp8JvKacHO+AtUrrJmA5ZIq36E=",
+      "requires": {
+        "lower-case": "^1.1.2"
       }
     },
     "lru-cache": {
@@ -10021,6 +10125,14 @@
         }
       }
     },
+    "no-case": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
+      "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
+      "requires": {
+        "lower-case": "^1.1.1"
+      }
+    },
     "node-cache": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-4.2.1.tgz",
@@ -10278,6 +10390,28 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
         }
+      }
+    },
+    "node-sass-glob-importer": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/node-sass-glob-importer/-/node-sass-glob-importer-5.3.2.tgz",
+      "integrity": "sha512-QTX7KPsISgp55REV6pMH703nzHfWCOEYEQC0cDyTRo7XO6WDvyC0OAzekuQ4gs505IZcxv9KxZ3uPJ5s5H9D3g==",
+      "requires": {
+        "node-sass-magic-importer": "^5.3.2"
+      }
+    },
+    "node-sass-magic-importer": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/node-sass-magic-importer/-/node-sass-magic-importer-5.3.2.tgz",
+      "integrity": "sha512-T3wTUdUoXQE3QN+EsyPpUXRI1Gj1lEsrySQ9Kzlzi15QGKi+uRa9fmvkcSy2y3BKgoj//7Mt9+s+7p0poMpg6Q==",
+      "requires": {
+        "css-node-extract": "^2.1.3",
+        "css-selector-extract": "^3.3.6",
+        "findup-sync": "^3.0.0",
+        "glob": "^7.1.3",
+        "object-hash": "^1.3.1",
+        "postcss-scss": "^2.0.0",
+        "resolve": "^1.10.1"
       }
     },
     "nopt": {
@@ -11466,6 +11600,11 @@
         }
       }
     },
+    "object-hash": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-1.3.1.tgz",
+      "integrity": "sha512-OSuu/pU4ENM9kmREg0BdNrUDIl1heYa4mBZacJc+vVWz4GtAwu7jO8s4AIt2aGRUTqxykpWzI3Oqnsm13tTMDA=="
+    },
     "object-inspect": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
@@ -11971,6 +12110,14 @@
         "readable-stream": "^2.1.5"
       }
     },
+    "param-case": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",
+      "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
+      "requires": {
+        "no-case": "^2.2.0"
+      }
+    },
     "parse-asn1": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.5.tgz",
@@ -12006,8 +12153,7 @@
     "parse-passwd": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
-      "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
-      "dev": true
+      "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY="
     },
     "parse5": {
       "version": "3.0.3",
@@ -12023,6 +12169,15 @@
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
     },
+    "pascal-case": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-2.0.1.tgz",
+      "integrity": "sha1-LVeNNFX2YNpl7KGO+VtODekSdh4=",
+      "requires": {
+        "camel-case": "^3.0.0",
+        "upper-case-first": "^1.1.0"
+      }
+    },
     "pascalcase": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
@@ -12032,6 +12187,14 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.1.tgz",
       "integrity": "sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ=="
+    },
+    "path-case": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/path-case/-/path-case-2.1.1.tgz",
+      "integrity": "sha1-lLgDfDctP+KQbkZbtF4l0ibo7qU=",
+      "requires": {
+        "no-case": "^2.2.0"
+      }
     },
     "path-dirname": {
       "version": "1.0.2",
@@ -12564,6 +12727,39 @@
         "has": "^1.0.1",
         "postcss": "^5.0.8",
         "postcss-value-parser": "^3.0.1"
+      }
+    },
+    "postcss-scss": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-2.0.0.tgz",
+      "integrity": "sha512-um9zdGKaDZirMm+kZFKKVsnKPF7zF7qBAtIfTSnZXD1jZ0JNZIxdB6TxQOjCnlSzLRInVl2v3YdBh/M881C4ug==",
+      "requires": {
+        "postcss": "^7.0.0"
+      },
+      "dependencies": {
+        "postcss": {
+          "version": "7.0.27",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.27.tgz",
+          "integrity": "sha512-WuQETPMcW9Uf1/22HWUWP9lgsIC+KEHg2kozMflKjbeUtw9ujvFX6QmIfozaErDkmLWS9WEnEdEe6Uo9/BNTdQ==",
+          "requires": {
+            "chalk": "^2.4.2",
+            "source-map": "^0.6.1",
+            "supports-color": "^6.1.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        },
+        "supports-color": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
       }
     },
     "postcss-selector-parser": {
@@ -13870,7 +14066,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
       "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
-      "dev": true,
       "requires": {
         "expand-tilde": "^2.0.0",
         "global-modules": "^1.0.0"
@@ -13880,7 +14075,6 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
           "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
-          "dev": true,
           "requires": {
             "global-prefix": "^1.0.1",
             "is-windows": "^1.0.1",
@@ -14151,6 +14345,15 @@
         }
       }
     },
+    "sentence-case": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-2.1.1.tgz",
+      "integrity": "sha1-H24t2jnBaL+S0T+G1KkYkz9mftQ=",
+      "requires": {
+        "no-case": "^2.2.0",
+        "upper-case-first": "^1.1.2"
+      }
+    },
     "serialize-javascript": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-2.1.2.tgz",
@@ -14376,6 +14579,14 @@
       "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.1.0.tgz",
       "integrity": "sha512-iVICrxOzCynf/SNaBQCw34eM9jROU/s5rzIhpOvzhzuYHfJR/DhZfDkXiZSgKXfgv26HT3Yni3AV/DGw0cGnnw==",
       "dev": true
+    },
+    "snake-case": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-2.1.0.tgz",
+      "integrity": "sha1-Qb2xtz8w7GagTU4srRt2OH1NbZ8=",
+      "requires": {
+        "no-case": "^2.2.0"
+      }
     },
     "snapdragon": {
       "version": "0.8.2",
@@ -15001,6 +15212,15 @@
         }
       }
     },
+    "swap-case": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/swap-case/-/swap-case-1.1.2.tgz",
+      "integrity": "sha1-w5IDpFhzhfrTyFCgvRvK+ggZdOM=",
+      "requires": {
+        "lower-case": "^1.1.1",
+        "upper-case": "^1.1.1"
+      }
+    },
     "symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -15221,6 +15441,15 @@
       "integrity": "sha512-60aV6sgJ5YEbzUdn9c8kYGIqOubPoUdqQCul3SBAsRCZ40s6Y5cMcrW4dt3/k/EsbLVJNl9n6Vz3fTc+k2GeKQ==",
       "requires": {
         "setimmediate": "^1.0.4"
+      }
+    },
+    "title-case": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/title-case/-/title-case-2.1.1.tgz",
+      "integrity": "sha1-PhJyFtpY0rxb7PE3q5Ha46fNj6o=",
+      "requires": {
+        "no-case": "^2.2.0",
+        "upper-case": "^1.0.3"
       }
     },
     "tmp": {
@@ -15507,6 +15736,19 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
       "integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg=="
+    },
+    "upper-case": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
+      "integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg="
+    },
+    "upper-case-first": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-1.1.2.tgz",
+      "integrity": "sha1-XXm+3P8UQZUY/S7bCgUHybaFkRU=",
+      "requires": {
+        "upper-case": "^1.1.1"
+      }
     },
     "uri-js": {
       "version": "4.2.2",

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "iso": "5.2.0",
     "jsonwebtoken": "^8.3.0",
     "node-sass": "^4.9.0",
+    "node-sass-glob-importer": "^5.3.2",
     "prop-types": "15.5.10",
     "react": "^16.12.0",
     "react-a11y": "0.3.4",

--- a/src/app/components/SubjectHeading/NestedTableColumnHeading.jsx
+++ b/src/app/components/SubjectHeading/NestedTableColumnHeading.jsx
@@ -32,12 +32,12 @@ const NestedTableColumnHeading = (props) => {
       data={`${subjectHeading.uuid}, ${container}`}
       className={`
         subjectHeadingRow
+        nestedTable
         ${(indentation || 0) === 0 ? 'topLevel' : ''}
         ${(indentation || 0) !== 0 ? 'nestedSubjectHeading' : ''}
-        headingStyle
         `}
     >
-      <td className={`subjectHeadingsTableCell subjectHeadingLabel ${sortBy === 'alphabetical' ? 'selected' : ''}`} >
+      <th className={`subjectHeadingsTableCell subjectHeadingLabel ${sortBy === 'alphabetical' ? 'selected' : ''}`} >
         <div className="subjectHeadingLabelInner" style={positionStyle}>
           { updateSort
             ? <SortButton handler={updateSort} type="alphabetical" direction={calculateDirection('alphabetical')} />
@@ -45,8 +45,8 @@ const NestedTableColumnHeading = (props) => {
           }
           <span className="emph"><span className="noEmph">Heading</span></span>
         </div>
-      </td>
-      <td className={`subjectHeadingsTableCell subjectHeadingAttribute titles ${sortBy === 'bibs' ? 'selected' : ''}`}>
+      </th>
+      <th className={`subjectHeadingsTableCell subjectHeadingAttribute titles ${sortBy === 'bibs' ? 'selected' : ''}`}>
         <div className="subjectHeadingAttributeInner">
           { updateSort
             ? <SortButton handler={updateSort} type="bibs" direction={calculateDirection('bibs')} />
@@ -54,8 +54,8 @@ const NestedTableColumnHeading = (props) => {
           }
         Title Count
         </div>
-      </td>
-      <td className={`subjectHeadingsTableCell subjectHeadingAttribute narrower ${sortBy === 'descendants' ? 'selected' : ''}`}>
+      </th>
+      <th className={`subjectHeadingsTableCell subjectHeadingAttribute narrower ${sortBy === 'descendants' ? 'selected' : ''}`}>
         <div className="subjectHeadingAttributeInner">
           { updateSort
             ? <SortButton handler={updateSort} type="descendants" direction={calculateDirection('descendants')} />
@@ -63,7 +63,7 @@ const NestedTableColumnHeading = (props) => {
           }
       Subheading Count
         </div>
-      </td>
+      </th>
     </tr>
   );
 };

--- a/src/app/components/SubjectHeading/SubjectHeading.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeading.jsx
@@ -237,7 +237,6 @@ class SubjectHeading extends React.Component {
             ${(open || children || isMain) ? "openSubjectHeading" : ""}
             ${(indentation || 0) === 0 ? 'topLevel' : ''}
             ${(indentation || 0) !== 0 ? 'nestedSubjectHeading' : ''}
-            ${this.props.subjectHeading.heading_style ? 'headingStyle' : ''}
           `}
         >
           <td className={`subjectHeadingsTableCell subjectHeadingLabel ${sortBy === 'alphabetical' ? 'selected' : ''}`} >

--- a/src/client/styles/components/SubjectHeadings.scss
+++ b/src/client/styles/components/SubjectHeadings.scss
@@ -1,167 +1,6 @@
 $lighter-grey: #E8E4E3;
 $darker-grey: lightgray;
 
-.subjectHeadingsTable {
-  display: table;
-  width: 100%;
-  font-size: 16px;
-  a {
-    text-decoration: none;
-    display: flex;
-  }
-
-  thead {
-    .subjectHeadingsTableCell.selected {
-      color: #a83232,
-    }
-    .subjectHeadingAttributeInner {
-      display: inline-flex;
-    }
-
-    .subjectHeadingLabelInner {
-      display: flex;
-    }
-
-    .subjectSortButton {
-      padding-right: 10px;
-    }
-  }
-
-  tbody > .openSubjectHeading {
-    background-color: $lighter-grey;
-      &.topLevel {
-        background-color: $darker-grey;
-      }
-      .subjectHeadingLabelInner, .subjectHeadingAttribute, .sortButton {
-        background-color: $darker-grey;
-      }
-  }
-  .nestedSubjectHeading {
-    background-color: $lighter-grey;
-    .subjectHeadingsTableCell {
-      border-top: 1px solid $lighter-grey;
-    }
-  }
-  .subjectHeadingRow {
-    text-align: left;
-    display: table-row;
-    &.preview {
-      width: 100%;
-      .previewDiv {
-        width: 100%;
-        justify-content: center;
-        > em {
-          margin-left: 15%;
-        }
-        .previewInner {
-          width: 100%;
-          justify-content: center;
-          display: flex;
-        }
-        em {
-          color: #31806a;
-        }
-      }
-      .previewUl {
-        justify-content: space-around;
-        display: flex;
-        width: 100%;
-        margin-bottom: 0px;
-        list-style: none;
-        ul {
-          width: 100%;
-          justify-content: left;
-          li {
-            display: flex;
-            justify-content: left;
-            margin-bottom: 5px;
-            &.fullLabel {
-              font-size: .75rem;
-            }
-            &.bibCount {
-              color: #31806a;
-            }
-          }
-        }
-      }
-    }
-    .subjectHeadingAttribute {
-      padding-left: 10px;
-      text-align: right;
-    }
-    .subjectHeadingsTableCell {
-      height: 100%;
-      display: table-cell;
-      &.sortButton {
-        text-align: center;
-        &.selected {
-          font-weight: bold;
-        }
-        padding-left: 10px;
-        width: 125px;
-        box-sizing: border-box;
-
-        & > select {
-          border-width: 1px;
-          border-color: black;
-          font-size: 10px;
-        }
-      }
-
-      .subjectHeadingLabelInner {
-        height: 100%;
-        position: relative;
-        padding-left: 5px;
-        a:hover {
-          color: #176e91;
-          cursor: pointer;
-        }
-        .subjectHeadingToggle {
-          position: absolute;
-          left: -20px;
-
-          &:focus {
-            outline-color: #ffb81d;
-            outline-style: solid;
-            outline-width: 0.125rem;
-          }
-        }
-      }
-    }
-  }
-  .seeMoreButton {
-    background-color: $lighter-grey;
-    border: none;
-    background: none;
-    padding: 0;
-    text-align: inherit;
-
-    &:focus {
-      outline-color: #ffb81d;
-      outline-style: solid;
-      outline-width: 0.125rem;
-    }
-
-  }
-
-  th {
-    &> .subjectHeadingLabelInner {
-      text-align: initial;
-      padding-left: 5px;
-    }
-
-    &.sort {
-      text-align: center;
-    }
-
-    &.subjectHeadingAttribute {
-      text-align: right;
-    }
-  }
-
-}
-
-
 .emph {
   &.mainHeading {
     font-weight: bold;
@@ -226,21 +65,6 @@ $darker-grey: lightgray;
 
   em {
     font-style: italic;
-  }
-}
-
-.seeMoreButton {
-  color: #104d65;
-  font-size: 14px;
-  margin-left: 40px;
-  cursor: default;
-
-  em {
-    padding-left: 10px;
-  }
-
-  &:hover {
-    color: #1b7fa7;
   }
 }
 
@@ -467,10 +291,6 @@ span > .verticalEllipse {
   }
 }
 
-.subjectHeadingLabel.mainLabel {
-  font-style: italic;
-}
-
 $light-border: 0.08333rem solid #d7d4d0;
 
 .alphabeticalPagination {
@@ -558,23 +378,6 @@ $bottom-left-corner: 0 0 0 0.2rem;
     }
     a:nth-child(n+21) {
       border-top: unset;
-    }
-  }
-}
-
-.headingStyle {
-  font-weight: 300;
-  .selected {
-    font-weight: bold;
-  }
-  .emph {
-    color: black;
-  }
-  .subjectHeadingLabelInner, .subjectHeadingAttributeInner {
-    display: inline-flex;
-    .subjectSortButton {
-      margin-right: 10px;
-      font-size: 15px;
     }
   }
 }

--- a/src/client/styles/components/SubjectHeadings/AdditionalSubjectHeadingsButton.scss
+++ b/src/client/styles/components/SubjectHeadings/AdditionalSubjectHeadingsButton.scss
@@ -1,0 +1,25 @@
+.seeMoreButton {
+  color: #104d65;
+  font-size: 14px;
+  margin-left: 40px;
+  cursor: default;
+  background-color: $lighter-grey;
+  border: 0;
+  background: none;
+  padding: 0;
+  text-align: inherit;
+
+  em {
+    padding-left: 10px;
+  }
+
+  &:focus {
+    outline-color: #ffb81d;
+    outline-style: solid;
+    outline-width: .125rem;
+  }
+
+  &:hover {
+    color: #1b7fa7;
+  }
+}

--- a/src/client/styles/components/SubjectHeadings/NestedTableColumnHeading.scss
+++ b/src/client/styles/components/SubjectHeadings/NestedTableColumnHeading.scss
@@ -1,0 +1,19 @@
+.nestedTable {
+  th {
+    font-weight: normal;
+  }
+
+  .selected {
+    font-weight: bold;
+  }
+  .emph {
+    color: black;
+  }
+  .subjectHeadingLabelInner, .subjectHeadingAttributeInner {
+    display: inline-flex;
+    .subjectSortButton {
+      margin-right: 10px;
+      font-size: 15px;
+    }
+  }
+}

--- a/src/client/styles/components/SubjectHeadings/SubjectHeading.scss
+++ b/src/client/styles/components/SubjectHeadings/SubjectHeading.scss
@@ -1,0 +1,110 @@
+.subjectHeadingLabel.mainLabel {
+  font-style: italic;
+}
+
+.subjectHeadingToggle {
+  position: absolute;
+  left: -20px;
+
+  &:focus {
+    outline-color: #ffb81d;
+    outline-style: solid;
+    outline-width: 0.125rem;
+  }
+}
+
+.subjectHeadingRow {
+  text-align: left;
+  display: table-row;
+  &.preview {
+    width: 100%;
+    .previewDiv {
+      width: 100%;
+      justify-content: center;
+      > em {
+        margin-left: 15%;
+      }
+      .previewInner {
+        width: 100%;
+        justify-content: center;
+        display: flex;
+      }
+      em {
+        color: #31806a;
+      }
+    }
+    .previewUl {
+      justify-content: space-around;
+      display: flex;
+      width: 100%;
+      margin-bottom: 0px;
+      list-style: none;
+      ul {
+        width: 100%;
+        justify-content: left;
+        li {
+          display: flex;
+          justify-content: left;
+          margin-bottom: 5px;
+          &.fullLabel {
+            font-size: .75rem;
+          }
+          &.bibCount {
+            color: #31806a;
+          }
+        }
+      }
+    }
+  }
+  .subjectHeadingAttribute {
+    padding-left: 10px;
+    text-align: right;
+  }
+  .subjectHeadingsTableCell {
+    height: 100%;
+    display: table-cell;
+    &.sortButton {
+      text-align: center;
+      &.selected {
+        font-weight: bold;
+      }
+      padding-left: 10px;
+      width: 125px;
+      box-sizing: border-box;
+
+      & > select {
+        border-width: 1px;
+        border-color: black;
+        font-size: 10px;
+      }
+    }
+
+    .subjectHeadingLabelInner {
+      height: 100%;
+      position: relative;
+      padding-left: 5px;
+      a:hover {
+        color: #176e91;
+        cursor: pointer;
+      }
+    }
+  }
+}
+
+.nestedSubjectHeading {
+  background-color: $lighter-grey;
+  .subjectHeadingsTableCell {
+    border-top: 1px solid $lighter-grey;
+  }
+}
+
+// styling for top level open heading
+tbody > .openSubjectHeading {
+  background-color: $lighter-grey;
+    &.topLevel {
+      background-color: $darker-grey;
+    }
+    .subjectHeadingLabelInner, .subjectHeadingAttribute, .sortButton {
+      background-color: $darker-grey;
+    }
+}

--- a/src/client/styles/components/SubjectHeadings/SubjectHeadingsTable.scss
+++ b/src/client/styles/components/SubjectHeadings/SubjectHeadingsTable.scss
@@ -1,0 +1,26 @@
+.subjectHeadingsTable {
+  display: table;
+  font-size: 16px;
+  width: 100%;
+
+  a {
+    display: flex;
+    text-decoration: none;
+  }
+
+  th {
+    &> .subjectHeadingLabelInner {
+      text-align: initial;
+      padding-left: 5px;
+    }
+
+    &.sort {
+      text-align: center;
+    }
+
+    &.subjectHeadingAttribute {
+      text-align: right;
+    }
+  }
+
+}

--- a/src/client/styles/components/SubjectHeadings/SubjectHeadingsTableHeader.scss
+++ b/src/client/styles/components/SubjectHeadings/SubjectHeadingsTableHeader.scss
@@ -1,0 +1,16 @@
+.subjectHeadingsTable thead {
+  .subjectHeadingsTableCell.selected {
+    color: #a83232;
+  }
+  .subjectHeadingAttributeInner {
+    display: inline-flex;
+  }
+
+  .subjectHeadingLabelInner {
+    display: flex;
+  }
+
+  .subjectSortButton {
+    padding-right: 10px;
+  }
+}

--- a/src/client/styles/main.scss
+++ b/src/client/styles/main.scss
@@ -19,19 +19,7 @@ Import style rules from NYPL React module components
 @import "~@nypl/dgx-header-component/dist/styles/main";
 @import "~@nypl/dgx-react-footer/dist/styles/styles";
 
-@import "components/BibPage.scss";
-@import "components/Feedback.scss";
-@import "components/Home.scss";
-@import "components/_forms.v2.scss";
-@import "components/ItemTable.scss";
-@import "components/LoadingLayer.scss";
-@import "components/FilterPopup.scss";
-@import "components/Search.scss";
-@import "components/SelectedFilters.scss";
-@import "components/HoldConfirmation.scss";
-@import "components/SubjectHeadings.scss";
-@import "components/ShepContainer.scss";
-@import "components/SubjectHeadings/BibsList.scss";
+@import "components/**/*.scss";
 
 @import "style-v2.scss";
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,6 +4,7 @@ const merge = require('webpack-merge');
 const CleanBuild = require('clean-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const sassPaths = require('@nypl/design-toolkit').includePaths;
+const globImporter = require('node-sass-glob-importer');
 // const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 
 // References the applications root path
@@ -141,6 +142,7 @@ if (ENV === 'development') {
             { loader: 'sass-loader',
               options: {
                 includePaths: sassPaths,
+                importer: globImporter(),
               },
             },
           ],
@@ -182,6 +184,7 @@ if (ENV === 'production') {
               options: {
                 sourceMap: true,
                 includePaths: sassPaths,
+                importer: globImporter(),
               },
             },
           ],


### PR DESCRIPTION
**What's this do?**
Implements glob import for SCSS to make it easier to architect our SCSS in a componentized way.

**Why are we doing this? (w/ JIRA link if applicable)**
This is a small task to allow for more seamless larger refactoring and restyling.
https://jira.nypl.org/browse/SCC-1839

**How should this be tested? / Do these changes have associated tests?**
No tests yet.

**Dependencies for merging? Releasing to production?**
Run `npm i` before running locally.
There is a pre-existing issue from changing the CSS wrapper class to the one from Header with the focus styling. I applied a band-aid to a couple elements I noticed in a previous PR. A nicer fix will be to come. Just wanted to note that here because it threw me off initially and to emphasize that it is unrelated to changes in this PR.

**Has the application documentation been updated for these changes?**
No.

**Did someone actually run this code to verify it works?**
Yes. I did.