### PR TITLE
For production: bump @nypl/design-toolkit to "0.1.38"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -190,9 +190,9 @@
       }
     },
     "@nypl/design-toolkit": {
-      "version": "0.1.37",
-      "resolved": "https://registry.npmjs.org/@nypl/design-toolkit/-/design-toolkit-0.1.37.tgz",
-      "integrity": "sha512-RqHNUHpVIuh6rti00mkt5xw+ZjQHmCVqGfwrcor639TgX1zh53e1rq6Vj4EaJAKzuXZlfneIUbFoM/HElzr0vw==",
+      "version": "0.1.38",
+      "resolved": "https://registry.npmjs.org/@nypl/design-toolkit/-/design-toolkit-0.1.38.tgz",
+      "integrity": "sha512-HjfeRp96wh1afuwllBKPClTiO5UDF7fJZpFpGMavjUP5LgDCW9PZ5kBKNM47zI3mS0gaC5in2Lqkw3PYX6GbWA==",
       "requires": {
         "node-sass": "4.9.0"
       }

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "webpack-dev-server": "2.7.1"
   },
   "dependencies": {
-    "@nypl/design-toolkit": "^0.1.37",
+    "@nypl/design-toolkit": "^0.1.38",
     "@nypl/dgx-header-component": "2.6.0",
     "@nypl/dgx-react-footer": "0.5.4",
     "@nypl/dgx-svg-icons": "0.2.5",


### PR DESCRIPTION
**What's this do?**
Styling from previous version of "@nypl/design-toolkit" was misapplying focus styling to all `<a>` tags.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SCC-2015

**Did someone actually run this code to verify it works?**
I did.