### PR TITLE
change Subject Heading Search -> Subject Heading Lookup

### DIFF
--- a/src/app/components/SubjectHeading/Search/SubjectHeadingSearch.jsx
+++ b/src/app/components/SubjectHeading/Search/SubjectHeadingSearch.jsx
@@ -168,7 +168,7 @@ class SubjectHeadingSearch extends React.Component {
         id="mainContent"
       >
         <div className="autocomplete-field">
-          <label htmlFor="autosuggest">Subject Heading Search</label>
+          <label htmlFor="autosuggest">Subject Heading Lookup</label>
           <div className="autosuggestInput">
             <input
               id="autosuggest"


### PR DESCRIPTION
**What's this do?**
Change's the label text for the search to "Subject Heading Lookup"

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SCC-2042