### PR TITLE
Remove border above nested table header

### DIFF
--- a/src/client/styles/components/SubjectHeadings/SubjectHeading.scss
+++ b/src/client/styles/components/SubjectHeadings/SubjectHeading.scss
@@ -42,6 +42,7 @@
   line-height: 32px;
 
   &.openSubjectHeading {
+    border-bottom: 0;
     font-weight: $emphasis-font-weight;
   }
 


### PR DESCRIPTION
One more tweak for implementing new designs. Remove the border-bottom between an open heading and the nested table header.