### PR TITLE
Restyle links and buttons to match SCC;

### DIFF
--- a/src/client/styles/components/SubjectHeadings/SubjectHeading.scss
+++ b/src/client/styles/components/SubjectHeadings/SubjectHeading.scss
@@ -11,9 +11,13 @@
   @include removeDefaultButtonStyle;
 
   &:focus {
-    outline-color: #ffb81d;
-    outline-style: solid;
-    outline-width: 0.125rem;
+    // outline: -webkit-focus-ring-color auto 5px;
+    outline-color: #0f465c;
+    // outline-width: .125rem;
+    outline-offset: -6px;
+    background-color: inherit;
+    box-shadow: none;
+    // box-shadow: 1px 1px 1px 1px #082530;
   }
 }
 
@@ -70,4 +74,10 @@
   &:hover {
     color: inherit;
   }
+}
+
+
+
+a:focus {
+  background-color: inherit;
 }


### PR DESCRIPTION
- Fixes the non-matching background color
- Fixes the outline color to match SCC
- phantom toggle buttons do not get focus
- The focus on the toggle buttons is closer to the styling on SCC, but not exactly, because the width is a little different and the shadow is a little different. This was the easiest way to avoid overlapping the neighboring headings without adding padding. If it doesn't look good I can try adding some padding, but want to get feedback on this first.