### PR TITLE
SCC-1887 Proposed nested table change and disable sort columns when there is no sort functionality

### DIFF
--- a/src/app/components/SubjectHeading/NestedTableHeader.jsx
+++ b/src/app/components/SubjectHeading/NestedTableHeader.jsx
@@ -6,23 +6,21 @@ import SortButton from './SortButton';
 
 const NestedTableHeader = (props) => {
   const {
-    subjectHeading,
     indentation,
     container,
     sortBy,
     direction,
-  } = props;
-
-  const {
+    parentUuid,
     updateSort,
-  } = subjectHeading;
+    interactive,
+  } = props;
 
   const positionStyle = container === 'narrower' ? null : { marginLeft: 30 * ((indentation || 0) + 1) };
   const calculateDirectionForType = calculateDirection(sortBy, direction);
 
   return (
     <tr
-      data={`${subjectHeading.uuid}, ${container}`}
+      data={`${parentUuid}, ${container}`}
       style={{ backgroundColor: props.backgroundColor }}
       className="nestedTableHeader"
     >
@@ -32,6 +30,7 @@ const NestedTableHeader = (props) => {
             handler={updateSort}
             type="alphabetical"
             direction={calculateDirectionForType('alphabetical')}
+            interactive={interactive}
           />
         </div>
       </th>
@@ -40,6 +39,7 @@ const NestedTableHeader = (props) => {
           handler={updateSort}
           type="descendants"
           direction={calculateDirectionForType('descendants')}
+          interactive={interactive}
         />
       </th>
       <th className={`subjectHeadingsTableCell subjectHeadingAttribute titles ${sortBy === 'bibs' ? 'selected' : ''}`}>
@@ -47,6 +47,7 @@ const NestedTableHeader = (props) => {
           handler={updateSort}
           type="bibs"
           direction={calculateDirectionForType('bibs')}
+          interactive={interactive}
         />
       </th>
     </tr>
@@ -54,12 +55,14 @@ const NestedTableHeader = (props) => {
 };
 
 NestedTableHeader.propTypes = {
-  subjectHeading: PropTypes.object,
   indentation: PropTypes.number,
   sortBy: PropTypes.string,
   container: PropTypes.string,
   direction: PropTypes.string,
   backgroundColor: PropTypes.string,
+  parentUuid: PropTypes.string,
+  updateSort: PropTypes.func,
+  interactive: PropTypes.bool,
 };
 
 export default NestedTableHeader;

--- a/src/app/components/SubjectHeading/SortButton.jsx
+++ b/src/app/components/SubjectHeading/SortButton.jsx
@@ -2,21 +2,28 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const SortButton = (props) => {
+  const {
+    type,
+    direction,
+    handler,
+    interactive,
+  } = props;
+
   const columnText = () => ({
     bibs: 'Titles',
     descendants: 'Subheadings',
     alphabetical: 'Heading',
-  }[props.type]);
+  }[type]);
 
   return (
     <button
       className="subjectSortButton"
-      onClick={() => props.handler(props.type, props.direction)}
-      disabled={!props.handler}
+      onClick={() => handler(type, direction)}
+      disabled={!handler || !interactive}
     >
       <span className="emph">
         <span className="noEmph">{columnText()}
-          {props.handler ? <span className="sortCharacter">^</span> : null}
+          {(handler && interactive) ? <span className="sortCharacter">^</span> : null}
         </span>
       </span>
     </button>
@@ -27,6 +34,7 @@ SortButton.propTypes = {
   handler: PropTypes.func,
   type: PropTypes.string,
   direction: PropTypes.string,
+  interactive: PropTypes.bool,
 };
 
 export default SortButton;

--- a/src/app/components/SubjectHeading/SubjectHeadingsTableBody.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeadingsTableBody.jsx
@@ -25,13 +25,12 @@ class SubjectHeadingsTableBody extends React.Component {
     this.updateRange = this.updateRange.bind(this);
     this.listItemsInRange = this.listItemsInRange.bind(this);
     this.listItemsInInterval = this.listItemsInInterval.bind(this);
-    this.subHeadingHeadings = this.subHeadingHeadings.bind(this);
     this.tableRow = this.tableRow.bind(this);
     this.backgroundColor = this.backgroundColor.bind(this);
   }
 
   componentDidMount() {
-    const { linked } = this.props
+    const { linked } = this.props;
 
     if (linked) {
       const url = `${appConfig.baseUrl}/api/subjectHeadings/subject_headings/${linked}/context?type=relatives`;
@@ -41,7 +40,7 @@ class SubjectHeadingsTableBody extends React.Component {
             this.mergeSubjectHeadings(res.data.subject_headings, linked);
           },
         );
-    };
+    }
   }
 
   mergeSubjectHeadings(subjectHeadings, linked) {
@@ -66,25 +65,14 @@ class SubjectHeadingsTableBody extends React.Component {
     this.setState(prevState => prevState);
   }
 
-  subHeadingHeadings() {
-    if (this.props.top) return [];
-    return [
-      {
-        nestedTableHeader: true,
-        indentation: this.props.indentation,
-        updateSort: this.props.updateSort,
-      },
-    ];
-  }
-
   listItemsInRange() {
     const {
       range,
     } = this.state;
 
-    return this.subHeadingHeadings().concat(range.intervals.reduce((acc, el) =>
-      acc.concat(this.listItemsInInterval(el))
-      , []));
+    return range.intervals.reduce((acc, interval) =>
+      acc.concat(this.listItemsInInterval(interval))
+      , []);
   }
 
   listItemsInInterval(interval) {
@@ -153,19 +141,6 @@ class SubjectHeadingsTableBody extends React.Component {
         />
       );
     }
-    if (listItem.nestedTableHeader) {
-      return (
-        <NestedTableHeader
-          subjectHeading={listItem}
-          key={`nestedTableHeader${listItem.indentation}`}
-          indentation={indentation}
-          container={container}
-          sortBy={sortBy}
-          direction={direction}
-          backgroundColor={this.backgroundColor(true)}
-        />
-      );
-    }
 
     return (
       <SubjectHeading
@@ -188,8 +163,32 @@ class SubjectHeadingsTableBody extends React.Component {
       subjectHeadings,
     } = this.state;
 
+    const {
+      nested,
+      parentUuid,
+      indentation,
+      container,
+      sortBy,
+      direction,
+      updateSort,
+    } = this.props;
+
     return (
       <React.Fragment>
+        {nested && subjectHeadings ?
+          <NestedTableHeader
+            parentUuid={parentUuid}
+            key={`nestedTableHeader${indentation}`}
+            indentation={indentation}
+            container={container}
+            sortBy={sortBy}
+            direction={direction}
+            backgroundColor={this.backgroundColor(true)}
+            updateSort={updateSort}
+            interactive={subjectHeadings.length > 1}
+          />
+          : null
+        }
         {
           subjectHeadings ?
           this.listItemsInRange(subjectHeadings)
@@ -209,7 +208,6 @@ SubjectHeadingsTableBody.propTypes = {
   sortBy: PropTypes.string,
   container: PropTypes.string,
   parentUuid: PropTypes.string,
-  top: PropTypes.bool,
   updateSort: PropTypes.func,
   pathname: PropTypes.string,
   direction: PropTypes.string,
@@ -217,7 +215,7 @@ SubjectHeadingsTableBody.propTypes = {
 
 SubjectHeadingsTableBody.defaultProps = {
   indentation: 0,
-}
+};
 
 SubjectHeadingsTableBody.contextTypes = {
   router: PropTypes.object,


### PR DESCRIPTION
I did this a little quick and dirty, but I believe I switched to this approach pretty cleanly. The inspiration for this came from wanting to disable the `SortButton` element if there is only one narrower heading. To accomplish this, the `NestedTableHeader` needed access to the number of narrower headings being rendered. Also, this approach makes it more obvious where and when the `NestedTableHeader` will be rendered.