### PR TITLE
Add punctuation button and change approach to border styling

### DIFF
--- a/src/app/components/SubjectHeading/AlphabeticalPagination.jsx
+++ b/src/app/components/SubjectHeading/AlphabeticalPagination.jsx
@@ -18,7 +18,7 @@ const AlphabeticalPagination = () => {
 
   const punctuationButton = (
     <Link key="punctuation" to={`${appConfig.baseUrl}/subject_headings?fromLabel=!`}>
-      !"*,-./
+      !"*,-
     </Link>
   );
 

--- a/src/app/components/SubjectHeading/AlphabeticalPagination.jsx
+++ b/src/app/components/SubjectHeading/AlphabeticalPagination.jsx
@@ -16,6 +16,12 @@ const AlphabeticalPagination = () => {
     </Link>
   );
 
+  const punctuationButton = (
+    <Link key="punctuation" to={`${appConfig.baseUrl}/subject_headings?fromLabel=!`}>
+      !"*,-./
+    </Link>
+  );
+
   const numericalButton = (
     <Link key="numerical" to={`${appConfig.baseUrl}/subject_headings?fromLabel=0`}>
       0-9
@@ -23,7 +29,7 @@ const AlphabeticalPagination = () => {
   );
 
   const buttons = [allButton].concat(letterButtons);
-  buttons.push(numericalButton);
+  buttons.push(punctuationButton, numericalButton);
 
   return (
     <div className="alphabeticalPagination">

--- a/src/client/styles/components/SubjectHeadings/AlphabeticalPagination.scss
+++ b/src/client/styles/components/SubjectHeadings/AlphabeticalPagination.scss
@@ -16,7 +16,6 @@ $light-border: 1px solid #d7d4d0;
   a {
     box-sizing: border-box;
     background-color: #ffffff;
-    cursor: pointer;
     display: inline-block;
     flex: auto;
     font-size: 14px;
@@ -26,5 +25,9 @@ $light-border: 1px solid #d7d4d0;
     min-width: 32px;
     border: 1px solid #d7d4d0;
     border-radius: 1px;
+
+    &:focus {
+      z-index: 1;
+    }
   }
 }

--- a/src/client/styles/components/SubjectHeadings/AlphabeticalPagination.scss
+++ b/src/client/styles/components/SubjectHeadings/AlphabeticalPagination.scss
@@ -25,6 +25,7 @@ $light-border: 1px solid #d7d4d0;
     min-width: 32px;
     border: 1px solid #d7d4d0;
     border-radius: 1px;
+    margin: -1px;
 
     &:focus {
       z-index: 1;

--- a/src/client/styles/components/SubjectHeadings/AlphabeticalPagination.scss
+++ b/src/client/styles/components/SubjectHeadings/AlphabeticalPagination.scss
@@ -12,6 +12,7 @@ $light-border: 1px solid #d7d4d0;
   text-align: center;
   background-color: #d7d4d0;
   line-height: 32px;
+  padding: 1px;
 
   a {
     box-sizing: border-box;

--- a/src/client/styles/components/SubjectHeadings/AlphabeticalPagination.scss
+++ b/src/client/styles/components/SubjectHeadings/AlphabeticalPagination.scss
@@ -1,4 +1,4 @@
-$light-border: 0.08333rem solid #d7d4d0;
+$light-border: 1px solid #d7d4d0;
 
 .alphabeticalPagination {
   border: $light-border;
@@ -24,6 +24,7 @@ $light-border: 0.08333rem solid #d7d4d0;
     text-align: center;
     text-decoration: none;
     min-width: 32px;
-    margin: 0 0 1px 1px;
+    border: 1px solid #d7d4d0;
+    border-radius: 1px;
   }
 }

--- a/src/client/styles/components/SubjectHeadings/AlphabeticalPagination.scss
+++ b/src/client/styles/components/SubjectHeadings/AlphabeticalPagination.scss
@@ -1,90 +1,29 @@
 $light-border: 0.08333rem solid #d7d4d0;
 
 .alphabeticalPagination {
-  margin-top: 1.5rem;
+  border: $light-border;
+  border-radius: .2rem;
+  box-sizing: border-box;
+  display: flex;
+  flex-wrap: wrap;
   margin-bottom: 1.5rem;
+  margin-top: 1.5rem;
   max-width: 100%;
   text-align: center;
-  display: flex;
+  background-color: #d7d4d0;
+  line-height: 32px;
 
   a {
-    border: $light-border;
-    border-right: 0;
-    font-weight: 400;
-    font-size: 14px;
-    text-align: center;
-    min-width: 24px;
-    text-decoration: none;
+    box-sizing: border-box;
+    background-color: #ffffff;
     cursor: pointer;
-    flex: 3%;
     display: inline-block;
-  }
-  a:last-child {
-    border-right: $light-border;
-    border-radius: 0 0.2rem 0.2rem 0;
-  }
-  a:first-child {
-    border-radius: 0.2rem 0 0 0.2rem;
-  }
-}
-
-$top-left-corner: 0.2rem 0 0 0;
-$top-right-corner: 0 0.2rem 0 0;
-$bottom-right-corner: 0 0 0.2rem 0;
-$bottom-left-corner: 0 0 0 0.2rem;
-
-@media screen and (max-width: 750px) {
-  .alphabeticalPagination {
-    flex-wrap: wrap;
-    a:first-child {
-      border-radius: $top-left-corner;
-    }
-    a:last-child {
-      border-radius: $bottom-right-corner;
-    }
-  }
-}
-
-@media screen and (max-width: 750px) and (min-width: 420px) {
-  .alphabeticalPagination {
-    a {
-      flex: 6.6%;
-      max-width: 45px;
-    }
-    a:nth-child(14) {
-      border-right: $light-border;
-      border-radius: $top-right-corner;
-    }
-    a:nth-child(15) {
-      border-radius: $bottom-left-corner;
-    }
-    a:nth-child(-n+14) {
-      border-bottom: unset;
-    }
-  }
-}
-
-
-@media screen and (max-width: 419px) {
-  .alphabeticalPagination {
-    a {
-      flex: 9.5%;
-      max-width: 34px;
-    }
-    a:nth-child(10n) {
-      border-right: $light-border;
-    }
-    a:nth-child(10){
-      border-radius: $top-right-corner;
-    }
-    a:nth-child(21) {
-      border-radius: $top-left-corner;
-    }
-    a:nth-child(-n+10) {
-      border-bottom: unset;
-    }
-    a:nth-child(n+21) {
-      border-top: unset;
-    }
+    flex: auto;
+    font-size: 14px;
+    font-weight: 400;
+    text-align: center;
+    text-decoration: none;
+    min-width: 32px;
+    margin: 0 0 1px 1px;
   }
 }

--- a/src/client/styles/components/SubjectHeadings/AlphabeticalPagination.scss
+++ b/src/client/styles/components/SubjectHeadings/AlphabeticalPagination.scss
@@ -28,6 +28,7 @@ $light-border: 1px solid #d7d4d0;
 
     &:focus {
       z-index: 1;
+      background-color: #ffffff;
     }
   }
 }


### PR DESCRIPTION
I used working on SCC-1838 on the backend to simultaneously fix the UX for this feature by implementing the approach @hokei recommended 👍
Looks a little different than the current version, but will be a lot easier to maintain.

Problem with previous version (goes off page unpredictably):
<img width="762" alt="Screen Shot 2020-03-18 at 3 35 35 PM" src="https://user-images.githubusercontent.com/47210101/77000094-26e25280-692e-11ea-8256-28c9eb82da09.png">

Current version:
<img width="835" alt="Screen Shot 2020-03-18 at 3 49 35 PM" src="https://user-images.githubusercontent.com/47210101/77001290-18953600-6930-11ea-927a-64b09d895a83.png">