### PR TITLE
Scc 1832 filtered sort

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -111,6 +111,7 @@
           "@item": "./src/app/utils/item.js",
           "@subjectFilterUtils": "./src/app/utils/subjectFilterUtils.js",
           "@utils": "./src/app/utils/utils.js",
+          "@calculateDirection": "./src/app/utils/calculateDirection.js",
           "@App": "./src/client/App.jsx",
           "@floor_plan": "./src/client/images/floor_plan.png",
           "@componentsBibPage": "./src/client/styles/components/BibPage.scss",

--- a/src/app/components/SubjectHeading/NestedTableHeader.jsx
+++ b/src/app/components/SubjectHeading/NestedTableHeader.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import calculateDirection from '@calculateDirection';
 
 import SortButton from './SortButton';
 
@@ -16,16 +17,8 @@ const NestedTableHeader = (props) => {
     updateSort,
   } = subjectHeading;
 
-  const calculateDirection = (sortType) => {
-    if (sortType === sortBy) return (direction === 'ASC' ? 'DESC' : 'ASC');
-    return {
-      alphabetical: 'ASC',
-      bibs: 'DESC',
-      descendants: 'DESC',
-    }[sortType];
-  };
-
   const positionStyle = container === 'narrower' ? null : { marginLeft: 30 * ((indentation || 0) + 1) };
