### PR TITLE
Add back in link with "searchKeywords" for no-JS

### DIFF
--- a/src/app/components/ResultsList/ResultsList.jsx
+++ b/src/app/components/ResultsList/ResultsList.jsx
@@ -109,11 +109,19 @@ class ResultsList extends React.Component {
 
     let bibUrl = `${appConfig.baseUrl}/bib/${bibId}`;
 
+    const handleClick = (e) => {
+      e.preventDefault();
+      trackDiscovery('Bib', bibTitle);
+      this.context.router.push(`${appConfig.baseUrl}/bib/${bibId}`)
+    };
+
+    if (this.props.searchKeywords) bibUrl += `?searchKeywords=${this.props.searchKeywords}`;
+
     return (
       <li key={i} className={`nypl-results-item ${hasRequestTable ? 'has-request' : ''}`}>
         <h3>
           <Link
-            onClick={() => trackDiscovery('Bib', bibTitle)}
+            onClick={handleClick}
             to={bibUrl}
             className="title"
           >


### PR DESCRIPTION
**What's this do?**
It is totally optional to merge this PR.

This adds back in functionality modified in [PR-1144](https://github.com/NYPL-discovery/discovery-front-end/pull/1144), which caused a bug rendering a bad "Search Results" breadcrumb. Basically, with JS, the bib page loads without the "searchKeywords" param in the URL. Without JS, the "searchKeywords" param is in the URL and allows for there to be a "Search Results" breadcrumb that takes the user back to the search results for that query. This is how links to Hold Request, EDD Request, and the Confirmation page work as well. Changes in PR #1291 keeps the "Search Results" breadcrumb from rendering if the "searchKeywords" param is empty, because it seems like we do not want to link back to the wild card search.

**Did someone actually run this code to verify it works?**
PR author did.