### PR TITLE
Change All to Home

### DIFF
--- a/src/app/components/SubjectHeading/AlphabeticalPagination.jsx
+++ b/src/app/components/SubjectHeading/AlphabeticalPagination.jsx
@@ -12,7 +12,7 @@ const AlphabeticalPagination = () => {
 
   const allButton = (
     <Link key="all" to={`${appConfig.baseUrl}/subject_headings`}>
-      All
+      Home
     </Link>
   );
 


### PR DESCRIPTION
**What's this do?**
Change 'All' to 'Home' in the subject heading index alphabetical navigation tool.

**Why are we doing this? (w/ JIRA link if applicable)**
JIRA ticket scc-1950. We think 'Home' is less confusing and more accurate than 'All' since the index doesn't start at the very beginning of our listings.

**How should this be tested? / Do these changes have associated tests?**
This can be tested manually by navigating to the subject heading index

**Dependencies for merging? Releasing to production?**
No

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Checked by PR author.