### PR TITLE
`package-lock` changes for dgx footer '0.5.4'

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nypl-discovery",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -337,11 +337,12 @@
       }
     },
     "@nypl/dgx-react-footer": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@nypl/dgx-react-footer/-/dgx-react-footer-0.5.2.tgz",
-      "integrity": "sha512-ItzXH3eJGygszWhI94T4/7EgqVe3lZ00QCNYHkSeVg6wuAPoKvvyFGG4VKy3EWxtPeQPXu3TYVc9X2aKC7ZrZA==",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@nypl/dgx-react-footer/-/dgx-react-footer-0.5.4.tgz",
+      "integrity": "sha512-yHHYFkrancVb6gNtY1vHMA/kWIDpUrY0N1wAMc0Pm6zHqz7rpSl5BWoaZz6dFBumyKeq5XTgz3yYfojTa/JLqA==",
       "requires": {
-        "@nypl/dgx-svg-icons": "0.3.8"
+        "@nypl/dgx-svg-icons": "0.3.8",
+        "system-font-css": "^2.0.2"
       },
       "dependencies": {
         "@nypl/dgx-svg-icons": {


### PR DESCRIPTION
Update `package-lock` for dgx-react-footer upgrade to '0.5.4'