### PR TITLE
Scc 1885 add fragments

### DIFF
--- a/src/app/components/SubjectHeading/SubjectHeadingsTableBody.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeadingsTableBody.jsx
@@ -70,9 +70,7 @@ class SubjectHeadingsTableBody extends React.Component {
       range,
     } = this.state;
 
-    return range.intervals.reduce((acc, interval) =>
-      acc.concat(this.listItemsInInterval(interval))
-      , []);
+    return range.intervals.map((interval => this.listItemsInInterval(interval)));
   }
 
   listItemsInInterval(interval) {
@@ -94,7 +92,11 @@ class SubjectHeadingsTableBody extends React.Component {
         updateParent: () => this.updateRange(range, interval, 'end', 10),
       });
     }
-    return subjectHeadingsInInterval;
+    return (
+      <React.Fragment>
+        { subjectHeadingsInInterval.map(item => this.tableRow(item)) }
+      </React.Fragment>
+    );
   }
 
   backgroundColor(nestedTable = false) {
@@ -112,7 +114,7 @@ class SubjectHeadingsTableBody extends React.Component {
     return backgroundColor;
   }
 
-  tableRow(listItem, index) {
+  tableRow(listItem) {
     const {
       indentation,
       nested,
@@ -134,7 +136,7 @@ class SubjectHeadingsTableBody extends React.Component {
           indentation={listItem.indentation || indentation}
           button={listItem.button}
           updateParent={listItem.updateParent}
-          key={`${listItem.button}${listItem.indentation}${index}`}
+          key={`${listItem.button}${listItem.indentation}${direction}`}
           nested={nested}
           interactive={interactive}
           backgroundColor={this.backgroundColor()}
@@ -191,8 +193,7 @@ class SubjectHeadingsTableBody extends React.Component {
         }
         {
           subjectHeadings ?
-          this.listItemsInRange(subjectHeadings)
-          .map(this.tableRow) :
+          this.listItemsInRange(subjectHeadings) :
           null
         }
       </React.Fragment>

--- a/src/app/components/SubjectHeading/SubjectHeadingsTableBody.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeadingsTableBody.jsx
@@ -81,7 +81,7 @@ class SubjectHeadingsTableBody extends React.Component {
     const {
       range,
     } = this.state;
-    
+
     return this.subHeadingHeadings().concat(range.intervals.reduce((acc, el) =>
       acc.concat(this.listItemsInInterval(el))
       , []));
@@ -124,7 +124,7 @@ class SubjectHeadingsTableBody extends React.Component {
     return backgroundColor;
   }
 
-  tableRow(listItem) {
+  tableRow(listItem, index) {
     const {
       indentation,
       nested,
@@ -146,7 +146,7 @@ class SubjectHeadingsTableBody extends React.Component {
           indentation={listItem.indentation || indentation}
           button={listItem.button}
           updateParent={listItem.updateParent}
-          key={`${listItem.button}${listItem.indentation}`}
+          key={`${listItem.button}${listItem.indentation}${index}`}
           nested={nested}
           interactive={interactive}
           backgroundColor={this.backgroundColor()}


### PR DESCRIPTION
- Weird issue with buttons not disappearing was caused by having buttons with the same key in the same list. 
- This is one possible fix which uses `React.Fragment` to make sure buttons are in different virtual DOM elements
- Another possible fix is to add random keys. See PR 1210 for that approach. We should only merge one.