### PR TITLE
Scc 2025

### DIFF
--- a/src/app/components/Pagination/Pagination.jsx
+++ b/src/app/components/Pagination/Pagination.jsx
@@ -87,13 +87,14 @@ class Pagination extends React.Component {
       nextPage = (total < perPage || pageFactor > total) ? null : this.getPage(page, 'Next');
       totalPages = Math.floor(total / perPage) + 1;
     } else {
+      if (total && perPage) totalPages = Math.ceil(total / perPage);
       nextPage = this.getPage(page, 'Next');
     }
 
     return (
       <nav className="nypl-results-pagination showPage" aria-label="More results">
         {prevPage}
-        {!subjectHeadingPage
+        {page && totalPages
           ?
             <span
               className={`page-count ${page === 1 ? 'first' : ''}`}

--- a/src/app/components/SubjectHeading/BibsList.jsx
+++ b/src/app/components/SubjectHeading/BibsList.jsx
@@ -135,6 +135,8 @@ class BibsList extends React.Component {
       <Pagination
         updatePage={this.updateBibPage}
         page={bibPage}
+        total={total}
+        perPage={this.perPage}
         subjectShowPage
         ariaControls="nypl-results-list"
         hasNext={bibPage < lastPage || nextUrl}


### PR DESCRIPTION
**What's this do?**
Adds some logic to display the current page and total number of pages below the `BibsList` on the Subject Heading show page.

**Why are we doing this? (w/ JIRA link if applicable)**
SCC-2025. In the Jira ticket this element is supposed to be interactive, but that requirement is being postponed.

**How should this be tested? / Do these changes have associated tests?**
Should be visible on any show page.

**Did someone actually run this code to verify it works?**
PR author tested locally.