### PR TITLE
SCC-1833: stylesheets for SubjectHeadingsTable and descendant components

### DIFF
--- a/src/app/components/SubjectHeading/NestedTableColumnHeading.jsx
+++ b/src/app/components/SubjectHeading/NestedTableColumnHeading.jsx
@@ -32,9 +32,9 @@ const NestedTableColumnHeading = (props) => {
       data={`${subjectHeading.uuid}, ${container}`}
       className={`
         subjectHeadingRow
+        selectedColumnStyle
         ${(indentation || 0) === 0 ? 'topLevel' : ''}
         ${(indentation || 0) !== 0 ? 'nestedSubjectHeading' : ''}
-        headingStyle
         `}
     >
       <td className={`subjectHeadingsTableCell subjectHeadingLabel ${sortBy === 'alphabetical' ? 'selected' : ''}`} >

--- a/src/app/components/SubjectHeading/NestedTableColumnHeading.jsx
+++ b/src/app/components/SubjectHeading/NestedTableColumnHeading.jsx
@@ -32,12 +32,12 @@ const NestedTableColumnHeading = (props) => {
       data={`${subjectHeading.uuid}, ${container}`}
       className={`
         subjectHeadingRow
-        selectedColumnStyle
+        nestedTable
         ${(indentation || 0) === 0 ? 'topLevel' : ''}
         ${(indentation || 0) !== 0 ? 'nestedSubjectHeading' : ''}
         `}
     >
-      <td className={`subjectHeadingsTableCell subjectHeadingLabel ${sortBy === 'alphabetical' ? 'selected' : ''}`} >
+      <th className={`subjectHeadingsTableCell subjectHeadingLabel ${sortBy === 'alphabetical' ? 'selected' : ''}`} >
         <div className="subjectHeadingLabelInner" style={positionStyle}>
           { updateSort
             ? <SortButton handler={updateSort} type="alphabetical" direction={calculateDirection('alphabetical')} />
@@ -45,8 +45,8 @@ const NestedTableColumnHeading = (props) => {
           }
           <span className="emph"><span className="noEmph">Heading</span></span>
         </div>
-      </td>
-      <td className={`subjectHeadingsTableCell subjectHeadingAttribute titles ${sortBy === 'bibs' ? 'selected' : ''}`}>
+      </th>
+      <th className={`subjectHeadingsTableCell subjectHeadingAttribute titles ${sortBy === 'bibs' ? 'selected' : ''}`}>
         <div className="subjectHeadingAttributeInner">
           { updateSort
             ? <SortButton handler={updateSort} type="bibs" direction={calculateDirection('bibs')} />
@@ -54,8 +54,8 @@ const NestedTableColumnHeading = (props) => {
           }
         Title Count
         </div>
-      </td>
-      <td className={`subjectHeadingsTableCell subjectHeadingAttribute narrower ${sortBy === 'descendants' ? 'selected' : ''}`}>
+      </th>
+      <th className={`subjectHeadingsTableCell subjectHeadingAttribute narrower ${sortBy === 'descendants' ? 'selected' : ''}`}>
         <div className="subjectHeadingAttributeInner">
           { updateSort
             ? <SortButton handler={updateSort} type="descendants" direction={calculateDirection('descendants')} />
@@ -63,7 +63,7 @@ const NestedTableColumnHeading = (props) => {
           }
       Subheading Count
         </div>
-      </td>
+      </th>
     </tr>
   );
 };

--- a/src/app/components/SubjectHeading/SubjectHeading.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeading.jsx
@@ -237,7 +237,6 @@ class SubjectHeading extends React.Component {
             ${(open || children || isMain) ? "openSubjectHeading" : ""}
             ${(indentation || 0) === 0 ? 'topLevel' : ''}
             ${(indentation || 0) !== 0 ? 'nestedSubjectHeading' : ''}
-            ${this.props.subjectHeading.heading_style ? 'headingStyle' : ''}
           `}
         >
           <td className={`subjectHeadingsTableCell subjectHeadingLabel ${sortBy === 'alphabetical' ? 'selected' : ''}`} >

--- a/src/client/styles/components/SubjectHeadings.scss
+++ b/src/client/styles/components/SubjectHeadings.scss
@@ -1,167 +1,6 @@
 $lighter-grey: #E8E4E3;
 $darker-grey: lightgray;
 
-.subjectHeadingsTable {
-  display: table;
-  width: 100%;
-  font-size: 16px;
-  a {
-    text-decoration: none;
-    display: flex;
-  }
-
-  thead {
-    .subjectHeadingsTableCell.selected {
-      color: #a83232,
-    }
-    .subjectHeadingAttributeInner {
-      display: inline-flex;
-    }
-
-    .subjectHeadingLabelInner {
-      display: flex;
-    }
-
-    .subjectSortButton {
-      padding-right: 10px;
-    }
-  }
-
-  tbody > .openSubjectHeading {
-    background-color: $lighter-grey;
-      &.topLevel {
-        background-color: $darker-grey;
-      }
-      .subjectHeadingLabelInner, .subjectHeadingAttribute, .sortButton {
-        background-color: $darker-grey;
-      }
-  }
-  .nestedSubjectHeading {
-    background-color: $lighter-grey;
-    .subjectHeadingsTableCell {
-      border-top: 1px solid $lighter-grey;
-    }
-  }
-  .subjectHeadingRow {
-    text-align: left;
-    display: table-row;
-    &.preview {
-      width: 100%;
-      .previewDiv {
-        width: 100%;
-        justify-content: center;
-        > em {
-          margin-left: 15%;
-        }
-        .previewInner {
-          width: 100%;
-          justify-content: center;
-          display: flex;
-        }
-        em {
-          color: #31806a;
-        }
-      }
-      .previewUl {
-        justify-content: space-around;
-        display: flex;
-        width: 100%;
-        margin-bottom: 0px;
-        list-style: none;
-        ul {
-          width: 100%;
-          justify-content: left;
-          li {
-            display: flex;
-            justify-content: left;
-            margin-bottom: 5px;
-            &.fullLabel {
-              font-size: .75rem;
-            }
-            &.bibCount {
-              color: #31806a;
-            }
-          }
-        }
-      }
-    }
-    .subjectHeadingAttribute {
-      padding-left: 10px;
-      text-align: right;
-    }
-    .subjectHeadingsTableCell {
-      height: 100%;
-      display: table-cell;
-      &.sortButton {
-        text-align: center;
-        &.selected {
-          font-weight: bold;
-        }
-        padding-left: 10px;
-        width: 125px;
-        box-sizing: border-box;
-
-        & > select {
-          border-width: 1px;
-          border-color: black;
-          font-size: 10px;
-        }
-      }
-
-      .subjectHeadingLabelInner {
-        height: 100%;
-        position: relative;
-        padding-left: 5px;
-        a:hover {
-          color: #176e91;
-          cursor: pointer;
-        }
-        .subjectHeadingToggle {
-          position: absolute;
-          left: -20px;
-
-          &:focus {
-            outline-color: #ffb81d;
-            outline-style: solid;
-            outline-width: 0.125rem;
-          }
-        }
-      }
-    }
-  }
-  .seeMoreButton {
-    background-color: $lighter-grey;
-    border: none;
-    background: none;
-    padding: 0;
-    text-align: inherit;
-
-    &:focus {
-      outline-color: #ffb81d;
-      outline-style: solid;
-      outline-width: 0.125rem;
-    }
-
-  }
-
-  th {
-    &> .subjectHeadingLabelInner {
-      text-align: initial;
-      padding-left: 5px;
-    }
-
-    &.sort {
-      text-align: center;
-    }
-
-    &.subjectHeadingAttribute {
-      text-align: right;
-    }
-  }
-
-}
-
-
 .emph {
   &.mainHeading {
     font-weight: bold;
@@ -226,21 +65,6 @@ $darker-grey: lightgray;
 
   em {
     font-style: italic;
-  }
-}
-
-.seeMoreButton {
-  color: #104d65;
-  font-size: 14px;
-  margin-left: 40px;
-  cursor: default;
-
-  em {
-    padding-left: 10px;
-  }
-
-  &:hover {
-    color: #1b7fa7;
   }
 }
 
@@ -467,10 +291,6 @@ span > .verticalEllipse {
   }
 }
 
-.subjectHeadingLabel.mainLabel {
-  font-style: italic;
-}
-
 $light-border: 0.08333rem solid #d7d4d0;
 
 .alphabeticalPagination {
@@ -558,23 +378,6 @@ $bottom-left-corner: 0 0 0 0.2rem;
     }
     a:nth-child(n+21) {
       border-top: unset;
-    }
-  }
-}
-
-.headingStyle {
-  font-weight: 300;
-  .selected {
-    font-weight: bold;
-  }
-  .emph {
-    color: black;
-  }
-  .subjectHeadingLabelInner, .subjectHeadingAttributeInner {
-    display: inline-flex;
-    .subjectSortButton {
-      margin-right: 10px;
-      font-size: 15px;
     }
   }
 }

--- a/src/client/styles/components/SubjectHeadings/AdditionalSubjectHeadingsButton.scss
+++ b/src/client/styles/components/SubjectHeadings/AdditionalSubjectHeadingsButton.scss
@@ -1,0 +1,25 @@
+.seeMoreButton {
+  color: #104d65;
+  font-size: 14px;
+  margin-left: 40px;
+  cursor: default;
+  background-color: $lighter-grey;
+  border: 0;
+  background: none;
+  padding: 0;
+  text-align: inherit;
+
+  em {
+    padding-left: 10px;
+  }
+
+  &:focus {
+    outline-color: #ffb81d;
+    outline-style: solid;
+    outline-width: .125rem;
+  }
+
+  &:hover {
+    color: #1b7fa7;
+  }
+}

--- a/src/client/styles/components/SubjectHeadings/NestedTableColumnHeading.scss
+++ b/src/client/styles/components/SubjectHeadings/NestedTableColumnHeading.scss
@@ -1,0 +1,16 @@
+.selectedColumnStyle {
+  font-weight: 300;
+  .selected {
+    font-weight: bold;
+  }
+  .emph {
+    color: black;
+  }
+  .subjectHeadingLabelInner, .subjectHeadingAttributeInner {
+    display: inline-flex;
+    .subjectSortButton {
+      margin-right: 10px;
+      font-size: 15px;
+    }
+  }
+}

--- a/src/client/styles/components/SubjectHeadings/NestedTableColumnHeading.scss
+++ b/src/client/styles/components/SubjectHeadings/NestedTableColumnHeading.scss
@@ -1,5 +1,8 @@
-.selectedColumnStyle {
-  font-weight: 300;
+.nestedTable {
+  th {
+    font-weight: normal;
+  }
+
   .selected {
     font-weight: bold;
   }

--- a/src/client/styles/components/SubjectHeadings/SubjectHeading.scss
+++ b/src/client/styles/components/SubjectHeadings/SubjectHeading.scss
@@ -1,0 +1,110 @@
+.subjectHeadingLabel.mainLabel {
+  font-style: italic;
+}
+
+.subjectHeadingToggle {
+  position: absolute;
+  left: -20px;
+
+  &:focus {
+    outline-color: #ffb81d;
+    outline-style: solid;
+    outline-width: 0.125rem;
+  }
+}
+
+.subjectHeadingRow {
+  text-align: left;
+  display: table-row;
+  &.preview {
+    width: 100%;
+    .previewDiv {
+      width: 100%;
+      justify-content: center;
+      > em {
+        margin-left: 15%;
+      }
+      .previewInner {
+        width: 100%;
+        justify-content: center;
+        display: flex;
+      }
+      em {
+        color: #31806a;
+      }
+    }
+    .previewUl {
+      justify-content: space-around;
+      display: flex;
+      width: 100%;
+      margin-bottom: 0px;
+      list-style: none;
+      ul {
+        width: 100%;
+        justify-content: left;
+        li {
+          display: flex;
+          justify-content: left;
+          margin-bottom: 5px;
+          &.fullLabel {
+            font-size: .75rem;
+          }
+          &.bibCount {
+            color: #31806a;
+          }
+        }
+      }
+    }
+  }
+  .subjectHeadingAttribute {
+    padding-left: 10px;
+    text-align: right;
+  }
+  .subjectHeadingsTableCell {
+    height: 100%;
+    display: table-cell;
+    &.sortButton {
+      text-align: center;
+      &.selected {
+        font-weight: bold;
+      }
+      padding-left: 10px;
+      width: 125px;
+      box-sizing: border-box;
+
+      & > select {
+        border-width: 1px;
+        border-color: black;
+        font-size: 10px;
+      }
+    }
+
+    .subjectHeadingLabelInner {
+      height: 100%;
+      position: relative;
+      padding-left: 5px;
+      a:hover {
+        color: #176e91;
+        cursor: pointer;
+      }
+    }
+  }
+}
+
+.nestedSubjectHeading {
+  background-color: $lighter-grey;
+  .subjectHeadingsTableCell {
+    border-top: 1px solid $lighter-grey;
+  }
+}
+
+// styling for top level open heading
+tbody > .openSubjectHeading {
+  background-color: $lighter-grey;
+    &.topLevel {
+      background-color: $darker-grey;
+    }
+    .subjectHeadingLabelInner, .subjectHeadingAttribute, .sortButton {
+      background-color: $darker-grey;
+    }
+}

--- a/src/client/styles/components/SubjectHeadings/SubjectHeadingsTable.scss
+++ b/src/client/styles/components/SubjectHeadings/SubjectHeadingsTable.scss
@@ -1,0 +1,26 @@
+.subjectHeadingsTable {
+  display: table;
+  font-size: 16px;
+  width: 100%;
+
+  a {
+    display: flex;
+    text-decoration: none;
+  }
+
+  th {
+    &> .subjectHeadingLabelInner {
+      text-align: initial;
+      padding-left: 5px;
+    }
+
+    &.sort {
+      text-align: center;
+    }
+
+    &.subjectHeadingAttribute {
+      text-align: right;
+    }
+  }
+
+}

--- a/src/client/styles/components/SubjectHeadings/SubjectHeadingsTableHeader.scss
+++ b/src/client/styles/components/SubjectHeadings/SubjectHeadingsTableHeader.scss
@@ -1,0 +1,16 @@
+.subjectHeadingsTable thead {
+  .subjectHeadingsTableCell.selected {
+    color: #a83232;
+  }
+  .subjectHeadingAttributeInner {
+    display: inline-flex;
+  }
+
+  .subjectHeadingLabelInner {
+    display: flex;
+  }
+
+  .subjectSortButton {
+    padding-right: 10px;
+  }
+}


### PR DESCRIPTION
I am creating this initial PR to demonstrate the new approach to organizing our style sheets. 
I removed one line from `src/app/components/SubjectHeading/NestedTableColumnHeading.jsx` that we determined is an unimplemented idea and changed the ambiguous classname "headingStyle" to "nestedTable". 

There are a lot of changes that could be made, like consolidating or disambiguating classnames or changing them to something more appropriate. I made a change to the `NestedTableHeading` to make them `th`s instead of `tr`s because I believe that is more accessible and it makes the intent of the code easier to decipher. But I will refrain from doing other further changes beyond moving SCSS from one file to another in relation to this exact ticket.
https://jira.nypl.org/browse/SCC-1833

Also, I think we should refactor the `AdditionalSubjectHeadingsButton` and `SubjectHeadings` a bit to decouple them and consider making separate components for different applications of the table or `SubjectHeading` component.