### PR TITLE
SCC-1914 Fix breakpoint behavior for show page

### DIFF
--- a/src/client/styles/components/ShepContainer.scss
+++ b/src/client/styles/components/ShepContainer.scss
@@ -31,7 +31,7 @@
 
   .nypl-column-full {
     margin-left: 150px;
-    @include media(1015px) {
+    @include media(1025px) {
       margin-left: 25px;
     }
   }

--- a/src/client/styles/components/SubjectHeadings.scss
+++ b/src/client/styles/components/SubjectHeadings.scss
@@ -51,17 +51,6 @@ $table-row-border: 1px solid rgb(215, 210, 205);
   }
 }
 
-.subjectHeadingShow {
-  h2 {
-    max-width: 40rem;
-    padding-left: 1.5%;
-  }
-
-  .nypl-results-item h2, .nypl-results-item h3 {
-    font-size: 1rem;
-  }
-}
-
 .not-in-discovery {
   color: grey;
   font-style: italic;


### PR DESCRIPTION
Quickest change for [SCC-1914] Show page info box jagged breakpoint. This change increases the screen width at which the left margin disappears. Right now, it is applied to both the show and index page, due to the HTML structure and current classname usage. We could also add another classname to `.nypl-column-full`<div> in the ShepContainer to only apply this change to the show page and not the index page.