### PR TITLE
RENO-1153-update-dgx-react-footer-to-0.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## CHANGE LOG
 
+### 1.6.5
+- Updating @nypl/dgx-react-footer to 0.5.4.
+
 ### 1.6.4
 - Updating @nypl/dgx-header-component to 2.6.0
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## Discovery
 
 ### Version
-> 1.6.4
+> 1.6.5
 
 ### Shared Collection Catalog
 [![GitHub version](https://badge.fury.io/gh/nypl-discovery%2Fdiscovery-front-end.svg)](https://badge.fury.io/gh/nypl-discovery%2Fdiscovery-front-end)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nypl-discovery",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -337,11 +337,12 @@
       }
     },
     "@nypl/dgx-react-footer": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@nypl/dgx-react-footer/-/dgx-react-footer-0.5.2.tgz",
-      "integrity": "sha512-ItzXH3eJGygszWhI94T4/7EgqVe3lZ00QCNYHkSeVg6wuAPoKvvyFGG4VKy3EWxtPeQPXu3TYVc9X2aKC7ZrZA==",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@nypl/dgx-react-footer/-/dgx-react-footer-0.5.4.tgz",
+      "integrity": "sha512-yHHYFkrancVb6gNtY1vHMA/kWIDpUrY0N1wAMc0Pm6zHqz7rpSl5BWoaZz6dFBumyKeq5XTgz3yYfojTa/JLqA==",
       "requires": {
-        "@nypl/dgx-svg-icons": "0.3.8"
+        "@nypl/dgx-svg-icons": "0.3.8",
+        "system-font-css": "^2.0.2"
       },
       "dependencies": {
         "@nypl/dgx-svg-icons": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nypl-discovery",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "description": "Isomorphic React App for NYPL Research Catalog.",
   "main": "index.js",
   "scripts": {
@@ -77,7 +77,7 @@
   "dependencies": {
     "@nypl/design-toolkit": "^0.1.37",
     "@nypl/dgx-header-component": "2.6.0",
-    "@nypl/dgx-react-footer": "0.5.2",
+    "@nypl/dgx-react-footer": "0.5.4",
     "@nypl/dgx-svg-icons": "0.2.5",
     "@nypl/nypl-data-api-client": "0.2.5",
     "aws-sdk": "2.99.0",


### PR DESCRIPTION
[Related Jira ticket](https://jira.nypl.org/browse/RENO-1153)

**This PR does the following:**

- Updates dgx-react-footer to v0.5.4
- The footer update removes the Kievit font, Tumbler icon, and adds [system-font-css](https://github.com/jonathantneal/system-font-css) according to this [migration guide](https://docs.google.com/document/d/1gErDfbmTuKvSUkmfFnhRh9BAF1CCqUl66koTAtOZmdU/edit#)