### PR TITLE
SCC-1877 / fix search results breadcrumb bug

### DIFF
--- a/src/app/components/Breadcrumbs/Breadcrumbs.jsx
+++ b/src/app/components/Breadcrumbs/Breadcrumbs.jsx
@@ -51,7 +51,7 @@ const Breadcrumbs = ({ query, type, bibUrl, itemUrl, edd }) => {
       return crumbs;
     }
 
-    const stringifiedQuery = query.replace("q=", "")
+    const stringifiedQuery = query.replace(/^q=/, "")
 
     if (stringifiedQuery && stringifiedQuery !== "undefined") {
       crumbs.push(

--- a/src/app/components/Breadcrumbs/Breadcrumbs.jsx
+++ b/src/app/components/Breadcrumbs/Breadcrumbs.jsx
@@ -51,12 +51,16 @@ const Breadcrumbs = ({ query, type, bibUrl, itemUrl, edd }) => {
       return crumbs;
     }
 
-    crumbs.push(
+    const stringifiedQuery = query.replace("q=", "")
+
+    if (stringifiedQuery && stringifiedQuery !== "undefined") {
+      crumbs.push(
       <li key="search">
         <Link to={`${baseUrl}/search?${query}`} onClick={() => onClick('Search Results')}>
           Search Results
         </Link>
       </li>);
+    }
 
     if (type === 'bib') {
       crumbs.push(<li key="bib">Item Details</li>);
@@ -66,7 +70,8 @@ const Breadcrumbs = ({ query, type, bibUrl, itemUrl, edd }) => {
     crumbs.push(
       <li key="bib">
         <Link to={`${baseUrl}${bibUrl}`} onClick={() => onClick('Item Details')}>Item Details</Link>
-      </li>);
+      </li>
+    );
 
     if (type === 'hold') {
       crumbs.push(<li key="hold">Item Request</li>);

--- a/src/app/components/Results/ResultsList.jsx
+++ b/src/app/components/Results/ResultsList.jsx
@@ -104,12 +104,17 @@ class ResultsList extends React.Component {
     const totalItems = items.length;
     const hasRequestTable = items.length === 1;
 
+    let bibUrl = `${appConfig.baseUrl}/bib/${bibId}`
+
+    if (this.props.searchKeywords) bibUrl += `?searchKeywords=${this.props.searchKeywords}`
+    else if (Store.state.searchKeywords) bibUrl += `?searchKeywords=${Store.state.searchKeywords}`
+
     return (
       <li key={i} className={`nypl-results-item ${hasRequestTable ? 'has-request' : ''}`}>
         <h3>
           <Link
             onClick={() => trackDiscovery('Bib', bibTitle)}
-            to={`${appConfig.baseUrl}/bib/${bibId}?searchKeywords=${this.props.searchKeywords}`}
+            to={bibUrl}
             className="title"
           >
             {bibTitle}

--- a/src/app/components/SubjectHeading/SubjectHeadingsTableBody.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeadingsTableBody.jsx
@@ -89,9 +89,7 @@ class SubjectHeadingsTableBody extends React.Component {
     const {
       range,
     } = this.state;
-    console.log(this.subHeadingHeadings().concat(range.intervals.reduce((acc, el) =>
-      acc.concat(this.listItemsInInterval(el))
-      , [])));
+    
     return this.subHeadingHeadings().concat(range.intervals.reduce((acc, el) =>
       acc.concat(this.listItemsInInterval(el))
       , []));


### PR DESCRIPTION
I updated the Breadcrumbs component so that "Search Results" is only shown if there is indeed a search query.

I also updated the ResultsList component used on the SHEP show page, because it was adding "searchKeyword=undefined" onto the urls to bib show pages. Now, if there is a searchKeyword from the Store or from props, the query will be appended to the url. If not, it will just be the standard bib page url.

This exact logic could be tweaked. But it will stop most of the bad links to Search Results that we were finding.

https://jira.nypl.org/browse/SCC-1877