### PR TITLE
SCC-2011/ remove dummy toggle button

### DIFF
--- a/src/app/components/ShepContainer/ShepContainer.jsx
+++ b/src/app/components/ShepContainer/ShepContainer.jsx
@@ -34,12 +34,6 @@ const ShepContainer = (props) => {
           </div>
         </div>
       </div>
-      { props.secondaryExtraBannerElement }
-
-      { props.extraRow }
-      <div className="nypl-full-width-wrapper">
-        { null && props.mainContent }
-      </div>
     </main>
   );
 };

--- a/src/app/components/SubjectHeading/SubjectHeading.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeading.jsx
@@ -240,7 +240,6 @@ class SubjectHeading extends React.Component {
 
     const toggle = () => {
       const symbol = !open ? '+' : '-';
-      const innerText = desc_count > 0 ? symbol : '';
       const props = {};
 
       props.onClick = this.toggleOpen;
@@ -250,7 +249,7 @@ class SubjectHeading extends React.Component {
         props.onKeyDown = event => handleEnter(event);
       }
 
-      return <button {...props}>{innerText}</button>;
+      return <button {...props}>{symbol}</button>;
     };
 
     const positionStyle = container === 'related' ? null : { marginLeft: 30 * ((indentation || 0) + 1) };
@@ -269,7 +268,7 @@ class SubjectHeading extends React.Component {
         >
           <td className={`subjectHeadingsTableCell subjectHeadingLabel ${onMainPath ? 'selected' : ''}`} >
             <div className="subjectHeadingLabelInner" style={positionStyle}>
-              { toggle() }
+              { desc_count > 0 && toggle() }
               <Link to={this.generateUrl}>
                 <span
                   className={`emph ${isMain ? 'mainHeading' : ''}`}


### PR DESCRIPTION
**What's this do?**
Removes the empty toggle button for subject headings with no narrower headings.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SCC-2011