### PR TITLE
Increase AlphabeticalPagination buttons on mobile

### DIFF
--- a/src/app/components/SubjectHeading/SubjectHeading.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeading.jsx
@@ -265,11 +265,7 @@ class SubjectHeading extends React.Component {
     const showRest = (
       rest !== '' &&
       container !== 'context' &&
-      (
-        media !== 'mobile' &&
-        (!filter ||
-        (filter && topLevel))
-      )
+      (media !== 'mobile' || (filter && topLevel))
     );
 
     // changes to HTML structure here will need to be replicated in ./SubjectHeadingTableHeader

--- a/src/app/components/SubjectHeading/SubjectHeadingsTable.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeadingsTable.jsx
@@ -30,7 +30,7 @@ class SubjectHeadingsTable extends React.Component {
       <table className={
         `subjectHeadingsTable
         ${container}
-        ${['context', 'related'].includes(container) ? ' nypl-column-half subjectHeadingInfoBox' : null}`}
+        ${['context', 'related'].includes(container) ? ' nypl-column-half subjectHeadingInfoBox' : ''}`}
       >
         <SubjectHeadingsTableHeader
           updateSort={updateSort}

--- a/src/client/styles/components/SubjectHeadings/AlphabeticalPagination.scss
+++ b/src/client/styles/components/SubjectHeadings/AlphabeticalPagination.scss
@@ -34,3 +34,13 @@ $light-border: 1px solid #d7d4d0;
     }
   }
 }
+
+@include media($xtrasmall-breakpoint) {
+  .alphabeticalPagination {
+    line-height: 35px;
+
+    a {
+      min-width: 35px;
+    }
+  }
+}

--- a/test/helpers/routing.js
+++ b/test/helpers/routing.js
@@ -10,7 +10,7 @@ const mockRouter = push => ({
   goForward: stub(),
   setRouteLeaveHook: stub(),
   isActive: stub(),
-  location: { location: 'default' },
+  location: { query: {} },
   routes: [
     { component: { name: 'default' } },
   ],

--- a/test/unit/SubjectHeadingIndex.test.js
+++ b/test/unit/SubjectHeadingIndex.test.js
@@ -1,0 +1,38 @@
+/* eslint-env mocha */
+import React from 'react';
+import { expect } from 'chai';
+import { shallow, mount } from 'enzyme';
+
+import SubjectHeadingsIndex from '@SubjectHeadingsIndex';
+import { mockRouterContext } from '../helpers/routing';
+
+describe('SubjectHeadingsIndex', () => {
+  const context = mockRouterContext();
+  let component;
+  describe('Unfiltered index', () => {
+    before(() => {
+      component = mount(
+        <SubjectHeadingsIndex />,
+        { context });
+    });
+    it('should render `Alphabetical Pagination`', () => {
+      expect(component.find('AlphabeticalPagination').length).to.equal(1);
+    });
+  });
+
+  describe('Filtered index', () => {
+    before(() => {
+      context.router.location.query.filter = 'pottery';
+      component = mount(
+        <SubjectHeadingsIndex />,
+        { context },
+      );
+    });
+    after(() => {
+      context.router.location.query.filter = undefined;
+    });
+    it('should not render `Alphabetical Pagination`', () => {
+      expect(component.find('AlphabeticalPagination').length).to.equal(0);
+    });
+  });
+});


### PR DESCRIPTION
**What's this do?**
Increases alphabetical pagination buttons from 32px squares to 35px ones on mobile. Plus, tests!
Also, quick bug fix in `showRest` conditional. Might write a test for this later.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SCC-2021

**Did someone actually run this code to verify it works?**
PR author did.