### PR TITLE
SCC-1865 debug SortButton interactivity

### DIFF
--- a/src/app/components/SubjectHeading/SortButton.jsx
+++ b/src/app/components/SubjectHeading/SortButton.jsx
@@ -20,7 +20,7 @@ const SortButton = (props) => {
     <button
       className="subjectSortButton"
       onClick={() => handler(type, direction, numberOpen)}
-      disabled={!handler || !interactive}
+      disabled={!handler || !interactive || numberOpen < 2}
     >
       <span className="emph">
         <span className="noEmph">{columnText()}


### PR DESCRIPTION
Small bug fix for `SCC-1865-debug`. SortButton created bugs if only one subject heading was displayed. We also could hide the '^', but when you click 'See more' , the '^' becomes relevant.