### PR TITLE
Add reordering of bibs sortoptions

### DIFF
--- a/src/app/components/SubjectHeading/BibsList.jsx
+++ b/src/app/components/SubjectHeading/BibsList.jsx
@@ -143,14 +143,14 @@ class BibsList extends React.Component {
         tabIndex='0'
         aria-label="Titles related to this Subject Heading"
       >
-        <h4>Titles</h4>
+        <h4 id="titles">Titles</h4>
         <Sorter
           page="shepBibs"
           sortOptions={[
+            { val: 'date_desc', label: 'date (new to old)' },
+            { val: 'date_asc', label: 'date (old to new)' },
             { val: 'title_asc', label: 'title (a - z)' },
             { val: 'title_desc', label: 'title (z - a)' },
-            { val: 'date_asc', label: 'date (old to new)' },
-            { val: 'date_desc', label: 'date (new to old)' },
           ]}
           sortBy={`${sort}_${sortDirection}`}
           updateResults={this.changeBibSorting}

--- a/src/client/styles/components/SubjectHeadings.scss
+++ b/src/client/styles/components/SubjectHeadings.scss
@@ -126,3 +126,7 @@ $table-row-border: 1px solid rgb(215, 210, 205);
   float: left;
   margin-bottom: 0;
 }
+
+#sort-by-label {
+  width: 160px;
+}


### PR DESCRIPTION
**What's this do?**
Change the ordering of bib sort options so date comes first. Also make the select options a little wider so the chevron doesn't overlap with the sort option.

**Why are we doing this? (w/ JIRA link if applicable)**
SCC-1951

**How should this be tested? / Do these changes have associated tests?**
Navigate to any show page.

**Dependencies for merging? Releasing to production?**
Back end changes for the same ticket https://github.com/NYPL/subject-headings-explorer-poc/pull/148 should be checked in locally.

**Has the application documentation been updated for these changes?**

**Did someone actually run this code to verify it works?**
PR author