### PR TITLE
Add logic to remove ellipse

### DIFF
--- a/src/app/components/SubjectHeading/SubjectHeading.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeading.jsx
@@ -93,6 +93,7 @@ class SubjectHeading extends React.Component {
           button: 'next',
           updateParent: this.fetchAndUpdate(data.next_url),
           indentation: (this.props.subjectHeading.indentation || 0) + 1,
+          noEllipse: true,
         });
       }
 
@@ -173,7 +174,12 @@ class SubjectHeading extends React.Component {
           } = resp.data;
           narrower.forEach((child) => { child.indentation = (indentation || 0) + 1; });
           if (next_url) {
-            narrower.push({ button: 'next', updateParent: this.fetchAndUpdate(next_url), indentation: (indentation || 0) + 1 });
+            narrower.push({
+              button: 'next',
+              updateParent: this.fetchAndUpdate(next_url),
+              indentation: (indentation || 0) + 1,
+              noEllipse: true,
+            });
           }
           this.updateSubjectHeading(
             Object.assign(


### PR DESCRIPTION
Remove the ellipsis for the `AdditionalSubjectHeadingsButton` that is generated by the `SubjectHeadingComponent`. This is the button at the end of the list of narrower headings. Long term (hopefully not too long) we want to refactor so that only one component is responsible for generating these buttons, but this at least gets the feature working for now.