### PR TITLE
Sib/empty item table bug

### DIFF
--- a/src/app/components/Breadcrumbs/Breadcrumbs.jsx
+++ b/src/app/components/Breadcrumbs/Breadcrumbs.jsx
@@ -38,12 +38,17 @@ const Breadcrumbs = ({ query = '', type, bibUrl, itemUrl, edd }) => {
       return crumbs;
     }
 
-    crumbs.push(
-      <li key="search">
-        <Link to={`${baseUrl}/search?${query}`} onClick={() => onClick('Search Results')}>
-          Search Results
-        </Link>
-      </li>);
+    const stringifiedQuery = query.replace(/^q=/, "");
+
+    if (stringifiedQuery && stringifiedQuery !== "undefined") {
+      crumbs.push(
+        <li key="search">
+          <Link to={`${baseUrl}/search?${query}`} onClick={() => onClick('Search Results')}>
+            Search Results
+          </Link>
+        </li>
+      );
+    }
 
     if (type === 'bib') {
       crumbs.push(<li key="bib">Item Details</li>);

--- a/src/app/components/Item/ItemTable.jsx
+++ b/src/app/components/Item/ItemTable.jsx
@@ -8,7 +8,7 @@ const ItemTable = ({ items, bibId, getRecord, id, searchKeywords }) => {
   if (
     !_isArray(items) ||
     !items.length ||
-    !items.find(item => !item.isElectronicResource)
+    items.every(item => item.isElectronicResource)
   ) {
     return null;
   }

--- a/src/app/components/Item/ItemTable.jsx
+++ b/src/app/components/Item/ItemTable.jsx
@@ -5,7 +5,11 @@ import { isArray as _isArray } from 'underscore';
 import ItemTableRow from './ItemTableRow';
 
 const ItemTable = ({ items, bibId, getRecord, id, searchKeywords }) => {
-  if (!_isArray(items) || !items.length) {
+  if (
+    !_isArray(items) ||
+    !items.length ||
+    !items.find(item => !item.isElectronicResource)
+  ) {
     return null;
   }
 

--- a/src/app/components/Results/ResultsList.jsx
+++ b/src/app/components/Results/ResultsList.jsx
@@ -6,6 +6,7 @@ import {
   isArray as _isArray,
 } from 'underscore';
 
+import Store from '../../stores/Store';
 import Actions from '../../actions/Actions';
 import LibraryItem from '../../utils/item';
 import {
@@ -135,6 +136,11 @@ class ResultsList extends React.Component {
     const items = LibraryItem.getItems(result);
     const totalItems = items.length;
     const hasRequestTable = items.length === 1;
+
+    let bibUrl = `${appConfig.baseUrl}/bib/${bibId}`
+
+    if (this.props.searchKeywords) bibUrl += `?searchKeywords=${this.props.searchKeywords}`;
+    else if (Store.state.searchKeywords) bibUrl += `?searchKeywords=${Store.state.searchKeywords}`;
 
     return (
       <li key={i} className={`nypl-results-item ${hasRequestTable ? 'has-request' : ''}`}>

--- a/test/unit/Breadcrumbs.test.js
+++ b/test/unit/Breadcrumbs.test.js
@@ -11,7 +11,7 @@ const baseUrl = `${appConfig.baseUrl}/`;
 
 // The current page is the last item in the breadcrumb and it is not linked.
 describe('Breadcrumbs', () => {
-  // Shared Collection Catalog > Search Results > Item Details > Item Request > Request Confirmation
+  // Shared Collection Catalog > Item Details > Item Request > Request Confirmation
   describe('Default rendering - all links', () => {
     let component;
 
@@ -25,17 +25,16 @@ describe('Breadcrumbs', () => {
     });
 
     it('should render five li\'s and four links', () => {
-      expect(component.find('li').length).to.equal(5);
-      expect(component.find('Link').length).to.equal(4);
+      expect(component.find('li').length).to.equal(4);
+      expect(component.find('Link').length).to.equal(3);
     });
 
     it('should render all the navigation', () => {
       const li = component.find('li');
       expect(li.at(0).render().text()).to.equal(appTitle);
-      expect(li.at(1).render().text()).to.equal('Search Results');
-      expect(li.at(2).render().text()).to.equal('Item Details');
-      expect(li.at(3).render().text()).to.equal('Item Request');
-      expect(li.at(4).render().text()).to.equal('Request Confirmation');
+      expect(li.at(1).render().text()).to.equal('Item Details');
+      expect(li.at(2).render().text()).to.equal('Item Request');
+      expect(li.at(3).render().text()).to.equal('Request Confirmation');
     });
   });
 
@@ -64,8 +63,8 @@ describe('Breadcrumbs', () => {
     });
   });
 
-  // Shared Collection Catalog > Search Results > Item Details
   describe('On the Bib page', () => {
+    // Shared Collection Catalog > Item Details
     describe('No search keyword', () => {
       let component;
 
@@ -74,17 +73,17 @@ describe('Breadcrumbs', () => {
       });
 
       it('should contain two Link elements', () => {
-        expect(component.find('Link')).to.have.length(2);
+        expect(component.find('Link')).to.have.length(1);
       });
 
-      it('should link back to the regular search results page', () => {
+      xit('should link back to the regular search results page', () => {
         const searchLink = component.find('Link').at(1);
         expect(searchLink.children().text()).to.equal('Search Results');
         expect(searchLink.prop('to')).to.equal(`${baseUrl}search?`);
       });
 
       it('should display the current page with the item title', () => {
-        expect(component.find('li').at(2).text()).to.equal('Item Details');
+        expect(component.find('li').at(1).text()).to.equal('Item Details');
       });
     });
 
@@ -143,7 +142,7 @@ describe('Breadcrumbs', () => {
     });
   });
 
-  // Shared Collection Catalog > Search Results > Item Details > Item Request
+  // Shared Collection Catalog > Item Details > Item Request
   //  > Electronic Delivery Request
   describe('On the Electronic Delivery Request page', () => {
     const bibId = 'b123456789';
@@ -161,16 +160,16 @@ describe('Breadcrumbs', () => {
     });
 
     it('should contain four Link elements', () => {
-      expect(component.find('Link')).to.have.length(4);
+      expect(component.find('Link')).to.have.length(3);
     });
 
     it('should link back to the item request page as the fouth link', () => {
-      const searchLink = component.find('Link').at(3);
+      const searchLink = component.find('Link').at(2);
       expect(searchLink.prop('to')).to.equal(`${baseUrl}hold/request/${bibId}-${itemId}`);
     });
 
     it('should display "Electronic Delivery Request" on the current page', () => {
-      expect(component.find('li').at(4).text()).to.equal('Electronic Delivery Request');
+      expect(component.find('li').at(3).text()).to.equal('Electronic Delivery Request');
     });
   });
 
@@ -178,8 +177,7 @@ describe('Breadcrumbs', () => {
     const bibId = 'b123456789';
     const itemId = 'i987654321';
 
-    // Shared Collection Catalog > Search Results > Item Details > Item Request
-    //  > Request Confirmation
+    // Shared Collection Catalog > Item Details > Item Request > Request Confirmation
     describe('From a physical Hold Request', () => {
       const fromEdd = false;
       let component;
@@ -196,21 +194,20 @@ describe('Breadcrumbs', () => {
       });
 
       it('should contain four Link elements', () => {
-        expect(component.find('Link')).to.have.length(4);
+        expect(component.find('Link')).to.have.length(3);
       });
 
       it('should link back to the item request page as the fouth link', () => {
-        const searchLink = component.find('Link').at(3);
+        const searchLink = component.find('Link').at(2);
         expect(searchLink.prop('to')).to.equal(`${baseUrl}hold/request/${bibId}-${itemId}`);
       });
 
       it('should display "Request Confirmation" on the current page', () => {
-        expect(component.find('li').at(4).text()).to.equal('Request Confirmation');
+        expect(component.find('li').at(3).text()).to.equal('Request Confirmation');
       });
     });
 
-    // Shared Collection Catalog > Search Results > Item Details > Item Request
-    //  > Electronic Delivery Request > Request Confirmation
+    // Shared Collection Catalog > Item Details > Item Request > Electronic Delivery Request > Request Confirmation
     describe('From the Electronic Delivery Request page', () => {
       const fromEdd = true;
       let component;
@@ -227,16 +224,16 @@ describe('Breadcrumbs', () => {
       });
 
       it('should contain five Link elements', () => {
-        expect(component.find('Link')).to.have.length(5);
+        expect(component.find('Link')).to.have.length(4);
       });
 
       it('should link back to the Electronic Delivery Request page as the fifth link', () => {
-        const searchLink = component.find('Link').at(4);
+        const searchLink = component.find('Link').at(3);
         expect(searchLink.prop('to')).to.equal(`${baseUrl}hold/request/${bibId}-${itemId}/edd`);
       });
 
       it('should display "Request Confirmation" on the current page', () => {
-        expect(component.find('li').at(5).text()).to.equal('Request Confirmation');
+        expect(component.find('li').at(4).text()).to.equal('Request Confirmation');
       });
     });
   });


### PR DESCRIPTION
Small frontend bug I fixed while working on the item request functionality to avoid these superfluous tableheaders:
<img width="771" alt="Screen Shot 2020-03-06 at 11 42 50 AM" src="https://user-images.githubusercontent.com/47210101/76103431-b3405d00-5f9f-11ea-987c-b0001e81f412.png">