### PR TITLE
Change show page see more text and remove extra ellipse

### DIFF
--- a/src/app/components/SubjectHeading/AdditionalSubjectHeadingsButton.jsx
+++ b/src/app/components/SubjectHeading/AdditionalSubjectHeadingsButton.jsx
@@ -5,11 +5,17 @@ import { Link } from 'react-router';
 class AdditionalSubjectHeadingsButton extends React.Component {
   constructor(props) {
     super(props);
+    this.state = {};
     this.onClick = this.onClick.bind(this);
+    this.hide = this.hide.bind(this);
   }
 
   onClick() {
     if (this.props.interactive) this.props.updateParent(this);
+  }
+
+  hide() {
+    this.setState({ hidden: true });
   }
 
   render() {
@@ -18,7 +24,11 @@ class AdditionalSubjectHeadingsButton extends React.Component {
       interactive,
       text,
       linkUrl,
+      noEllipse,
     } = this.props;
+
+    if (this.state.hidden) return null;
+
     const previous = this.props.button === 'previous';
 
     const seeMoreText = text || 'See more';
@@ -42,7 +52,7 @@ class AdditionalSubjectHeadingsButton extends React.Component {
           >
             {previous ? '↑' : '↓'} <em key="seeMoreText">{seeMoreText}</em>
             {previous ? null : <br /> }
-            {previous ? null : <VerticalEllipse />}
+            {previous || noEllipse ? null : <VerticalEllipse />}
           </button>
         )
 

--- a/src/app/components/SubjectHeading/SubjectHeadingShow.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeadingShow.jsx
@@ -155,13 +155,15 @@ class SubjectHeadingShow extends React.Component {
                 showId={uuid}
                 keyId="context"
                 container="context"
+                seeMoreLinkUrl={linkUrl}
+                seeMoreText="See More in Subject Headings Index"
                 tfootContent={
                   <tr>
                     <td>
                       <Link
-                        to={contextHeadings && contextHeadings.length ? this.generateFullContextUrl() : '#'}
+                        to={linkUrl}
                         className="toIndex"
-                        >
+                      >
                         Explore more in Subject Heading index
                       </Link>
                     </td>

--- a/src/app/components/SubjectHeading/SubjectHeadingsTableBody.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeadingsTableBody.jsx
@@ -71,12 +71,14 @@ class SubjectHeadingsTableBody extends React.Component {
       range,
     } = this.state;
 
-    return range.intervals.reduce((acc, interval) =>
-      acc.concat(this.listItemsInInterval(interval))
+    const lastIndex = range.intervals.length - 1;
+
+    return range.intervals.reduce((acc, interval, index) =>
+      acc.concat(this.listItemsInInterval(interval, index, lastIndex))
       , []);
   }
 
-  listItemsInInterval(interval) {
+  listItemsInInterval(interval, index, lastIndex) {
     const { indentation } = this.props;
     const { subjectHeadings, range } = this.state;
     const { start, end } = interval;
@@ -92,6 +94,7 @@ class SubjectHeadingsTableBody extends React.Component {
       subjectHeadingsInInterval.push({
         button: 'next',
         indentation,
+        noEllipse: index === lastIndex,
         updateParent: () => this.updateRange(range, interval, 'end', 10),
       });
     }
@@ -146,6 +149,7 @@ class SubjectHeadingsTableBody extends React.Component {
           linkUrl={seeMoreLinkUrl}
           text={seeMoreText}
           backgroundColor={this.backgroundColor()}
+          noEllipse={listItem.noEllipse}
         />
       );
     }


### PR DESCRIPTION
Addresses remaining requirements in SCC-1846

- Changes the see more button text on show pages to say "See more in subject headings index"
- Removes arrows/ellipses on show page
- Only display ellipse when there is both an up and a down arrow.

Unfortunately some commits from another PR crept in, the stuff involving `hide` is not relevant.