### PR TITLE
Add check for e-resource before rendering item table

### DIFF
--- a/src/app/components/Item/ItemTable.jsx
+++ b/src/app/components/Item/ItemTable.jsx
@@ -5,7 +5,11 @@ import { isArray as _isArray } from 'underscore';
 import ItemTableRow from './ItemTableRow';
 
 const ItemTable = ({ items, bibId, getRecord, id, searchKeywords }) => {
-  if (!_isArray(items) || !items.length) {
+  if (
+    !_isArray(items) ||
+    !items.length ||
+    items.every(item => item.isElectronicResource)
+  ) {
     return null;
   }
 


### PR DESCRIPTION
This PR adds a check to make sure at least one item is not an e-resource before rendering the ItemTable, because this allows for empty tables on the SearchResults page.