### PR TITLE
remove node-sass package and update package lock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -948,10 +948,10 @@
       }
     },
     "@nypl/dgx-header-component": {
-      "version": "git+https://git@github.com/NYPL/dgx-header-component.git#3650130f8845f61812dac434a40b85d63020f5b1",
+      "version": "git+https://git@github.com/NYPL/dgx-header-component.git#2913dd935cef141f6176d40426bd8e3a330dcd40",
       "from": "git+https://git@github.com/NYPL/dgx-header-component.git#reactupdate",
       "requires": {
-        "@nypl/design-toolkit": "0.1.36",
+        "@nypl/design-toolkit": "^0.1.37",
         "@nypl/dgx-svg-icons": "0.3.7",
         "axios": "0.9.1",
         "classnames": "2.1.3",
@@ -969,22 +969,17 @@
       },
       "dependencies": {
         "@nypl/design-toolkit": {
-          "version": "0.1.36",
-          "resolved": "https://registry.npmjs.org/@nypl/design-toolkit/-/design-toolkit-0.1.36.tgz",
-          "integrity": "sha512-2bUq24rKeB32Ens++mDdyu8usfDZ8UsB6xkcdwFN8Xsfh3cebdR3OLZKteg4FbVIOyBCFE5zLeUcOYsYLbK6BA==",
+          "version": "0.1.37",
+          "resolved": "https://registry.npmjs.org/@nypl/design-toolkit/-/design-toolkit-0.1.37.tgz",
+          "integrity": "sha512-RqHNUHpVIuh6rti00mkt5xw+ZjQHmCVqGfwrcor639TgX1zh53e1rq6Vj4EaJAKzuXZlfneIUbFoM/HElzr0vw==",
           "requires": {
-            "node-sass": "4.6.0"
+            "node-sass": "4.9.0"
           }
         },
         "@nypl/dgx-svg-icons": {
           "version": "0.3.7",
           "resolved": "https://registry.npmjs.org/@nypl/dgx-svg-icons/-/dgx-svg-icons-0.3.7.tgz",
           "integrity": "sha512-5grNReXumLM1+zj5lnZJx5h8KEk1Aa2/tyogTiLAhB06RrpaH83WbINhzL1eJeMbz4h/NFWrj8SUIoqLPHM9tA=="
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
         },
         "axios": {
           "version": "0.9.1",
@@ -994,57 +989,15 @@
             "follow-redirects": "0.0.7"
           }
         },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
-          }
-        },
         "classnames": {
           "version": "2.1.3",
           "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.1.3.tgz",
           "integrity": "sha1-r5skU/wUOuhUbQ5zu+6kD3S342M="
         },
-        "node-sass": {
-          "version": "4.6.0",
-          "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.6.0.tgz",
-          "integrity": "sha512-rh0CvkxpYdQdbWx4EQfunmG0+99BVyVwQHlFE+yUzc6lteF5K3WUcJ0bdmv9E9CqQA1RfuMyvmpDP99cmBObow==",
-          "requires": {
-            "async-foreach": "^0.1.3",
-            "chalk": "^1.1.1",
-            "cross-spawn": "^3.0.0",
-            "gaze": "^1.0.0",
-            "get-stdin": "^4.0.1",
-            "glob": "^7.0.3",
-            "in-publish": "^2.0.0",
-            "lodash.assign": "^4.2.0",
-            "lodash.clonedeep": "^4.3.2",
-            "lodash.mergewith": "^4.6.0",
-            "meow": "^3.7.0",
-            "mkdirp": "^0.5.1",
-            "nan": "^2.3.2",
-            "node-gyp": "^3.3.1",
-            "npmlog": "^4.0.0",
-            "request": "^2.79.0",
-            "sass-graph": "^2.2.4",
-            "stdout-stream": "^1.4.0"
-          }
-        },
         "react-tappable": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/react-tappable/-/react-tappable-1.0.0.tgz",
           "integrity": "sha1-FqPp5s4qt2RWnsVuRaWR1mCpZqY="
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
         }
       }
     },
@@ -10373,9 +10326,9 @@
       }
     },
     "node-sass": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.13.1.tgz",
-      "integrity": "sha512-TTWFx+ZhyDx1Biiez2nB0L3YrCZ/8oHagaDalbuBSlqXgUPsdkUSzJsVxeDO9LtPB49+Fh3WQl3slABo6AotNw==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.9.0.tgz",
+      "integrity": "sha512-QFHfrZl6lqRU3csypwviz2XLgGNOoWQbo2GOvtsfQqOfL4cy1BtWnhx/XUeAO9LT3ahBzSRXcEO6DdvAH9DzSg==",
       "requires": {
         "async-foreach": "^0.1.3",
         "chalk": "^1.1.1",
@@ -10384,13 +10337,15 @@
         "get-stdin": "^4.0.1",
         "glob": "^7.0.3",
         "in-publish": "^2.0.0",
-        "lodash": "^4.17.15",
+        "lodash.assign": "^4.2.0",
+        "lodash.clonedeep": "^4.3.2",
+        "lodash.mergewith": "^4.6.0",
         "meow": "^3.7.0",
         "mkdirp": "^0.5.1",
-        "nan": "^2.13.2",
-        "node-gyp": "^3.8.0",
+        "nan": "^2.10.0",
+        "node-gyp": "^3.3.1",
         "npmlog": "^4.0.0",
-        "request": "^2.88.0",
+        "request": "~2.79.0",
         "sass-graph": "^2.2.4",
         "stdout-stream": "^1.4.0",
         "true-case-path": "^1.0.2"
@@ -10411,33 +10366,6 @@
             "has-ansi": "^2.0.0",
             "strip-ansi": "^3.0.0",
             "supports-color": "^2.0.0"
-          }
-        },
-        "request": {
-          "version": "2.88.2",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
-          "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
-          "requires": {
-            "aws-sign2": "~0.7.0",
-            "aws4": "^1.8.0",
-            "caseless": "~0.12.0",
-            "combined-stream": "~1.0.6",
-            "extend": "~3.0.2",
-            "forever-agent": "~0.6.1",
-            "form-data": "~2.3.2",
-            "har-validator": "~5.1.3",
-            "http-signature": "~1.2.0",
-            "is-typedarray": "~1.0.0",
-            "isstream": "~0.1.2",
-            "json-stringify-safe": "~5.0.1",
-            "mime-types": "~2.1.19",
-            "oauth-sign": "~0.9.0",
-            "performance-now": "^2.1.0",
-            "qs": "~6.5.2",
-            "safe-buffer": "^5.1.2",
-            "tough-cookie": "~2.5.0",
-            "tunnel-agent": "^0.6.0",
-            "uuid": "^3.3.2"
           }
         },
         "supports-color": {

--- a/package.json
+++ b/package.json
@@ -106,7 +106,6 @@
     "history": "3.3.0",
     "iso": "5.2.0",
     "jsonwebtoken": "^8.3.0",
-    "node-sass": "^4.9.0",
     "node-sass-glob-importer": "^5.3.2",
     "prop-types": "15.5.10",
     "react": "^16.12.0",


### PR DESCRIPTION
This PR includes two needs. One is that it seems like we can just pull in `node-sass` from `@nypl/design-toolkit` and that way we run less of a risk of having conflicting `node-sass` version. We also need to update the `package.lock` because of changes to the branch of Header we are using.