### PR TITLE
Navigation bugs between search result pages and bib pages

### DIFF
--- a/src/app/components/Application/Application.jsx
+++ b/src/app/components/Application/Application.jsx
@@ -32,7 +32,7 @@ class App extends React.Component {
   componentDidMount() {
     Store.listen(this.onChange);
     // Listen to the browser's navigation buttons.
-    this.context.router.listen((location = { action: '', search: '', query: {} }) => {
+    this.props.route.history.listen((location = { action: '', search: '', query: {} }) => {
       const {
         action,
         search,

--- a/src/app/components/BibPage/BibDetails.jsx
+++ b/src/app/components/BibPage/BibDetails.jsx
@@ -184,7 +184,7 @@ class BibDetails extends React.Component {
           bibValues.map((value) => {
             const url = `filters[${fieldValue}]=${value}`;
             return (
-              <li key={`filter${fieldValue}`}>
+              <li key={`filter${fieldValue}${value}`}>
                 {this.getDefinitionOneItem(
                   value,
                   url,

--- a/src/app/components/DataLoader/DataLoader.jsx
+++ b/src/app/components/DataLoader/DataLoader.jsx
@@ -52,7 +52,7 @@ class DataLoader extends React.Component {
   }
 
   reducePathExpressions(acc, instruction) {
-    const { location } = this.props;
+    const { location } = this.context.router;
     const matchData = location.pathname.match(instruction.expression);
     if (matchData) this.pathType = instruction.pathType;
     return matchData || acc;
@@ -64,5 +64,9 @@ class DataLoader extends React.Component {
     );
   }
 }
+
+DataLoader.contextTypes = {
+  router: PropTypes.object,
+};
 
 export default DataLoader;

--- a/src/app/components/ResultsList/ResultsList.jsx
+++ b/src/app/components/ResultsList/ResultsList.jsx
@@ -109,9 +109,6 @@ class ResultsList extends React.Component {
 
     let bibUrl = `${appConfig.baseUrl}/bib/${bibId}`;
 
-    const searchKeywords = this.props.searchKeywords || Store.getState().searchKeywords;
-    if (searchKeywords) bibUrl += `?searchKeywords=${searchKeywords}`;
-
     return (
       <li key={i} className={`nypl-results-item ${hasRequestTable ? 'has-request' : ''}`}>
         <h3>

--- a/test/unit/DataLoader.test.js
+++ b/test/unit/DataLoader.test.js
@@ -3,7 +3,7 @@ import React from 'react';
 import sinon from 'sinon';
 import axios from 'axios';
 import { expect } from 'chai';
-import Enzyme, { shallow } from 'enzyme';
+import Enzyme, { shallow, mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 
 import DataLoader from './../../src/app/components/DataLoader/DataLoader';
@@ -26,7 +26,16 @@ describe('DataLoader', () => {
     before(() => {
       loadingAction = sinon.spy(Actions, 'updateLoadingStatus');
       bibAction = sinon.spy(Actions, 'updateBib');
-      component = shallow(<DataLoader location={location} children={[]} />);
+      component = mount(
+        <DataLoader children={[]} />,
+        { context:
+          { router:
+            { location: {
+              pathname: '/research/collections/shared-collection-catalog/nonMatchingPath',
+            } },
+          },
+        },
+      );
 
       axiosStub = sinon.stub(axios, 'get').callsFake(args =>
         new Promise((resolve) => {
@@ -54,10 +63,6 @@ describe('DataLoader', () => {
   });
 
   describe('Matching path', () => {
-    const location = {
-      pathname: '/research/collections/shared-collection-catalog/bib/b1234',
-    };
-
     describe('OK Bib response', () => {
       let component;
       let loadingAction;
@@ -76,7 +81,16 @@ describe('DataLoader', () => {
           }),
         );
 
-        component = shallow(<DataLoader location={location} children={[]} />);
+        component = mount(
+          <DataLoader children={[]} />,
+          { context:
+            { router:
+              { location: {
+                pathname: '/research/collections/shared-collection-catalog/bib/b1234',
+              } },
+            },
+          },
+        );
       });
 
       after(() => {
@@ -134,7 +148,14 @@ describe('DataLoader', () => {
           }),
         );
 
-        component = shallow(<DataLoader location={location} children={[]} />);
+        component = mount(
+          <DataLoader children={[]}/>,
+          { context:
+            { router:
+              { location: { pathname: '/research/collections/shared-collection-catalog/bib/b1234' } },
+            },
+          },
+        );
       });
 
       after(() => {


### PR DESCRIPTION
**What's this do?**
This supersedes the previous PR for this issue to provide a less intrusive fix so there is less chance of introducing new bugs

This PR removes the `searchKeyworld` param from the bib url. It is in the href for bibs on the ResultsList for no-JS, but ends up not being there with JS. Originally, there was a click handler that updated the bib in the store and pushed the bib page URL without that param to the router. When the click handler was removed, the url with the `searchKeyword` end up becoming the one we routed to with or without JS. I also made the logic for whether or not to update the Store when using navigation buttons a little more strict.

This PR includes some other changes, like using router context in `DataLoader`, instead of passing location as a prop.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SCC-2013

**How should this be tested? / Do these changes have associated tests?**
Follow steps detailed in above ticket.

**Did someone actually run this code to verify it works?**
PR author checked above issue.