### PR TITLE
SCC-2013/replace "searchKeywords" param with "q" from url

### DIFF
--- a/src/app/components/Application/Application.jsx
+++ b/src/app/components/Application/Application.jsx
@@ -92,7 +92,6 @@ class App extends React.Component {
           />
           <DataLoader
             key={JSON.stringify(dataLocation)}
-            location={dataLocation}
           >
             {React.cloneElement(this.props.children, this.state.data)}
           </DataLoader>

--- a/src/app/components/Application/Application.jsx
+++ b/src/app/components/Application/Application.jsx
@@ -46,6 +46,7 @@ class App extends React.Component {
       });
 
       if (action === 'POP' && search && query.q !== Store.getState().searchKeywords) {
+        Actions.updateLoadingStatus(true);
         ajaxCall(`${appConfig.baseUrl}/api${decodeURI(search)}`, (response) => {
           const { data } = response;
           if (data.filters && data.searchResults) {
@@ -55,6 +56,7 @@ class App extends React.Component {
             Actions.updateSearchResults(data.searchResults);
             Actions.updatePage(query.page || '1');
             if (qParameter) Actions.updateSearchKeywords(qParameter);
+            Actions.updateLoadingStatus(false);
           }
         });
       }

--- a/src/app/components/Application/Application.jsx
+++ b/src/app/components/Application/Application.jsx
@@ -44,20 +44,6 @@ class App extends React.Component {
         }
         return null;
       });
-
-      if (action === 'POP' && search) {
-        ajaxCall(`${appConfig.baseUrl}/api${decodeURI(search)}`, (response) => {
-          const { data } = response;
-          if (data.filters && data.searchResults) {
-            const selectedFilters = destructureFilters(urlFilters, data.filters);
-            Actions.updateSelectedFilters(selectedFilters);
-            Actions.updateFilters(data.filters);
-            Actions.updateSearchResults(data.searchResults);
-            Actions.updatePage(query.page || '1');
-            if (qParameter) Actions.updateSearchKeywords(qParameter);
-          }
-        });
-      }
     });
   }
 

--- a/src/app/components/Application/Application.jsx
+++ b/src/app/components/Application/Application.jsx
@@ -44,6 +44,20 @@ class App extends React.Component {
         }
         return null;
       });
+
+      if (action === 'POP' && search && query.q !== Store.getState().searchKeywords) {
+        ajaxCall(`${appConfig.baseUrl}/api${decodeURI(search)}`, (response) => {
+          const { data } = response;
+          if (data.filters && data.searchResults) {
+            const selectedFilters = destructureFilters(urlFilters, data.filters);
+            Actions.updateSelectedFilters(selectedFilters);
+            Actions.updateFilters(data.filters);
+            Actions.updateSearchResults(data.searchResults);
+            Actions.updatePage(query.page || '1');
+            if (qParameter) Actions.updateSearchKeywords(qParameter);
+          }
+        });
+      }
     });
   }
 

