### PR TITLE
SCC-1844 swap title count and subheading count columns

### DIFF
--- a/src/app/components/SubjectHeading/SubjectHeading.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeading.jsx
@@ -256,15 +256,6 @@ class SubjectHeading extends React.Component {
               </Link>
             </div>
           </td>
-          <td className={`subjectHeadingsTableCell subjectHeadingAttribute titles ${sortBy === 'bibs' ? 'selected' : ''}`}>
-            <div className="subjectHeadingAttributeInner">
-              { updateSort
-                   ? <SortButton handler={updateSort} type="bibs" />
-                   : null
-               }
-              {`${bib_count}`}
-            </div>
-          </td>
           <td className={`subjectHeadingsTableCell subjectHeadingAttribute narrower ${sortBy === 'descendants' ? 'selected' : ''}`}>
             <div className="subjectHeadingAttributeInner">
               { updateSort
@@ -272,6 +263,15 @@ class SubjectHeading extends React.Component {
                 : null
               }
               {`${desc_count || '-'}`}
+            </div>
+          </td>
+          <td className={`subjectHeadingsTableCell subjectHeadingAttribute titles ${sortBy === 'bibs' ? 'selected' : ''}`}>
+            <div className="subjectHeadingAttributeInner">
+              { updateSort
+                   ? <SortButton handler={updateSort} type="bibs" />
+                   : null
+               }
+              {`${bib_count}`}
             </div>
           </td>
         </tr>

--- a/src/app/components/SubjectHeading/SubjectHeadingsTableHeader.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeadingsTableHeader.jsx
@@ -19,17 +19,17 @@ const SubjectHeadingsTableHeader = (props) => {
             Heading
           </div>
         </th>
-        <th className={`subjectHeadingsTableCell subjectHeadingAttribute titles ${selected === 'bibs' ? 'selected' : ''}`}>
-          <div className="subjectHeadingAttributeInner">
-            {updateSort && <SortButton handler={updateSort} type="bibs" />}
-          </div>
-          Title Count
-        </th>
         <th className={`subjectHeadingsTableCell subjectHeadingAttribute narrower ${selected === 'descendants' ? 'selected' : ''}`}>
           <div className="subjectHeadingAttributeInner">
             {updateSort && <SortButton handler={updateSort} type="descendants" />}
             Subheading Count
           </div>
+        </th>
+        <th className={`subjectHeadingsTableCell subjectHeadingAttribute titles ${selected === 'bibs' ? 'selected' : ''}`}>
+          <div className="subjectHeadingAttributeInner">
+            {updateSort && <SortButton handler={updateSort} type="bibs" />}
+          </div>
+          Title Count
         </th>
       </tr>
     </thead>


### PR DESCRIPTION
This PR swaps the positions of the `Title Count` and `Subheading Count` columns. It is an easy initial change for the new design.

https://jira.nypl.org/browse/SCC-1844 - task
https://jira.nypl.org/browse/SCC-1843 - story