### PR TITLE
SCC-2024

### DIFF
--- a/src/app/components/Application/Application.jsx
+++ b/src/app/components/Application/Application.jsx
@@ -66,7 +66,7 @@ class App extends React.Component {
   }
 
   shouldStoreUpdate() {
-    return `?${basicQuery({})(Store.getState())}` !== this.context.router.location.search;
+    return `${basicQuery({})(Store.getState())}` !== this.context.router.location.search;
   }
 
   componentWillUnmount() {

--- a/src/app/components/Application/Application.jsx
+++ b/src/app/components/Application/Application.jsx
@@ -18,7 +18,7 @@ import Actions from '../../actions/Actions';
 import appConfig from '../../data/appConfig';
 import DataLoader from '../DataLoader/DataLoader';
 
-class App extends React.Component {
+class Application extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
@@ -66,7 +66,7 @@ class App extends React.Component {
   }
 
   shouldStoreUpdate() {
-    return `${basicQuery({})(Store.getState())}` !== this.context.router.location.search;
+    return `?${basicQuery({})(Store.getState())}` !== this.context.router.location.search;
   }
 
   componentWillUnmount() {
@@ -109,19 +109,19 @@ class App extends React.Component {
   }
 }
 
-App.propTypes = {
+Application.propTypes = {
   children: PropTypes.object,
   location: PropTypes.object,
 };
 
-App.defaultProps = {
+Application.defaultProps = {
   children: {},
   location: {},
 };
 
-App.contextTypes = {
+Application.contextTypes = {
   router: PropTypes.object,
 };
 
 
-export default App;
+export default Application;

--- a/src/app/components/BibPage/BackLink.jsx
+++ b/src/app/components/BibPage/BackLink.jsx
@@ -5,8 +5,8 @@ import { Link } from 'react-router';
 import { trackDiscovery } from '../../utils/utils';
 import appConfig from '../../data/appConfig';
 
-const BibPage = ({ searchURL, searchKeywords = '' }) => {
-  if (!searchURL) {
+const BackLink = ({ searchUrl, searchKeywords = '' }) => {
+  if (!searchUrl) {
     return null;
   }
 
@@ -15,16 +15,16 @@ const BibPage = ({ searchURL, searchKeywords = '' }) => {
       title={`Go back to search results ${searchKeywords ? `for ${searchKeywords}` : ''}`}
       className="nypl-back-link"
       onClick={() => trackDiscovery('Back', 'Back to Search')}
-      to={`${appConfig.baseUrl}/search?${searchURL}`}
+      to={`${appConfig.baseUrl}/search?${searchUrl}`}
     >
       Back to Results
     </Link>
   );
 };
 
-BibPage.propTypes = {
+BackLink.propTypes = {
   searchKeywords: PropTypes.string,
-  searchURL: PropTypes.string,
+  searchUrl: PropTypes.string,
 };
 
-export default BibPage;
+export default BackLink;

--- a/src/app/components/BibPage/BibPage.jsx
+++ b/src/app/components/BibPage/BibPage.jsx
@@ -38,7 +38,6 @@ const BibPage = (props) => {
   // Related to removing MarcRecord because the webpack MarcRecord is not working. Sep/28/2017
   // const isNYPLReCAP = LibraryItem.isNYPLReCAP(bib['@id']);
   // const bNumber = bib && bib.idBnum ? bib.idBnum : '';
-  const searchURL = createAPIQuery({});
   const itemPage = location.search;
   const aggregatedElectronicResources = getAggregatedElectronicResources(items);
   let shortenItems = true;
@@ -127,6 +126,10 @@ const BibPage = (props) => {
       bottomDetails
       : <AdditionalDetailsViewer bib={bib} />
   );
+
+  const createAPIQuery = basicQuery(props);
+  const searchURL = createAPIQuery({});
+  console.log(searchURL);
 
   return (
     <DocumentTitle title="Item Details | Shared Collection Catalog | NYPL">

--- a/src/app/components/BibPage/BibPage.jsx
+++ b/src/app/components/BibPage/BibPage.jsx
@@ -29,7 +29,6 @@ const BibPage = (props) => {
     searchKeywords,
   } = props;
 
-  const createAPIQuery = basicQuery(props);
   const bib = props.bib ? props.bib : {};
   const bibId = bib && bib['@id'] ? bib['@id'].substring(4) : '';
   const title = bib.title && bib.title.length ? bib.title[0] : '';
@@ -128,8 +127,7 @@ const BibPage = (props) => {
   );
 
   const createAPIQuery = basicQuery(props);
-  const searchURL = createAPIQuery({});
-  console.log(searchURL);
+  const searchUrl = createAPIQuery({});
 
   return (
     <DocumentTitle title="Item Details | Shared Collection Catalog | NYPL">
@@ -142,7 +140,7 @@ const BibPage = (props) => {
           <div className="nypl-full-width-wrapper">
             <div className="nypl-row">
               <div className="nypl-column-three-quarters">
-                <Breadcrumbs type="bib" query={searchURL} />
+                <Breadcrumbs type="bib" searchUrl={searchUrl} />
                 <h1 id="mainContent">{title}</h1>
                 {
                   searchKeywords && (
@@ -152,7 +150,7 @@ const BibPage = (props) => {
                         title="Back to Results"
                       />
                       <BackLink
-                        searchURL={searchURL}
+                        searchUrl={searchUrl}
                         searchKeywords={searchKeywords}
                       />
                     </div>

--- a/src/app/components/Breadcrumbs/Breadcrumbs.jsx
+++ b/src/app/components/Breadcrumbs/Breadcrumbs.jsx
@@ -11,7 +11,7 @@ const {
   displayTitle,
 } = appConfig;
 
-const Breadcrumbs = ({ query, type, bibUrl, itemUrl, edd }) => {
+const Breadcrumbs = ({ searchUrl, type, bibUrl, itemUrl, edd }) => {
   const defaultText = displayTitle;
   const onClick = pageTitle => trackDiscovery('Breadcrumbs', pageTitle);
   const homeLink = (
@@ -33,27 +33,29 @@ const Breadcrumbs = ({ query, type, bibUrl, itemUrl, edd }) => {
     // The first link is the homepage and it will being appearing starting from the
     // Search Results page.
     const crumbs = [homeLink];
-    const { searchKeywords } = Store.getState();
 
-    const searchKeywordsCrumb = searchKeywords ? (
+    const searchCrumb = searchUrl ? (
       <li key="search">
-        <Link to={`${baseUrl}/search?q=${searchKeywords}`} onClick={() => onClick('Search Results')}>
+        <Link to={`${baseUrl}/search?${searchUrl}`} onClick={() => onClick('Search Results')}>
           Search Results
         </Link>
-      </li>
-    ) : null;
+      </li>)
+      : null;
+
+    const bibCrumb = (
+      <li key="bib">
+        <Link to={`${baseUrl}${bibUrl}`} onClick={() => onClick('Item Details')}>Item Details</Link>
+      </li>);
 
     if (type.startsWith('subjectHeading')) {
-      if (searchKeywordsCrumb) {
-        crumbs.push(searchKeywordsCrumb);
-      }
+      if (searchCrumb) crumbs.push(searchCrumb);
+      if (bibUrl) crumbs.push(bibCrumb);
       crumbs.push(
         <li key="subjectHeading">
           <Link to={`${baseUrl}/subject_headings`}>
             Subject Headings
           </Link>
-        </li>
-      );
+        </li>);
       if (type === 'subjectHeading') {
         crumbs.push(<li key="subjectHeadingDetails">Heading Details</li>);
       }
@@ -65,16 +67,8 @@ const Breadcrumbs = ({ query, type, bibUrl, itemUrl, edd }) => {
       return crumbs;
     }
 
-    if (query) {
-      crumbs.push(
-        <li key="search">
-          <Link to={`${baseUrl}/search?${query}`} onClick={() => onClick('Search Results')}>
-            Search Results
-          </Link>
-        </li>
-      );
-    } else if (searchKeywordsCrumb) {
-      crumbs.push(searchKeywordsCrumb);
+    if (searchCrumb) {
+      crumbs.push(searchCrumb);
     }
 
     if (type === 'bib') {
@@ -82,11 +76,7 @@ const Breadcrumbs = ({ query, type, bibUrl, itemUrl, edd }) => {
       return crumbs;
     }
 
-    crumbs.push(
-      <li key="bib">
-        <Link to={`${baseUrl}${bibUrl}`} onClick={() => onClick('Item Details')}>Item Details</Link>
-      </li>
-    );
+    crumbs.push(bibCrumb);
 
     if (type === 'hold') {
       crumbs.push(<li key="hold">Item Request</li>);
@@ -137,7 +127,7 @@ const Breadcrumbs = ({ query, type, bibUrl, itemUrl, edd }) => {
 };
 
 Breadcrumbs.propTypes = {
-  query: PropTypes.string,
+  searchUrl: PropTypes.string,
   type: PropTypes.string,
   bibUrl: PropTypes.string,
   itemUrl: PropTypes.string,
@@ -145,7 +135,6 @@ Breadcrumbs.propTypes = {
 };
 
 Breadcrumbs.defaultProps = {
-  query: '',
   type: '',
 };
 

--- a/src/app/components/ElectronicDelivery/ElectronicDelivery.jsx
+++ b/src/app/components/ElectronicDelivery/ElectronicDelivery.jsx
@@ -209,8 +209,7 @@ class ElectronicDelivery extends React.Component {
       && this.state.patron.emails.length
     ) ? this.state.patron.emails[0] : '';
 
-    const createAPIQuery = basicQuery(this.props);
-    const searchUrl = createAPIQuery({});
+    const searchUrl = basicQuery(this.props)({});
 
     return (
       <DocumentTitle title="Electronic Delivery Request | Shared Collection Catalog | NYPL">

--- a/src/app/components/ElectronicDelivery/ElectronicDelivery.jsx
+++ b/src/app/components/ElectronicDelivery/ElectronicDelivery.jsx
@@ -20,7 +20,10 @@ import appConfig from '../../data/appConfig';
 import ElectronicDeliveryForm from './ElectronicDeliveryForm';
 import LibraryItem from '../../utils/item';
 import LoadingLayer from '../LoadingLayer/LoadingLayer';
-import { trackDiscovery } from '../../utils/utils';
+import {
+  trackDiscovery,
+  basicQuery,
+} from '../../utils/utils';
 
 class ElectronicDelivery extends React.Component {
   constructor(props) {
@@ -118,7 +121,7 @@ class ElectronicDelivery extends React.Component {
       itemSource,
     }, fields);
     const searchKeywords = this.props.searchKeywords;
-    const searchKeywordsQuery = (searchKeywords) ? `&searchKeywords=${searchKeywords}` : '';
+    const searchKeywordsQuery = searchKeywords ? `&q=${searchKeywords}` : '';
     const fromUrlQuery = this.props.location.query && this.props.location.query.fromUrl ?
       `&fromUrl=${encodeURIComponent(this.props.location.query.fromUrl)}` : '';
     const itemSourceMapping = {
@@ -205,7 +208,9 @@ class ElectronicDelivery extends React.Component {
       this.state.patron.emails && _isArray(this.state.patron.emails)
       && this.state.patron.emails.length
     ) ? this.state.patron.emails[0] : '';
-    const searchKeywords = this.props.searchKeywords;
+
+    const createAPIQuery = basicQuery(this.props);
+    const searchUrl = createAPIQuery({});
 
     return (
       <DocumentTitle title="Electronic Delivery Request | Shared Collection Catalog | NYPL">
@@ -218,7 +223,7 @@ class ElectronicDelivery extends React.Component {
             <div className="row">
               <div className="content-wrapper">
                 <Breadcrumbs
-                  query={searchKeywords}
+                  searchUrl={searchUrl}
                   type="edd"
                   bibUrl={`/bib/${bibId}`}
                   itemUrl={`/hold/request/${bibId}-${itemId}`}
@@ -272,7 +277,7 @@ class ElectronicDelivery extends React.Component {
                 error={error}
                 form={form}
                 defaultEmail={patronEmail}
-                searchKeywords={searchKeywords}
+                searchKeywords={this.props.searchKeywords}
               />
             </div>
           </div>

--- a/src/app/components/HoldConfirmation/HoldConfirmation.jsx
+++ b/src/app/components/HoldConfirmation/HoldConfirmation.jsx
@@ -12,7 +12,10 @@ import DocumentTitle from 'react-document-title';
 import PatronStore from '../../stores/PatronStore';
 import appConfig from '../../data/appConfig';
 import Breadcrumbs from '../Breadcrumbs/Breadcrumbs';
-import { trackDiscovery } from '../../utils/utils';
+import {
+  trackDiscovery,
+  basicQuery,
+} from '../../utils/utils';
 
 class HoldConfirmation extends React.Component {
   constructor(props) {
@@ -341,6 +344,8 @@ class HoldConfirmation extends React.Component {
       trackDiscovery('Error', 'Hold Confirmation');
     }
 
+    const searchUrl = basicQuery(this.props)({});
+
     return (
       <DocumentTitle title={`${confirmationPageTitle} | Shared Collection Catalog | NYPL`}>
         <main className="main-page">
@@ -349,7 +354,7 @@ class HoldConfirmation extends React.Component {
               <div className="nypl-full-width-wrapper">
                 <div className="nypl-column-full">
                   <Breadcrumbs
-                    query={this.props.location.query.searchKeywords}
+                    searchUrl={searchUrl}
                     type="confirmation"
                     bibUrl={`/bib/${bibId}`}
                     itemUrl={`/hold/request/${bibId}-${itemId}`}

--- a/src/app/components/HoldRequest/HoldRequest.jsx
+++ b/src/app/components/HoldRequest/HoldRequest.jsx
@@ -113,7 +113,7 @@ class HoldRequest extends React.Component {
       'recap-cul': 'Columbia',
     };
     const searchKeywordsQuery =
-      (this.props.searchKeywords) ? `searchKeywords=${this.props.searchKeywords}` : '';
+      (this.props.searchKeywords) ? `q=${this.props.searchKeywords}` : '';
     const searchKeywordsQueryPhysical = searchKeywordsQuery ? `&${searchKeywordsQuery}` : '';
     const fromUrlQuery = this.props.location.query && this.props.location.query.fromUrl ?
       `&fromUrl=${encodeURIComponent(this.props.location.query.fromUrl)}` : '';
@@ -288,7 +288,7 @@ class HoldRequest extends React.Component {
   }
 
   render() {
-    const searchKeywords = this.props.searchKeywords || '';
+    const searchKeywords = this.props.searchKeywords;
     const bib = (this.props.bib && !_isEmpty(this.props.bib)) ?
       this.props.bib : null;
     const title = (bib && _isArray(bib.title) && bib.title.length) ?
@@ -372,7 +372,7 @@ class HoldRequest extends React.Component {
               <div className="row">
                 <div className="nypl-column-full">
                   <Breadcrumbs
-                    query={`q=${searchKeywords}`}
+                    query={searchKeywords ? `q=${searchKeywords}` : null}
                     bibUrl={`/bib/${bibId}`}
                     type="hold"
                   />
@@ -426,7 +426,6 @@ HoldRequest.propTypes = {
 HoldRequest.defaultProps = {
   location: {},
   bib: {},
-  searchKeywords: '',
   params: {},
   deliveryLocations: [],
   isEddRequestable: false,

--- a/src/app/components/HoldRequest/HoldRequest.jsx
+++ b/src/app/components/HoldRequest/HoldRequest.jsx
@@ -16,7 +16,10 @@ import PatronStore from '../../stores/PatronStore';
 import appConfig from '../../data/appConfig';
 import LibraryItem from '../../utils/item';
 import LoadingLayer from '../LoadingLayer/LoadingLayer';
-import { trackDiscovery } from '../../utils/utils';
+import {
+  trackDiscovery,
+  basicQuery,
+} from '../../utils/utils';
 
 import Actions from '@Actions'
 import Store from '@Store'
@@ -360,6 +363,8 @@ class HoldRequest extends React.Component {
       );
     }
 
+    const searchUrl = basicQuery(this.props)({});
+
     return (
       <DocumentTitle title="Item Request | Shared Collection Catalog | NYPL">
         <div>
@@ -372,7 +377,7 @@ class HoldRequest extends React.Component {
               <div className="row">
                 <div className="nypl-column-full">
                   <Breadcrumbs
-                    query={searchKeywords ? `q=${searchKeywords}` : null}
+                    searchUrl={searchUrl}
                     bibUrl={`/bib/${bibId}`}
                     type="hold"
                   />

--- a/src/app/components/ShepContainer/ShepContainer.jsx
+++ b/src/app/components/ShepContainer/ShepContainer.jsx
@@ -11,7 +11,8 @@ const ShepContainer = (props) => {
           <div className="nypl-row container-row">
             <div className="nypl-column-full">
               <Breadcrumbs
-                type={props.breadcrumbsType}
+                type={props.breadcrumbProps.type}
+                {...props.breadcrumbProps.urls}
               />
               { props.extraBannerElement }
               <h1
@@ -44,7 +45,7 @@ ShepContainer.propTypes = {
   secondaryExtraBannerElement: PropTypes.element,
   extraRow: PropTypes.element,
   loadingLayerText: PropTypes.string,
-  breadcrumbsType: PropTypes.string,
+  breadcrumbProps: PropTypes.object,
   bannerOptions: PropTypes.object,
 };
 
@@ -52,6 +53,10 @@ ShepContainer.defaultProps = {
   mainContent: null,
   extraBannerElement: null,
   loadingLayerText: "Loading",
+  breadcrumbProps: {
+    type: '',
+    breadcrumbUrls: {},
+  },
 };
 
 export default ShepContainer;

--- a/src/app/components/SubjectHeading/Search/SubjectHeadingSearch.jsx
+++ b/src/app/components/SubjectHeading/Search/SubjectHeadingSearch.jsx
@@ -1,3 +1,4 @@
+/* global document */
 import React from 'react';
 import PropTypes from 'prop-types';
 import axios from 'axios';
@@ -30,7 +31,6 @@ class SubjectHeadingSearch extends React.Component {
     };
 
     document.addEventListener('click', (e) => {
-      console.log('document clicked ', e.target, e.currentTarget);
       if (!hasParentAutosuggest(e.target)) this.setState({ hidden: true });
     });
   }

--- a/src/app/pages/SubjectHeadingShowPage.jsx
+++ b/src/app/pages/SubjectHeadingShowPage.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import ShepContainer from '../components/ShepContainer/ShepContainer';
 import SubjectHeadingShow from '../components/SubjectHeading/SubjectHeadingShow';
 import SubjectHeadingSearch from '../components/SubjectHeading/Search/SubjectHeadingSearch';
+import { basicQuery } from '../utils/utils';
 
 const SubjectHeadingShowPage = (props) => {
   const {
@@ -13,6 +14,10 @@ const SubjectHeadingShowPage = (props) => {
   } = props;
 
   const [label, setLabel] = useState('');
+  const breadcrumbUrls = {};
+  const searchUrl = basicQuery(props)({});
+  if (searchUrl) breadcrumbUrls.searchUrl = searchUrl;
+  if (props.bib.uri) breadcrumbUrls.bibUrl = `/bib/${props.bib.uri}`;
 
   return (
     <ShepContainer
@@ -30,13 +35,21 @@ const SubjectHeadingShowPage = (props) => {
       }
       extraBannerElement={<SubjectHeadingSearch />}
       loadingLayerText="Subject Heading"
-      breadcrumbsType="subjectHeading"
+      breadcrumbProps={{
+        type: 'subjectHeading',
+        urls: breadcrumbUrls,
+      }}
     />
   );
 };
 
 SubjectHeadingShowPage.propTypes = {
   params: PropTypes.object,
+  bib: PropTypes.object,
+};
+
+SubjectHeadingShowPage.defaultProps = {
+  bib: {},
 };
 
 export default SubjectHeadingShowPage;

--- a/src/app/pages/SubjectHeadingsIndexPage.jsx
+++ b/src/app/pages/SubjectHeadingsIndexPage.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import ShepContainer from '../components/ShepContainer/ShepContainer';
 import SubjectHeadingsIndex from '../components/SubjectHeading/SubjectHeadingsIndex';
 import SubjectHeadingSearch from '../components/SubjectHeading/Search/SubjectHeadingSearch';
+import { basicQuery } from '../utils/utils';
 
 const SubjectHeadingsIndexPage = (props) => {
   const {
@@ -16,6 +17,10 @@ const SubjectHeadingsIndexPage = (props) => {
   } = props;
 
   const componentKey = `subjectHeadingIndex${search}`;
+  const breadcrumbUrls = {}
+  const searchUrl = basicQuery(props)({});
+  if (searchUrl) breadcrumbUrls.searchUrl = searchUrl;
+  if (props.bib.uri) breadcrumbUrls.bibUrl = `/bib/${props.bib.uri}`;
 
   return (
     <ShepContainer
@@ -27,7 +32,10 @@ const SubjectHeadingsIndexPage = (props) => {
       }
       extraBannerElement={<SubjectHeadingSearch />}
       loadingLayerText="Subject Headings"
-      breadcrumbsType="subjectHeadings"
+      breadcrumbProps={{
+        type: 'subjectHeadings',
+        urls: breadcrumbUrls,
+      }}
       key={componentKey}
     />
   );

--- a/src/app/utils/utils.js
+++ b/src/app/utils/utils.js
@@ -218,7 +218,7 @@ const basicQuery = (props = {}) => {
     const filterQuery = getFilterParam(selectedFilters || props.selectedFilters);
     // `searchKeywords` can be an empty string, so check if it's undefined instead.
     const query = searchKeywords !== undefined ? searchKeywords : props.searchKeywords;
-    const searchKeywordsQuery = query ? encodeURIComponent(query) : '';
+    const searchKeywordsQuery = query ? `${encodeURIComponent(query)}` : '';
     let pageQuery = props.page && props.page !== '1' ? `&page=${props.page}` : '';
     pageQuery = page && page !== '1' ? `&page=${page}` : pageQuery;
     pageQuery = page === '1' ? '' : pageQuery;

--- a/src/server/ApiRoutes/Hold.js
+++ b/src/server/ApiRoutes/Hold.js
@@ -150,7 +150,7 @@ function confirmRequestServer(req, res, next) {
   const bibId = req.params.bibId || '';
   const loggedIn = User.requireUser(req, res);
   const requestId = req.query.requestId || '';
-  const searchKeywords = req.query.searchKeywords || '';
+  const searchKeywords = req.query.q || '';
   const errorStatus = req.query.errorStatus ? req.query.errorStatus : null;
   const errorMessage = req.query.errorMessage ? req.query.errorMessage : null;
   const error = _extend({}, { errorStatus, errorMessage });

--- a/src/server/ApiRoutes/Hold.js
+++ b/src/server/ApiRoutes/Hold.js
@@ -435,7 +435,7 @@ function createHoldRequestServer(req, res, pickedUpBibId = '', pickedUpItemId = 
   const pickupLocation = req.body['delivery-location'];
   const docDeliveryData = (req.body.form && pickupLocation === 'edd') ? req.body.form : null;
   const searchKeywordsQuery = (req.body['search-keywords']) ?
-    `&searchKeywords=${req.body['search-keywords']}` : '';
+    `&q=${req.body['search-keywords']}` : '';
 
   if (!bibId || !itemId) {
     // Dummy redirect for now
@@ -444,7 +444,7 @@ function createHoldRequestServer(req, res, pickedUpBibId = '', pickedUpItemId = 
 
   if (pickupLocation === 'edd') {
     const eddSearchKeywordsQuery = (req.body['search-keywords']) ?
-      `?searchKeywords=${req.body['search-keywords']}` : '';
+      `?q=${req.body['search-keywords']}` : '';
 
     return res.redirect(
       `${appConfig.baseUrl}/hold/request/${bibId}-${itemId}/edd${eddSearchKeywordsQuery}`,
@@ -556,7 +556,7 @@ function eddServer(req, res) {
     itemId,
     searchKeywords,
   } = req.body;
-  const searchKeywordsQuery = (searchKeywords) ? `&searchKeywords=${searchKeywords}` : '';
+  const searchKeywordsQuery = (searchKeywords) ? `&q=${searchKeywords}` : '';
 
   let serverErrors = {};
 

--- a/test/unit/Breadcrumbs.test.js
+++ b/test/unit/Breadcrumbs.test.js
@@ -15,8 +15,8 @@ const baseUrl = `${appConfig.baseUrl}/`;
 
 // The current page is the last item in the breadcrumb and it is not linked.
 describe('Breadcrumbs', () => {
-  // Shared Collection Catalog > Search Results > Item Details > Item Request > Request Confirmation
-  describe('Default rendering - all links', () => {
+  // Shared Collection Catalog > Item Details > Item Request > Request Confirmation
+  describe('Default rendering - links for "Request Confirmation"', () => {
     let component;
 
     before(() => {
@@ -28,18 +28,17 @@ describe('Breadcrumbs', () => {
       expect(component.find('ol').length).to.equal(1);
     });
 
-    it('should render five li\'s and four links', () => {
-      expect(component.find('li').length).to.equal(5);
-      expect(component.find('Link').length).to.equal(4);
+    it('should render four li\'s and three links', () => {
+      expect(component.find('li').length).to.equal(4);
+      expect(component.find('Link').length).to.equal(3);
     });
 
     it('should render all the navigation', () => {
       const li = component.find('li');
       expect(li.at(0).render().text()).to.equal(appTitle);
-      expect(li.at(1).render().text()).to.equal('Search Results');
-      expect(li.at(2).render().text()).to.equal('Item Details');
-      expect(li.at(3).render().text()).to.equal('Item Request');
-      expect(li.at(4).render().text()).to.equal('Request Confirmation');
+      expect(li.at(1).render().text()).to.equal('Item Details');
+      expect(li.at(2).render().text()).to.equal('Item Request');
+      expect(li.at(3).render().text()).to.equal('Request Confirmation');
     });
   });
 
@@ -77,18 +76,12 @@ describe('Breadcrumbs', () => {
         component = shallow(<Breadcrumbs type="bib" />);
       });
 
-      it('should contain two Link elements', () => {
-        expect(component.find('Link')).to.have.length(2);
-      });
-
-      xit('should link back to the regular search results page', () => {
-        const searchLink = component.find('Link').at(1);
-        expect(searchLink.children().text()).to.equal('Search Results');
-        expect(searchLink.prop('to')).to.equal(`${baseUrl}search?`);
+      it('should contain one Link elements', () => {
+        expect(component.find('Link')).to.have.length(1);
       });
 
       it('should display the current page with the item title', () => {
-        expect(component.find('li').at(2).text()).to.equal('Item Details');
+        expect(component.find('li').at(1).text()).to.equal('Item Details');
       });
     });
 
@@ -96,7 +89,7 @@ describe('Breadcrumbs', () => {
       let component;
 
       before(() => {
-        component = shallow(<Breadcrumbs type="bib" query="q=locofocos" />);
+        component = shallow(<Breadcrumbs type="bib" searchUrl="q=locofocos" />);
       });
 
       it('should contain two Link elements', () => {
@@ -118,32 +111,59 @@ describe('Breadcrumbs', () => {
   // The search keyword/no search keyword scenarios were tested above and won't be
   // tested again in the following tests.
 
-  // Shared Collection Catalog > Search Results > Item Details > Item Request
   describe('On the Hold Request page', () => {
     const bibId = 'b123456789';
     let component;
 
-    before(() => {
-      component = shallow(
-        <Breadcrumbs
-          query="q=hamlet"
+    // Shared Collection Catalog > Item Details > Item Request
+    describe('No search keyword', () => {
+      before(() => {
+        component = shallow(
+          <Breadcrumbs
           bibUrl={`/bib/${bibId}`}
           type="hold"
-        />,
-      );
+          />,
+        );
+      });
+
+      it('should contain two Link elements', () => {
+        expect(component.find('Link')).to.have.length(2);
+      });
+
+      it('should link back to the bib page as the second link', () => {
+        const searchLink = component.find('Link').at(1);
+        expect(searchLink.prop('to')).to.equal(`${baseUrl}bib/${bibId}`);
+      });
+
+      it('should display "Item Request" on the current page', () => {
+        expect(component.find('li').at(2).text()).to.equal('Item Request');
+      });
     });
 
-    it('should contain three Link elements', () => {
-      expect(component.find('Link')).to.have.length(3);
-    });
+    // Shared Collection Catalog > Search Results > Item Details > Item Request
+    describe('With a search keyword', () => {
+      before(() => {
+        component = shallow(
+          <Breadcrumbs
+            bibUrl={`/bib/${bibId}`}
+            searchUrl="q=locofocos"
+            type="hold"
+          />,
+        );
+      });
 
-    it('should link back to the bib page as the third link', () => {
-      const searchLink = component.find('Link').at(2);
-      expect(searchLink.prop('to')).to.equal(`${baseUrl}bib/${bibId}`);
-    });
+      it('should contain three Link elements', () => {
+        expect(component.find('Link')).to.have.length(3);
+      });
 
-    it('should display "Item Request" on the current page', () => {
-      expect(component.find('li').at(3).text()).to.equal('Item Request');
+      it('should link back to the bib page as the third link', () => {
+        const searchLink = component.find('Link').at(2);
+        expect(searchLink.prop('to')).to.equal(`${baseUrl}bib/${bibId}`);
+      });
+
+      it('should display "Item Request" on the current page', () => {
+        expect(component.find('li').at(3).text()).to.equal('Item Request');
+      });
     });
   });
 
@@ -160,6 +180,7 @@ describe('Breadcrumbs', () => {
           type="edd"
           bibUrl={`/bib/${bibId}`}
           itemUrl={`/hold/request/${bibId}-${itemId}`}
+          searchUrl="q=locofocos"
         />,
       );
     });
@@ -195,6 +216,7 @@ describe('Breadcrumbs', () => {
             bibUrl={`/bib/${bibId}`}
             itemUrl={`/hold/request/${bibId}-${itemId}`}
             edd={fromEdd}
+            searchUrl="q=locofocos"
           />,
         );
       });
@@ -226,6 +248,7 @@ describe('Breadcrumbs', () => {
             bibUrl={`/bib/${bibId}`}
             itemUrl={`/hold/request/${bibId}-${itemId}`}
             edd={fromEdd}
+            searchUrl="q=locofocos"
           />,
         );
       });

--- a/test/unit/DataLoader.test.js
+++ b/test/unit/DataLoader.test.js
@@ -3,7 +3,7 @@ import React from 'react';
 import sinon from 'sinon';
 import axios from 'axios';
 import { expect } from 'chai';
-import Enzyme, { shallow, mount } from 'enzyme';
+import Enzyme, { mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 
 import DataLoader from './../../src/app/components/DataLoader/DataLoader';
@@ -19,9 +19,6 @@ describe('DataLoader', () => {
     let bibAction;
     let axiosStub;
     const axiosCalls = [];
-    const location = {
-      pathname: '/research/collections/shared-collection-catalog/nonMatchingPath',
-    };
 
     before(() => {
       loadingAction = sinon.spy(Actions, 'updateLoadingStatus');


### PR DESCRIPTION
**What's this do?**
This cleans up the source of the url for the "Search Results" breadcrumb and does not render that breadcrumb if there are no search params in the main component's props.

**Why are we doing this? (w/ JIRA link if applicable)**
These changes are related to a few of the navigation bugs we have had, particularly, linking back to the search results page when there are no search params in the Store.

**How should this be tested? / Do these changes have associated tests?**
Feel free to point out cases and areas of the code to test. I would like to add more test coverage soon.

Try going through the flow of "Search Results" page to "Bib" page to "HoldRequest" page, EDD, and confirmation. Click on the "Search Results" breadcrumb. Also, reload the page, if the "Search Results" breadcrumb does appear, click on it. We do not want to see the wildcard results or "No results..."

**Did someone actually run this code to verify it works?**
PR author did.