### PR TITLE
Add local loading layer for context subject headings

### DIFF
--- a/src/app/components/SubjectHeading/BibsList.jsx
+++ b/src/app/components/SubjectHeading/BibsList.jsx
@@ -129,7 +129,12 @@ class BibsList extends React.Component {
     );
 
     if (this.state.componentLoading) {
-      return (<LocalLoadingLayer message="Loading More Titles" />);
+      return (
+        <LocalLoadingLayer
+          message="Loading More Titles"
+          classNames="bibsList"
+        />
+      );
     }
 
     return (

--- a/src/app/components/SubjectHeading/BibsList.jsx
+++ b/src/app/components/SubjectHeading/BibsList.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import axios from 'axios';
 import Pagination from '../Pagination/Pagination';
 import ResultsList from '../ResultsList/ResultsList';
+import LocalLoadingLayer from './LocalLoadingLayer';
 /* eslint-disable import/first, import/no-unresolved, import/extensions */
 import Sorter from '@Sorter';
 import appConfig from '@appConfig';
@@ -128,22 +129,7 @@ class BibsList extends React.Component {
     );
 
     if (this.state.componentLoading) {
-      return (
-        <div className="nypl-column-half bibsList subjectHeadingShowLoadingWrapper">
-          <span
-            id="loading-animation"
-            className="loadingLayer-texts-loadingWord"
-          >
-            Loading More Titles
-          </span>
-          <div className="loadingDots">
-            <span />
-            <span />
-            <span />
-            <span />
-          </div>
-        </div>
-      );
+      return (<LocalLoadingLayer message="Loading More Titles" />);
     }
 
     return (

--- a/src/app/components/SubjectHeading/LocalLoadingLayer.jsx
+++ b/src/app/components/SubjectHeading/LocalLoadingLayer.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+export default props => (
+  <div className="nypl-column-half bibsList subjectHeadingShowLoadingWrapper">
+    <span
+      id="loading-animation"
+      className="loadingLayer-texts-loadingWord"
+    >
+      { props.message }
+    </span>
+    <div className="loadingDots">
+      <span />
+      <span />
+      <span />
+      <span />
+    </div>
+  </div>
+);

--- a/src/app/components/SubjectHeading/LocalLoadingLayer.jsx
+++ b/src/app/components/SubjectHeading/LocalLoadingLayer.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
-export default props => (
-  <div className="nypl-column-half bibsList subjectHeadingShowLoadingWrapper">
+const LocalLoadingLayer = props => (
+  <div className={`nypl-column-half ${props.classNames} subjectHeadingShowLoadingWrapper`}>
     <span
       id="loading-animation"
       className="loadingLayer-texts-loadingWord"
@@ -16,3 +17,15 @@ export default props => (
     </div>
   </div>
 );
+
+LocalLoadingLayer.propTypes = {
+  message: PropTypes.string,
+  classNames: PropTypes.string,
+};
+
+LocalLoadingLayer.defaultProps = {
+  message: '',
+  classNames: '',
+};
+
+export default LocalLoadingLayer;

--- a/src/app/components/SubjectHeading/NeighboringHeadingsBox.jsx
+++ b/src/app/components/SubjectHeading/NeighboringHeadingsBox.jsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { Link } from 'react-router';
+import PropTypes from 'prop-types';
+import LocalLoadingLayer from './LocalLoadingLayer';
+import SubjectHeadingsTable from './SubjectHeadingsTable';
+
+class NeighboringHeadingsBox extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {};
+  }
+
+  render() {
+    const {
+      contextHeadings,
+      contextIsLoading,
+      location,
+      uuid,
+      linkUrl,
+      contextError,
+    } = this.props;
+
+    let content;
+
+    if (contextError) {
+      content = (<div>Error loading neighboring headings</div>);
+    } else if (contextIsLoading) {
+      content = (<LocalLoadingLayer message="Loading More Subject Headings" />);
+    } else {
+      content = (
+        <SubjectHeadingsTable
+          subjectHeadings={contextHeadings}
+          location={location}
+          showId={uuid}
+          keyId="context"
+          container="context"
+          seeMoreLinkUrl={linkUrl}
+          seeMoreText="See More in Subject Headings Index"
+          tfootContent={
+            <tr>
+              <td>
+                <Link
+                  to={linkUrl}
+                  className="toIndex"
+                >
+                  Explore more in Subject Heading index
+                </Link>
+              </td>
+            </tr>
+          }
+        />
+      );
+    }
+
+    return (
+      <div
+        className="nypl-column-half subjectHeadingInfoBox"
+        tabIndex='0'
+        aria-label="Neighboring Subject Headings"
+      >
+        <div className="backgroundContainer">
+          <h4>Neighboring Subject Headings</h4>
+        </div>
+        {content}
+      </div>
+    );
+  }
+}
+
+NeighboringHeadingsBox.propTypes = {
+  location: PropTypes.object,
+  uuid: PropTypes.string,
+  linkUrl: PropTypes.string,
+  contextHeadings: PropTypes.object,
+  contextIsLoading: PropTypes.bool,
+  contextError: PropTypes.bool,
+};
+
+export default NeighboringHeadingsBox;

--- a/src/app/components/SubjectHeading/SubjectHeadingShow.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeadingShow.jsx
@@ -48,7 +48,10 @@ class SubjectHeadingShow extends React.Component {
       .catch(
         (err) => {
           console.error('error: ', err);
-          this.setState({ error: true });
+          this.setState({
+            error: true,
+            contextHeadings: [],
+          });
         },
       );
 
@@ -102,6 +105,7 @@ class SubjectHeadingShow extends React.Component {
   }
 
   processContextHeadings(headings, uuid) {
+    if (!headings) return [];
     headings.forEach((heading) => {
       this.removeChildrenOffMainPath(heading, uuid);
       Range.addRangeData(heading, uuid, 'show');

--- a/src/app/components/SubjectHeading/SubjectHeadingShow.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeadingShow.jsx
@@ -5,6 +5,7 @@ import { Link } from 'react-router';
 
 import SubjectHeadingsTable from './SubjectHeadingsTable';
 import BibsList from './BibsList';
+import LocalLoadingLayer from './LocalLoadingLayer';
 import Range from '../../models/Range';
 import appConfig from '../../data/appConfig';
 import Actions from '../../actions/Actions';
@@ -171,7 +172,7 @@ class SubjectHeadingShow extends React.Component {
                 }
               />
             </div>
-            : null
+            : <LocalLoadingLayer message="Loading More Subject Headings" />
           }
           {relatedHeadings ?
             <div

--- a/src/app/components/SubjectHeading/SubjectHeadingShow.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeadingShow.jsx
@@ -4,6 +4,7 @@ import axios from 'axios';
 import { Link } from 'react-router';
 
 import SubjectHeadingsTable from './SubjectHeadingsTable';
+import NeighboringHeadingsBox from './NeighboringHeadingsBox';
 import BibsList from './BibsList';
 import LocalLoadingLayer from './LocalLoadingLayer';
 import Range from '../../models/Range';
@@ -21,6 +22,9 @@ class SubjectHeadingShow extends React.Component {
       },
       shepBibs: [],
       bibsLoaded: false,
+      contextError: null,
+      contextIsLoading: true,
+      contextHeadings: [],
     };
 
     this.generateFullContextUrl = this.generateFullContextUrl.bind(this);
@@ -123,6 +127,8 @@ class SubjectHeadingShow extends React.Component {
   render() {
     const {
       contextHeadings,
+      contextError,
+      contextIsLoading,
       relatedHeadings,
       error,
       mainHeading,
@@ -147,39 +153,14 @@ class SubjectHeadingShow extends React.Component {
         <div
           className="nypl-column-half subjectHeadingsSideBar"
         >
-          {contextHeadings ?
-            <div
-              className="nypl-column-half subjectHeadingInfoBox"
-              tabIndex='0'
-              aria-label="Neighboring Subject Headings"
-            >
-              <div className="backgroundContainer">
-                <h4>Neighboring Subject Headings</h4>
-              </div>
-              <SubjectHeadingsTable
-                subjectHeadings={contextHeadings}
-                location={location}
-                showId={uuid}
-                keyId="context"
-                container="context"
-                seeMoreLinkUrl={linkUrl}
-                seeMoreText="See More in Subject Headings Index"
-                tfootContent={
-                  <tr>
-                    <td>
-                      <Link
-                        to={linkUrl}
-                        className="toIndex"
-                      >
-                        Explore more in Subject Heading index
-                      </Link>
-                    </td>
-                  </tr>
-                }
-              />
-            </div>
-            : <LocalLoadingLayer message="Loading More Subject Headings" />
-          }
+          <NeighboringHeadingsBox
+            contextHeadings={contextHeadings}
+            contextIsLoading={contextIsLoading}
+            location={location}
+            uuid={uuid}
+            linkUrl={linkUrl}
+            contextError={contextError}
+          />
           {relatedHeadings ?
             <div
               className="nypl-column-half subjectHeadingInfoBox"

--- a/src/app/components/SubjectHeading/SubjectHeadingShow.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeadingShow.jsx
@@ -40,6 +40,7 @@ class SubjectHeadingShow extends React.Component {
           mainHeading: {
             label: res.data.request.main_label,
           },
+          contextIsLoading: false,
         }, () => {
           this.props.setBannerText(this.state.mainHeading.label);
           Actions.updateLoadingStatus(false);
@@ -49,7 +50,8 @@ class SubjectHeadingShow extends React.Component {
         (err) => {
           console.error('error: ', err);
           this.setState({
-            error: true,
+            contextIsLoading: false,
+            contextError: true,
             contextHeadings: [],
           });
         },

--- a/src/app/components/SubjectHeading/SubjectHeadingsTable.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeadingsTable.jsx
@@ -53,7 +53,7 @@ class SubjectHeadingsTable extends React.Component {
       </table>
     );
   }
-};
+}
 
 SubjectHeadingsTable.propTypes = {
   subjectHeadings: PropTypes.array,


### PR DESCRIPTION
**What's this do?**
- In the `SubjectHeadingShow` component, instead of rendering null when there are no neighboring headings, render the loading page
- Factor out the `Loading Layer` component from the `BibsList` component so it can be reused

**Why are we doing this? (w/ JIRA link if applicable)**
Ticket is SCC-1933. This is needed because of the lag receiving results from the context API, which results in the Neighboring Subject Headings box loading late. This is a jumpy and confusing experience.

**How should this be tested? / Do these changes have associated tests?**
This can be tested by navigating to the show page for any moderately large subject heading. I have been using 'China'. You should see the loading layer for a couple of seconds, and then the subject headings should replace it.

**Dependencies for merging? Releasing to production?**
No dependencies.

**Has the application documentation been updated for these changes?**
This doesn't require additional documentation.

**Did someone actually run this code to verify it works?**
PR author has run this locally.

**Possible UI/UX questions**
- What should the loading text be?
- Should we give this box a fixed height? For more highly nested cases, the Neighboring headings box can push the Related headings box down a bit when it loads (see United States -- 1783-1815 -- History -- Registers)
