### PR TITLE
SCC-1865 maintain number of displayed subheadings when resorting nested table

### DIFF
--- a/src/app/components/BibPage/BibDetails.jsx
+++ b/src/app/components/BibPage/BibDetails.jsx
@@ -130,8 +130,8 @@ class BibDetails extends React.Component {
     if (Array.isArray(entities) && entities.length > 0) {
       const markup = entities
         .map((ent) => {
-          const nodes = [(<span key={`${ent["@value"]}`}>{ent['@value']}</span>)];
-          if (ent.identifierStatus) nodes.push(<span key={`${ent["@value"]}`}> <em>({ent.identifierStatus})</em></span>);
+          const nodes = [(<span key={`${ent['@value']}`}>{ent['@value']}</span>)];
+          if (ent.identifierStatus) nodes.push(<span key={`${ent['@value']}`}> <em>({ent.identifierStatus})</em></span>);
           return nodes;
         });
 
@@ -181,10 +181,10 @@ class BibDetails extends React.Component {
     return (
       <ul>
         {
-          bibValues.map((value, i) => {
+          bibValues.map((value) => {
             const url = `filters[${fieldValue}]=${value}`;
             return (
-              <li key={`filter${fieldValue}${i}`}>
+              <li key={`filter${fieldValue}`}>
                 {this.getDefinitionOneItem(
                   value,
                   url,
@@ -456,7 +456,7 @@ class BibDetails extends React.Component {
             e => this.newSearch(e, urlWithFilterQuery, fieldValue, urlArray[index], fieldLabel)
           }
           to={`${appConfig.baseUrl}/search?${urlWithFilterQuery}`}
-          key={index}
+          key={heading}
         >
           {heading}
         </Link>

--- a/src/app/components/BibPage/BibPage.jsx
+++ b/src/app/components/BibPage/BibPage.jsx
@@ -85,9 +85,11 @@ const BibPage = (props) => {
   // if the subject heading API call failed for some reason,
   // we will use the subjectLiteral property from the
   // Discovery API response instead
-  if (!bib['subjectHeadingData']) bottomFields.push({
-    label: 'Subject', value: 'subjectLiteral', linkable: true
-  })
+  if (!bib.subjectHeadingData) {
+    bottomFields.push({
+      label: 'Subject', value: 'subjectLiteral', linkable: true,
+    });
+  }
 
   const itemHoldings = items.length && !isElectronicResources ? (
     <ItemHoldings

--- a/src/app/components/SubjectHeading/AdditionalSubjectHeadingsButton.jsx
+++ b/src/app/components/SubjectHeading/AdditionalSubjectHeadingsButton.jsx
@@ -69,6 +69,7 @@ AdditionalSubjectHeadingsButton.propTypes = {
   indentation: PropTypes.number,
   button: PropTypes.string,
   interactive: PropTypes.bool,
+  backgroundColor: PropTypes.string,
 };
 
 export default AdditionalSubjectHeadingsButton;

--- a/src/app/components/SubjectHeading/NestedTableHeader.jsx
+++ b/src/app/components/SubjectHeading/NestedTableHeader.jsx
@@ -6,23 +6,21 @@ import SortButton from './SortButton';
 
 const NestedTableHeader = (props) => {
   const {
-    subjectHeading,
     indentation,
     container,
     sortBy,
     direction,
-  } = props;
-
-  const {
+    parentUuid,
     updateSort,
-  } = subjectHeading;
+    interactive,
+  } = props;
 
   const positionStyle = container === 'narrower' ? null : { marginLeft: 30 * ((indentation || 0) + 1) };
   const calculateDirectionForType = calculateDirection(sortBy, direction);
 
   return (
     <tr
-      data={`${subjectHeading.uuid}, ${container}`}
+      data={`${parentUuid}, ${container}`}
       style={{ backgroundColor: props.backgroundColor }}
       className="nestedTableHeader"
     >
@@ -32,6 +30,7 @@ const NestedTableHeader = (props) => {
             handler={updateSort}
             type="alphabetical"
             direction={calculateDirectionForType('alphabetical')}
+            interactive={interactive}
           />
         </div>
       </th>
@@ -40,6 +39,7 @@ const NestedTableHeader = (props) => {
           handler={updateSort}
           type="descendants"
           direction={calculateDirectionForType('descendants')}
+          interactive={interactive}
         />
       </th>
       <th className={`subjectHeadingsTableCell subjectHeadingAttribute titles ${sortBy === 'bibs' ? 'selected' : ''}`}>
@@ -47,6 +47,7 @@ const NestedTableHeader = (props) => {
           handler={updateSort}
           type="bibs"
           direction={calculateDirectionForType('bibs')}
+          interactive={interactive}
         />
       </th>
     </tr>
@@ -54,12 +55,14 @@ const NestedTableHeader = (props) => {
 };
 
 NestedTableHeader.propTypes = {
-  subjectHeading: PropTypes.object,
   indentation: PropTypes.number,
   sortBy: PropTypes.string,
   container: PropTypes.string,
   direction: PropTypes.string,
   backgroundColor: PropTypes.string,
+  parentUuid: PropTypes.string,
+  updateSort: PropTypes.func,
+  interactive: PropTypes.bool,
 };
 
 export default NestedTableHeader;

--- a/src/app/components/SubjectHeading/SortButton.jsx
+++ b/src/app/components/SubjectHeading/SortButton.jsx
@@ -2,21 +2,28 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const SortButton = (props) => {
+  const {
+    type,
+    direction,
+    handler,
+    interactive,
+  } = props;
+
   const columnText = () => ({
     bibs: 'Titles',
     descendants: 'Subheadings',
     alphabetical: 'Heading',
-  }[props.type]);
+  }[type]);
 
   return (
     <button
       className="subjectSortButton"
-      onClick={() => props.handler(props.type, props.direction)}
-      disabled={!props.handler}
+      onClick={() => handler(type, direction)}
+      disabled={!handler || !interactive}
     >
       <span className="emph">
         <span className="noEmph">{columnText()}
-          {props.handler ? <span className="sortCharacter">^</span> : null}
+          {(handler && interactive) ? <span className="sortCharacter">^</span> : null}
         </span>
       </span>
     </button>
@@ -27,6 +34,7 @@ SortButton.propTypes = {
   handler: PropTypes.func,
   type: PropTypes.string,
   direction: PropTypes.string,
+  interactive: PropTypes.bool,
 };
 
 export default SortButton;

--- a/src/app/components/SubjectHeading/SortButton.jsx
+++ b/src/app/components/SubjectHeading/SortButton.jsx
@@ -12,6 +12,7 @@ const SortButton = (props) => {
     <button
       className="subjectSortButton"
       onClick={() => props.handler(props.type, props.direction)}
+      disabled={!props.handler}
     >
       <span className="emph">
         <span className="noEmph">{columnText()}

--- a/src/app/components/SubjectHeading/SubjectHeading.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeading.jsx
@@ -120,7 +120,11 @@ class SubjectHeading extends React.Component {
   }
 
   updateSort(sortType, direction) {
-    this.fetchInitial({ sortBy: sortType, direction, range: Range.default() });
+    this.fetchInitial({
+      sortBy: sortType,
+      direction,
+      range: Range.default(),
+    });
   }
 
   fetchInitial(additionalParameters = {}) {
@@ -132,9 +136,16 @@ class SubjectHeading extends React.Component {
       sortBy,
       direction,
     } = this.state;
+
+    const limit = this.state.narrower.length;
+
     if (additionalParameters.sortBy) sortBy = additionalParameters.sortBy;
     if (additionalParameters.direction) direction = additionalParameters.direction;
-    const url = `${appConfig.baseUrl}/api/subjectHeadings/subject_headings/${uuid}/narrower?sort_by=${sortBy}${direction ? `&direction=${direction}` : ''}`;
+    let url = `${appConfig.baseUrl}/api/subjectHeadings/subject_headings/${uuid}/narrower?sort_by=${sortBy}`;
+
+    if (direction) url += `&direction=${direction}`;
+    if (limit) url += `&limit=${limit}`;
+
     axios(url)
       .then(
         (resp) => {
@@ -296,6 +307,7 @@ SubjectHeading.propTypes = {
 
 SubjectHeading.defaultProps = {
   indentation: 0,
+  narrower: [],
 };
 
 SubjectHeading.contextTypes = {

--- a/src/app/components/SubjectHeading/SubjectHeading.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeading.jsx
@@ -102,7 +102,7 @@ class SubjectHeading extends React.Component {
   }
 
   addEmphasis(string) {
-    const components = string.split(" -- ");
+    const components = string.split(' -- ');
     return { emph: components.slice(-1), rest: components.slice(0, -1).join(' -- ') };
   }
 
@@ -206,7 +206,7 @@ class SubjectHeading extends React.Component {
       const props = {};
 
       props.onClick = this.toggleOpen;
-      props.className = "subjectHeadingToggle";
+      props.className = 'subjectHeadingToggle';
 
       if (desc_count > 0) {
         props.onKeyDown = event => handleEnter(event);
@@ -215,7 +215,7 @@ class SubjectHeading extends React.Component {
       return <button {...props}>{innerText}</button>;
     };
 
-    const positionStyle = ["narrower", "related"].includes(container) ? null : { marginLeft: 30 * ((indentation || 0) + 1) };
+    const positionStyle = ['narrower', 'related'].includes(container) ? null : { marginLeft: 30 * ((indentation || 0) + 1) };
     const isMain = (pathname + search).includes(uuid);
     // changes to HTML structure here will need to be replicated in ./SubjectHeadingTableHeader
 
@@ -291,11 +291,12 @@ SubjectHeading.propTypes = {
   indentation: PropTypes.number,
   container: PropTypes.string,
   direction: PropTypes.string,
+  backgroundColor: PropTypes.string,
 };
 
 SubjectHeading.defaultProps = {
   indentation: 0,
-}
+};
 
 SubjectHeading.contextTypes = {
   router: PropTypes.object,

--- a/src/app/components/SubjectHeading/SubjectHeading.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeading.jsx
@@ -70,17 +70,26 @@ class SubjectHeading extends React.Component {
   }
 
   addMore(element, data) {
-    const {
-      narrower,
-    } = this.state;
-    data.narrower.forEach(
-      (child) => { child.indentation = (this.props.subjectHeading.indentation || 0) + 1; }
-    );
-    narrower.splice(-1, 1, ...data.narrower);
-    if (data.next_url) {
-      narrower.splice(-1, 1, { button: 'next', updateParent: this.fetchAndUpdate(data.next_url), indentation: (this.props.subjectHeading.indentation || 0) + 1 });
-    }
-    this.setState(prevState => prevState);
+    this.setState((prevState) => {
+      const { narrower } = prevState;
+      data.narrower.forEach(
+        (child) => { child.indentation = (this.props.subjectHeading.indentation || 0) + 1; }
+      );
+
+      narrower.splice(-1, 1, ...data.narrower);
+
+      if (data.next_url) {
+        narrower.splice(-1, 1, {
+          button: 'next',
+          updateParent: this.fetchAndUpdate(data.next_url),
+          indentation: (this.props.subjectHeading.indentation || 0) + 1,
+        });
+      }
+
+      this.setState({
+        narrower,
+      });
+    });
   }
 
   fetchAndUpdate(url) {

--- a/src/app/components/SubjectHeading/SubjectHeadingsTableBody.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeadingsTableBody.jsx
@@ -25,13 +25,12 @@ class SubjectHeadingsTableBody extends React.Component {
     this.updateRange = this.updateRange.bind(this);
     this.listItemsInRange = this.listItemsInRange.bind(this);
     this.listItemsInInterval = this.listItemsInInterval.bind(this);
-    this.subHeadingHeadings = this.subHeadingHeadings.bind(this);
     this.tableRow = this.tableRow.bind(this);
     this.backgroundColor = this.backgroundColor.bind(this);
   }
 
   componentDidMount() {
-    const { linked } = this.props
+    const { linked } = this.props;
 
     if (linked) {
       const url = `${appConfig.baseUrl}/api/subjectHeadings/subject_headings/${linked}/context?type=relatives`;
@@ -41,7 +40,7 @@ class SubjectHeadingsTableBody extends React.Component {
             this.mergeSubjectHeadings(res.data.subject_headings, linked);
           },
         );
-    };
+    }
   }
 
   mergeSubjectHeadings(subjectHeadings, linked) {
@@ -66,25 +65,14 @@ class SubjectHeadingsTableBody extends React.Component {
     this.setState(prevState => prevState);
   }
 
-  subHeadingHeadings() {
-    if (this.props.top) return [];
-    return [
-      {
-        nestedTableHeader: true,
-        indentation: this.props.indentation,
-        updateSort: this.props.updateSort,
-      },
-    ];
-  }
-
   listItemsInRange() {
     const {
       range,
     } = this.state;
 
-    return this.subHeadingHeadings().concat(range.intervals.reduce((acc, el) =>
-      acc.concat(this.listItemsInInterval(el))
-      , []));
+    return range.intervals.reduce((acc, interval) =>
+      acc.concat(this.listItemsInInterval(interval))
+      , []);
   }
 
   listItemsInInterval(interval) {
@@ -153,19 +141,6 @@ class SubjectHeadingsTableBody extends React.Component {
         />
       );
     }
-    if (listItem.nestedTableHeader) {
-      return (
-        <NestedTableHeader
-          subjectHeading={listItem}
-          key={`nestedTableHeader${listItem.indentation}`}
-          indentation={indentation}
-          container={container}
-          sortBy={sortBy}
-          direction={direction}
-          backgroundColor={this.backgroundColor(true)}
-        />
-      );
-    }
 
     return (
       <SubjectHeading
@@ -188,8 +163,32 @@ class SubjectHeadingsTableBody extends React.Component {
       subjectHeadings,
     } = this.state;
 
+    const {
+      nested,
+      parentUuid,
+      indentation,
+      container,
+      sortBy,
+      direction,
+      updateSort,
+    } = this.props;
+
     return (
       <React.Fragment>
+        {nested && subjectHeadings ?
+          <NestedTableHeader
+            parentUuid={parentUuid}
+            key={`nestedTableHeader${indentation}`}
+            indentation={indentation}
+            container={container}
+            sortBy={sortBy}
+            direction={direction}
+            backgroundColor={this.backgroundColor(true)}
+            updateSort={updateSort}
+            interactive={subjectHeadings.length > 1}
+          />
+          : null
+        }
         {
           subjectHeadings ?
           this.listItemsInRange(subjectHeadings)
@@ -209,7 +208,6 @@ SubjectHeadingsTableBody.propTypes = {
   sortBy: PropTypes.string,
   container: PropTypes.string,
   parentUuid: PropTypes.string,
-  top: PropTypes.bool,
   updateSort: PropTypes.func,
   pathname: PropTypes.string,
   direction: PropTypes.string,
@@ -217,7 +215,7 @@ SubjectHeadingsTableBody.propTypes = {
 
 SubjectHeadingsTableBody.defaultProps = {
   indentation: 0,
-}
+};
 
 SubjectHeadingsTableBody.contextTypes = {
   router: PropTypes.object,

--- a/src/app/components/SubjectHeading/SubjectHeadingsTableBody.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeadingsTableBody.jsx
@@ -81,7 +81,7 @@ class SubjectHeadingsTableBody extends React.Component {
     const {
       range,
     } = this.state;
-    
+
     return this.subHeadingHeadings().concat(range.intervals.reduce((acc, el) =>
       acc.concat(this.listItemsInInterval(el))
       , []));


### PR DESCRIPTION
(Formerly "Disable SortButton on main table header when not interactive")
The main change in this PR is to maintain the number of displayed narrower headings when resorting a nested table.

This PR also disables the SortButton on the main table header when not interactive. We could do this for the NestedTableHeader when there is only one subject heading, if that component had the number of narrower headings passed to it. That is what PR #1205 Proposed nested table change acccomplishes.

(Side note: ignore the branch name)