### PR TITLE
Scc 1867 include partner bibs in path

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -948,7 +948,7 @@
       }
     },
     "@nypl/dgx-header-component": {
-      "version": "git+https://git@github.com/NYPL/dgx-header-component.git#3650130f8845f61812dac434a40b85d63020f5b1",
+      "version": "git+https://git@github.com/NYPL/dgx-header-component.git#2913dd935cef141f6176d40426bd8e3a330dcd40",
       "from": "git+https://git@github.com/NYPL/dgx-header-component.git#reactupdate",
       "requires": {
         "@nypl/design-toolkit": "^0.1.37",
@@ -16456,7 +16456,7 @@
     "webpack-dev-middleware": {
       "version": "1.12.2",
       "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.12.2.tgz",
-      "integrity": "sha512-FCrqPy1yy/sN6U/SaEZcHKRXGlqU0DUaEBL45jkUYoB8foVb6wCnbIJ1HKIx+qUFTW+3JpVcCJCxZ8VATL4e+A==",
+      "integrity": "sha1-+PwRIM47T8VoDO7LQ9d3lmshEF4=",
       "dev": true,
       "requires": {
         "memory-fs": "~0.4.1",

--- a/src/app/components/DataLoader/DataLoader.jsx
+++ b/src/app/components/DataLoader/DataLoader.jsx
@@ -9,7 +9,7 @@ class DataLoader extends React.Component {
     super(props);
     this.pathInstructions = [
       {
-        expression: /\/research\/collections\/shared-collection-catalog\/bib\/(b\d*)/,
+        expression: /\/research\/collections\/shared-collection-catalog\/bib\/([cp]?b\d*)/,
         pathType: 'bib',
       },
     ];
@@ -27,6 +27,7 @@ class DataLoader extends React.Component {
   componentDidMount() {
     const matchData = this.pathInstructions
       .reduce(this.reducePathExpressions, null);
+    console.log('dataloader mount ', this.props.location, matchData)
     if (this.routes[this.pathType]) {
       const {
         apiRoute,

--- a/src/app/components/DataLoader/DataLoader.jsx
+++ b/src/app/components/DataLoader/DataLoader.jsx
@@ -27,7 +27,7 @@ class DataLoader extends React.Component {
   componentDidMount() {
     const matchData = this.pathInstructions
       .reduce(this.reducePathExpressions, null);
-    console.log('dataloader mount ', this.props.location, matchData)
+
     if (this.routes[this.pathType]) {
       const {
         apiRoute,


### PR DESCRIPTION
A small change to the path for bib pages, we need to add `[cp]?` to make sure we load the data on partner items as well.