### PR TITLE
Change position of "mainContent" id on SHEP pages

### DIFF
--- a/src/app/components/ShepContainer/ShepContainer.jsx
+++ b/src/app/components/ShepContainer/ShepContainer.jsx
@@ -8,7 +8,7 @@ const ShepContainer = (props) => {
     <main className="main-page shepcontainer">
       <div className="header-wrapper container-header">
         <div className="header-topWrapper filter-page">
-          <div className="nypl-row container-row" id="mainContent">
+          <div className="nypl-row container-row">
             <div className="nypl-column-full">
               <Breadcrumbs
                 type={props.breadcrumbsType}

--- a/src/app/components/SubjectHeading/Search/SubjectHeadingSearch.jsx
+++ b/src/app/components/SubjectHeading/Search/SubjectHeadingSearch.jsx
@@ -138,6 +138,7 @@ class SubjectHeadingSearch extends React.Component {
         autoComplete="off"
         onSubmit={onSubmit}
         onKeyDown={changeActiveSuggestion}
+        id="mainContent"
       >
         <div className="autocomplete-field">
           <label htmlFor="autosuggest">Subject Heading Search:</label>


### PR DESCRIPTION
**What's this do?**
Zach said the first UI component is preferable to the breadcrumb. For the shep pages that is the autosuggest search box.

**How should this be tested? / Do these changes have associated tests?**
Check subject heading index and show page. Either append "#mainContent" to end of URL or tab to "Skip to main content"

**Did someone actually run this code to verify it works?**
PR author did