### PR TITLE
Add css to hide all but one breadcrumb in mobile

### DIFF
--- a/src/client/styles/components/SubjectHeadings.scss
+++ b/src/client/styles/components/SubjectHeadings.scss
@@ -101,6 +101,18 @@ $table-row-border: 1px solid rgb(215, 210, 205);
   .breadcrumbs-and-search-wrapper {
     display: flex;
     justify-content: space-between;
+
+    @include media($mobile-breakpoint) {
+      ol {
+        li:not(:nth-last-child(2)) {
+          display: none;
+        }
+
+        li:nth-last-child(2)::before {
+          content: " < ";
+        }
+      }
+    }
   }
 }
 


### PR DESCRIPTION
**What's this do?**
Adds some styling to hide unwanted breadcrumbs in mobile. We only want to show the breadcrumb for the previous page. Also reverses the arrow in this case, to match the designs.

**Why are we doing this? (w/ JIRA link if applicable)**
This is SCC-2017

**How should this be tested? / Do these changes have associated tests?**
Navigate around in the mobile view, you should always only see the breadcrumb for the previous page. It shouldn't change any other view.

**Dependencies for merging? Releasing to production?**
No.

**Has the application documentation been updated for these changes?**
NA

**Did someone actually run this code to verify it works?**
PR author tested locally.