### PR TITLE
SCC-1930/implement context for `container`

### DIFF
--- a/src/app/components/SubjectHeading/AdditionalSubjectHeadingsButton.jsx
+++ b/src/app/components/SubjectHeading/AdditionalSubjectHeadingsButton.jsx
@@ -11,7 +11,7 @@ class AdditionalSubjectHeadingsButton extends React.Component {
   }
 
   onClick() {
-    if (this.props.interactive) this.props.updateParent(this);
+    this.props.updateParent(this);
   }
 
   hide() {
@@ -21,7 +21,6 @@ class AdditionalSubjectHeadingsButton extends React.Component {
   render() {
     const {
       indentation,
-      interactive,
       text,
       linkUrl,
       noEllipse,
@@ -93,7 +92,6 @@ AdditionalSubjectHeadingsButton.propTypes = {
   updateParent: PropTypes.func,
   indentation: PropTypes.number,
   button: PropTypes.string,
-  interactive: PropTypes.bool,
   linkUrl: PropTypes.string,
   text: PropTypes.string,
   backgroundColor: PropTypes.string,

--- a/src/app/components/SubjectHeading/NestedTableHeader.jsx
+++ b/src/app/components/SubjectHeading/NestedTableHeader.jsx
@@ -7,21 +7,19 @@ import SortButton from './SortButton';
 const NestedTableHeader = (props) => {
   const {
     indentation,
-    container,
     sortBy,
     direction,
     parentUuid,
     updateSort,
-    interactive,
     numberOpen,
+    interactive
   } = props;
 
-  const positionStyle = container === 'narrower' ? null : { marginLeft: 30 * ((indentation || 0) + 1) };
+  const positionStyle = { marginLeft: 30 * ((indentation || 0) + 1) };
   const calculateDirectionForType = calculateDirection(sortBy, direction);
 
   return (
     <tr
-      data={`${parentUuid}, ${container}`}
       style={{ backgroundColor: props.backgroundColor }}
       className="nestedTableHeader"
     >
@@ -61,7 +59,6 @@ const NestedTableHeader = (props) => {
 NestedTableHeader.propTypes = {
   indentation: PropTypes.number,
   sortBy: PropTypes.string,
-  container: PropTypes.string,
   direction: PropTypes.string,
   backgroundColor: PropTypes.string,
   parentUuid: PropTypes.string,

--- a/src/app/components/SubjectHeading/SubjectHeading.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeading.jsx
@@ -203,10 +203,11 @@ class SubjectHeading extends React.Component {
         pathname: '',
         search: '',
       },
-      container,
       seeMoreText,
       seeMoreLinkUrl,
     } = this.props;
+
+    const { container } = this.context;
 
     const {
       label,
@@ -251,14 +252,13 @@ class SubjectHeading extends React.Component {
       return <button {...props}>{innerText}</button>;
     };
 
-    const positionStyle = ['narrower', 'related'].includes(container) ? null : { marginLeft: 30 * ((indentation || 0) + 1) };
+    const positionStyle = container === 'related' ? null : { marginLeft: 30 * ((indentation || 0) + 1) };
     const isMain = (pathname + search).includes(uuid);
     // changes to HTML structure here will need to be replicated in ./SubjectHeadingTableHeader
 
     return (
       <React.Fragment>
         <tr
-          data={`${subjectHeading.uuid}, ${container}`}
           className={`
             subjectHeadingRow
             ${(open || children || isMain) ? 'openSubjectHeading' : ''}
@@ -304,7 +304,6 @@ class SubjectHeading extends React.Component {
             nested="true"
             indentation={(indentation || 0) + 1}
             range={range}
-            container={container}
             parentUuid={uuid}
             sortBy={sortBy}
             direction={direction}
@@ -326,7 +325,6 @@ SubjectHeading.propTypes = {
   sortBy: PropTypes.string,
   linked: PropTypes.string,
   indentation: PropTypes.number,
-  container: PropTypes.string,
   direction: PropTypes.string,
   seeMoreText: PropTypes.string,
   seeMoreLinkUrl: PropTypes.string,
@@ -341,6 +339,7 @@ SubjectHeading.defaultProps = {
 
 SubjectHeading.contextTypes = {
   router: PropTypes.object,
+  container: PropTypes.string,
 };
 
 export default SubjectHeading;

--- a/src/app/components/SubjectHeading/SubjectHeadingsTable.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeadingsTable.jsx
@@ -4,55 +4,59 @@ import PropTypes from 'prop-types';
 import SubjectHeadingsTableHeader from './SubjectHeadingsTableHeader';
 import SubjectHeadingsTableBody from './SubjectHeadingsTableBody';
 
+class SubjectHeadingsTable extends React.Component {
+  getChildContext() {
+    const { container } = this.props;
+    return { container };
+  }
 
-const SubjectHeadingsTable = (props) => {
-  const {
-    subjectHeadings,
-    location,
-    sortBy,
-    showId,
-    keyId,
-    container,
-    updateSort,
-    seeMoreText,
-    seeMoreLinkUrl,
-    tfootContent,
-    direction,
-    preOpen,
-  } = props;
+  render() {
+    const {
+      subjectHeadings,
+      location,
+      sortBy,
+      showId,
+      keyId,
+      updateSort,
+      seeMoreText,
+      seeMoreLinkUrl,
+      container,
+      tfootContent,
+      direction,
+      preOpen,
+    } = this.props;
 
-  return (
-    <table className={`subjectHeadingsTable ${container}`}>
-      <SubjectHeadingsTableHeader updateSort={updateSort} selected={sortBy} />
-      <tbody data={`${seeMoreText}-${seeMoreLinkUrl}`}>
-        <SubjectHeadingsTableBody
-          subjectHeadings={subjectHeadings}
-          linked={location.query.linked}
-          location={location}
-          sortBy={sortBy}
-          showId={showId}
-          keyId={keyId}
-          container={container}
-          seeMoreText={seeMoreText}
-          seeMoreLinkUrl={seeMoreLinkUrl}
-          direction={direction}
-          top
-          preOpen={preOpen}
-        />
-      </tbody>
-      { tfootContent ?
-        <tfoot>
-          {tfootContent}
-        </tfoot>
-        : null
-      }
-    </table>
-  );
+    return (
+      <table className={`subjectHeadingsTable ${container}`}>
+        <SubjectHeadingsTableHeader updateSort={updateSort} selected={sortBy} />
+        <tbody data={`${seeMoreText}-${seeMoreLinkUrl}`}>
+          <SubjectHeadingsTableBody
+            subjectHeadings={subjectHeadings}
+            linked={location.query.linked}
+            location={location}
+            sortBy={sortBy}
+            showId={showId}
+            keyId={keyId}
+            seeMoreText={seeMoreText}
+            seeMoreLinkUrl={seeMoreLinkUrl}
+            direction={direction}
+            top
+            preOpen={preOpen}
+          />
+        </tbody>
+        { tfootContent ?
+          <tfoot>
+            {tfootContent}
+          </tfoot>
+          : null
+        }
+      </table>
+    );
+  }
 };
 
 SubjectHeadingsTable.propTypes = {
   subjectHeadings: PropTypes.array,
-  linked: PropTypes.string,
   location: PropTypes.object,
   sortBy: PropTypes.string,
   showId: PropTypes.string,
@@ -61,6 +65,10 @@ SubjectHeadingsTable.propTypes = {
   updateSort: PropTypes.func,
   seeMoreText: PropTypes.string,
   seeMoreLinkUrl: PropTypes.string,
+};
+
+SubjectHeadingsTable.childContextTypes = {
+  container: PropTypes.string,
 };
 
 export default SubjectHeadingsTable;

--- a/src/app/components/SubjectHeading/SubjectHeadingsTableBody.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeadingsTableBody.jsx
@@ -13,14 +13,13 @@ class SubjectHeadingsTableBody extends React.Component {
     super(props);
     const {
       subjectHeadings,
-      container,
       parentUuid,
       pathname,
     } = props;
+
     this.state = {
       subjectHeadings,
       range: this.initialRange(props),
-      interactive: !(container === 'context') || (pathname && pathname.includes(parentUuid)),
     };
     this.updateRange = this.updateRange.bind(this);
     this.listItemsInRange = this.listItemsInRange.bind(this);
@@ -120,7 +119,6 @@ class SubjectHeadingsTableBody extends React.Component {
     const {
       indentation,
       nested,
-      container,
       sortBy,
       linked,
       direction,
@@ -132,10 +130,6 @@ class SubjectHeadingsTableBody extends React.Component {
 
     const { location } = this.context.router;
 
-    const {
-      interactive,
-    } = this.state;
-
     if (listItem.button) {
       return (
         <AdditionalSubjectHeadingsButton
@@ -144,8 +138,6 @@ class SubjectHeadingsTableBody extends React.Component {
           updateParent={listItem.updateParent}
           key={`${listItem.button}${listItem.indentation}${index}`}
           nested={nested}
-          interactive={interactive}
-          container={container}
           linkUrl={seeMoreLinkUrl}
           text={seeMoreText}
           backgroundColor={this.backgroundColor()}
@@ -161,7 +153,6 @@ class SubjectHeadingsTableBody extends React.Component {
         nested={nested}
         indentation={indentation}
         location={location}
-        container={container}
         sortBy={sortBy}
         linked={linked}
         seeMoreText={seeMoreText}
@@ -185,7 +176,6 @@ class SubjectHeadingsTableBody extends React.Component {
       sortBy,
       direction,
       updateSort,
-      container,
     } = this.props;
 
     const inRange = this.listItemsInRange(subjectHeadings);
@@ -199,7 +189,6 @@ class SubjectHeadingsTableBody extends React.Component {
             parentUuid={parentUuid}
             key={`nestedTableHeader${indentation}`}
             indentation={indentation}
-            container={container}
             sortBy={sortBy}
             direction={direction}
             backgroundColor={this.backgroundColor(true)}
@@ -225,7 +214,6 @@ SubjectHeadingsTableBody.propTypes = {
   indentation: PropTypes.number,
   linked: PropTypes.string,
   sortBy: PropTypes.string,
-  container: PropTypes.string,
   parentUuid: PropTypes.string,
   updateSort: PropTypes.func,
   pathname: PropTypes.string,

--- a/src/app/components/SubjectHeading/SubjectHeadingsTableHeader.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeadingsTableHeader.jsx
@@ -1,7 +1,8 @@
-import React from 'react';
+import React, {useContext} from 'react';
 import PropTypes from 'prop-types';
 
 import SortButton from './SortButton';
+import TableContainerContext from './TableContainerContext';
 
 const SubjectHeadingsTableHeader = (props) => {
   const {

--- a/src/app/components/SubjectHeading/SubjectHeadingsTableHeader.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeadingsTableHeader.jsx
@@ -2,7 +2,6 @@ import React, {useContext} from 'react';
 import PropTypes from 'prop-types';
 
 import SortButton from './SortButton';
-import TableContainerContext from './TableContainerContext';
 
 const SubjectHeadingsTableHeader = (props) => {
   const {

--- a/src/app/components/SubjectHeading/SubjectHeadingsTableHeader.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeadingsTableHeader.jsx
@@ -1,4 +1,4 @@
-import React, {useContext} from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 
 import SortButton from './SortButton';


### PR DESCRIPTION
**What's this do?**
Implement React context (_legacy API_) for `container` rather than passing as prop. Also, there is a lot of stale code I believe. One thing I am not sure about is the `interactive` state/prop for the `AdditionalSubjectHeadingButton`. I believe we are not really using it any more?

**Why are we doing this? (w/ JIRA link if applicable)**
Well, I managed to clean up some code! Also, we might be able to use context for other properties going forward and can follow this pattern.

**How should this be tested? / Do these changes have associated tests?**
Check the index and couple show pages. They seem to be working the same to me.

**Dependencies for merging? Releasing to production?**
None.

**Has the application documentation been updated for these changes?**
Not necessary right now.

**Did someone actually run this code to verify it works?**
Yes.