### PR TITLE
SCC-2023/ Remove tab index for content boxes on show page

### DIFF
--- a/src/app/components/SubjectHeading/BibsList.jsx
+++ b/src/app/components/SubjectHeading/BibsList.jsx
@@ -148,7 +148,6 @@ class BibsList extends React.Component {
     return (
       <div
         className="nypl-column-half bibsList"
-        tabIndex='0'
         aria-label="Titles related to this Subject Heading"
       >
         <h2 id="titles">Titles</h2>

--- a/src/app/components/SubjectHeading/NeighboringHeadingsBox.jsx
+++ b/src/app/components/SubjectHeading/NeighboringHeadingsBox.jsx
@@ -55,7 +55,6 @@ class NeighboringHeadingsBox extends React.Component {
     return (
       <div
         className="nypl-column-half subjectHeadingInfoBox"
-        tabIndex='0'
         aria-label="Neighboring Subject Headings"
       >
         <div className="backgroundContainer">

--- a/src/app/components/SubjectHeading/SubjectHeadingShow.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeadingShow.jsx
@@ -165,7 +165,6 @@ class SubjectHeadingShow extends React.Component {
           {relatedHeadings ?
             <div
               className="nypl-column-half subjectHeadingInfoBox"
-              tabIndex='0'
               aria-label="Related Subject Headings"
             >
               <div className="backgroundContainer">


### PR DESCRIPTION
**What's this do?**
Remove tab index/focus for content boxes on show page, as suggested by Ellen and approved by Matt.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SCC-2023

**Did someone actually run this code to verify it works?**
PR author did.