### PR TITLE
Remove nested repetition in mobile

### DIFF
--- a/src/app/components/Application/Application.jsx
+++ b/src/app/components/Application/Application.jsx
@@ -17,7 +17,7 @@ import {
 import Actions from '../../actions/Actions';
 import appConfig from '../../data/appConfig';
 import DataLoader from '../DataLoader/DataLoader';
-import style from '../../../client/styles/main.scss';
+// import style from '../../../client/styles/main.scss';
 
 class App extends React.Component {
   constructor(props) {
@@ -70,13 +70,14 @@ class App extends React.Component {
         });
       }
     });
-
+    const style = {
+      mobileBreakPoint: '965px',
+    };
     const mediaMatcher = window.matchMedia(`(max-width: ${style.mobileBreakPoint})`);
     this.checkMedia(mediaMatcher);
     mediaMatcher.addListener(this.checkMedia);
     console.log('mobileBreakPoint: ', `(max-width: ${style.mobileBreakPoint})`);
   }
-
 
   shouldStoreUpdate() {
     return `?${basicQuery({})(Store.getState())}` !== this.context.router.location.search;

--- a/src/app/components/Application/Application.jsx
+++ b/src/app/components/Application/Application.jsx
@@ -17,6 +17,7 @@ import {
 import Actions from '../../actions/Actions';
 import appConfig from '../../data/appConfig';
 import DataLoader from '../DataLoader/DataLoader';
+import style from '../../../client/styles/main.scss';
 
 class App extends React.Component {
   constructor(props) {
@@ -70,9 +71,10 @@ class App extends React.Component {
       }
     });
 
-    const mediaMatcher = window.matchMedia('(max-width: 700px)');
+    const mediaMatcher = window.matchMedia(`(max-width: ${style.mobileBreakPoint})`);
     this.checkMedia(mediaMatcher);
     mediaMatcher.addListener(this.checkMedia);
+    console.log('mobileBreakPoint: ', `(max-width: ${style.mobileBreakPoint})`);
   }
 
 
@@ -88,8 +90,8 @@ class App extends React.Component {
     this.setState({ data: Store.getState() });
   }
 
-  checkMedia(x) {
-    if (x.matches) {
+  checkMedia(media) {
+    if (media.matches) {
       this.setState({ media: 'mobile' });
     } else {
       this.setState({ media: 'desktop' });

--- a/src/app/components/Application/Application.jsx
+++ b/src/app/components/Application/Application.jsx
@@ -24,9 +24,15 @@ class App extends React.Component {
     this.state = {
       data: Store.getState(),
       patron: PatronStore.getState(),
+      media: 'desktop',
     };
     this.onChange = this.onChange.bind(this);
     this.shouldStoreUpdate = this.shouldStoreUpdate.bind(this);
+    this.checkMedia = this.checkMedia.bind(this);
+  }
+
+  getChildContext() {
+    return { media: this.state.media };
   }
 
   componentDidMount() {
@@ -63,7 +69,12 @@ class App extends React.Component {
         });
       }
     });
+
+    const mediaMatcher = window.matchMedia('(max-width: 700px)');
+    this.checkMedia(mediaMatcher);
+    mediaMatcher.addListener(this.checkMedia);
   }
+
 
   shouldStoreUpdate() {
     return `?${basicQuery({})(Store.getState())}` !== this.context.router.location.search;
@@ -75,6 +86,14 @@ class App extends React.Component {
 
   onChange() {
     this.setState({ data: Store.getState() });
+  }
+
+  checkMedia(x) {
+    if (x.matches) {
+      this.setState({ media: 'mobile' });
+    } else {
+      this.setState({ media: 'desktop' });
+    }
   }
 
   render() {
@@ -121,6 +140,10 @@ App.defaultProps = {
 
 App.contextTypes = {
   router: PropTypes.object,
+};
+
+App.childContextTypes = {
+  media: PropTypes.string,
 };
 
 

--- a/src/app/components/SubjectHeading/NestedTableHeader.jsx
+++ b/src/app/components/SubjectHeading/NestedTableHeader.jsx
@@ -12,10 +12,11 @@ const NestedTableHeader = (props) => {
     parentUuid,
     updateSort,
     numberOpen,
-    interactive
+    interactive,
+    marginSize,
   } = props;
 
-  const positionStyle = { marginLeft: 30 * ((indentation || 0) + 1) };
+  const positionStyle = { marginLeft: marginSize * ((indentation || 0) + 1) };
   const calculateDirectionForType = calculateDirection(sortBy, direction);
 
   const sortButtons = {};

--- a/src/app/components/SubjectHeading/SubjectHeading.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeading.jsx
@@ -257,9 +257,10 @@ class SubjectHeading extends React.Component {
       return <button {...props}>{symbol}</button>;
     };
 
-    if (media === 'mobile') indentation = 0;
+    // if (media === 'mobile') indentation = 0;
+    const marginSize = media === 'mobile' ? 10 : 30;
 
-    const positionStyle = container === 'related' ? null : { marginLeft: 30 * ((indentation || 0) + 1) };
+    const positionStyle = container === 'related' ? null : { marginLeft: marginSize * ((indentation || 0) + 1) };
     const isMain = (pathname + search).includes(uuid);
 
     // changes to HTML structure here will need to be replicated in ./SubjectHeadingTableHeader
@@ -281,7 +282,7 @@ class SubjectHeading extends React.Component {
                   className={`emph ${isMain ? 'mainHeading' : ''}`}
                 >
                   {
-                    rest === '' || container === 'context' ?
+                    rest === '' || container === 'context' || media === 'mobile' ?
                     null :
                     <span className="noEmph">
                       {`${rest}\u0020--\u00a0`}
@@ -318,6 +319,7 @@ class SubjectHeading extends React.Component {
             seeMoreText={seeMoreText}
             seeMoreLinkUrl={seeMoreLinkUrl}
             preOpen={false}
+            marginSize={marginSize}
           />
           : null}
       </React.Fragment>

--- a/src/app/components/SubjectHeading/SubjectHeading.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeading.jsx
@@ -194,7 +194,6 @@ class SubjectHeading extends React.Component {
 
   render() {
     const {
-      indentation,
       subjectHeading,
       location,
       location: {
@@ -208,7 +207,13 @@ class SubjectHeading extends React.Component {
       seeMoreLinkUrl,
     } = this.props;
 
-    const { container } = this.context;
+    let {
+      indentation,
+    } = this.props;
+
+    const { container, media } = this.context;
+
+    console.log(media);
 
     const {
       label,
@@ -251,6 +256,8 @@ class SubjectHeading extends React.Component {
 
       return <button {...props}>{symbol}</button>;
     };
+
+    if (media === 'mobile') indentation = 0;
 
     const positionStyle = container === 'related' ? null : { marginLeft: 30 * ((indentation || 0) + 1) };
     const isMain = (pathname + search).includes(uuid);
@@ -338,6 +345,7 @@ SubjectHeading.defaultProps = {
 SubjectHeading.contextTypes = {
   router: PropTypes.object,
   container: PropTypes.string,
+  media: PropTypes.string,
 };
 
 export default SubjectHeading;

--- a/src/app/components/SubjectHeading/SubjectHeadingsTableBody.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeadingsTableBody.jsx
@@ -132,6 +132,7 @@ class SubjectHeadingsTableBody extends React.Component {
       sortBy,
       direction,
       updateSort,
+      marginSize,
     } = this.props;
 
     const {
@@ -154,6 +155,7 @@ class SubjectHeadingsTableBody extends React.Component {
             updateSort={updateSort}
             interactive={subjectHeadings.length > 1}
             numberOpen={numberOpen}
+            marginSize={marginSize}
           />
           : null
         }

--- a/src/client/styles/components/ShepContainer.scss
+++ b/src/client/styles/components/ShepContainer.scss
@@ -41,5 +41,15 @@
     @include media(1025px) {
       margin-left: 25px;
     }
+    @include media($mobile-breakpoint) {
+      margin-left: 0px;
+    }
+  }
+
+  .nypl-row.container-row {
+    @include media($mobile-breakpoint) {
+      padding-right: 0px;
+      padding-left: 10px;
+    }
   }
 }

--- a/src/client/styles/components/SubjectHeadings/SubjectHeading.scss
+++ b/src/client/styles/components/SubjectHeadings/SubjectHeading.scss
@@ -36,6 +36,12 @@
         cursor: pointer;
       }
     }
+
+  }
+  .subjectHeadingAttribute {
+    @include media($mobile-breakpoint) {
+      vertical-align: top;
+    }
   }
 }
 

--- a/src/client/styles/main.scss
+++ b/src/client/styles/main.scss
@@ -192,3 +192,7 @@ div {
     outline-offset: 0;
   }
 }
+
+:export {
+  mobileBreakPoint: $mobile-breakpoint;
+}

--- a/src/views/index.ejs
+++ b/src/views/index.ejs
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="x-ua-compatible" content="ie=edge">
-
+    <meta name="viewport" content="width=350">
     <title><%- appTitle %></title>
 
     <link rel="icon" type="image/png" href="<%- favicon %>">


### PR DESCRIPTION
**What's this do?**
This is supposed to reduce the indentation and duplication in the nested view so it can fit in mobile. What I am currently trying is setting an event listener in the Application component which checks if the screen width is small. If it is, the downstream components receive 'mobile' as the `media` prop and 1. Reduce the indentation size and 2. Remove the repeated parts of the subject headings.
For some reason it seems to work if you switch to the mobile view, but not if you start out in the mobile view. Also, for some reason the 'Explore more from here' button stopped working properly. 

**Why are we doing this? (w/ JIRA link if applicable)**
This is for SCC-2007, for accessibility reasons 

**How should this be tested? / Do these changes have associated tests?**
Family -- Marriage is a good example for testing, it nests to about 10 levels

**Dependencies for merging? Releasing to production?**
[Description of any watchouts, dependencies, or issues we should be aware of goes here]

**Has the application documentation been updated for these changes?**

**Did someone actually run this code to verify it works?**
It doesn't work :-(
