### PR TITLE
package lock for dgx-header with updated design-toolkit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -948,10 +948,10 @@
       }
     },
     "@nypl/dgx-header-component": {
-      "version": "git+https://git@github.com/NYPL/dgx-header-component.git#3650130f8845f61812dac434a40b85d63020f5b1",
+      "version": "git+https://git@github.com/NYPL/dgx-header-component.git#2913dd935cef141f6176d40426bd8e3a330dcd40",
       "from": "git+https://git@github.com/NYPL/dgx-header-component.git#reactupdate",
       "requires": {
-        "@nypl/design-toolkit": "0.1.36",
+        "@nypl/design-toolkit": "^0.1.37",
         "@nypl/dgx-svg-icons": "0.3.7",
         "axios": "0.9.1",
         "classnames": "2.1.3",


### PR DESCRIPTION
Here is a PR just for pulling in the necessary `package-lock` change for Header with updated `@nypl/design-toolkit`. The diff is actually very small. So, worth loading it and taking a look if interested.