### PR TITLE
change the behavior of `basicQuery()` to avoid fake "Search Results"

### DIFF
--- a/src/app/utils/utils.js
+++ b/src/app/utils/utils.js
@@ -225,9 +225,7 @@ const basicQuery = (props = {}) => {
 
     const completeQuery = `${searchKeywordsQuery}${filterQuery}${sortQuery}${fieldQuery}${pageQuery}`;
 
-    if (!completeQuery) return null;
-
-    return `q=${searchKeywordsQuery}${filterQuery}${sortQuery}${fieldQuery}${pageQuery}`;
+    return completeQuery ? `q=${completeQuery}` : null;
   };
 };
 

--- a/src/app/utils/utils.js
+++ b/src/app/utils/utils.js
@@ -223,6 +223,10 @@ const basicQuery = (props = {}) => {
     pageQuery = page && page !== '1' ? `&page=${page}` : pageQuery;
     pageQuery = page === '1' ? '' : pageQuery;
 
+    const completeQuery = `${searchKeywordsQuery}${filterQuery}${sortQuery}${fieldQuery}${pageQuery}`;
+
+    if (!completeQuery) return null;
+
     return `q=${searchKeywordsQuery}${filterQuery}${sortQuery}${fieldQuery}${pageQuery}`;
   };
 };

--- a/test/unit/utils.test.js
+++ b/test/unit/utils.test.js
@@ -344,16 +344,15 @@ describe('basicQuery', () => {
       expect(basicQuery(defaultQueryObj)).to.be.a('function');
     });
 
-    // Why was this behavior originally implemented?
-    xit('should take empty objects as input and return default string when invoked', () => {
+    it('should return null when the input is an empty object', () => {
       const createAPIQuery = basicQuery({});
 
-      expect(createAPIQuery({})).to.equal('q=');
+      expect(createAPIQuery({})).to.equal(null);
     });
 
-    xit('should still return the default string even with the default object', () => {
+    it('should return null with the default object', () => {
       const createAPIQuery = basicQuery(defaultQueryObj);
-      expect(createAPIQuery({})).to.equal('q=');
+      expect(createAPIQuery({})).to.equal(null);
     });
   });
 

--- a/test/unit/utils.test.js
+++ b/test/unit/utils.test.js
@@ -344,13 +344,14 @@ describe('basicQuery', () => {
       expect(basicQuery(defaultQueryObj)).to.be.a('function');
     });
 
-    it('should take empty objects as input and return default string when invoked', () => {
+    // Why was this behavior originally implemented?
+    xit('should take empty objects as input and return default string when invoked', () => {
       const createAPIQuery = basicQuery({});
 
       expect(createAPIQuery({})).to.equal('q=');
     });
 
-    it('should still return the default string even with the default object', () => {
+    xit('should still return the default string even with the default object', () => {
       const createAPIQuery = basicQuery(defaultQueryObj);
       expect(createAPIQuery({})).to.equal('q=');
     });


### PR DESCRIPTION
**What's this do?**
This changes the behavior of the `basicQuery` util function to not return the default string of "q=" if there are no search parameters. Maybe this is over kill or more QA trouble than it is worth? I am trying to figure out how to eliminate the behavior we do not want more concisely, because I keep finding it.

**Why are we doing this? (w/ JIRA link if applicable)** 
There are JIRA tickets related to this. We do not want to pretend there are search results or show it in the breadcrumbs if a search was not actually made and if the data is not in the store or props for whatever reason.

**How should this be tested? / Do these changes have associated tests?** 
This effects two tests. I marked them as pending and left a temporary comment. I think @EdwinGuzman said the original intent was the opposite of the behavior we prefer now. I am checking in about that.

**Dependencies for merging? Releasing to production?** 
I did not check all the places this function is used yet. I will do that if we decide this approach is alright.

**Has the application documentation been updated for these changes?**
I have not removed or updated the tests that are now failing due to this change.

**Did someone actually run this code to verify it works?**
The bib page works and the "Search Results" link does not appear following the same actions that led me to see it before.
