### PR TITLE
Refactor to use existing data fetching

### DIFF
--- a/src/app/components/SubjectHeading/SubjectHeading.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeading.jsx
@@ -35,6 +35,16 @@ class SubjectHeading extends React.Component {
     this.fetchInitial = this.fetchInitial.bind(this);
   }
 
+  componentDidMount() {
+    const {
+      subjectHeading,
+      preOpen,
+    } = this.props;
+    if (preOpen || subjectHeading.preview) {
+      this.fetchInitial();
+    }
+  }
+
   componentDidUpdate() {
     if (this.state.narrower.length === 0 && this.props.subjectHeading.children) {
       this.setState({
@@ -271,7 +281,7 @@ class SubjectHeading extends React.Component {
             </div>
           </td>
         </tr>
-        { narrower.length > 0 ?
+        { open && narrower.length > 0 ?
           <SubjectHeadingsTableBody
             pathname={location.pathname}
             subjectHeadings={narrower}
@@ -284,6 +294,7 @@ class SubjectHeading extends React.Component {
             direction={direction}
             key={`${uuid}-list-${sortBy}-${direction}`}
             updateSort={this.updateSort}
+            preOpen={false}
           />
           : null}
       </React.Fragment>
@@ -300,10 +311,12 @@ SubjectHeading.propTypes = {
   container: PropTypes.string,
   direction: PropTypes.string,
   backgroundColor: PropTypes.string,
+  preOpen: PropTypes.bool,
 };
 
 SubjectHeading.defaultProps = {
   indentation: 0,
+  preOpen: false,
 };
 
 SubjectHeading.contextTypes = {

--- a/src/app/components/SubjectHeading/SubjectHeadingsTable.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeadingsTable.jsx
@@ -16,6 +16,7 @@ const SubjectHeadingsTable = (props) => {
     updateSort,
     tfootContent,
     direction,
+    preOpen,
   } = props;
 
   return (
@@ -32,6 +33,7 @@ const SubjectHeadingsTable = (props) => {
           container={container}
           direction={direction}
           top
+          preOpen={preOpen}
         />
       </tbody>
       { tfootContent ?

--- a/src/app/components/SubjectHeading/SubjectHeadingsTableBody.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeadingsTableBody.jsx
@@ -121,6 +121,7 @@ class SubjectHeadingsTableBody extends React.Component {
       sortBy,
       linked,
       direction,
+      preOpen,
     } = this.props;
 
     const { location } = this.context.router;
@@ -155,6 +156,7 @@ class SubjectHeadingsTableBody extends React.Component {
         linked={linked}
         backgroundColor={this.backgroundColor()}
         direction={direction}
+        preOpen={preOpen}
       />
     );
   }


### PR DESCRIPTION
This PR is to debug the error we were seeing with, e.g. `filter=China`.
It seems the actual error was a typo in the destructuring on line 101:

```const data = { resp }```

which should be 

``` const {data} = resp```

However after I fixed that it seemed it was still buggy. You could try fixing that issue and working from there. Alternatively, this PR tries a different approach, which is to use the existing `fetchInitial` method in the `SubjectHeading` components whenever we are pre-opening. I suspect this will be less error-prone. It does mean we'll have to think a little harder when we make SHEP isomorphic, but I wouldn't worry about that right now.

Also, while this is expedient for now, eventually we will probably want to get these headings on the backend (and same for the linked index page). I'll create a ticket for that, and we can discuss priority in our next planning.