### PR TITLE
Scc 2012

### DIFF
--- a/src/app/components/SubjectHeading/BibsList.jsx
+++ b/src/app/components/SubjectHeading/BibsList.jsx
@@ -151,7 +151,7 @@ class BibsList extends React.Component {
         tabIndex='0'
         aria-label="Titles related to this Subject Heading"
       >
-        <h4 id="titles">Titles</h4>
+        <h2 id="titles">Titles</h2>
         <Sorter
           page="shepBibs"
           sortOptions={[

--- a/src/client/styles/components/ShepContainer.scss
+++ b/src/client/styles/components/ShepContainer.scss
@@ -38,4 +38,8 @@
       margin-left: 25px;
     }
   }
+
+  h2 {
+    font-weight: 400;
+  }
 }

--- a/src/client/styles/components/ShepContainer.scss
+++ b/src/client/styles/components/ShepContainer.scss
@@ -38,8 +38,4 @@
       margin-left: 25px;
     }
   }
-
-  h2 {
-    font-weight: 400;
-  }
 }

--- a/src/client/styles/components/SubjectHeadings/BibsList.scss
+++ b/src/client/styles/components/SubjectHeadings/BibsList.scss
@@ -18,5 +18,6 @@
 
 #titles {
     font-weight: 400;
+    font-family: Milo-Light;
   }
 }

--- a/src/client/styles/components/SubjectHeadings/BibsList.scss
+++ b/src/client/styles/components/SubjectHeadings/BibsList.scss
@@ -14,4 +14,9 @@
   .bibsList {
     min-height: 22rem;
   }
+
+
+#titles {
+    font-weight: 400;
+  }
 }


### PR DESCRIPTION
**What's this do?**
Changes the `h4` on the Subject Heading Show page to an `h2`, and adds some styling for `h2`. I added `font-weight: 400` for the `h2`, let me know what you think (and we should run this by Ellen).

**Why are we doing this? (w/ JIRA link if applicable)**
This is SCC-2012, the goal is to implement a more standard html structure for accessibility reasons.

**How should this be tested? / Do these changes have associated tests?**
You can see the change on any subject heading show page.

**Dependencies for merging? Releasing to production?**
NA

**Has the application documentation been updated for these changes?**
NA

**Did someone actually run this code to verify it works?**
PR author checked locally.
