### PR TITLE
Fix order of banner elements

### DIFF
--- a/src/app/components/SccContainer/SccContainer.jsx
+++ b/src/app/components/SccContainer/SccContainer.jsx
@@ -17,12 +17,12 @@ const SccContainer = props => (
         <div className="nypl-row">
           <div className="nypl-column-full">
             <Breadcrumbs type={props.breadcrumbsType} />
-            { props.extraBannerElement }
             <h1
               aria-label={props.bannerOptions.ariaLabel || props.bannerOptions.text}
             >
               { props.bannerOptions.text }
             </h1>
+            { props.extraBannerElement }
           </div>
         </div>
       </div>


### PR DESCRIPTION
The "extraBannerElement" and the header were in the wrong order in the `SccContainer`.