### PR TITLE
Move enzyme adapter to test helper and lint files

### DIFF
--- a/test/helpers/browser.js
+++ b/test/helpers/browser.js
@@ -1,8 +1,13 @@
+const enzyme = require('enzyme');
+const Adapter = require('enzyme-adapter-react-16');
+
+enzyme.configure({ adapter: new Adapter() });
+
 require('@babel/register')();
 
-var jsdom = require('jsdom').jsdom;
+const jsdom = require('jsdom').jsdom;
 
-var exposedProperties = ['window', 'navigator', 'document'];
+const exposedProperties = ['window', 'navigator', 'document'];
 
 global.document = jsdom('');
 global.window = document.defaultView;
@@ -14,7 +19,7 @@ Object.keys(document.defaultView).forEach((property) => {
 });
 
 global.navigator = {
-  userAgent: 'node.js'
+  userAgent: 'node.js',
 };
 
 documentRef = document;

--- a/test/unit/AdditionalDetailsViewer.test.js
+++ b/test/unit/AdditionalDetailsViewer.test.js
@@ -1,9 +1,8 @@
 import React from 'react';
 import { expect } from 'chai';
-import Enzyme, { shallow, mount } from 'enzyme';
+import Enzyme, { mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 
-Enzyme.configure({ adapter: new Adapter() });
 // Import the component that is going to be tested
 import AdditionalDetailsViewer from './../../src/app/components/BibPage/AdditionalDetailsViewer';
 

--- a/test/unit/BibDetails.test.js
+++ b/test/unit/BibDetails.test.js
@@ -1,14 +1,12 @@
 /* eslint-env mocha */
 import React from 'react';
 import { expect } from 'chai';
-import Enzyme, { shallow, mount } from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import { shallow, mount } from 'enzyme';
 
 // Import the component that is going to be tested
 import BibDetails from './../../src/app/components/BibPage/BibDetails';
 import DefinitionList from './../../src/app/components/BibPage/DefinitionList';
 
-Enzyme.configure({ adapter: new Adapter() });
 const bibs = [
   {
     '@type': ['nypl:Item', 'nypl:Resource'],

--- a/test/unit/Breadcrumbs.test.js
+++ b/test/unit/Breadcrumbs.test.js
@@ -1,14 +1,10 @@
 /* eslint-env mocha */
 import React from 'react';
 import { expect } from 'chai';
-import Enzyme, { shallow } from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
-
+import { shallow } from 'enzyme';
 
 import Breadcrumbs from './../../src/app/components/Breadcrumbs/Breadcrumbs';
 import appConfig from '../../src/app/data/appConfig';
-
-Enzyme.configure({ adapter: new Adapter() });
 
 const appTitle = appConfig.displayTitle;
 const baseUrl = `${appConfig.baseUrl}/`;

--- a/test/unit/DataLoader.test.js
+++ b/test/unit/DataLoader.test.js
@@ -3,14 +3,11 @@ import React from 'react';
 import sinon from 'sinon';
 import axios from 'axios';
 import { expect } from 'chai';
-import Enzyme, { mount } from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import { mount } from 'enzyme';
 
 import DataLoader from './../../src/app/components/DataLoader/DataLoader';
 import Actions from './../../src/app/actions/Actions';
 import appConfig from '@appConfig';
-
-Enzyme.configure({ adapter: new Adapter() });
 
 describe('DataLoader', () => {
   describe('Non-matching path', () => {

--- a/test/unit/FieldsetDate.test.js
+++ b/test/unit/FieldsetDate.test.js
@@ -1,12 +1,10 @@
 /* eslint-env mocha */
 import React from 'react';
 import { expect } from 'chai';
-import Enzyme, { mount } from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import { mount } from 'enzyme';
 
 import FieldsetDate from '../../src/app/components/Filters/FieldsetDate';
 
-Enzyme.configure({ adapter: new Adapter() });
 describe('FieldsetDate', () => {
   describe('Default', () => {
     let component;

--- a/test/unit/FieldsetList.test.js
+++ b/test/unit/FieldsetList.test.js
@@ -1,13 +1,10 @@
 /* eslint-env mocha */
 import React from 'react';
 import { expect } from 'chai';
-import Enzyme, { mount } from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
-
+import { mount } from 'enzyme';
 
 import FieldsetList from '../../src/app/components/Filters/FieldsetList';
 
-Enzyme.configure({ adapter: new Adapter() });
 const listItemAt = (component, n) => component.find('li').at(n);
 
 describe('FilterPopup', () => {

--- a/test/unit/FilterPopup.test.js
+++ b/test/unit/FilterPopup.test.js
@@ -1,20 +1,19 @@
 /* eslint-env mocha */
 import React from 'react';
 import { expect } from 'chai';
-import Enzyme, { shallow, mount } from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
-
+import { shallow, mount } from 'enzyme';
 
 import FilterPopup from '../../src/app/components/FilterPopup/FilterPopup';
 
-Enzyme.configure({ adapter: new Adapter() });
 describe('FilterPopup', () => {
   describe('Default - no javascript', () => {
     // Since this is a shallow render, the component itself is not mounted. The `js` flag
     // becomes true when the component is mounted on the client-side so we know that
     // javascript is enabled.
     it('should not render an open button but an <a> instead', () => {
-      const component = shallow(<FilterPopup totalResults={1} />, { disableLifecycleMethods: true });
+      const component = shallow(
+        <FilterPopup totalResults={1} />, { disableLifecycleMethods: true }
+      );
 
       expect(component.state('js')).to.equal(false);
       // These tests will need to be updated when the DOM structure gets updated.

--- a/test/unit/HoldConfirmation.test.js
+++ b/test/unit/HoldConfirmation.test.js
@@ -2,15 +2,13 @@
 import React from 'react';
 import sinon from 'sinon';
 import { expect } from 'chai';
-import Enzyme, { mount } from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import { mount } from 'enzyme';
 
 // Import the component that is going to be tested
 import HoldConfirmation from './../../src/app/components/HoldConfirmation/HoldConfirmation';
 import Actions from './../../src/app/actions/Actions';
 import appConfig from '../../src/app/data/appConfig';
 
-Enzyme.configure({ adapter: new Adapter() });
 describe('HoldConfirmation', () => {
   describe('After being rendered, <HoldConfirmation>', () => {
     let component;
@@ -99,10 +97,9 @@ describe('HoldConfirmation', () => {
       it('should render the error message.', () => {
         const main = component.find('main');
         const expectedHTML = new RegExp(
-          '<p>(.*)We could not process your request at this time\.' +
+          '<p>(.*)We could not process your request at this time.' +
           '(.*)Please try again or contact 917-ASK-NYPL(.*)' +
-          '((.*)<a href="tel:19172756975">917-275-6975<\/a>(.*))\.(.*)<\/p>'
-        );
+          '((.*)<a href="tel:19172756975">917-275-6975</a>(.*)).(.*)</p>');
         expect(
           expectedHTML
             .test(main.html()))
@@ -186,8 +183,8 @@ describe('HoldConfirmation', () => {
       expect(pageHeader.find('h1')).to.have.length(1);
       expect(pageHeader.find('h1').text()).to.equal('Request Confirmation');
       expect(
-        pageHeader.contains(<h1 id="mainContent" tabIndex="0">Request Confirmation</h1>)
-      ).to.equal(true);
+        pageHeader.contains(
+          <h1 id="mainContent" tabIndex="0">Request Confirmation</h1>)).to.equal(true);
     });
 
     it('should display the layout of request confirmation page\'s contents.', () => {
@@ -631,18 +628,20 @@ describe('HoldConfirmation', () => {
   describe('If there are eligibility errors', () => {
     it('should render an error message with specific errors when available', () => {
       const location = { query: { errorStatus: 'eligibility', errorMessage: '{"expired":true,"blocked":true,"moneyOwed":true}' } };
-      const component = mount(<HoldConfirmation location={location} />, { attachTo: document.body });
+      const component = mount(
+        <HoldConfirmation location={location} />, { attachTo: document.body });
       const text = component.text();
-      component.unmount()
+      component.unmount();
       expect(text.includes('Your account has expired')).to.equal(true);
       expect(text.includes('There is a problem with your library account')).to.equal(true);
       expect(text.includes('Your fines have exceeded the limit')).to.equal(true);
     });
     it('should render a default error message when no specific errors are available', () => {
       const location = { query: { errorStatus: 'eligibility', errorMessage: '{}' } };
-      const component = mount(<HoldConfirmation location={location} />, { attachTo: document.body });
+      const component = mount(
+        <HoldConfirmation location={location} />, { attachTo: document.body });
       const text = component.text();
-      component.unmount()
+      component.unmount();
       expect(text.includes('There is a problem with your library account.')).to.equal(true);
     });
   });

--- a/test/unit/HoldRequest.test.js
+++ b/test/unit/HoldRequest.test.js
@@ -2,15 +2,12 @@
 import React from 'react';
 import sinon from 'sinon';
 import { expect } from 'chai';
-import Enzyme, { mount } from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
-
+import { mount } from 'enzyme';
 import axios from 'axios';
 // Import the component that is going to be tested
 import HoldRequest from './../../src/app/components/HoldRequest/HoldRequest';
 import Actions from './../../src/app/actions/Actions';
 
-Enzyme.configure({ adapter: new Adapter() });
 const mockedItems = [
   {
     "@id": "res:i10000003",
@@ -78,47 +75,37 @@ describe('HoldRequest', () => {
     beforeEach(() => {
       component = mount(<HoldRequest />, { attachTo: document.body });
       instance = component.instance();
-      redirect = sinon.stub(instance, 'redirectWithErrors').callsFake(() => {
-        return true;
-      });
-    })
+      redirect = sinon.stub(instance, 'redirectWithErrors').callsFake(() => true);
+    });
     afterEach(() => {
       axios.get.restore();
       component.unmount();
     });
     it('should redirect for ineligible patrons', () => {
-      router = sinon.stub(axios, 'get').callsFake(() => {
-        return new Promise((resolve, reject) => {
-          resolve({ data: { eligibility: false } });
-        });
-      });
-      return new Promise((resolve, reject) => {
+      router = sinon.stub(axios, 'get').callsFake(() => new Promise((resolve) => {
+        resolve({ data: { eligibility: false } });
+      }));
+      return new Promise((resolve) => {
         instance.setState({ patron: { id: 1 } });
         resolve();
       })
-        .then(() => {
-          return instance.conditionallyRedirect()
-            .then(() => {
-              expect(redirect.called).to.equal(true);
-            })
-        });
+        .then(() => instance.conditionallyRedirect()
+          .then(() => {
+            expect(redirect.called).to.equal(true);
+          }));
     });
     it('should not redirect for eligible patrons', () => {
-      router = sinon.stub(axios, 'get').callsFake(() => {
-        return new Promise((resolve, reject) => {
-          resolve({ data: { eligibility: true } });
-        });
-      });
-      return new Promise((resolve, reject) => {
+      router = sinon.stub(axios, 'get').callsFake(() => new Promise((resolve) => {
+        resolve({ data: { eligibility: true } });
+      }));
+      return new Promise((resolve) => {
         instance.setState({ patron: { id: 2 } });
         resolve();
       })
-        .then(() => {
-          return instance.conditionallyRedirect()
-            .then(() => {
-              expect(redirect.called).to.equal(false);
-            })
-        })
+        .then(() => instance.conditionallyRedirect()
+          .then(() => {
+            expect(redirect.called).to.equal(false);
+          }));
     });
   });
 
@@ -193,8 +180,7 @@ describe('HoldRequest', () => {
           <h2>
             This item cannot be requested at this time. Please try again later or
             contact 917-ASK-NYPL (<a href="tel:917-275-6975">917-275-6975</a>).
-          </h2>)
-        ).to.equal(true);
+          </h2>)).to.equal(true);
       });
     },
   );
@@ -231,8 +217,7 @@ describe('HoldRequest', () => {
         <h2 className="nypl-request-form-title">
           Delivery options for this item are currently unavailable. Please try again later or
           contact 917-ASK-NYPL (<a href="tel:917-275-6975">917-275-6975</a>).
-        </h2>
-      )).to.equal(true);
+        </h2>)).to.equal(true);
     });
   });
 
@@ -287,8 +272,9 @@ describe('HoldRequest', () => {
 
       expect(form.find('h2')).to.have.length(1);
       expect(form.contains(
-        <h2 className="nypl-request-form-title">Choose a delivery option or location</h2>
-      )).to.equal(true);
+        <h2 className="nypl-request-form-title">
+          Choose a delivery option or location
+        </h2>)).to.equal(true);
     });
 
     it('should display the form of the display locations.', () => {

--- a/test/unit/Home.test.js
+++ b/test/unit/Home.test.js
@@ -1,12 +1,10 @@
 /* eslint-env mocha */
 import React from 'react';
 import { expect } from 'chai';
-import Enzyme, { mount } from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import { mount } from 'enzyme';
 
 import Home from '../../src/app/components/Home/Home';
 
-Enzyme.configure({ adapter: new Adapter() });
 describe('Home', () => {
   let component;
 
@@ -58,6 +56,6 @@ describe('Home', () => {
   });
 
   xit('should have an isLoading state of true when updateIsLoadingState is called', () => {
-    
+
   });
 });

--- a/test/unit/ItemHoldings.test.js
+++ b/test/unit/ItemHoldings.test.js
@@ -1,12 +1,10 @@
 /* eslint-env mocha */
 import React from 'react';
 import { expect } from 'chai';
-import Enzyme, { shallow, mount } from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import { shallow, mount } from 'enzyme';
 
 import ItemHoldings from './../../src/app/components/Item/ItemHoldings';
 
-Enzyme.configure({ adapter: new Adapter() });
 const items = [
   {
     accessMessage: {
@@ -222,7 +220,8 @@ describe('ItemHoldings', () => {
     // NOTE: This is the initial rendering so we are only doing shallow. The chunking process
     // gets done in componentDidMount which is called when the component actually mounts.
     it('should have an empty chunkedItems state', () => {
-      const component = shallow(<ItemHoldings items={longListItems} />, { disableLifecycleMethods: true });
+      const component = shallow(
+        <ItemHoldings items={longListItems} />, { disableLifecycleMethods: true });
       expect(component.state('chunkedItems')).to.eql([]);
     });
 

--- a/test/unit/ItemTable.test.js
+++ b/test/unit/ItemTable.test.js
@@ -1,13 +1,11 @@
 /* eslint-env mocha */
 import React from 'react';
 import { expect } from 'chai';
-import Enzyme, { shallow } from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import { shallow } from 'enzyme';
 
 // Import the component that is going to be tested
 import ItemTable from './../../src/app/components/Item/ItemTable';
 
-Enzyme.configure({ adapter: new Adapter() });
 describe('ItemTable', () => {
   describe('No rendered table', () => {
     it('should return null with no props passed', () => {

--- a/test/unit/ItemTableRow.test.js
+++ b/test/unit/ItemTableRow.test.js
@@ -1,13 +1,11 @@
 /* eslint-env mocha */
 import React from 'react';
 import { expect } from 'chai';
-import Enzyme, { shallow } from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import { shallow } from 'enzyme';
 
 // Import the component that is going to be tested
 import ItemTableRow from './../../src/app/components/Item/ItemTableRow';
 
-Enzyme.configure({ adapter: new Adapter() });
 const item = {
   full: {
     accessMessage: {

--- a/test/unit/NotFound404.test.js
+++ b/test/unit/NotFound404.test.js
@@ -1,14 +1,12 @@
 /* eslint-env mocha */
 import React from 'react';
 import { expect } from 'chai';
-import Enzyme, { shallow } from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import { shallow } from 'enzyme';
 
 import config from '../../src/app/data/appConfig';
 
 import NotFound404 from '../../src/app/components/NotFound404/NotFound404';
 
-Enzyme.configure({ adapter: new Adapter() });
 describe('NotFound404', () => {
   let component;
 

--- a/test/unit/Pagination.test.js
+++ b/test/unit/Pagination.test.js
@@ -1,15 +1,13 @@
 /* eslint-env mocha */
 import React from 'react';
 import { expect } from 'chai';
-import Enzyme, { shallow, mount } from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import { shallow, mount } from 'enzyme';
 
 import Pagination from '../../src/app/components/Pagination/Pagination';
 
 // The Pagination component displays the items currently being displayed. If there are more
 // than 50 items then the "next" link gets rendered. If the page prop is greater than 1,
 // the "previous" link gets rendered.
-Enzyme.configure({ adapter: new Adapter() });
 describe('Pagination', () => {
   describe('Default component', () => {
     let component;

--- a/test/unit/ResultsCount.test.js
+++ b/test/unit/ResultsCount.test.js
@@ -1,14 +1,12 @@
 /* eslint-env mocha */
 import React from 'react';
 import { expect } from 'chai';
-import Enzyme, { shallow, mount } from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import { shallow, mount } from 'enzyme';
 
 import sinon from 'sinon';
 
 import ResultsCount from '../../src/app/components/ResultsCount/ResultsCount';
 
-Enzyme.configure({ adapter: new Adapter() });
 const filters = {
   subjectLiteral: {
     owner: [{}],
@@ -103,7 +101,6 @@ describe('ResultsCount', () => {
   });
 
   describe('Loading display', () => {
-    const isLoading = true;
     let component;
 
     before(() => {

--- a/test/unit/ResultsList.test.js
+++ b/test/unit/ResultsList.test.js
@@ -1,16 +1,13 @@
 /* eslint-env mocha */
 import React from 'react';
 import { expect } from 'chai';
-import Enzyme, { shallow, mount } from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import { shallow, mount } from 'enzyme';
 
 import MockAdapter from 'axios-mock-adapter';
 import axios from 'axios';
-import sinon from 'sinon';
 
 import ResultsList from '../../src/app/components/ResultsList/ResultsList';
 
-Enzyme.configure({ adapter: new Adapter() });
 const results = [{}, {}, {}];
 const singleBibNoTitleDisplay = {
   result: {

--- a/test/unit/Search.test.js
+++ b/test/unit/Search.test.js
@@ -3,8 +3,7 @@ import axios from 'axios';
 import React from 'react';
 import MockAdapter from 'axios-mock-adapter';
 import { expect } from 'chai';
-import Enzyme, { mount } from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import { mount } from 'enzyme';
 
 import sinon from 'sinon';
 import Search from '../../src/app/components/Search/Search';
@@ -12,7 +11,6 @@ import { basicQuery } from '../../src/app/utils/utils';
 import appConfig from '../../src/app/data/appConfig';
 import store from '../../src/app/stores/Store';
 
-Enzyme.configure({ adapter: new Adapter() });
 describe('Search', () => {
   describe('Default render', () => {
     let component;

--- a/test/unit/SearchButton.test.js
+++ b/test/unit/SearchButton.test.js
@@ -1,12 +1,10 @@
 /* eslint-env mocha */
 import React from 'react';
 import { expect } from 'chai';
-import Enzyme, { shallow } from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import { shallow } from 'enzyme';
 
 import SearchButton from './../../src/app/components/Buttons/SearchButton';
 
-Enzyme.configure({ adapter: new Adapter() });
 describe('SearchButton', () => {
   describe('Default props', () => {
     let component;

--- a/test/unit/SearchResultsPage.test.js
+++ b/test/unit/SearchResultsPage.test.js
@@ -1,14 +1,11 @@
 /* eslint-env mocha */
 import React from 'react';
 import { expect } from 'chai';
-import Enzyme, { mount } from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import { mount } from 'enzyme';
 
 import SearchResults from '../../src/app/pages/SearchResults';
 
-
 // Eventually, it would be nice to have mocked data in a different file and imported.
-Enzyme.configure({ adapter: new Adapter() });
 const searchResults = {
   '@context': 'http://api.data.nypl.org/api/v1/context_all.jsonld',
   '@type': 'itemList',

--- a/test/unit/SearchResultsSorter.test.js
+++ b/test/unit/SearchResultsSorter.test.js
@@ -2,8 +2,7 @@
 import React from 'react';
 import MockAdapter from 'axios-mock-adapter';
 import { expect } from 'chai';
-import Enzyme, { shallow, mount } from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import { shallow, mount } from 'enzyme';
 
 import axios from 'axios';
 import sinon from 'sinon';
@@ -12,7 +11,6 @@ import { basicQuery } from '../../src/app/utils/utils';
 import SearchResultsSorter from '@SearchResultsSorter';
 import appConfig from '../../src/app/data/appConfig';
 
-Enzyme.configure({ adapter: new Adapter() });
 describe('SearchResultsSorter', () => {
   describe('Default - no javascript', () => {
     // Since this is a shallow render, the component itself is not mounted. The `js` flag
@@ -96,7 +94,8 @@ describe('SearchResultsSorter', () => {
       const searchKeywords = 'harry potter';
       const sortBy = 'title_asc';
       const field = 'title';
-      component = mount(<SearchResultsSorter sortBy={sortBy} searchKeywords={searchKeywords} field={field} />);
+      component = mount(
+        <SearchResultsSorter sortBy={sortBy} searchKeywords={searchKeywords} field={field} />);
     });
 
     it('should have updated state based on sortBy prop', () => {

--- a/test/unit/SelectedFilters.test.js
+++ b/test/unit/SelectedFilters.test.js
@@ -1,15 +1,12 @@
 /* eslint-env mocha */
 import React from 'react';
 import { expect } from 'chai';
-import Enzyme, { shallow, mount } from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
-
+import { shallow, mount } from 'enzyme';
 
 import SelectedFilters from '../../src/app/components/Filters/SelectedFilters';
 
 const listItemAt = (component, n) => component.find('li').at(n);
 
-Enzyme.configure({ adapter: new Adapter() });
 describe('SelectedFilters', () => {
   describe('Default', () => {
     it('should not render a div', () => {
@@ -34,7 +31,8 @@ describe('SelectedFilters', () => {
     let component;
 
     before(() => {
-      component = shallow(<SelectedFilters selectedFilters={selectedFilters} />, { disableLifecycleMethods: true });
+      component = shallow(
+        <SelectedFilters selectedFilters={selectedFilters} />, { disableLifecycleMethods: true });
     });
 
     it('should render a ul', () => {

--- a/test/unit/SubjectHeadingShow.test.js
+++ b/test/unit/SubjectHeadingShow.test.js
@@ -1,12 +1,9 @@
 /* eslint-env mocha */
 import React from 'react';
 import { expect } from 'chai';
-import Enzyme, { shallow } from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import { shallow } from 'enzyme';
 
 import SubjectHeadingShow from '@SubjectHeadingShow';
-
-Enzyme.configure({ adapter: new Adapter() });
 
 describe('SubjectHeadingShow', () => {
   describe('finding uuid', () => {

--- a/test/unit/Tabbed.test.js
+++ b/test/unit/Tabbed.test.js
@@ -1,15 +1,12 @@
 /* eslint-env mocha */
 import React from 'react';
 import { expect } from 'chai';
-import Enzyme, { shallow, mount } from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import { mount } from 'enzyme';
 
 import BibDetails from './../../src/app/components/BibPage/BibDetails';
 import AdditionalDetailsViewer from './../../src/app/components/BibPage/AdditionalDetailsViewer';
 import Tabbed from './../../src/app/components/BibPage/Tabbed';
-import sinon from 'sinon';
 
-Enzyme.configure({ adapter: new Adapter() });
 describe('Tabbed', () => {
   const sampleBib =
   {
@@ -107,8 +104,6 @@ describe('Tabbed', () => {
   }
 };
 
-  const ReactDOM = require('react-dom');
-
   const bottomFields = [
     { label: 'Publication', value: 'publicationStatement' },
     { label: 'Publication Date', value: 'serialPublicationDates' },
@@ -139,11 +134,13 @@ describe('Tabbed', () => {
   />);
 
 
-  const additionalDetails = (<AdditionalDetailsViewer bib={sampleBib}/>);
+  const additionalDetails = (<AdditionalDetailsViewer bib={sampleBib} />);
 
-  let component = mount(<Tabbed tabs={[{title: 'Details', content: bibDetails}, {title: 'Full Description', content: additionalDetails}]} />);
+  let component = mount(<Tabbed tabs={[{ title: 'Details', content: bibDetails }, { title: 'Full Description', content: additionalDetails }]} />);
   let details = component.find('a').at(0);
   let fullDescription = component.find('a').at(1);
+  let focused;
+  let section;
 
   describe('Initial Rendering', () => {
     it('should focus on Details', () => {
@@ -153,43 +150,41 @@ describe('Tabbed', () => {
     });
 
     it('should have a tab for Full Description', () => {
-      expect(component.find('a').at(1).text()).to.equal("Full Description");
-    })
-  })
+      expect(component.find('a').at(1).text()).to.equal('Full Description');
+    });
+  });
 
   describe('Navigating with Click', () => {
-
     it('should focus on Full Description on click', () => {
       fullDescription.simulate('click');
-      let focused = document.activeElement;
+      focused = document.activeElement;
       expect(fullDescription.getDOMNode()).to.equal(focused);
     });
 
     it('should focus on Details when clicked back', () => {
       details.simulate('click');
-      let focused = document.activeElement;
+      focused = document.activeElement;
       expect(details.getDOMNode()).to.equal(focused);
     });
   })
 
   describe('Navigating with Key Press', () => {
-
     it('should focus on Full Description on Right Arrow Press', () => {
       details.simulate('keydown', { keyCode: 39, which: 39 });
-      let focused = document.activeElement;
+      focused = document.activeElement;
       expect(fullDescription.getDOMNode()).to.equal(focused);
     });
 
     it('should focus on Details on Left Arrow Press', () => {
-      fullDescription.simulate('keydown', {keycode: 37, which: 37});
-      let focused = document.activeElement;
+      fullDescription.simulate('keydown', { keycode: 37, which: 37 });
+      focused = document.activeElement;
       expect(details.getDOMNode()).to.equal(focused);
     });
 
     it('should focus on panel on Down Arrow Press', () => {
-      details.simulate('keydown', {keycode: 40, which: 40});
-      let focused = document.activeElement;
-      let section = component.find('section').at(0);
+      details.simulate('keydown', { keycode: 40, which: 40 });
+      focused = document.activeElement;
+      section = component.find('section').at(0);
       expect(section.getDOMNode()).to.equal(focused);
     });
 
@@ -198,17 +193,17 @@ describe('Tabbed', () => {
   describe('Displaying Correct Tab on Click', () => {
     it('should display Full Description when clicked', () => {
       fullDescription.simulate('click');
-      fullDescription.simulate('keydown', {keycode: 40, which: 40});
-      let focused = document.activeElement;
-      let section = component.find('section').at(1);
+      fullDescription.simulate('keydown', { keycode: 40, which: 40 });
+      focused = document.activeElement;
+      section = component.find('section').at(1);
       expect(section.getDOMNode()).to.equal(focused);
     });
 
     it('should display Details when clicked', () => {
       details.simulate('click');
-      details.simulate('keydown', {keycode: 40, which: 40});
-      let focused = document.activeElement;
-      let section = component.find('section').at(0);
+      details.simulate('keydown', { keycode: 40, which: 40 });
+      focused = document.activeElement;
+      section = component.find('section').at(0);
       expect(section.getDOMNode()).to.equal(focused);
     });
   });


### PR DESCRIPTION
**What's this do?**
I implemented Edwin's suggested re-iterated in his comments on #1300 to move the Enzyme Adapter to the test helper. I could not get the `afterAll` hook to work in that file. Any suggestions? Also, would using `alt.flush` work for resetting the `Store`?
