### PR TITLE
SCC-1961/implement new sort button SVG

### DIFF
--- a/src/app/components/SubjectHeading/NestedTableHeader.jsx
+++ b/src/app/components/SubjectHeading/NestedTableHeader.jsx
@@ -18,6 +18,21 @@ const NestedTableHeader = (props) => {
   const positionStyle = { marginLeft: 30 * ((indentation || 0) + 1) };
   const calculateDirectionForType = calculateDirection(sortBy, direction);
 
+  const sortButtons = {};
+  ['alphabetical', 'descendants', 'bibs'].forEach((type) => {
+    sortButtons[type] = (
+      <SortButton
+        handler={updateSort}
+        type={type}
+        calculateDirection={calculateDirectionForType}
+        interactive={interactive}
+        numberOpen={numberOpen}
+        active={sortBy === type}
+      />
+    );
+  });
+
+
   return (
     <tr
       style={{ backgroundColor: props.backgroundColor }}
@@ -25,35 +40,14 @@ const NestedTableHeader = (props) => {
     >
       <th className={`subjectHeadingsTableCell subjectHeadingLabel ${sortBy === 'alphabetical' ? 'selected' : ''}`} >
         <div className="subjectHeadingLabelInner" style={positionStyle}>
-          <SortButton
-            handler={updateSort}
-            type="alphabetical"
-            calculateDirection={calculateDirectionForType}
-            interactive={interactive}
-            numberOpen={numberOpen}
-            active={sortBy === 'alphabetical'}
-          />
+          {sortButtons.alphabetical}
         </div>
       </th>
       <th className={`subjectHeadingsTableCell subjectHeadingAttribute narrower ${sortBy === 'descendants' ? 'selected' : ''}`}>
-        <SortButton
-          handler={updateSort}
-          type="descendants"
-          calculateDirection={calculateDirectionForType}
-          interactive={interactive}
-          numberOpen={numberOpen}
-          active={sortBy === 'descendants'}
-        />
+        {sortButtons.descendants}
       </th>
       <th className={`subjectHeadingsTableCell subjectHeadingAttribute titles ${sortBy === 'bibs' ? 'selected' : ''}`}>
-        <SortButton
-          handler={updateSort}
-          type="bibs"
-          calculateDirection={calculateDirectionForType}
-          interactive={interactive}
-          numberOpen={numberOpen}
-          active={sortBy === 'bibs'}
-        />
+        {sortButtons.bibs}
       </th>
     </tr>
   );

--- a/src/app/components/SubjectHeading/NestedTableHeader.jsx
+++ b/src/app/components/SubjectHeading/NestedTableHeader.jsx
@@ -28,7 +28,7 @@ const NestedTableHeader = (props) => {
           <SortButton
             handler={updateSort}
             type="alphabetical"
-            direction={calculateDirectionForType('alphabetical')}
+            calculateDirection={calculateDirectionForType}
             interactive={interactive}
             numberOpen={numberOpen}
             active={sortBy === 'alphabetical'}
@@ -39,7 +39,7 @@ const NestedTableHeader = (props) => {
         <SortButton
           handler={updateSort}
           type="descendants"
-          direction={calculateDirectionForType('descendants')}
+          calculateDirection={calculateDirectionForType}
           interactive={interactive}
           numberOpen={numberOpen}
           active={sortBy === 'descendants'}
@@ -49,7 +49,7 @@ const NestedTableHeader = (props) => {
         <SortButton
           handler={updateSort}
           type="bibs"
-          direction={calculateDirectionForType('bibs')}
+          calculateDirection={calculateDirectionForType}
           interactive={interactive}
           numberOpen={numberOpen}
           active={sortBy === 'bibs'}

--- a/src/app/components/SubjectHeading/NestedTableHeader.jsx
+++ b/src/app/components/SubjectHeading/NestedTableHeader.jsx
@@ -31,6 +31,7 @@ const NestedTableHeader = (props) => {
             direction={calculateDirectionForType('alphabetical')}
             interactive={interactive}
             numberOpen={numberOpen}
+            active={sortBy === 'alphabetical'}
           />
         </div>
       </th>
@@ -41,6 +42,7 @@ const NestedTableHeader = (props) => {
           direction={calculateDirectionForType('descendants')}
           interactive={interactive}
           numberOpen={numberOpen}
+          active={sortBy === 'descendants'}
         />
       </th>
       <th className={`subjectHeadingsTableCell subjectHeadingAttribute titles ${sortBy === 'bibs' ? 'selected' : ''}`}>
@@ -50,6 +52,7 @@ const NestedTableHeader = (props) => {
           direction={calculateDirectionForType('bibs')}
           interactive={interactive}
           numberOpen={numberOpen}
+          active={sortBy === 'bibs'}
         />
       </th>
     </tr>

--- a/src/app/components/SubjectHeading/SortButton.jsx
+++ b/src/app/components/SubjectHeading/SortButton.jsx
@@ -8,12 +8,20 @@ import DefaultIcon from '../../../client/assets/Default';
 const SortButton = (props) => {
   const {
     type,
-    direction,
+    calculateDirection,
     handler,
     interactive,
     numberOpen,
     active,
   } = props;
+
+  const defaultSort = {
+    alphabetical: 'ASC',
+    bibs: 'DESC',
+    descendants: 'DESC',
+  }[type]
+
+  const nextDirection = calculateDirection ? calculateDirection(type) : defaultSort;
 
   const columnText = () => ({
     bibs: 'Titles',
@@ -23,14 +31,14 @@ const SortButton = (props) => {
 
   const icon = () => {
     if (!active) return <DefaultIcon />;
-    else if (direction === 'ASC') return <DescendingIcon />;
+    else if (nextDirection === 'ASC') return <DescendingIcon />;
     return <AscendingIcon />;
   };
 
   return (
     <button
       className="subjectSortButton"
-      onClick={() => handler(type, direction, numberOpen)}
+      onClick={() => handler(type, nextDirection, numberOpen)}
       disabled={!handler || !interactive || numberOpen < 2}
     >
       <span className="emph">

--- a/src/app/components/SubjectHeading/SortButton.jsx
+++ b/src/app/components/SubjectHeading/SortButton.jsx
@@ -23,8 +23,8 @@ const SortButton = (props) => {
 
   const icon = () => {
     if (!active) return <DefaultIcon />;
-    else if (direction === 'ASC') return <AscendingIcon />;
-    return <DescendingIcon />;
+    else if (direction === 'ASC') return <DescendingIcon />;
+    return <AscendingIcon />;
   };
 
   return (

--- a/src/app/components/SubjectHeading/SortButton.jsx
+++ b/src/app/components/SubjectHeading/SortButton.jsx
@@ -1,6 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import AscendingIcon from '../../../client/assets/Ascending';
+import DescendingIcon from '../../../client/assets/Descending';
+import DefaultIcon from '../../../client/assets/Default';
+
 const SortButton = (props) => {
   const {
     type,
@@ -8,6 +12,7 @@ const SortButton = (props) => {
     handler,
     interactive,
     numberOpen,
+    active,
   } = props;
 
   const columnText = () => ({
@@ -15,6 +20,12 @@ const SortButton = (props) => {
     descendants: 'Subheadings',
     alphabetical: 'Heading',
   }[type]);
+
+  const icon = () => {
+    if (!active) return <DefaultIcon />;
+    else if (direction === 'ASC') return <AscendingIcon />;
+    return <DescendingIcon />;
+  };
 
   return (
     <button
@@ -24,7 +35,7 @@ const SortButton = (props) => {
     >
       <span className="emph">
         <span className="noEmph">{columnText()}
-          {(handler && interactive) ? <span className="sortCharacter">^</span> : null}
+          {(handler && interactive) ? <span className="sortCharacter">{ icon() }</span> : null}
         </span>
       </span>
     </button>

--- a/src/client/assets/Ascending.jsx
+++ b/src/client/assets/Ascending.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+const AscendingIcon = () => (
+  <svg width="8" height="10" viewBox="0 0 6 4" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path d="M5 3L3 1L1 3" stroke="black" strokeWidth="0.666667" />
+  </svg>
+);
+
+export default AscendingIcon;

--- a/src/client/assets/Ascending.jsx
+++ b/src/client/assets/Ascending.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 const AscendingIcon = () => (
-  <svg width="8" height="10" viewBox="0 0 6 4" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <svg width="8" height="14" viewBox="0 0 6 4" fill="none" xmlns="http://www.w3.org/2000/svg">
     <path d="M5 3L3 1L1 3" stroke="black" strokeWidth="0.666667" />
   </svg>
 );

--- a/src/client/assets/Default.jsx
+++ b/src/client/assets/Default.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+const DefaultIcon = () => (
+  <svg width="10" height="10" viewBox="0 0 6 8" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path d="M5 3L3 1L1 3" stroke="black" strokeWidth="0.666667" />
+    <path d="M1 5L3 7L5 5" stroke="black" strokeWidth="0.666667" />
+  </svg>
+);
+
+export default DefaultIcon;

--- a/src/client/assets/Descending.jsx
+++ b/src/client/assets/Descending.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 const DescendingIcon = () => (
-  <svg width="8" height="10" viewBox="0 0 6 4" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <svg width="8" height="5" viewBox="0 0 6 4" fill="none" xmlns="http://www.w3.org/2000/svg">
     <path d="M1 1L3 3L5 0.999999" stroke="black" strokeWidth="0.666667" />
   </svg>
 );

--- a/src/client/assets/Descending.jsx
+++ b/src/client/assets/Descending.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+const DescendingIcon = () => (
+  <svg width="8" height="10" viewBox="0 0 6 4" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path d="M1 1L3 3L5 0.999999" stroke="black" strokeWidth="0.666667" />
+  </svg>
+);
+
+export default DescendingIcon;


### PR DESCRIPTION
**What's this do?**
Implements the SVG assets for the sort buttons to match Ellen's design.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SCC-1961

**Questions for reviewer.**
Any thoughts on where the arrow icon components should go in the code base? Also, any ideas for fixing the bug described below? How is the spacing looking?

**Did someone actually run this code to verify it works?**
I did. There is currently a bug with the `calculateDirection` function. It returns the opposite direction for the initial sort, because it is intending to switch the current sort type. This manifests in the arrow appearing in the wrong direction for the default "alphabetical" sort.