--- a/src/app/components/BibPage/BibDetails.jsx
+++ b/src/app/components/BibPage/BibDetails.jsx
@@ -184,7 +184,7 @@ class BibDetails extends React.Component {
           bibValues.map((value) => {
             const url = `filters[${fieldValue}]=${value}`;
             return (
-              <li key={`filter${fieldValue}`}>
+              <li key={`filter${fieldValue}${value}`}>
                 {this.getDefinitionOneItem(
                   value,
                   url,

--- a/src/app/components/DataLoader/DataLoader.jsx
+++ b/src/app/components/DataLoader/DataLoader.jsx
@@ -52,7 +52,7 @@ class DataLoader extends React.Component {
   }
 
   reducePathExpressions(acc, instruction) {
-    const { location } = this.props;
+    const { location } = this.context.router;
     const matchData = location.pathname.match(instruction.expression);
     if (matchData) this.pathType = instruction.pathType;
     return matchData || acc;
@@ -64,5 +64,9 @@ class DataLoader extends React.Component {
     );
   }
 }
+
+DataLoader.contextTypes = {
+  router: PropTypes.object,
+};
 
 export default DataLoader;

--- a/src/app/components/ElectronicDelivery/ElectronicDelivery.jsx
+++ b/src/app/components/ElectronicDelivery/ElectronicDelivery.jsx
@@ -118,7 +118,7 @@ class ElectronicDelivery extends React.Component {
       itemSource,
     }, fields);
     const searchKeywords = this.props.searchKeywords;
-    const searchKeywordsQuery = (searchKeywords) ? `&searchKeywords=${searchKeywords}` : '';
+    const searchKeywordsQuery = (searchKeywords) ? `&q=${searchKeywords}` : '';
     const fromUrlQuery = this.props.location.query && this.props.location.query.fromUrl ?
       `&fromUrl=${encodeURIComponent(this.props.location.query.fromUrl)}` : '';
     const itemSourceMapping = {

--- a/src/app/components/HoldRequest/HoldRequest.jsx
+++ b/src/app/components/HoldRequest/HoldRequest.jsx
@@ -113,7 +113,7 @@ class HoldRequest extends React.Component {
       'recap-cul': 'Columbia',
     };
     const searchKeywordsQuery =
-      (this.props.searchKeywords) ? `searchKeywords=${this.props.searchKeywords}` : '';
+      (this.props.searchKeywords) ? `q=${this.props.searchKeywords}` : '';
     const searchKeywordsQueryPhysical = searchKeywordsQuery ? `&${searchKeywordsQuery}` : '';
     const fromUrlQuery = this.props.location.query && this.props.location.query.fromUrl ?
       `&fromUrl=${encodeURIComponent(this.props.location.query.fromUrl)}` : '';

--- a/src/app/components/Item/ItemTableRow.jsx
+++ b/src/app/components/Item/ItemTableRow.jsx
@@ -23,7 +23,7 @@ const ItemTableRow = ({ item, bibId, getRecord, searchKeywords }) => {
       itemRequestBtn = item.available ?
         (<Link
           to={
-            `${appConfig.baseUrl}/hold/request/${bibId}-${item.id}?searchKeywords=${searchKeywords}`
+            `${appConfig.baseUrl}/hold/request/${bibId}-${item.id}?q=${searchKeywords}`
           }
           onClick={e => getRecord(e, bibId, item.id)}
           tabIndex="0"

--- a/src/app/components/ResultsList/ResultsList.jsx
+++ b/src/app/components/ResultsList/ResultsList.jsx
@@ -152,7 +152,7 @@ class ResultsList extends React.Component {
   }
 
   render() {
-    const results = this.props.results;
+    const { results } = this.props;
     let resultsElm = null;
 
     if (!results || !_isArray(results) || !results.length) {

--- a/src/app/components/ResultsList/ResultsList.jsx
+++ b/src/app/components/ResultsList/ResultsList.jsx
@@ -110,7 +110,7 @@ class ResultsList extends React.Component {
     let bibUrl = `${appConfig.baseUrl}/bib/${bibId}`;
 
     const searchKeywords = this.props.searchKeywords || Store.getState().searchKeywords;
-    if (searchKeywords) bibUrl += `?searchKeywords=${searchKeywords}`;
+    if (searchKeywords) bibUrl += `?q=${searchKeywords}`;
 
     return (
       <li key={i} className={`nypl-results-item ${hasRequestTable ? 'has-request' : ''}`}>

--- a/src/server/ApiRoutes/Hold.js
+++ b/src/server/ApiRoutes/Hold.js
@@ -556,7 +556,7 @@ function eddServer(req, res) {
     itemId,
     searchKeywords,
   } = req.body;
-  const searchKeywordsQuery = (searchKeywords) ? `&searchKeywords=${searchKeywords}` : '';
+  const searchKeywordsQuery = (searchKeywords) ? `&q=${searchKeywords}` : '';
 
   let serverErrors = {};
 

--- a/test/unit/DataLoader.test.js
+++ b/test/unit/DataLoader.test.js
@@ -3,7 +3,7 @@ import React from 'react';
 import sinon from 'sinon';
 import axios from 'axios';
 import { expect } from 'chai';
-import Enzyme, { shallow } from 'enzyme';
+import Enzyme, { mount, shallow } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 
 import DataLoader from './../../src/app/components/DataLoader/DataLoader';
@@ -19,14 +19,20 @@ describe('DataLoader', () => {
     let bibAction;
     let axiosStub;
     const axiosCalls = [];
-    const location = {
-      pathname: '/research/collections/shared-collection-catalog/nonMatchingPath',
-    };
 
     before(() => {
       loadingAction = sinon.spy(Actions, 'updateLoadingStatus');
       bibAction = sinon.spy(Actions, 'updateBib');
-      component = shallow(<DataLoader location={location} children={[]} />);
+      component = mount(
+        <DataLoader children={[]} />,
+        { context:
+          { router:
+            { location: {
+              pathname: '/research/collections/shared-collection-catalog/nonMatchingPath',
+            } },
+          },
+        },
+      );
 
       axiosStub = sinon.stub(axios, 'get').callsFake(args =>
         new Promise((resolve) => {
@@ -54,15 +60,11 @@ describe('DataLoader', () => {
   });
 
   describe('Matching path', () => {
-    const location = {
-      pathname: '/research/collections/shared-collection-catalog/bib/b1234',
-    };
-
     describe('OK Bib response', () => {
-      let component;
       let loadingAction;
       let bibAction;
       let axiosStub;
+      let component;
       const axiosCalls = [];
 
       before(() => {
@@ -76,7 +78,16 @@ describe('DataLoader', () => {
           }),
         );
 
-        component = shallow(<DataLoader location={location} children={[]} />);
+        component = mount(
+          <DataLoader children={[]} />,
+          { context:
+            { router:
+              { location: {
+                pathname: '/research/collections/shared-collection-catalog/bib/b1234',
+              } },
+            },
+          },
+        );
       });
 
       after(() => {
@@ -134,7 +145,14 @@ describe('DataLoader', () => {
           }),
         );
 
-        component = shallow(<DataLoader location={location} children={[]} />);
+        component = mount(
+          <DataLoader children={[]}/>,
+          { context:
+            { router:
+              { location: { pathname: '/research/collections/shared-collection-catalog/bib/b1234' } },
+            },
+          },
+        );
       });
 
       after(() => {


### PR DESCRIPTION
**What's this do?**
This PR removes the "searchKeyworld" param from the url and uses "q" instead for consistency. There are some other changes, like using router context in the DataLoader, instead of passing location as a prop.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SCC-2013

**How should this be tested? / Do these changes have associated tests?**
Follow steps detailed above.

**Did someone actually run this code to verify it works?**
PR author checked above issue, plus "Search Results" breadcrumb with back button on Hold Request, EDD, and Hold Confirmation