### PR TITLE
SCC-1862, SCC-2034: Prevent empty keyword and unfiltered searches

### DIFF
--- a/src/app/components/FilterPopup/FilterPopup.jsx
+++ b/src/app/components/FilterPopup/FilterPopup.jsx
@@ -488,17 +488,20 @@ class FilterPopup extends React.Component {
 
     return (
       <div className="filter-container">
-        <div className="nypl-full-width-wrapper">
-          <div className="nypl-row">
-            <div className="nypl-column-full">
-              <div className="filter-text">
-                <h2 id="filter-title" ref={this.filterTitle} tabIndex="0">Refine your search</h2>
-                <p>Toggle filters to narrow and define your search</p>
+        {(!showForm && !!(totalResults && totalResults !== 0)) && (
+            <div className="nypl-full-width-wrapper">
+              <div className="nypl-row">
+                <div className="nypl-column-full">
+                  <div className="filter-text">
+                    <h2 id="filter-title" ref={this.filterTitle} tabIndex="0">Refine your search</h2>
+                    <p>Toggle filters to narrow and define your search</p>
+                  </div>
+                  {openPopupButton}
+                </div>
               </div>
-              {(!showForm && !!(totalResults && totalResults !== 0)) && openPopupButton}
             </div>
-          </div>
-        </div>
+          )
+        }
         {
           showForm && (
             <div

--- a/src/app/components/Search/Search.jsx
+++ b/src/app/components/Search/Search.jsx
@@ -6,6 +6,7 @@ import SearchButton from '../Buttons/SearchButton';
 import {
   trackDiscovery,
   ajaxCall,
+  hasValidFilters,
 } from '../../utils/utils';
 import appConfig from '../../data/appConfig';
 
@@ -127,7 +128,7 @@ class Search extends React.Component {
         Actions.updatePage('1');
         setTimeout(() => {
           Actions.updateLoadingStatus(false);
-          this.context.router.push(`${appConfig.baseUrl}/search?${apiQuery}`);
+          this.context.router.push(`${appConfig.baseUrl}/search?${apiQuery || ''}`);
         }, 500);
         resolve();
       }, reject);
@@ -173,6 +174,7 @@ class Search extends React.Component {
                 id="search-query"
                 aria-labelledby="search-input-label"
                 aria-controls="results-description"
+                aria-required={!hasValidFilters(this.props.selectedFilters)}
                 placeholder="Keyword, title, or author/contributor"
                 onChange={this.inputChange}
                 value={this.state.searchKeywords}

--- a/src/app/data/appConfig.js
+++ b/src/app/data/appConfig.js
@@ -29,6 +29,7 @@ export default {
     dateAfter: '',
     dateBefore: '',
     subjectLiteral: [],
+    creatorLiteral: [],
   },
   closedLocations: (
     process.env.CLOSED_LOCATIONS

--- a/src/app/pages/SearchResults.jsx
+++ b/src/app/pages/SearchResults.jsx
@@ -12,6 +12,7 @@ import SearchResultsSorter from '@SearchResultsSorter';
 
 import {
   basicQuery,
+  hasValidFilters,
 } from '../utils/utils';
 
 const SearchResults = (props) => {
@@ -45,23 +46,11 @@ const SearchResults = (props) => {
       value: 'Date',
     });
   }
-  const checkForSelectedFilters = () => {
-    if (selectedFilters &&
-      (selectedFilters.dateBefore !== '' ||
-        selectedFilters.dateAfter !== '' ||
-        (selectedFilters.language && selectedFilters.language.length) ||
-        (selectedFilters.materialType && selectedFilters.materialType.length) ||
-        (selectedFilters.subjectLiteral && selectedFilters.subjectLiteral.length)
-      )
-    ) {
-      if (!dropdownOpen) {
-        return true;
-      }
-    }
-    return false;
-  };
 
-  const selectedFiltersAvailable = checkForSelectedFilters();
+  // This determines whether or not to show selectedfilters:
+  const selectedFiltersAvailable = hasValidFilters(selectedFilters) && !dropdownOpen;
+  // Is there an active keyword or filter?
+  const hasValidSearch = !!(searchKeywords || hasValidFilters(selectedFilters));
 
   return (
     <DocumentTitle title="Search Results | Shared Collection Catalog | NYPL">
@@ -105,33 +94,45 @@ const SearchResults = (props) => {
                 </div>
               </div>
             }
+            { !hasValidSearch &&
+              <div className="nypl-full-width-wrapper">
+                <div className="nypl-row">
+                  <div className="nypl-column-full">
+                    <div className="nypl-results-summary">
+                      Please enter a search term
+                    </div>
+                  </div>
+                </div>
+              </div>
+            }
           </React.Fragment>
         }
         extraRow={
-          <div className="nypl-sorter-row">
-            <div className="nypl-full-width-wrapper">
-              <div className="nypl-row">
-                <div className="nypl-column-full">
-                  <ResultsCount
-                    count={totalResults}
-                    selectedFilters={selectedFilters}
-                    searchKeywords={searchKeywords}
-                    field={field}
-                    page={parseInt(page, 10)}
-                  />
-                  {
-                    !!(totalResults && totalResults !== 0) &&
-                    <SearchResultsSorter
-                      sortBy={sortBy}
-                      page={page}
+          hasValidSearch &&
+            <div className="nypl-sorter-row">
+              <div className="nypl-full-width-wrapper">
+                <div className="nypl-row">
+                  <div className="nypl-column-full">
+                    <ResultsCount
+                      count={totalResults}
+                      selectedFilters={selectedFilters}
                       searchKeywords={searchKeywords}
-                      createAPIQuery={createAPIQuery}
+                      field={field}
+                      page={parseInt(page, 10)}
                     />
-                  }
+                    {
+                      !!(totalResults && totalResults !== 0) &&
+                      <SearchResultsSorter
+                        sortBy={sortBy}
+                        page={page}
+                        searchKeywords={searchKeywords}
+                        createAPIQuery={createAPIQuery}
+                      />
+                    }
+                  </div>
                 </div>
               </div>
             </div>
-          </div>
         }
         loadingLayerText="Searching"
         breadcrumbsType="search"

--- a/src/app/utils/utils.js
+++ b/src/app/utils/utils.js
@@ -370,6 +370,53 @@ const getUpdatedFilterValues = (props) => {
   return updatedFilterValues;
 };
 
+/**
+ * hasValidFilters (filters)
+ *
+ * Returns true if the hash of filters contains at least one valid filter value.
+ *
+ * @example
+ * // The following returns false:
+ * hasValidFilters({
+ *   materialType: [],
+ *   language: [],
+ *   dateAfter: '',
+ *   dateBefore: '',
+ *   subjectLiteral: []
+ * })
+ *
+ * @example
+ * // The following returns true:
+ * hasValidFilters({
+ *   language: [],
+ *   dateAfter: '0',
+ *   dateBefore: '',
+ *   subjectLiteral: []
+ * })
+ *
+ * @example
+ * // The following returns true:
+ * hasValidFilters({
+ *   materialType: [
+ *     { selected: true,
+ *       value: 'resourcetypes:aud',
+ *       label: 'Audio',
+ *       count: 400314
+ *     }
+ *   ],
+ *   language: [],
+ *   dateAfter: '',
+ *   dateBefore: '',
+ *   subjectLiteral: []
+ * })
+ *
+ * @param {object} filters - A hash of filter names mapped to filter values
+ * @return {boolean}
+ */
+const hasValidFilters = (selectedFilters) => {
+  return Object.values(selectedFilters || {}).some((v) => Array.isArray(v) ? v.length > 0 : v );
+};
+
 export {
   trackDiscovery,
   ajaxCall,
@@ -384,4 +431,5 @@ export {
   parseServerSelectedFilters,
   getAggregatedElectronicResources,
   getUpdatedFilterValues,
+  hasValidFilters,
 };

--- a/src/server/ApiRoutes/Search.js
+++ b/src/server/ApiRoutes/Search.js
@@ -11,6 +11,7 @@ import {
   getReqParams,
   basicQuery,
   parseServerSelectedFilters,
+  hasValidFilters,
 } from '../../app/utils/utils';
 import nyplApiClient from '../routes/nyplApiClient';
 import logger from '../../../logger';
@@ -41,6 +42,11 @@ function search(searchKeywords = '', page, sortBy, order, field, filters, cb, er
     selectedFilters: filters,
     field,
   });
+  // If no keyword or filter used, don't execute search:
+  if (!searchKeywords && !hasValidFilters(filters || {})) {
+    logger.info('Skipping empty search', searchKeywords, filters);
+    cb();
+  }
 
   const aggregationQuery = `/aggregations?${encodedAggregationsQueryString}`;
   const resultsQuery = `?${encodedResultsQueryString}&per_page=50`;

--- a/test/unit/SearchResultsPage.test.js
+++ b/test/unit/SearchResultsPage.test.js
@@ -54,8 +54,9 @@ describe('SearchResultsPage', () => {
       expect(component.find('Search')).to.have.length(1);
     });
 
-    it('should render a <ResultsCount /> components', () => {
-      expect(component.find('ResultsCount')).to.have.length(1);
+    it('should not render a <ResultsCount /> components', () => {
+      // Without a valid search, the ResultsCount component is not included
+      expect(component.find('ResultsCount')).to.have.length(0);
     });
 
     it('should not render a <SearchResultsSorter /> components, since there are no results', () => {
@@ -114,6 +115,10 @@ describe('SearchResultsPage', () => {
 
     it('should render a <Pagination /> components', () => {
       expect(component.find('Pagination')).to.have.length(1);
+    });
+
+    it('should render a <ResultsCount /> components', () => {
+      expect(component.find('ResultsCount')).to.have.length(1);
     });
   });
 

--- a/test/unit/utils.test.js
+++ b/test/unit/utils.test.js
@@ -122,6 +122,7 @@ describe('getDefaultFilters', () => {
       dateAfter: '',
       dateBefore: '',
       subjectLiteral: [],
+      creatorLiteral: [],
     });
   });
 });

--- a/test/unit/utils.test.js
+++ b/test/unit/utils.test.js
@@ -16,6 +16,7 @@ import {
   basicQuery,
   getReqParams,
   getAggregatedElectronicResources,
+  hasValidFilters,
 } from '../../src/app/utils/utils';
 
 /**
@@ -636,5 +637,46 @@ describe('getAggregatedElectronicResources', () => {
           },
         ]);
     });
+  });
+});
+
+/**
+ * hasValidFilters
+ */
+describe('hasValidFilters', () => {
+  it('should return false for falsey filters', () => {
+    expect(hasValidFilters()).to.equal(false);
+    expect(hasValidFilters(undefined)).to.equal(false);
+  });
+
+  it('should return false if no filters have values', () => {
+    const filters = {
+      materialType: [],
+      language: [],
+      dateAfter: '',
+      dateBefore: '',
+      subjectLiteral: []
+    };
+    expect(hasValidFilters(filters)).to.equal(false);
+  });
+
+  it('should return true if dateAfter is any number', () => {
+    expect(hasValidFilters({ dateAfter: '0' })).to.equal(true);
+    expect(hasValidFilters({ dateAfter: '-1' })).to.equal(true);
+    expect(hasValidFilters({ dateAfter: '20201' })).to.equal(true);
+  });
+
+  it('should return true if a materialType filter is present', () => {
+    const filters = {
+      materialType: [
+        {
+          selected: true,
+          value: 'resourcetypes:aud',
+          label: 'Audio',
+          count: 400314
+        }
+      ]
+    };
+    expect(hasValidFilters(filters)).to.equal(true);
   });
 });


### PR DESCRIPTION
**What's this do?**
If no keyword query and no filters are specified, prevent fetching results. If an empty search is attempted, "Please enter a search term" is shown.

<img width="837" alt="Screen Shot 2020-05-20 at 8 56 17 PM" src="https://user-images.githubusercontent.com/439581/82518154-afc36900-9aec-11ea-8b6d-07943621534f.png">

This also fixes missing filter button(s) on search results pages when creatorLiteral filter is active.

Includes tests.

Also fixes:
 - Centralizes logic around whether or not one has entered a valid filter
 - Removes "Refine your search" text when "Refine Search" button not
 available

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SCC-1862
https://jira.nypl.org/browse/SCC-2034

**How should this be tested? / Do these changes have associated tests?**
Several unit tests added. Should verify the interaction works in browsers

**Dependencies for merging? Releasing to production?**
n/a

**Has the application documentation been updated for these changes?**
n/a

**Did someone actually run this code to verify it works?**
Yes. I tested it to work in FF on OSX