### PR TITLE
Add logic to remove bottom border below ellipse

### DIFF
--- a/src/app/components/SubjectHeading/AdditionalSubjectHeadingsButton.jsx
+++ b/src/app/components/SubjectHeading/AdditionalSubjectHeadingsButton.jsx
@@ -65,7 +65,7 @@ class AdditionalSubjectHeadingsButton extends React.Component {
 
     return (
       <tr
-        className={`subjectHeadingRow nestedSubjectHeading ${previous || noEllipse ? '' : 'ellipse'}`}
+        className={`subjectHeadingRow ${previous || noEllipse ? '' : 'ellipse'}`}
       >
         <td className="subjectHeadingsTableCell" colSpan="4">
           <div className="subjectHeadingLabelInner" style={{ marginLeft: `${30 * indentation}px` }}>

--- a/src/app/components/SubjectHeading/AdditionalSubjectHeadingsButton.jsx
+++ b/src/app/components/SubjectHeading/AdditionalSubjectHeadingsButton.jsx
@@ -65,7 +65,7 @@ class AdditionalSubjectHeadingsButton extends React.Component {
 
     return (
       <tr
-        className="subjectHeadingRow nestedSubjectHeading"
+        className={`subjectHeadingRow nestedSubjectHeading ${previous || noEllipse ? '' : 'ellipse'}`}
       >
         <td className="subjectHeadingsTableCell" colSpan="4">
           <div className="subjectHeadingLabelInner" style={{ marginLeft: `${30 * indentation}px` }}>

--- a/src/client/styles/components/SubjectHeadings/SubjectHeading.scss
+++ b/src/client/styles/components/SubjectHeadings/SubjectHeading.scss
@@ -44,6 +44,10 @@
   line-height: 32px;
   background-color: $subjectHeadingBackground;
 
+  &.ellipse {
+    border-bottom: none;
+  }
+
   .selected .emph {
     font-weight: 700;
   }


### PR DESCRIPTION
**What's this do?**
Adds some extra logic/styling to remove the bottom border below an ellipse

**Why are we doing this? (w/ JIRA link if applicable)**
SCC-2004

**How should this be tested? / Do these changes have associated tests?**
`Aachen (Germany) -- Climate` is a good test case for this. Navigate to the show page, and click on `Explore more ... `. There should be no bottom border beneath the ellipse.

**Dependencies for merging? Releasing to production?**
No.

**Has the application documentation been updated for these changes?**
NA

**Did someone actually run this code to verify it works?**
PR author checked locally.
