### PR TITLE
Add new button type for 'More...' on show pages

### DIFF
--- a/src/app/components/SubjectHeading/AdditionalSubjectHeadingsButton.jsx
+++ b/src/app/components/SubjectHeading/AdditionalSubjectHeadingsButton.jsx
@@ -33,30 +33,39 @@ class AdditionalSubjectHeadingsButton extends React.Component {
 
     const seeMoreText = text || 'See more';
 
-    const button = (
-      linkUrl ?
-        (
-          <Link
-            to={linkUrl}
-            className="seeMoreButton toIndex"
-          >
-            {seeMoreText}
-          </Link>
-        )
-        :
-        (
-          <button
-            data={`${text}-${linkUrl}`}
-            onClick={this.onClick}
-            className="seeMoreButton"
-          >
-            {previous ? '↑' : '↓'} <em key="seeMoreText">{seeMoreText}</em>
-            {previous ? null : <br /> }
-            {previous || noEllipse ? null : <VerticalEllipse />}
-          </button>
-        )
+    let button;
 
-    );
+    if (linkUrl) {
+      button = (
+        <Link
+          to={linkUrl}
+          className="seeMoreButton toIndex"
+        >
+          {seeMoreText}
+        </Link>
+      );
+    } else if (this.props.button === 'contextMore') {
+      button = (
+        <span
+          data={`${text}-${linkUrl}`}
+          className="contextMore"
+        >
+          {seeMoreText}
+        </span>
+      );
+    } else {
+      button = (
+        <button
+          data={`${text}-${linkUrl}`}
+          onClick={this.onClick}
+          className="seeMoreButton"
+        >
+          {previous ? '↑' : '↓'} <em key="seeMoreText">{seeMoreText}</em>
+          {previous ? null : <br /> }
+          {previous || noEllipse ? null : <VerticalEllipse />}
+        </button>
+      );
+    }
 
     if (previous && linkUrl) return null;
 

--- a/src/app/components/SubjectHeading/NeighboringHeadingsBox.jsx
+++ b/src/app/components/SubjectHeading/NeighboringHeadingsBox.jsx
@@ -32,8 +32,7 @@ class NeighboringHeadingsBox extends React.Component {
         showId={uuid}
         keyId="context"
         container="context"
-        seeMoreLinkUrl={linkUrl}
-        seeMoreText="See More in Subject Headings Index"
+        seeMoreText="More..."
         tableHeaderText="Neighboring Subject Headings"
         tfootContent={
           <tr>

--- a/src/app/components/SubjectHeading/SubjectHeadingsTableBody.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeadingsTableBody.jsx
@@ -53,9 +53,11 @@ class SubjectHeadingsTableBody extends React.Component {
   listItemsInInterval(interval, index, lastIndex) {
     const { indentation } = this.props;
     const { subjectHeadings, range } = this.state;
+    const { container } = this.context;
     const { start, end } = interval;
     const subjectHeadingsInInterval = subjectHeadings.filter((el, i) => i >= start && i <= end);
-    if (subjectHeadings[start - 1]) {
+    const isContext = container === 'context';
+    if (subjectHeadings[start - 1] && !isContext) {
       subjectHeadingsInInterval.unshift({
         button: 'previous',
         indentation,
@@ -64,7 +66,7 @@ class SubjectHeadingsTableBody extends React.Component {
     }
     if (end !== Infinity && subjectHeadings[end + 1]) {
       subjectHeadingsInInterval.push({
-        button: 'next',
+        button: isContext ? 'contextMore' : 'next',
         indentation,
         noEllipse: index === lastIndex,
         updateParent: () => this.updateRange(range, interval, 'end', 10),
@@ -97,7 +99,6 @@ class SubjectHeadingsTableBody extends React.Component {
           updateParent={listItem.updateParent}
           key={`${listItem.button}${listItem.indentation}${index}`}
           nested={nested}
-          linkUrl={seeMoreLinkUrl}
           text={seeMoreText}
           noEllipse={listItem.noEllipse}
           marginSize={marginSize}

--- a/src/client/styles/components/SubjectHeadings/SubjectHeadingShow.scss
+++ b/src/client/styles/components/SubjectHeadings/SubjectHeadingShow.scss
@@ -32,6 +32,12 @@
   }
 }
 
+.context {
+  .contextMore {
+    color: gray;
+  }
+}
+
 .related {
   height: fit-content;
 


### PR DESCRIPTION
**What's this do?**
Changes the 'See More...' link on the show page to plaintext 'More...' This is achieved by:
- Adding a new button type `contextMore`
- Changing the text associated with this button type
- adding some styling
- Adding some logic to not create 'previous' buttons in the `context` container, so we don't get two copies i.e. 'More...' 'More...'. 

**Why are we doing this? (w/ JIRA link if applicable)**
SCC-2043.

**How should this be tested? / Do these changes have associated tests?**
Aachen (Germany) -- Church history is a good example for this.

**Dependencies for merging? Releasing to production?**
No

**Has the application documentation been updated for these changes?**
NA

**Did someone actually run this code to verify it works?**
PR author tested locally.
