### PR TITLE
Add logic to manage hiding autosuggest elements

### DIFF
--- a/src/app/components/SubjectHeading/Search/AutosuggestItem.jsx
+++ b/src/app/components/SubjectHeading/Search/AutosuggestItem.jsx
@@ -3,15 +3,13 @@ import PropTypes from 'prop-types';
 import { Link } from 'react-router';
 
 const AutosuggestItem = (props) => {
-  const { item, activeSuggestion, onClick, path, hidden } = props;
+  const { item, activeSuggestion, onClick, path } = props;
   const subjectComponent = item.class === 'subject_component';
 
   let className = "suggestion";
   if (activeSuggestion) {
     className += "-active";
   }
-
-  if (hidden) return null;
 
   return (
     <li

--- a/src/app/components/SubjectHeading/Search/AutosuggestItem.jsx
+++ b/src/app/components/SubjectHeading/Search/AutosuggestItem.jsx
@@ -3,13 +3,15 @@ import PropTypes from 'prop-types';
 import { Link } from 'react-router';
 
 const AutosuggestItem = (props) => {
-  const { item, activeSuggestion, onClick, path } = props;
+  const { item, activeSuggestion, onClick, path, hidden } = props;
   const subjectComponent = item.class === 'subject_component';
 
   let className = "suggestion";
   if (activeSuggestion) {
     className += "-active";
   }
+
+  if (hidden) return null;
 
   return (
     <li

--- a/src/app/components/SubjectHeading/Search/SubjectHeadingSearch.jsx
+++ b/src/app/components/SubjectHeading/Search/SubjectHeadingSearch.jsx
@@ -129,12 +129,13 @@ class SubjectHeadingSearch extends React.Component {
         suggestions,
         activeSuggestion,
         userInput,
+        hidden,
       },
     } = this;
 
-    let suggestionsListComponent;
+    let suggestionsListComponent = null;
 
-    if (userInput && suggestions.length) {
+    if (userInput && suggestions.length && !hidden) {
       suggestionsListComponent = (
         <ul className="suggestions">
           {suggestions.map((suggestion, index) => (
@@ -144,7 +145,6 @@ class SubjectHeadingSearch extends React.Component {
               activeSuggestion={index === activeSuggestion}
               key={suggestion.uuid || suggestion.label}
               onClick={this.resetAutosuggest}
-              hidden={this.state.hidden}
             />
           ))}
         </ul>

--- a/src/app/components/SubjectHeading/Search/SubjectHeadingSearch.jsx
+++ b/src/app/components/SubjectHeading/Search/SubjectHeadingSearch.jsx
@@ -19,6 +19,20 @@ class SubjectHeadingSearch extends React.Component {
     this.onSubmit = this.onSubmit.bind(this);
     this.resetAutosuggest = this.resetAutosuggest.bind(this);
     this.changeActiveSuggestion = this.changeActiveSuggestion.bind(this);
+    this.onFocus = this.onFocus.bind(this);
+  }
+
+  componentDidMount() {
+    const hasParentAutosuggest = (element) => {
+      if (element.id === 'autosuggest') return true;
+      if (element.parentElement) return hasParentAutosuggest(element.parentElement);
+      return false;
+    };
+
+    document.addEventListener('click', (e) => {
+      console.log('document clicked ', e.target, e.currentTarget);
+      if (!hasParentAutosuggest(e.target)) this.setState({ hidden: true });
+    });
   }
 
   onSubmit(submitEvent) {
@@ -34,6 +48,10 @@ class SubjectHeadingSearch extends React.Component {
     this.setState({
       userInput,
     }, this.makeApiCallWithThrottle(this.state.timerId));
+  }
+
+  onFocus() {
+    this.setState({ hidden: false });
   }
 
   makeApiCallWithThrottle(timerId) {
@@ -126,6 +144,7 @@ class SubjectHeadingSearch extends React.Component {
               activeSuggestion={index === activeSuggestion}
               key={suggestion.uuid || suggestion.label}
               onClick={this.resetAutosuggest}
+              hidden={this.state.hidden}
             />
           ))}
         </ul>
@@ -138,6 +157,7 @@ class SubjectHeadingSearch extends React.Component {
         autoComplete="off"
         onSubmit={onSubmit}
         onKeyDown={changeActiveSuggestion}
+        onFocus={this.onFocus}
         id="mainContent"
       >
         <div className="autocomplete-field">

--- a/src/client/styles/components/SubjectHeadings/SubjectHeadingSearch.scss
+++ b/src/client/styles/components/SubjectHeadings/SubjectHeadingSearch.scss
@@ -38,8 +38,6 @@
   margin-bottom: 0px;
   min-width: 202px;
   width: max-content;
-  // comment out the below line when styling this component
-  display: none;
 }
 
 .suggestion-active {


### PR DESCRIPTION
**What's this do?**
Changes the way we manage hiding/displaying autosuggestions from css-based to javascript-based. Specifically, when the `SubjectHeadingSearch` mounts, it adds an event listener to the document, which listens to clicks, and an onFocus listener. Using these, the component can tell whether the user is clicking inside or outside the form, and based on that passes a prop to hide/not hide suggestions.

**Why are we doing this? (w/ JIRA link if applicable)**
This is SCC-1992. The previous css implementation didn't work in Safari because Safari propagates events somewhat differently from Firefox/Chrome, so when the user clicked on a suggestion, the suggestion was hidden before the link was triggered.

**How should this be tested? / Do these changes have associated tests?**
Using Safari, enter a query into the search box. You should be able to click on suggestions and navigate properly to the right page. Clicking off should hide the suggestions. Clicking on should display them.

**Dependencies for merging? Releasing to production?**

**Has the application documentation been updated for these changes?**

**Did someone actually run this code to verify it works?**
PR author tested locally.
