### PR TITLE
Add background color: inherit back into link styling

### DIFF
--- a/src/client/styles/components/SubjectHeadings/SubjectHeading.scss
+++ b/src/client/styles/components/SubjectHeadings/SubjectHeading.scss
@@ -66,3 +66,7 @@
     color: inherit;
   }
 }
+
+a:focus {
+  background-color: inherit;
+}


### PR DESCRIPTION
**What's this do?**
Fixes a small styling bug introduced with SCC-1962

**Why are we doing this? (w/ JIRA link if applicable)**
This was never supposed to be removed

**How should this be tested? / Do these changes have associated tests?**
Can manually test by navigating around and clicking breadcrumbs, which should not have a white background now

**Dependencies for merging? Releasing to production?**
No

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
PR author tested locally.