### PR TITLE
changes to match design mockup for show page

### DIFF
--- a/src/app/components/SubjectHeading/SortButton.jsx
+++ b/src/app/components/SubjectHeading/SortButton.jsx
@@ -2,17 +2,15 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const SortButton = (props) => {
-  const columnText = () => {
-    return {
-      bibs: 'Titles',
-      descendants: 'Subheadings',
-      alphabetical: 'Heading',
-    }[props.type];
-  };
+  const columnText = () => ({
+    bibs: 'Titles',
+    descendants: 'Subheadings',
+    alphabetical: 'Heading',
+  }[props.type]);
 
   return (
     <button
-      className='subjectSortButton'
+      className="subjectSortButton"
       onClick={() => props.handler(props.type, props.direction)}
     >
       <span className="emph">
@@ -21,7 +19,7 @@ const SortButton = (props) => {
         </span>
       </span>
     </button>
-  )
+  );
 };
 
 SortButton.propTypes = {

--- a/src/app/components/SubjectHeading/SubjectHeadingShow.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeadingShow.jsx
@@ -149,13 +149,16 @@ class SubjectHeadingShow extends React.Component {
             showId={uuid}
             keyId="context"
             container="context"
+            tfootContent={
+              <Link
+                to={contextHeadings && contextHeadings.length ? this.generateFullContextUrl() : '#'}
+                className="toIndex"
+              >
+                Go to Subject Headings Index
+              </Link>
+            }
           />
-          <Link
-            to={contextHeadings && contextHeadings.length ? this.generateFullContextUrl() : '#'}
-            className="toIndex"
-          >
-            Go to Subject Headings Index
-          </Link>
+
         </div>
         <div
           className="nypl-column-half subjectHeadingRelated subjectHeadingInfoBox"

--- a/src/app/components/SubjectHeading/SubjectHeadingsTable.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeadingsTable.jsx
@@ -14,6 +14,7 @@ const SubjectHeadingsTable = (props) => {
     keyId,
     container,
     updateSort,
+    tfootContent,
   } = props;
 
   return (
@@ -31,6 +32,12 @@ const SubjectHeadingsTable = (props) => {
           top
         />
       </tbody>
+      { tfootContent ?
+        <tfoot>
+          {tfootContent}
+        </tfoot>
+        : null
+      }
     </table>
   );
 };

--- a/src/client/styles/components/SubjectHeadings/SubjectHeadingShow.scss
+++ b/src/client/styles/components/SubjectHeadings/SubjectHeadingShow.scss
@@ -2,12 +2,12 @@
 .subjectHeadingRelated {
   border-color: #000000;
   border-style: solid;
-  border-width: thin;
+  border-top-width: 3px;
   justify-self: end;
 
   h4 {
-    margin-bottom: 1%;
-    margin-left: 1%;
+    padding-left: 1%;
+    background-color: $subject-heading-table-header;
   }
 }
 
@@ -57,7 +57,6 @@
   }
   h4 {
     font-size: 16px;
-    padding-bottom: 8px;
   }
   .subjectHeadingLabelContainer {
     padding: 2px;

--- a/src/client/styles/components/SubjectHeadings/SubjectHeadingsTable.scss
+++ b/src/client/styles/components/SubjectHeadings/SubjectHeadingsTable.scss
@@ -2,6 +2,7 @@
   display: table;
   font-size: 15px;
   width: 100%;
+  background-color: $subject-heading-table-header;
 
   a {
     display: flex;

--- a/src/client/styles/components/SubjectHeadings/SubjectHeadingsTableHeader.scss
+++ b/src/client/styles/components/SubjectHeadings/SubjectHeadingsTableHeader.scss
@@ -1,5 +1,4 @@
 .subjectHeadingsTable thead {
-  background-color: $subject-heading-table-header;
   border-bottom: 1.5px solid #000000;
   line-height: 2.5;
 


### PR DESCRIPTION
The footer is used for the link to the index page. Also, now the grey for the show page box main headings and those main headings and that `toIndex` link just come from the background color for the whole table. The hierarchical coloring for the rows covers that grey when needed 👍