+  const calculateDirectionForType = calculateDirection(sortBy, direction);
 
   return (
     <tr
@@ -38,7 +31,7 @@ const NestedTableHeader = (props) => {
           <SortButton
             handler={updateSort}
             type="alphabetical"
-            direction={calculateDirection('alphabetical')}
+            direction={calculateDirectionForType('alphabetical')}
           />
         </div>
       </th>
@@ -46,14 +39,14 @@ const NestedTableHeader = (props) => {
         <SortButton
           handler={updateSort}
           type="descendants"
-          direction={calculateDirection('descendants')}
+          direction={calculateDirectionForType('descendants')}
         />
       </th>
       <th className={`subjectHeadingsTableCell subjectHeadingAttribute titles ${sortBy === 'bibs' ? 'selected' : ''}`}>
         <SortButton
           handler={updateSort}
           type="bibs"
-          direction={calculateDirection('bibs')}
+          direction={calculateDirectionForType('bibs')}
         />
       </th>
     </tr>

--- a/src/app/components/SubjectHeading/SubjectHeading.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeading.jsx
@@ -126,9 +126,10 @@ class SubjectHeading extends React.Component {
     } = this.props.subjectHeading;
     let {
       sortBy,
+      direction,
     } = this.state;
-    const direction = additionalParameters.direction;
     if (additionalParameters.sortBy) sortBy = additionalParameters.sortBy;
+    if (additionalParameters.direction) direction = additionalParameters.direction;
     const url = `${appConfig.baseUrl}/api/subjectHeadings/subject_headings/${uuid}/narrower?sort_by=${sortBy}${direction ? `&direction=${direction}` : ''}`;
     axios(url)
       .then(

--- a/src/app/components/SubjectHeading/SubjectHeadingsContainer.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeadingsContainer.jsx
@@ -116,8 +116,6 @@ class SubjectHeadingsContainer extends React.Component {
       },
     } = this.context.router.location;
 
-    console.log('query: ', query);
-
     const updatedDirection = calculateDirection(sortBy, direction)(type);
 
     const paramString = `filter=${query.filter}&sortBy=${type}&direction=${updatedDirection}`;

--- a/src/app/components/SubjectHeading/SubjectHeadingsContainer.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeadingsContainer.jsx
@@ -4,6 +4,7 @@ import axios from 'axios';
 
 import Pagination from '@Pagination';
 import AlphabeticalPagination from '@AlphabeticalPagination';
+import calculateDirection from '@calculateDirection';
 import SubjectHeadingsTable from './SubjectHeadingsTable';
 import SortButton from './SortButton';
 import appConfig from '../../data/appConfig';
@@ -31,6 +32,7 @@ class SubjectHeadingsContainer extends React.Component {
       filter,
       sortBy,
       fromAttributeValue,
+      direction,
     } = this.context.router.location.query;
 
     if (!fromComparator) fromComparator = filter ? null : "start";
@@ -43,6 +45,8 @@ class SubjectHeadingsContainer extends React.Component {
       sort_by: sortBy,
       from_attribute_value: fromAttributeValue,
     };
+
+    if (direction) apiParamHash.direction = direction;
 
     const apiParamString = Object
       .entries(apiParamHash)
@@ -106,9 +110,17 @@ class SubjectHeadingsContainer extends React.Component {
     const {
       pathname,
       query,
+      query: {
+        sortBy,
+        direction,
+      },
     } = this.context.router.location;
 
-    const paramString = `filter=${query.filter}&sortBy=${type}`;
+    console.log('query: ', query);
+
+    const updatedDirection = calculateDirection(sortBy, direction)(type);
+
+    const paramString = `filter=${query.filter}&sortBy=${type}&direction=${updatedDirection}`;
 
     if (type !== this.state.sortBy) {
       this.context.router.push(`${pathname}?${paramString}`);

--- a/src/app/components/SubjectHeading/SubjectHeadingsContainer.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeadingsContainer.jsx
@@ -150,7 +150,7 @@ class SubjectHeadingsContainer extends React.Component {
   render() {
     const { error, subjectHeadings } = this.state;
     const { location } = this.context.router;
-    const { linked, sortBy, filter } = location.query;
+    const { linked, sortBy, filter, direction } = location.query;
 
     if (error) {
       return (
@@ -189,6 +189,7 @@ class SubjectHeadingsContainer extends React.Component {
           linked={linked}
           location={location}
           sortBy={sortBy}
+          direction={direction}
           updateSort={filter ? this.updateSort : null}
           container={"index"}
         />

--- a/src/app/components/SubjectHeading/SubjectHeadingsTable.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeadingsTable.jsx
@@ -15,6 +15,7 @@ const SubjectHeadingsTable = (props) => {
     container,
     updateSort,
     tfootContent,
+    direction,
   } = props;
 
   return (
@@ -29,6 +30,7 @@ const SubjectHeadingsTable = (props) => {
           showId={showId}
           keyId={keyId}
           container={container}
+          direction={direction}
           top
         />
       </tbody>

--- a/src/app/components/SubjectHeading/SubjectHeadingsTableBody.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeadingsTableBody.jsx
@@ -198,9 +198,6 @@ class SubjectHeadingsTableBody extends React.Component {
       subjectHeadings,
     } = this.state;
 
-    window.tableBodies = window.tableBodies || [];
-    window.tableBodies.push(this);
-
     return (
       <React.Fragment>
         {

--- a/src/app/components/SubjectHeading/SubjectHeadingsTableBody.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeadingsTableBody.jsx
@@ -188,6 +188,7 @@ class SubjectHeadingsTableBody extends React.Component {
         sortBy={sortBy}
         linked={linked}
         backgroundColor={this.backgroundColor()}
+        direction={direction}
       />
     );
   }
@@ -196,6 +197,9 @@ class SubjectHeadingsTableBody extends React.Component {
     const {
       subjectHeadings,
     } = this.state;
+
+    window.tableBodies = window.tableBodies || [];
+    window.tableBodies.push(this);
 
     return (
       <React.Fragment>

--- a/src/app/utils/calculateDirection.js
+++ b/src/app/utils/calculateDirection.js
@@ -1,0 +1,11 @@
+const calculateDirection = (currentSortType, currentDirection) => (sortType) => {
+  console.log('currentSortType ', currentSortType, 'sortType ', sortType)
+  if (sortType === currentSortType) return (currentDirection === 'ASC' ? 'DESC' : 'ASC');
+  return {
+    alphabetical: 'ASC',
+    bibs: 'DESC',
+    descendants: 'DESC',
+  }[sortType];
+};
+
+export default calculateDirection;


### PR DESCRIPTION
- Adds ascending sort to filtered index page
- Fixes a bug where we were not passing the sort direction to nested components
- Currently if you change the direction and the preview box was opened, it will be closed. Since we have separate tickets for dealing with the preview box, and Stephen has stated we may not even launch with the preview box, I have left this as is.
- It's starting to get complicated to trace through the long lines of props passing in the nested subject headings. We should come back at some point and try to simplify