### PR TITLE
SCC-1958/ make sure 'Next' button does not show up when there is no next

### DIFF
--- a/src/app/components/Pagination/Pagination.jsx
+++ b/src/app/components/Pagination/Pagination.jsx
@@ -25,12 +25,18 @@ class Pagination extends React.Component {
    * @param {string} type Either 'Next' or 'Previous' to indication link label.
    */
   getPage(page, type = 'Next') {
+    const {
+      hasNext,
+      subjectShowPage,
+      shepNavigation,
+      subjectIndexPage,
+    } = this.props;
     if (!page) return null;
+    if (type == 'Next' && subjectShowPage && !hasNext) return null;
     const intPage = parseInt(page, 10);
     const pageNum = type === 'Next' ? intPage + 1 : intPage - 1;
     const svg = type === 'Next' ? <RightWedgeIcon /> : <LeftWedgeIcon />;
-    const { shepNavigation } = this.props;
-    const subjectHeadingPage = this.props.subjectShowPage || this.props.subjectIndexPage;
+    const subjectHeadingPage = subjectShowPage || subjectIndexPage;
 
     let url;
     let apiUrl;
@@ -51,7 +57,7 @@ class Pagination extends React.Component {
     linkProps.rel = type.toLowerCase();
     linkProps.className = `${type.toLowerCase()}-link`;
 
-    if (!this.props.subjectIndexPage) linkProps.onClick = e => this.onClick(e, pageNum);
+    if (!subjectIndexPage) linkProps.onClick = e => this.onClick(e, pageNum);
 
     return (
       <Link

--- a/src/app/components/SubjectHeading/BibsList.jsx
+++ b/src/app/components/SubjectHeading/BibsList.jsx
@@ -112,6 +112,7 @@ class BibsList extends React.Component {
     const {
       bibPage,
       bibs,
+      nextUrl,
     } = this.state;
 
     const sortParams = this.context.router.location.query;
@@ -125,6 +126,7 @@ class BibsList extends React.Component {
         page={bibPage}
         subjectShowPage
         ariaControls="nypl-results-list"
+        hasNext={!!nextUrl}
       />
     );
 

--- a/src/app/components/SubjectHeading/BibsList.jsx
+++ b/src/app/components/SubjectHeading/BibsList.jsx
@@ -39,6 +39,7 @@ class BibsList extends React.Component {
           bibs: res.data.bibs.filter(bib => bib['@id']),
           nextUrl: res.data.next_url,
           componentLoading: false,
+          hasNext: !!res.data.next_url,
         });
       })
       .catch(
@@ -79,7 +80,10 @@ class BibsList extends React.Component {
     const perPage = this.perPage;
 
     if (page < bibPage || this.lastBib() + perPage < bibs.length) {
-      this.setState({ bibPage: page });
+      this.setState({
+        bibPage: page,
+        hasNext: true,
+      });
     } else {
       this.setState({}, () => {
         axios(nextUrl)
@@ -90,6 +94,7 @@ class BibsList extends React.Component {
               bibs: newBibs,
               nextUrl: newNextUrl,
               bibPage: page,
+              hasNext: !!newNextUrl,
             }, () => window.scrollTo(0, 300));
           })
           .catch(
@@ -112,7 +117,7 @@ class BibsList extends React.Component {
     const {
       bibPage,
       bibs,
-      nextUrl,
+      hasNext,
     } = this.state;
 
     const sortParams = this.context.router.location.query;
@@ -126,7 +131,7 @@ class BibsList extends React.Component {
         page={bibPage}
         subjectShowPage
         ariaControls="nypl-results-list"
-        hasNext={!!nextUrl}
+        hasNext={hasNext}
       />
     );
 

--- a/src/app/components/SubjectHeading/BibsList.jsx
+++ b/src/app/components/SubjectHeading/BibsList.jsx
@@ -70,7 +70,7 @@ class BibsList extends React.Component {
     return Math.max(0, perPage * (bibPage - 1));
   }
 
-  updateBibPage(page) {
+  updateBibPage(newPage) {
     const {
       bibs,
       nextUrl,
@@ -79,10 +79,10 @@ class BibsList extends React.Component {
 
     const perPage = this.perPage;
 
-    if (page < bibPage || this.lastBib() + perPage < bibs.length) {
+    if (newPage < bibPage || this.lastBib() < bibs.length) {
       this.setState({
-        bibPage: page,
-        hasNext: true,
+        bibPage: newPage,
+        hasNext: newPage < bibPage,
       });
     } else {
       this.setState({}, () => {
@@ -93,7 +93,7 @@ class BibsList extends React.Component {
             this.setState({
               bibs: newBibs,
               nextUrl: newNextUrl,
-              bibPage: page,
+              bibPage: newPage,
               hasNext: !!newNextUrl,
             }, () => window.scrollTo(0, 300));
           })

--- a/src/app/components/SubjectHeading/BibsList.jsx
+++ b/src/app/components/SubjectHeading/BibsList.jsx
@@ -39,7 +39,6 @@ class BibsList extends React.Component {
           bibs: res.data.bibs.filter(bib => bib['@id']),
           nextUrl: res.data.next_url,
           componentLoading: false,
-          hasNext: !!res.data.next_url,
         });
       })
       .catch(
@@ -81,15 +80,10 @@ class BibsList extends React.Component {
       bibPage,
     } = this.state;
 
-    const perPage = this.perPage;
-
-    // conditionals for a bib page that has already been visited
+    // conditions for a bib page that has already been visited
     // therefore, no new API call
     if (newPage < bibPage || this.lastBib() < bibs.length) {
-      this.setState({
-        bibPage: newPage,
-        hasNext: newPage < bibPage || this.lastBib() + perPage < bibs.length,
-      });
+      this.setState({ bibPage: newPage });
     } else {
       this.setState({}, () => {
         axios(nextUrl)
@@ -100,7 +94,6 @@ class BibsList extends React.Component {
               bibs: newBibs,
               nextUrl: newNextUrl,
               bibPage: newPage,
-              hasNext: !!newNextUrl,
             }, () => window.scrollTo(0, 300));
           })
           .catch(
@@ -123,7 +116,7 @@ class BibsList extends React.Component {
     const {
       bibPage,
       bibs,
-      hasNext,
+      nextUrl,
     } = this.state;
 
     const sortParams = this.context.router.location.query;
@@ -131,13 +124,15 @@ class BibsList extends React.Component {
     const sort = sortParams.sort;
     const sortDirection = sortParams.sort_direction;
 
+    const lastPage = Math.ceil(bibs.length / this.perPage);
+
     const pagination = (
       <Pagination
         updatePage={this.updateBibPage}
         page={bibPage}
         subjectShowPage
         ariaControls="nypl-results-list"
-        hasNext={hasNext}
+        hasNext={bibPage < lastPage || nextUrl}
       />
     );
 

--- a/src/app/components/SubjectHeading/BibsList.jsx
+++ b/src/app/components/SubjectHeading/BibsList.jsx
@@ -70,6 +70,10 @@ class BibsList extends React.Component {
     return Math.max(0, perPage * (bibPage - 1));
   }
 
+  /*
+  * updatePage()
+  * @param {integer} newPage the page number of the page being rendered
+  */
   updateBibPage(newPage) {
     const {
       bibs,
@@ -79,10 +83,12 @@ class BibsList extends React.Component {
 
     const perPage = this.perPage;
 
+    // conditionals for a bib page that has already been visited
+    // therefore, no new API call
     if (newPage < bibPage || this.lastBib() < bibs.length) {
       this.setState({
         bibPage: newPage,
-        hasNext: newPage < bibPage,
+        hasNext: newPage < bibPage || this.lastBib() + perPage < bibs.length,
       });
     } else {
       this.setState({}, () => {

--- a/src/app/components/SubjectHeading/NeighboringHeadingsBox.jsx
+++ b/src/app/components/SubjectHeading/NeighboringHeadingsBox.jsx
@@ -71,7 +71,7 @@ NeighboringHeadingsBox.propTypes = {
   location: PropTypes.object,
   uuid: PropTypes.string,
   linkUrl: PropTypes.string,
-  contextHeadings: PropTypes.object,
+  contextHeadings: PropTypes.array,
   contextIsLoading: PropTypes.bool,
   contextError: PropTypes.bool,
 };

--- a/test/unit/Pagination.test.js
+++ b/test/unit/Pagination.test.js
@@ -161,6 +161,12 @@ describe('Pagination', () => {
       expect(nextPage.props.className).to.equal('previous-link');
       expect(nextPage.props.children[2]).to.equal('Previous');
     });
+
+    it('should return null for the next button if on a Subject Show Page and there is no next url', () => {
+      component = shallow(<Pagination subjectShowPage hasNext={false} />);
+
+      expect(component.instance().getPage(1)).to.equal(null);
+    });
   });
 
   describe('Start on the first page and go to the second page', () => {


### PR DESCRIPTION
**What's this do?**
This ticket and PR is to make sure the "Next" button does not appear on the BibsList on the Subject Heading Show page if there are no next bibs. It uses the next url from the API response to determine whether or not the button is show.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SCC-1958

**How should this be tested? / Do these changes have associated tests?**
"Aachen (Germany : Landkreis)" has 6 titles, which is how many we show at once. Therefore, no "Next" button.
"Aachen (Germany : Regierungsbezirk)" has 10. Therefore, "Next" button is shown on first page. On the second page, only the "Previous" button is shown.
Also, I wrote a unit test for the `Pagination` component.

**Did someone actually run this code to verify it works?**
I did.

**Notes**
The logic in the `Pagination` component is a bit messy to handle cases from original SCC pages, subject heading index, and subject heading show bibs list. I think we should refactor this. But I'm not 100% sure which approach we would like to take. Suggestions are welcome. 