### PR TITLE
Scc-1936/ make one API call for linked index

### DIFF
--- a/src/app/components/SubjectHeading/SubjectHeadingShow.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeadingShow.jsx
@@ -95,7 +95,7 @@ class SubjectHeadingShow extends React.Component {
     const uuid = this.props.params.subjectHeadingUuid;
     const linkFromLabel = this.getTopLevelLabel();
     const path = this.props.location.pathname.replace(/\/subject_headings.*/, '');
-    return `${path}/subject_headings?fromLabel=${linkFromLabel}&fromComparator=start&linked=${uuid}`;
+    return `${path}/subject_headings?linked=${uuid}`;
   }
 
   // returns true or false depending on whether the heading has a descendant with the given uuid.

--- a/src/app/components/SubjectHeading/SubjectHeadingsIndex.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeadingsIndex.jsx
@@ -35,6 +35,7 @@ class SubjectHeadingsIndex extends React.Component {
       sortBy,
       fromAttributeValue,
       direction,
+      linked,
     } = this.context.router.location.query;
 
     if (!fromComparator) fromComparator = filter ? null : 'start';
@@ -46,6 +47,7 @@ class SubjectHeadingsIndex extends React.Component {
       filter,
       sort_by: sortBy,
       from_attribute_value: fromAttributeValue,
+      linked,
     };
 
     if (direction) apiParamHash.direction = direction;
@@ -57,6 +59,7 @@ class SubjectHeadingsIndex extends React.Component {
       .join('&');
 
     const url = `${appConfig.baseUrl}/api/subjectHeadings/subject_headings?${apiParamString}`;
+
     axios(url)
       .then(
         (res) => {

--- a/src/app/components/SubjectHeading/SubjectHeadingsIndex.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeadingsIndex.jsx
@@ -9,6 +9,7 @@ import calculateDirection from '@calculateDirection';
 import SubjectHeadingsTable from './SubjectHeadingsTable';
 /* eslint-enable import/first, import/no-unresolved, import/extensions */
 import appConfig from '../../data/appConfig';
+import Range from '../../models/Range';
 
 
 class SubjectHeadingsIndex extends React.Component {
@@ -63,6 +64,10 @@ class SubjectHeadingsIndex extends React.Component {
     axios(url)
       .then(
         (res) => {
+          if (linked) {
+            const topLevelAncestor = res.data.subject_headings.find(subjectHeading => subjectHeading.children);
+            if (topLevelAncestor) Range.addRangeData(topLevelAncestor, linked);
+          }
           this.setState({
             previousUrl: res.data.previous_url,
             nextUrl: res.data.next_url,

--- a/src/app/components/SubjectHeading/SubjectHeadingsTableBody.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeadingsTableBody.jsx
@@ -26,19 +26,6 @@ class SubjectHeadingsTableBody extends React.Component {
     this.backgroundColor = this.backgroundColor.bind(this);
   }
 
-  mergeSubjectHeadings(incomingSubjectHeadings, linked) {
-    const responseSubjectHeading = incomingSubjectHeadings[0];
-    Range.addRangeData(responseSubjectHeading, linked);
-    this.setState((prevState) => {
-      const { subjectHeadings } = prevState;
-      const existingSubjectHeadingIndex = subjectHeadings.findIndex(
-        heading => heading.uuid === responseSubjectHeading.uuid,
-      );
-      subjectHeadings[existingSubjectHeadingIndex] = responseSubjectHeading;
-      return { subjectHeadings };
-    });
-  }
-
   initialRange(props) {
     if (props.range) return props.range;
     if (props.subjectHeadings) return new Range(0, Infinity, [{ start: 0, end: Infinity }]);

--- a/src/app/components/SubjectHeading/SubjectHeadingsTableBody.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeadingsTableBody.jsx
@@ -13,8 +13,6 @@ class SubjectHeadingsTableBody extends React.Component {
     super(props);
     const {
       subjectHeadings,
-      parentUuid,
-      pathname,
     } = props;
 
     this.state = {
@@ -26,19 +24,6 @@ class SubjectHeadingsTableBody extends React.Component {
     this.listItemsInInterval = this.listItemsInInterval.bind(this);
     this.tableRow = this.tableRow.bind(this);
     this.backgroundColor = this.backgroundColor.bind(this);
-  }
-
-  componentDidMount() {
-    const { linked } = this.props;
-
-    if (linked) {
-      const url = `${appConfig.baseUrl}/api/subjectHeadings/subject_headings/${linked}/context?type=relatives`;
-      axios(url)
-        .then((res) => {
-          this.mergeSubjectHeadings(res.data.subject_headings, linked);
-        })
-        .catch(console.error);
-    }
   }
 
   mergeSubjectHeadings(incomingSubjectHeadings, linked) {


### PR DESCRIPTION
**What's this do?**
This PR changes the way the linked index view data is retrieved. One API call is made for the index with a 'linked' param, which is the subject heading UUID.

**Why are we doing this? (w/ JIRA link if applicable)**
The context for the linked view comes after the top level index. It is harder to change the loading sequencing on the frontend for the two API queries this way.
https://jira.nypl.org/browse/SCC-1936

**Dependencies for merging? Releasing to production?**
There is a corresponding PR on the backend: https://github.com/NYPL/subject-headings-explorer-poc/pull/152

**Did someone actually run this code to verify it works?**
I did. There are some frontend tweaks that need to be made to properly condense the context part. I believe this just has to do with the "Range" model.