### PR TITLE
Scc 1991

### DIFF
--- a/src/app/components/Application/Application.jsx
+++ b/src/app/components/Application/Application.jsx
@@ -70,6 +70,16 @@ class App extends React.Component {
   }
 
   render() {
+    const dataLocation = Object.assign(
+      {},
+      this.context.router.location,
+      {
+        hash: null,
+        action: null,
+        key: null,
+      },
+    );
+
     return (
       <DocumentTitle title="Shared Collection Catalog | NYPL">
         <div className="app-wrapper">
@@ -79,8 +89,8 @@ class App extends React.Component {
             patron={this.state.patron}
           />
           <DataLoader
-            key={JSON.stringify(this.context.router.location)}
-            location={this.context.router.location}
+            key={JSON.stringify(dataLocation)}
+            location={dataLocation}
           >
             {React.cloneElement(this.props.children, this.state.data)}
           </DataLoader>

--- a/src/app/components/BibPage/Tabbed.jsx
+++ b/src/app/components/BibPage/Tabbed.jsx
@@ -16,11 +16,12 @@ class Tabbed extends React.Component {
   // componentDidMount will set the initial tab, either 1 or the number fetched from the
   // url hash (to accommodate deep linking)
   componentDidMount() {
+    console.log('mounting tabbed ', this.props, this.state, window.location);
     let hashNumber = 1;
     if (this.props.hash) {
       let hash = this.props.hash;
       hashNumber = this.props.hash.match(/[^\d]*(\d)/)[1];
-      window.location.replace(window.location.href + hash);
+      window.location.replace(window.location.href.replace(/#.*/, '') + hash);
       let tab = this.links[hashNumber];
       tab.focus();
     }
@@ -68,6 +69,7 @@ class Tabbed extends React.Component {
 
 
   render() {
+    console.log('rendering tabbed ', this.props, this.state);
     return (
       <div className="tabbed">
         <ul role='tablist'>

--- a/src/app/components/BibPage/Tabbed.jsx
+++ b/src/app/components/BibPage/Tabbed.jsx
@@ -16,7 +16,6 @@ class Tabbed extends React.Component {
   // componentDidMount will set the initial tab, either 1 or the number fetched from the
   // url hash (to accommodate deep linking)
   componentDidMount() {
-    console.log('mounting tabbed ', this.props, this.state, window.location);
     let hashNumber = 1;
     if (this.props.hash) {
       let hash = this.props.hash;

--- a/src/app/components/BibPage/Tabbed.jsx
+++ b/src/app/components/BibPage/Tabbed.jsx
@@ -69,7 +69,6 @@ class Tabbed extends React.Component {
 
 
   render() {
-    console.log('rendering tabbed ', this.props, this.state);
     return (
       <div className="tabbed">
         <ul role='tablist'>

--- a/src/app/components/BibPage/Tabbed.jsx
+++ b/src/app/components/BibPage/Tabbed.jsx
@@ -19,7 +19,8 @@ class Tabbed extends React.Component {
     let hashNumber = 1;
     if (this.props.hash) {
       let hash = this.props.hash;
-      hashNumber = this.props.hash.match(/[^\d]*(\d)/)[1];
+      const hashMatch = this.props.hash.match(/[^\d]*(\d)/);
+      if (hashMatch) hashNumber = hashMatch[1];
       window.location.replace(window.location.href.replace(/#.*/, '') + hash);
       let tab = this.links[hashNumber];
       tab.focus();

--- a/src/app/components/DataLoader/DataLoader.jsx
+++ b/src/app/components/DataLoader/DataLoader.jsx
@@ -25,6 +25,7 @@ class DataLoader extends React.Component {
   }
 
   componentDidMount() {
+    console.log('mounting dataloader ', this.props);
     const matchData = this.pathInstructions
       .reduce(this.reducePathExpressions, null);
 

--- a/src/app/components/DataLoader/DataLoader.jsx
+++ b/src/app/components/DataLoader/DataLoader.jsx
@@ -25,7 +25,6 @@ class DataLoader extends React.Component {
   }
 
   componentDidMount() {
-    console.log('mounting dataloader ', this.props);
     const matchData = this.pathInstructions
       .reduce(this.reducePathExpressions, null);
 


### PR DESCRIPTION
**What's this do?**
- Changes the props passed to `DataLoader`  so it will not be triggered by changes to the hash
- Changes the way `Tabbed` updates the url so that it will always replace the existing hash
- Adds a validation to check that the hash match in `Tabbed` actually has a match before proceeding

**Why are we doing this? (w/ JIRA link if applicable)**

- scc-1991
- Fixes infinite loop on bib page when clicking for full description
- Fixes bug with skip to main content

**How should this be tested? / Do these changes have
 associated tests?**
- Navigate to a bib page and click `Full description`. Should not crash
- Copy the url into a new browser tab. You should see what you were seeing before
- Click `skip to main content` in the corner. Should not crash.
- Copy the url into a new browser tab. Should not crash.

**Dependencies for merging? Releasing to production?**
NA

**Has the application documentation been updated for these changes?**
NA
**Did someone actually run this code to verify it works?**
I checked this locally.