### PR TITLE
Scc 1865 debug

### DIFF
--- a/src/app/components/SubjectHeading/AdditionalSubjectHeadingsButton.jsx
+++ b/src/app/components/SubjectHeading/AdditionalSubjectHeadingsButton.jsx
@@ -5,11 +5,17 @@ import { Link } from 'react-router';
 class AdditionalSubjectHeadingsButton extends React.Component {
   constructor(props) {
     super(props);
+    this.state = {};
     this.onClick = this.onClick.bind(this);
+    this.hide = this.hide.bind(this);
   }
 
   onClick() {
     if (this.props.interactive) this.props.updateParent(this);
+  }
+
+  hide() {
+    this.setState({ hidden: true });
   }
 
   render() {
@@ -19,6 +25,9 @@ class AdditionalSubjectHeadingsButton extends React.Component {
       text,
       linkUrl,
     } = this.props;
+
+    if (this.state.hidden) return null;
+
     const previous = this.props.button === 'previous';
 
     const seeMoreText = text || 'See more';

--- a/src/app/components/SubjectHeading/NestedTableHeader.jsx
+++ b/src/app/components/SubjectHeading/NestedTableHeader.jsx
@@ -13,6 +13,7 @@ const NestedTableHeader = (props) => {
     parentUuid,
     updateSort,
     interactive,
+    numberOpen,
   } = props;
 
   const positionStyle = container === 'narrower' ? null : { marginLeft: 30 * ((indentation || 0) + 1) };
@@ -31,6 +32,7 @@ const NestedTableHeader = (props) => {
             type="alphabetical"
             direction={calculateDirectionForType('alphabetical')}
             interactive={interactive}
+            numberOpen={numberOpen}
           />
         </div>
       </th>
@@ -40,6 +42,7 @@ const NestedTableHeader = (props) => {
           type="descendants"
           direction={calculateDirectionForType('descendants')}
           interactive={interactive}
+          numberOpen={numberOpen}
         />
       </th>
       <th className={`subjectHeadingsTableCell subjectHeadingAttribute titles ${sortBy === 'bibs' ? 'selected' : ''}`}>
@@ -48,6 +51,7 @@ const NestedTableHeader = (props) => {
           type="bibs"
           direction={calculateDirectionForType('bibs')}
           interactive={interactive}
+          numberOpen={numberOpen}
         />
       </th>
     </tr>

--- a/src/app/components/SubjectHeading/SortButton.jsx
+++ b/src/app/components/SubjectHeading/SortButton.jsx
@@ -7,6 +7,7 @@ const SortButton = (props) => {
     direction,
     handler,
     interactive,
+    numberOpen,
   } = props;
 
   const columnText = () => ({
@@ -18,7 +19,7 @@ const SortButton = (props) => {
   return (
     <button
       className="subjectSortButton"
-      onClick={() => handler(type, direction)}
+      onClick={() => handler(type, direction, numberOpen)}
       disabled={!handler || !interactive}
     >
       <span className="emph">

--- a/src/app/components/SubjectHeading/SortButton.jsx
+++ b/src/app/components/SubjectHeading/SortButton.jsx
@@ -20,7 +20,7 @@ const SortButton = (props) => {
     <button
       className="subjectSortButton"
       onClick={() => handler(type, direction, numberOpen)}
-      disabled={!handler || !interactive}
+      disabled={!handler || !interactive || numberOpen < 2}
     >
       <span className="emph">
         <span className="noEmph">{columnText()}

--- a/src/app/components/SubjectHeading/SubjectHeading.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeading.jsx
@@ -106,7 +106,14 @@ class SubjectHeading extends React.Component {
     return (element) => {
       axios(url)
         .then(
-          resp => this.addMore(element, resp.data),
+          (resp) => {
+            if (resp.data.narrower) {
+              this.addMore(element, resp.data);
+            } else {
+              console.log(this.state);
+              element.hide();
+            }
+          },
         ).catch((resp) => { console.error(resp); });
     };
   }

--- a/src/app/components/SubjectHeading/SubjectHeading.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeading.jsx
@@ -129,11 +129,12 @@ class SubjectHeading extends React.Component {
     return `${path}/subject_headings/${uuid}`;
   }
 
-  updateSort(sortType, direction) {
+  updateSort(sortType, direction, numberOpen) {
     this.fetchInitial({
       sortBy: sortType,
       direction,
       range: Range.default(),
+      numberOpen,
     });
   }
 
@@ -147,10 +148,11 @@ class SubjectHeading extends React.Component {
       direction,
     } = this.state;
 
-    const limit = this.state.narrower.length;
+    let limit;
 
     if (additionalParameters.sortBy) sortBy = additionalParameters.sortBy;
     if (additionalParameters.direction) direction = additionalParameters.direction;
+    if (additionalParameters.numberOpen) limit = additionalParameters.numberOpen;
     let url = `${appConfig.baseUrl}/api/subjectHeadings/subject_headings/${uuid}/narrower?sort_by=${sortBy}`;
 
     if (direction) url += `&direction=${direction}`;

--- a/src/app/components/SubjectHeading/SubjectHeading.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeading.jsx
@@ -86,10 +86,11 @@ class SubjectHeading extends React.Component {
         (child) => { child.indentation = (this.props.subjectHeading.indentation || 0) + 1; }
       );
 
+      console.log('adding to : ', narrower);
       narrower.splice(-1, 1, ...data.narrower);
 
       if (data.next_url) {
-        narrower.splice(-1, 1, {
+        narrower.splice(narrower.length, 1, {
           button: 'next',
           updateParent: this.fetchAndUpdate(data.next_url),
           indentation: (this.props.subjectHeading.indentation || 0) + 1,
@@ -110,7 +111,6 @@ class SubjectHeading extends React.Component {
             if (resp.data.narrower) {
               this.addMore(element, resp.data);
             } else {
-              console.log(this.state);
               element.hide();
             }
           },
@@ -174,7 +174,7 @@ class SubjectHeading extends React.Component {
           } = resp.data;
           narrower.forEach((child) => { child.indentation = (indentation || 0) + 1; });
           if (next_url) {
-            narrower[narrower.length - 1] = { button: 'next', updateParent: this.fetchAndUpdate(next_url), indentation: (indentation || 0) + 1 };
+            narrower.push({ button: 'next', updateParent: this.fetchAndUpdate(next_url), indentation: (indentation || 0) + 1 });
           }
           this.updateSubjectHeading(
             Object.assign(

--- a/src/app/components/SubjectHeading/SubjectHeading.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeading.jsx
@@ -86,7 +86,6 @@ class SubjectHeading extends React.Component {
         (child) => { child.indentation = (this.props.subjectHeading.indentation || 0) + 1; }
       );
 
-      console.log('adding to : ', narrower);
       narrower.splice(-1, 1, ...data.narrower);
 
       if (data.next_url) {

--- a/src/app/components/SubjectHeading/SubjectHeadingsTableBody.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeadingsTableBody.jsx
@@ -27,7 +27,6 @@ class SubjectHeadingsTableBody extends React.Component {
     this.listItemsInInterval = this.listItemsInInterval.bind(this);
     this.tableRow = this.tableRow.bind(this);
     this.backgroundColor = this.backgroundColor.bind(this);
-    this.numberOpen = this.numberOpen.bind(this);
   }
 
   componentDidMount() {
@@ -114,10 +113,6 @@ class SubjectHeadingsTableBody extends React.Component {
     return backgroundColor;
   }
 
-  numberOpen() {
-    return this.state.range.intervals.reduce((acc, interval) => acc + (interval.end - interval.start), 0);
-  }
-
   tableRow(listItem, index) {
     const {
       indentation,
@@ -189,7 +184,9 @@ class SubjectHeadingsTableBody extends React.Component {
       container,
     } = this.props;
 
-    const numberOpen = this.numberOpen();
+    const inRange = this.listItemsInRange(subjectHeadings);
+
+    const numberOpen = inRange.filter(item => !item.button).length;
 
     if (nested) { console.log('tbody ', this.state, numberOpen); }
 
@@ -212,8 +209,7 @@ class SubjectHeadingsTableBody extends React.Component {
         }
         {
           subjectHeadings ?
-          this.listItemsInRange(subjectHeadings)
-          .map(this.tableRow) :
+          inRange.map(this.tableRow) :
           null
         }
       </React.Fragment>

--- a/src/app/components/SubjectHeading/SubjectHeadingsTableBody.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeadingsTableBody.jsx
@@ -188,8 +188,6 @@ class SubjectHeadingsTableBody extends React.Component {
 
     const numberOpen = inRange.filter(item => !item.button).length;
 
-    if (nested) { console.log('tbody ', this.state, numberOpen); }
-
     return (
       <React.Fragment>
         {nested && subjectHeadings ?

--- a/src/app/components/SubjectHeading/SubjectHeadingsTableBody.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeadingsTableBody.jsx
@@ -27,6 +27,7 @@ class SubjectHeadingsTableBody extends React.Component {
     this.listItemsInInterval = this.listItemsInInterval.bind(this);
     this.tableRow = this.tableRow.bind(this);
     this.backgroundColor = this.backgroundColor.bind(this);
+    this.numberOpen = this.numberOpen.bind(this);
   }
 
   componentDidMount() {
@@ -113,6 +114,10 @@ class SubjectHeadingsTableBody extends React.Component {
     return backgroundColor;
   }
 
+  numberOpen() {
+    return this.state.range.intervals.reduce((acc, interval) => acc + (interval.end - interval.start), 0);
+  }
+
   tableRow(listItem, index) {
     const {
       indentation,
@@ -184,6 +189,10 @@ class SubjectHeadingsTableBody extends React.Component {
       container,
     } = this.props;
 
+    const numberOpen = this.numberOpen();
+
+    if (nested) { console.log('tbody ', this.state, numberOpen); }
+
     return (
       <React.Fragment>
         {nested && subjectHeadings ?
@@ -197,6 +206,7 @@ class SubjectHeadingsTableBody extends React.Component {
             backgroundColor={this.backgroundColor(true)}
             updateSort={updateSort}
             interactive={subjectHeadings.length > 1}
+            numberOpen={numberOpen}
           />
           : null
         }


### PR DESCRIPTION
Fixes some bugs that were introduced/surfaced by keeping the same number of headings when re-sorting:

- Changes the way we calculate how many items to fetch by counting up the number of items currently being shown, rather than the total number of 'narrower' headings the app has (these can get out of line in the linked view because we fetch all the data at once)
- In case we somehow are displaying a button but there are no more headings, we hide the button instead of attempting to add nonexistent headings, which was breaking the app.