### PR TITLE
Server shep routes

### DIFF
--- a/src/app/components/Pagination/Pagination.jsx
+++ b/src/app/components/Pagination/Pagination.jsx
@@ -32,16 +32,15 @@ class Pagination extends React.Component {
       subjectIndexPage,
     } = this.props;
     if (!page) return null;
-    if (type == 'Next' && subjectShowPage && !hasNext) return null;
+    if (type === 'Next' && subjectShowPage && !hasNext) return null;
     const intPage = parseInt(page, 10);
     const pageNum = type === 'Next' ? intPage + 1 : intPage - 1;
     const svg = type === 'Next' ? <RightWedgeIcon /> : <LeftWedgeIcon />;
-    const subjectHeadingPage = subjectShowPage || subjectIndexPage;
 
     let url;
     let apiUrl;
     let localUrl;
-    if (subjectHeadingPage && shepNavigation) {
+    if (shepNavigation) {
       if (!shepNavigation[type.toLowerCase()]) return null;
       url = type === 'Next' ? shepNavigation.next : shepNavigation.previous;
     } else {

--- a/src/app/components/Pagination/Pagination.jsx
+++ b/src/app/components/Pagination/Pagination.jsx
@@ -74,7 +74,7 @@ class Pagination extends React.Component {
       total,
       page,
       perPage,
-      subjectIndexPage
+      subjectIndexPage,
     } = this.props;
     const subjectHeadingPage = this.props.subjectShowPage || subjectIndexPage;
     let nextPage;

--- a/src/app/components/Pagination/Pagination.jsx
+++ b/src/app/components/Pagination/Pagination.jsx
@@ -122,6 +122,7 @@ Pagination.propTypes = {
   subjectShowPage: PropTypes.bool,
   shepNavigation: PropTypes.object,
   subjectIndexPage: PropTypes.bool,
+  hasNext: PropTypes.bool,
 };
 
 Pagination.defaultProps = {

--- a/src/app/components/SubjectHeading/BibsList.jsx
+++ b/src/app/components/SubjectHeading/BibsList.jsx
@@ -45,7 +45,7 @@ class BibsList extends React.Component {
     if (discoveryApiBibCount === 0) return false;
     const discrepancy = Math.abs(shepBibCount - discoveryApiBibCount);
 
-    return discrepancy > (shepBibCount * this.permittedMargin);
+    return discrepancy < (shepBibCount * this.permittedMargin);
   }
 
   discoveryApiBibsCall(stringifiedSortParams, initial, cb = () => {}) {

--- a/src/app/components/SubjectHeading/BibsList.jsx
+++ b/src/app/components/SubjectHeading/BibsList.jsx
@@ -168,6 +168,8 @@ class BibsList extends React.Component {
     const {
       bibsSource,
       bibPage,
+      bibs,
+      nextUrl,
     } = this.state;
 
     const paginationProps = {
@@ -183,10 +185,8 @@ class BibsList extends React.Component {
       paginationProps.total = totalResults;
       paginationProps.page = parseInt(page, 10);
       paginationProps.updatePage = this.updateDiscoveryBibPage;
-      // paginationProps.createAPIQuery = createAPIQuery
-      // paginationProps.updatePage = updatePage
     } else if (bibsSource === 'shepApi') {
-      const lastPage = Math.ceil(bibResults.length / this.perPage);
+      const lastPage = Math.ceil(bibs.length / this.perPage);
       paginationProps.total = this.props.totalBibs;
       paginationProps.updatePage = this.updateShepBibPage;
       paginationProps.hasNext = (bibPage < lastPage || nextUrl);
@@ -199,7 +199,7 @@ class BibsList extends React.Component {
         {...paginationProps}
       />
     );
-  };
+  }
 
   render() {
     const {

--- a/src/app/components/SubjectHeading/BibsList.jsx
+++ b/src/app/components/SubjectHeading/BibsList.jsx
@@ -28,6 +28,7 @@ class BibsList extends React.Component {
     this.perPage = 6;
     this.changeBibSorting = this.changeBibSorting.bind(this);
     this.discoveryApiBibsCall = this.discoveryApiBibsCall.bind(this);
+    this.shepApiBibsCall = this.shepApiBibsCall.bind(this);
     this.pagination = this.pagination.bind(this);
     this.permittedMargin = 0.2;
     this.useDiscoveryResults = this.useDiscoveryResults.bind(this);
@@ -48,13 +49,14 @@ class BibsList extends React.Component {
     return discrepancy < (shepBibCount * this.permittedMargin);
   }
 
-  discoveryApiBibsCall(stringifiedSortParams, initial, cb = () => {}) {
+  discoveryApiBibsCall(stringifiedSortParams, cb = () => {}) {
     const { label } = this.props;
+    const { bibsSource } = this.state;
 
     return axios(`${appConfig.baseUrl}/api/subjectHeading/${encodeURIComponent(label)}?&${stringifiedSortParams}`)
       .then((res) => {
         const totalResults = res.data.totalResults;
-        if (this.useDiscoveryResults(totalResults)) {
+        if (this.bibsSource === 'discoveryApi' || this.useDiscoveryResults(totalResults)) {
           this.setState({
             results: res.data,
             componentLoading: false,

--- a/src/app/components/SubjectHeading/BibsList.jsx
+++ b/src/app/components/SubjectHeading/BibsList.jsx
@@ -32,7 +32,7 @@ class BibsList extends React.Component {
     const sort = sortParams.sort || 'date';
     const sortDirection = sortParams.sort_direction || 'desc';
 
-    const stringifiedSortParams = sort && sortDirection ? `sort=${sort}&sort_direction=${sortDirection}` : '';
+    const stringifiedSortParams = sort && sortDirection ? `sort=${sort}&sort_direction=${sortDirection}&per_page=${this.perPage}` : '';
 
     this.discoveryApiBibsCall(stringifiedSortParams);
   }
@@ -40,13 +40,14 @@ class BibsList extends React.Component {
   discoveryApiBibsCall(stringifiedSortParams) {
     const { label } = this.props;
 
-    return axios(`${appConfig.baseUrl}/api?filters[subjectLiteral][0]=${encodeURIComponent(label)}&${stringifiedSortParams}`)
+    return axios(`${appConfig.baseUrl}/api/subjectHeading/${encodeURIComponent(label)}?&${stringifiedSortParams}`)
       .then((res) => {
-        this.setState({
-          results: res.data,
-          componentLoading: false,
-          bibsSource: 'discoveryApi',
-        });
+        console.log(res);
+        // this.setState({
+        //   results: res.data,
+        //   componentLoading: false,
+        //   bibsSource: 'discoveryApi',
+        // });
       })
       .catch(
         (err) => {

--- a/src/app/components/SubjectHeading/BibsList.jsx
+++ b/src/app/components/SubjectHeading/BibsList.jsx
@@ -43,11 +43,11 @@ class BibsList extends React.Component {
     return axios(`${appConfig.baseUrl}/api/subjectHeading/${encodeURIComponent(label)}?&${stringifiedSortParams}`)
       .then((res) => {
         console.log(res);
-        // this.setState({
-        //   results: res.data,
-        //   componentLoading: false,
-        //   bibsSource: 'discoveryApi',
-        // });
+        this.setState({
+          results: res.data,
+          componentLoading: false,
+          bibsSource: 'discoveryApi',
+        });
       })
       .catch(
         (err) => {

--- a/src/app/components/SubjectHeading/BibsList.jsx
+++ b/src/app/components/SubjectHeading/BibsList.jsx
@@ -46,6 +46,7 @@ class BibsList extends React.Component {
           results: res.data,
           componentLoading: false,
           bibsSource: 'discoveryApi',
+          bibPage: res.data.page,
         }, cb);
       })
       .catch(

--- a/src/app/components/SubjectHeading/BibsList.jsx
+++ b/src/app/components/SubjectHeading/BibsList.jsx
@@ -47,19 +47,19 @@ class BibsList extends React.Component {
           results,
           bibsSource,
           page,
-          totalResults,
         } = res.data;
+        const totalResults = res.data.totalResults || this.state.totalResults;
         const newState = {
           bibsSource,
-          bibPage: page,
+          bibPage: parseInt(page, 10),
           componentLoading: false,
+          totalResults,
         };
         if (bibsSource === 'discoveryApi') {
           newState.results = results;
           this.setState(newState, cb);
         } else if (bibsSource === 'shepApi') {
           newState.nextUrl = res.data.next_url;
-          newState.totalResults = this.props.shepBibCount;
           this.setState((prevState) => {
             newState.results = prevState.results.concat(res.data.newResults);
             return newState;
@@ -120,7 +120,7 @@ class BibsList extends React.Component {
           nextUrl: res.data.next_url,
           componentLoading: false,
           bibsSource: 'shepApi',
-          bibPage: newPage,
+          bibPage: parseInt(newPage, 10),
         }, () => window.scrollTo(0, 300));
       })
       .catch(
@@ -144,28 +144,21 @@ class BibsList extends React.Component {
     const {
       bibsSource,
       bibPage,
-      results,
       nextUrl,
       totalResults,
     } = this.state;
 
+    const lastPage = Math.ceil(totalResults / this.perPage);
+
     const paginationProps = {
       perPage: this.perPage,
       ariaControls: 'nypl-results-list',
+      updatePage: this.updateBibPage,
+      total: parseInt(totalResults, 10),
+      page: bibPage,
+      hasNext: (bibPage < lastPage || nextUrl),
+      subjectShowPage: true,
     };
-
-    if (bibsSource === 'discoveryApi') {
-      paginationProps.total = totalResults;
-      paginationProps.page = parseInt(bibPage, 10);
-      paginationProps.updatePage = this.updateBibPage;
-    } else if (bibsSource === 'shepApi') {
-      const lastPage = Math.ceil(results.length / this.perPage);
-      paginationProps.total = this.props.shepBibCount;
-      paginationProps.updatePage = this.updateShepBibPage;
-      paginationProps.hasNext = (bibPage < lastPage || nextUrl);
-      paginationProps.page = parseInt(bibPage, 10);
-      paginationProps.shepBibs = true;
-    }
 
     return (
       <Pagination

--- a/src/app/components/SubjectHeading/BibsList.jsx
+++ b/src/app/components/SubjectHeading/BibsList.jsx
@@ -37,7 +37,7 @@ class BibsList extends React.Component {
     this.discoveryApiBibsCall(stringifiedSortParams);
   }
 
-  discoveryApiBibsCall(stringifiedSortParams) {
+  discoveryApiBibsCall(stringifiedSortParams, cb = () => {}) {
     const { label } = this;
 
     return axios(`${appConfig.baseUrl}/api/subjectHeading/${encodeURIComponent(label)}?&${stringifiedSortParams}`)
@@ -46,7 +46,7 @@ class BibsList extends React.Component {
           results: res.data,
           componentLoading: false,
           bibsSource: 'discoveryApi',
-        });
+        }, cb);
       })
       .catch(
         (err) => {
@@ -107,18 +107,13 @@ class BibsList extends React.Component {
   }
 
   updateDiscoveryBibPage(newPage) {
-    const { label } = this;
-
     const stringifiedSortParams = `sort=${this.sort}&sort_direction=${this.sortDirection}&page=${newPage}&per_page=${this.perPage}`;
 
-    this.setState({ componentLoading: true }, () => {
-      axios(`${appConfig.baseUrl}/api/subjectHeading/${encodeURIComponent(label)}?&${stringifiedSortParams}`)
-        .then(res => this.setState({
-          results: res.data,
-          componentLoading: false,
-          bibsSource: 'discoveryApi',
-        }, () => window.scrollTo(0, 300)));
-    });
+    this.setState({
+      componentLoading: true,
+    }, () => this.discoveryApiBibsCall(
+      stringifiedSortParams,
+      () => window.scrollTo(0, 300)));
   }
 
   /*
@@ -265,7 +260,7 @@ class BibsList extends React.Component {
 }
 
 BibsList.propTypes = {
-
+  label: PropTypes.string,
 };
 
 BibsList.defaultProps = {

--- a/src/app/components/SubjectHeading/BibsList.jsx
+++ b/src/app/components/SubjectHeading/BibsList.jsx
@@ -32,7 +32,7 @@ class BibsList extends React.Component {
   }
 
   componentDidMount() {
-    const stringifiedSortParams = `sort=${this.sort}&sort_direction=${this.sortDirection}&per_page=${this.perPage}`;
+    const stringifiedSortParams = `sort=${this.sort}&sort_direction=${this.sortDirection}&per_page=${this.perPage}&shep_bib_count=${this.props.totalBibs}`;
 
     this.discoveryApiBibsCall(stringifiedSortParams);
   }
@@ -254,7 +254,7 @@ class BibsList extends React.Component {
               There are no titles for this subject heading.
             </div>
         }
-        {bibResults.length > 0 ? this.pagination() : null}
+        {bibResults && bibResults.length > 0 ? this.pagination() : null}
       </div>
     );
   }
@@ -262,6 +262,7 @@ class BibsList extends React.Component {
 
 BibsList.propTypes = {
   label: PropTypes.string,
+  totalBibs: PropTypes.number,
 };
 
 BibsList.defaultProps = {

--- a/src/app/components/SubjectHeading/BibsList.jsx
+++ b/src/app/components/SubjectHeading/BibsList.jsx
@@ -114,13 +114,12 @@ class BibsList extends React.Component {
 
     return axios(nextUrl)
       .then((res) => {
-        const results = this.state.results.concat(res.data.bibs);
+        const results = this.state.results.concat(res.data.results);
         this.setState({
           results,
           nextUrl: res.data.next_url,
           componentLoading: false,
-          bibsSource: 'shepApi',
-          bibPage: parseInt(newPage, 10),
+          bibPage: newPage,
         }, () => window.scrollTo(0, 300));
       })
       .catch(

--- a/src/app/components/SubjectHeading/BibsList.jsx
+++ b/src/app/components/SubjectHeading/BibsList.jsx
@@ -29,7 +29,6 @@ class BibsList extends React.Component {
     this.changeBibSorting = this.changeBibSorting.bind(this);
     this.fetchBibs = this.fetchBibs.bind(this);
     this.pagination = this.pagination.bind(this);
-    this.permittedMargin = 0.2;
   }
 
   componentDidMount() {
@@ -141,7 +140,6 @@ class BibsList extends React.Component {
 
   pagination() {
     const {
-      bibsSource,
       bibPage,
       nextUrl,
       totalResults,
@@ -168,9 +166,7 @@ class BibsList extends React.Component {
 
   render() {
     const {
-      bibPage,
       results,
-      nextUrl,
       bibsSource,
       totalResults,
     } = this.state;
@@ -230,6 +226,7 @@ class BibsList extends React.Component {
 BibsList.propTypes = {
   label: PropTypes.string,
   shepBibCount: PropTypes.number,
+  uuid: PropTypes.string,
 };
 
 BibsList.contextTypes = {

--- a/src/app/components/SubjectHeading/SubjectHeadingShow.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeadingShow.jsx
@@ -53,6 +53,7 @@ class SubjectHeadingShow extends React.Component {
           contextHeadings: this.processContextHeadings(subject_headings, uuid),
           mainHeading: {
             label,
+            uuid,
           },
           totalBibs: bib_count,
           contextIsLoading: false,

--- a/src/app/components/SubjectHeading/SubjectHeadingShow.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeadingShow.jsx
@@ -164,7 +164,7 @@ class SubjectHeadingShow extends React.Component {
           <BibsList
             uuid={uuid}
             key={this.context.router.location.search}
-            totalBibs={totalBibs}
+            shepBibCount={totalBibs}
             label={label}
           />
         }

--- a/src/app/components/SubjectHeading/SubjectHeadingShow.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeadingShow.jsx
@@ -164,7 +164,7 @@ class SubjectHeadingShow extends React.Component {
           <BibsList
             uuid={uuid}
             key={this.context.router.location.search}
-            total={totalBibs}
+            totalBibs={totalBibs}
             label={label}
           />
         }

--- a/src/app/components/SubjectHeading/SubjectHeadingShow.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeadingShow.jsx
@@ -1,12 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import axios from 'axios';
-import { Link } from 'react-router';
 
 import SubjectHeadingsTable from './SubjectHeadingsTable';
 import NeighboringHeadingsBox from './NeighboringHeadingsBox';
 import BibsList from './BibsList';
-import LocalLoadingLayer from './LocalLoadingLayer';
 import Range from '../../models/Range';
 import appConfig from '../../data/appConfig';
 import Actions from '../../actions/Actions';
@@ -19,8 +17,6 @@ class SubjectHeadingShow extends React.Component {
       mainHeading: {
         uuid: this.props.params.subjectHeadingUuid,
       },
-      shepBibs: [],
-      bibsLoaded: false,
       contextError: null,
       contextIsLoading: true,
       contextHeadings: [],
@@ -105,7 +101,6 @@ class SubjectHeadingShow extends React.Component {
 
   generateFullContextUrl() {
     const uuid = this.props.params.subjectHeadingUuid;
-    const linkFromLabel = this.getTopLevelLabel();
     const path = this.props.location.pathname.replace(/\/subject_headings.*/, '');
     return `${path}/subject_headings?linked=${uuid}`;
   }

--- a/src/app/components/SubjectHeading/SubjectHeadingShow.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeadingShow.jsx
@@ -18,7 +18,6 @@ class SubjectHeadingShow extends React.Component {
     this.state = {
       mainHeading: {
         uuid: this.props.params.subjectHeadingUuid,
-        label: '',
       },
       shepBibs: [],
       bibsLoaded: false,
@@ -160,12 +159,15 @@ class SubjectHeadingShow extends React.Component {
 
     return (
       <React.Fragment>
-        <BibsList
-          uuid={uuid}
-          key={this.context.router.location.search}
-          total={totalBibs}
-          label={label}
-        />
+        {
+          label &&
+          <BibsList
+            uuid={uuid}
+            key={this.context.router.location.search}
+            total={totalBibs}
+            label={label}
+          />
+        }
         <div
           className="nypl-column-half subjectHeadingsSideBar"
         >

--- a/src/app/utils/utils.js
+++ b/src/app/utils/utils.js
@@ -238,6 +238,7 @@ const basicQuery = (props = {}) => {
  */
 function getReqParams(query = {}) {
   const page = query.page || '1';
+  const perPage = query.per_page || '50';
   const q = query.q || '';
   const sort = query.sort || '';
   const order = query.sort_direction || '';
@@ -245,7 +246,7 @@ function getReqParams(query = {}) {
   const fieldQuery = query.search_scope || '';
   const filters = query.filters || {};
 
-  return { page, q, sort, order, sortQuery, fieldQuery, filters };
+  return { page, perPage, q, sort, order, sortQuery, fieldQuery, filters };
 }
 
 /*

--- a/src/server/ApiRoutes/ApiRoutes.js
+++ b/src/server/ApiRoutes/ApiRoutes.js
@@ -6,6 +6,7 @@ import Hold from './Hold';
 import Search from './Search';
 import appConfig from '../../app/data/appConfig';
 import SubjectHeading from './SubjectHeading';
+import SubjectHeadings from './SubjectHeadings';
 
 const router = express.Router();
 
@@ -84,8 +85,8 @@ router
   .post(Hold.createHoldRequestEdd);
 
 router
-  .route(`${appConfig.baseUrl}/subject_headings/:subjectHeadingUuid/`)
-  .get(SubjectHeading.bibsServer);
+  .route(`${appConfig.baseUrl}/api/subjectHeading/:subjectLiteral/`)
+  .get(SubjectHeading.bibsAjax);
 /**
  * This wildcard route proxies the following SHEP API routes:
  *  * /api/subjectHeadings/{UUID}/context => /api/v0.1/subject_headings/{UUID}/context
@@ -95,7 +96,7 @@ router
 
 router
   .route(`${appConfig.baseUrl}/api/subjectHeadings*`)
-  .get(SubjectHeading.proxyRequest);
+  .get(SubjectHeadings.proxyRequest);
 
 router
   .route(appConfig.baseUrl)

--- a/src/server/ApiRoutes/ApiRoutes.js
+++ b/src/server/ApiRoutes/ApiRoutes.js
@@ -5,7 +5,7 @@ import User from './User';
 import Hold from './Hold';
 import Search from './Search';
 import appConfig from '../../app/data/appConfig';
-import SubjectHeadings from './SubjectHeadings';
+import SubjectHeading from './SubjectHeading';
 
 const router = express.Router();
 
@@ -83,15 +83,19 @@ router
   .get(Hold.createHoldRequestAjax)
   .post(Hold.createHoldRequestEdd);
 
+router
+  .route(`${appConfig.baseUrl}/subject_headings/:subjectHeadingUuid/`)
+  .get(SubjectHeading.bibsServer);
 /**
  * This wildcard route proxies the following SHEP API routes:
  *  * /api/subjectHeadings/{UUID}/context => /api/v0.1/subject_headings/{UUID}/context
  *  * /api/subjectHeadings/{UUID}/bibs => /api/v0.1/subject_headings/{UUID}/bibs
  *  * /api/subjectHeadings/{UUID}/related => /api/v0.1/subject_headings/{UUID}/related
  */
+
 router
   .route(`${appConfig.baseUrl}/api/subjectHeadings*`)
-  .get(SubjectHeadings.proxyRequest)
+  .get(SubjectHeading.proxyRequest);
 
 router
   .route(appConfig.baseUrl)

--- a/src/server/ApiRoutes/SubjectHeading.js
+++ b/src/server/ApiRoutes/SubjectHeading.js
@@ -1,8 +1,11 @@
+import axios from 'axios';
+
 import {
   getReqParams,
 } from '../../app/utils/utils';
 import nyplApiClient from '../routes/nyplApiClient';
 import logger from '../../../logger';
+import appConfig from '@appConfig'
 
 const nyplApiClientCall = query => nyplApiClient()
   .then((client) => {
@@ -32,6 +35,52 @@ const bibsAjax = (req, res) => {
   const { subjectLiteral } = req.params;
   const { page, perPage, sort, order } = getReqParams(req.query);
   const shepApiBibCount = req.query.shep_bib_count;
+  const bibsSource = req.query.source;
+
+  const shepApiBibsCall = () => {
+    const stringifiedSortParams = `sort=${sort}&sort_direction=${order}`;
+    const queryUrl = `${appConfig.baseUrl}/api/subjectHeadings/subject_headings/${subjectLiteral}/bibs?${stringifiedSortParams}`;
+
+    return axios(queryUrl)
+      .then((response) => {
+        const newResults = response.data.bibs;
+        return response.json({
+          newResults,
+          nextUrl: response.data.next_url,
+          bibsSource: 'shepApi',
+          bibPage: page,
+        });
+      })
+      .catch(
+        (err) => {
+          // eslint-disable-next-line no-console
+          console.error('error: ', err);
+        },
+      );
+  };
+
+  const useDiscoveryResults = (discoveryApiBibCount) => {
+    if (shepApiBibCount === 0) return true;
+    if (discoveryApiBibCount === 0) return false;
+    const discrepancy = Math.abs(shepApiBibCount - discoveryApiBibCount);
+
+    return discrepancy < (shepApiBibCount * 0.2);
+  };
+
+  const processData = (data) => {
+    console.log(data);
+    const { totalResults } = data;
+    if (bibsSource === 'discoveryApi' || useDiscoveryResults(totalResults)) {
+      return res.json({
+        results: data.itemListElement,
+        page,
+        totalResults,
+        bibsSource: 'discoveryApi'
+      });
+    }
+    console.log("making shep api call");
+    return shepApiBibsCall();
+  };
 
   fetchBibs(
     page,
@@ -40,7 +89,7 @@ const bibsAjax = (req, res) => {
     order,
     subjectLiteral,
     shepApiBibCount,
-    data => res.json({ ...data, page }),
+    data => processData(data),
     error => res.json(error),
   );
 };

--- a/src/server/ApiRoutes/SubjectHeading.js
+++ b/src/server/ApiRoutes/SubjectHeading.js
@@ -35,7 +35,7 @@ const bibsAjax = (req, res) => {
     sort,
     order,
     subjectLiteral,
-    data => res.json(data),
+    data => res.json({ ...data, page }),
     error => res.json(error),
   );
 };

--- a/src/server/ApiRoutes/SubjectHeading.js
+++ b/src/server/ApiRoutes/SubjectHeading.js
@@ -6,8 +6,7 @@ import logger from '../../../logger';
 
 const nyplApiClientCall = query => nyplApiClient()
   .then((client) => {
-    console.log(`/discovery/resources${query}`);
-    client.get(`/discovery/resources${query}`, { cache: false });
+    return client.get(`/discovery/resources${query}`, { cache: false });
   })
   .catch(console.error);
 

--- a/src/server/ApiRoutes/SubjectHeading.js
+++ b/src/server/ApiRoutes/SubjectHeading.js
@@ -47,7 +47,7 @@ const bibsAjax = (req, res) => {
         const newResults = response.data.results;
         return res.json({
           newResults,
-          nextUrl: response.data.next_url,
+          next_url: response.data.next_url,
           bibsSource: 'shepApi',
           page,
           totalResults: shepApiBibCount,

--- a/src/server/ApiRoutes/SubjectHeading.js
+++ b/src/server/ApiRoutes/SubjectHeading.js
@@ -1,17 +1,12 @@
-import axios from 'axios';
-
 import {
   getReqParams,
 } from '../../app/utils/utils';
 import nyplApiClient from '../routes/nyplApiClient';
 import logger from '../../../logger';
-import appConfig from '../../app/data/appConfig';
 import SubjectHeadings from './SubjectHeadings';
 
 const nyplApiClientCall = query => nyplApiClient()
-  .then((client) => {
-    return client.get(`/discovery/resources${query}`, { cache: false });
-  })
+  .then(client => client.get(`/discovery/resources${query}`, { cache: false }))
   .catch(console.error);
 
 function fetchBibs(page, perPage, sortBy, order, subjectLiteral, shepApiBibCount, cb, errorcb) {
@@ -76,7 +71,7 @@ const bibsAjax = (req, res) => {
         results: data.itemListElement,
         page,
         totalResults,
-        bibsSource: 'discoveryApi'
+        bibsSource: 'discoveryApi',
       });
     }
 

--- a/src/server/ApiRoutes/SubjectHeading.js
+++ b/src/server/ApiRoutes/SubjectHeading.js
@@ -5,7 +5,8 @@ import {
 } from '../../app/utils/utils';
 import nyplApiClient from '../routes/nyplApiClient';
 import logger from '../../../logger';
-import appConfig from '@appConfig'
+import appConfig from '../../app/data/appConfig';
+import SubjectHeadings from './SubjectHeadings';
 
 const nyplApiClientCall = query => nyplApiClient()
   .then((client) => {
@@ -39,16 +40,17 @@ const bibsAjax = (req, res) => {
 
   const shepApiBibsCall = () => {
     const stringifiedSortParams = `sort=${sort}&sort_direction=${order}`;
-    const queryUrl = `${appConfig.baseUrl}/api/subjectHeadings/subject_headings/${subjectLiteral}/bibs?${stringifiedSortParams}`;
+    const queryUrl = `/subject_headings/${req.query.shep_uuid}/bibs?${stringifiedSortParams}`;
 
-    return axios(queryUrl)
+    return SubjectHeadings.shepApiCall(queryUrl)
       .then((response) => {
-        const newResults = response.data.bibs;
-        return response.json({
+        const newResults = response.data.results;
+        return res.json({
           newResults,
           nextUrl: response.data.next_url,
           bibsSource: 'shepApi',
-          bibPage: page,
+          page,
+          totalResults: shepApiBibCount,
         });
       })
       .catch(
@@ -68,7 +70,6 @@ const bibsAjax = (req, res) => {
   };
 
   const processData = (data) => {
-    console.log(data);
     const { totalResults } = data;
     if (bibsSource === 'discoveryApi' || useDiscoveryResults(totalResults)) {
       return res.json({
@@ -78,7 +79,7 @@ const bibsAjax = (req, res) => {
         bibsSource: 'discoveryApi'
       });
     }
-    console.log("making shep api call");
+
     return shepApiBibsCall();
   };
 

--- a/src/server/ApiRoutes/SubjectHeading.js
+++ b/src/server/ApiRoutes/SubjectHeading.js
@@ -1,155 +1,46 @@
-import axios from 'axios';
-
-import Bib from './Bib';
-import { search } from './Search';
-import logger from '../../../logger';
-import appConfig from '../../app/data/appConfig';
 import {
   getReqParams,
-  basicQuery,
-  // parseServerSelectedFilters,
 } from '../../app/utils/utils';
+import nyplApiClient from '../routes/nyplApiClient';
+import logger from '../../../logger';
 
-const bibsServer = (req, res, next) => {
-  const { page, sort, order, filters } = getReqParams(req.query);
+const nyplApiClientCall = query => nyplApiClient()
+  .then((client) => {
+    console.log(`/discovery/resources${query}`);
+    client.get(`/discovery/resources${query}`, { cache: false });
+  })
+  .catch(console.error);
 
-  search(
+function fetchBibs(page, perPage, sortBy, order, subjectLiteral, cb, errorcb) {
+  const bibResultsQuery = `?filters[subjectLiteral]=${encodeURIComponent(subjectLiteral)}&sort=${sortBy}&sort_direction=${order}&page=${page}&per_page=${perPage}`;
+
+  return nyplApiClientCall(bibResultsQuery)
+    .then((response) => {
+      console.log("response", response);
+      const results = response;
+      cb(results, page);
+    })
+    .catch((error) => {
+      logger.error('Error making ajax SubjectHeading bibs call in fetchBibs function', error);
+      errorcb(error);
+    });
+}
+
+const bibsAjax = (req, res) => {
+  const { subjectLiteral } = req.params;
+  const { page, perPage, sort, order } = getReqParams(req.query);
+
+  fetchBibs(
     page,
+    perPage,
     sort,
     order,
-    filters,
-    (apiFilters, data, pageQuery) => {
-      const selectedFilters = {
-        subjectLiteral: [],
-      };
-
-      if (!_isEmpty(filters)) {
-        _mapObject(filters, (value, key) => {
-          let filterObj;
-          if (key === 'subjectLiteral') {
-            const subjectLiteralValues = _isArray(value) ? value : [value];
-            subjectLiteralValues.forEach((subjectLiteralValue) => {
-              selectedFilters[key].push({
-                selected: true,
-                value: subjectLiteralValue,
-                label: subjectLiteralValue,
-              });
-            });
-          }
-        });
-      }
-
-      res.locals.data.ShepStore = {
-        bibResults: data,
-        subjectLiteral: selectedFilters.subjectLiteral,
-        page: pageQuery,
-        sortBy: sort ? `${sort}_${order}` : 'date_desc',
-        error: {},
-      };
-
-      next();
-    },
-    (error) => {
-      logger.error('Error retrieving search data in searchServer', error);
-      res.locals.data.ShepStore = {
-        searchResults: {},
-        subjectLiteral: '',
-        page: '1',
-        sortBy: 'date_desc',
-        error,
-      };
-
-      next();
-    },
+    subjectLiteral,
+    data => res.json(data),
+    error => res.json(error),
   );
 };
 
-const convertShepBibsToDiscoveryBibs = response =>
-  Promise.all(
-    response.data.bibs.map((bib) => {
-      // Determine relevant id prefix
-      const institutionCode = {
-        'recap-pul': 'pb',
-        'recap-cul': 'cb',
-      }[bib.institution] || 'b';
-
-      const prefixedIdentifier = [institutionCode, bib.bnumber].join('');
-
-      return Bib.nyplApiClientCall(prefixedIdentifier)
-        .then(resp =>
-          (resp.status === 404 ? bib : resp),
-        );
-    }),
-  ).then((bibs) => {
-    // Build "next" pagination URL based on SHEP API next_url..
-    // SHEP API next_url will be of form:
-    //   http://[fqdn]/api/v0.1/subject_headings/[uuid]/bibs?[filter params]
-    // We want to translate that into:
-    //   /[app base url]/api/subjectHeadings/subject_headings/[uuid]/bibs?[filter params]
-    const nextUrl = response.data.next_url
-      ? response.data.next_url.replace(/.*?subject_headings\//, `${appConfig.baseUrl}/api/subjectHeadings/subject_headings/`)
-      : null;
-
-    return {
-      data: {
-        bibs,
-        next_url: nextUrl,
-      },
-    };
-  });
-
-/**
- *  This method handles all calls on the SHEP API
- *
- *  @param {string} path The path relative to `process.env.SHEP_API`
- *  @param {object} queryParams An object containing query parameters
- *
- *  @return {Promise<Object>} A promise that resolves the response (or rejects
- *    with an Axios error object - See
- *    https://www.npmjs.com/package/axios#handling-errors )
- */
-const shepApiCall = (path, queryParams) => {
-  logger.debug(`Making shep api call: ${appConfig.shepApi}${path}`);
-
-  return axios({
-    method: 'GET',
-    url: `${appConfig.shepApi}${path}`,
-    params: queryParams,
-  }).then((response) => {
-    if (/\/bibs$/.test(path)) {
-      return convertShepBibsToDiscoveryBibs(response);
-    }
-
-    return response;
-  });
-};
-
-/**
- *  This method proxies arbitrary calls to the SHEP API.
- */
-const proxyRequest = (req, res) => {
-  const shepApiPath = req.params[0];
-
-  shepApiCall(shepApiPath, req.query)
-    .then(response => res.status(response.status || 200).json(response.data))
-    .catch((error) => {
-      logger.error(`Handling error: for SHEP API path ${shepApiPath}:`, error);
-
-      const httpStatus = error.status || 500;
-      let payload = Object.assign({}, { httpStatus });
-
-      // Make sure error payload is JSON (some errors return html)
-      if (error.data && error.headers && /application\/json/i.test(error.headers['content-type'])) {
-        payload = Object.assign(payload, error.data);
-      }
-
-      res.status(httpStatus)
-        .json(payload);
-    });
-};
-
 export default {
-  proxyRequest,
-  shepApiCall,
-  bibsServer,
+  bibsAjax,
 };

--- a/src/server/ApiRoutes/SubjectHeading.js
+++ b/src/server/ApiRoutes/SubjectHeading.js
@@ -16,7 +16,7 @@ function fetchBibs(page, perPage, sortBy, order, subjectLiteral, shepApiBibCount
   return nyplApiClientCall(bibResultsQuery)
     .then((response) => {
       const results = response;
-      if (shepApiBibCount !== results.totalResults) {
+      if (page === '1' && parseInt(shepApiBibCount, 10) !== results.totalResults) {
         logger.warning(
           `SHEP/Discovery bib count discrepancy for subject heading ${subjectLiteral}: SHEP API- ${shepApiBibCount}, Discovery API- ${results.totalResults}`);
       }

--- a/src/server/ApiRoutes/SubjectHeadings.js
+++ b/src/server/ApiRoutes/SubjectHeadings.js
@@ -1,0 +1,99 @@
+import axios from 'axios';
+
+import Bib from './Bib';
+import logger from '../../../logger';
+import appConfig from '../../app/data/appConfig';
+import {
+  getReqParams,
+  basicQuery,
+  // parseServerSelectedFilters,
+} from '../../app/utils/utils';
+
+const convertShepBibsToDiscoveryBibs = response =>
+  Promise.all(
+    response.data.bibs.map((bib) => {
+      // Determine relevant id prefix
+      const institutionCode = {
+        'recap-pul': 'pb',
+        'recap-cul': 'cb',
+      }[bib.institution] || 'b';
+
+      const prefixedIdentifier = [institutionCode, bib.bnumber].join('');
+
+      return Bib.nyplApiClientCall(prefixedIdentifier)
+        .then(resp =>
+          (resp.status === 404 ? bib : resp),
+        );
+    }),
+  ).then((bibs) => {
+    // Build "next" pagination URL based on SHEP API next_url..
+    // SHEP API next_url will be of form:
+    //   http://[fqdn]/api/v0.1/subject_headings/[uuid]/bibs?[filter params]
+    // We want to translate that into:
+    //   /[app base url]/api/subjectHeadings/subject_headings/[uuid]/bibs?[filter params]
+    const nextUrl = response.data.next_url
+      ? response.data.next_url.replace(/.*?subject_headings\//, `${appConfig.baseUrl}/api/subjectHeadings/subject_headings/`)
+      : null;
+
+    return {
+      data: {
+        bibs,
+        next_url: nextUrl,
+      },
+    };
+  });
+
+/**
+ *  This method handles all calls on the SHEP API
+ *
+ *  @param {string} path The path relative to `process.env.SHEP_API`
+ *  @param {object} queryParams An object containing query parameters
+ *
+ *  @return {Promise<Object>} A promise that resolves the response (or rejects
+ *    with an Axios error object - See
+ *    https://www.npmjs.com/package/axios#handling-errors )
+ */
+const shepApiCall = (path, queryParams) => {
+  logger.debug(`Making shep api call: ${appConfig.shepApi}${path}`);
+
+  return axios({
+    method: 'GET',
+    url: `${appConfig.shepApi}${path}`,
+    params: queryParams,
+  }).then((response) => {
+    if (/\/bibs$/.test(path)) {
+      return convertShepBibsToDiscoveryBibs(response);
+    }
+
+    return response;
+  });
+};
+
+/**
+ *  This method proxies arbitrary calls to the SHEP API.
+ */
+const proxyRequest = (req, res) => {
+  const shepApiPath = req.params[0];
+
+  shepApiCall(shepApiPath, req.query)
+    .then(response => res.status(response.status || 200).json(response.data))
+    .catch((error) => {
+      logger.error(`Handling error: for SHEP API path ${shepApiPath}:`, error);
+
+      const httpStatus = error.status || 500;
+      let payload = Object.assign({}, { httpStatus });
+
+      // Make sure error payload is JSON (some errors return html)
+      if (error.data && error.headers && /application\/json/i.test(error.headers['content-type'])) {
+        payload = Object.assign(payload, error.data);
+      }
+
+      res.status(httpStatus)
+        .json(payload);
+    });
+};
+
+export default {
+  proxyRequest,
+  shepApiCall,
+};

--- a/src/server/ApiRoutes/SubjectHeadings.js
+++ b/src/server/ApiRoutes/SubjectHeadings.js
@@ -3,11 +3,6 @@ import axios from 'axios';
 import Bib from './Bib';
 import logger from '../../../logger';
 import appConfig from '../../app/data/appConfig';
-import {
-  getReqParams,
-  basicQuery,
-  // parseServerSelectedFilters,
-} from '../../app/utils/utils';
 
 const convertShepBibsToDiscoveryBibs = response =>
   Promise.all(

--- a/src/server/ApiRoutes/SubjectHeadings.js
+++ b/src/server/ApiRoutes/SubjectHeadings.js
@@ -56,7 +56,7 @@ const shepApiCall = (path, queryParams) => {
     url: `${appConfig.shepApi}${path}`,
     params: queryParams,
   }).then((response) => {
-    if (/\/bibs$/.test(path)) {
+    if (/\/bibs/.test(path)) {
       return convertShepBibsToDiscoveryBibs(response);
     }
 

--- a/src/server/ApiRoutes/SubjectHeadings.js
+++ b/src/server/ApiRoutes/SubjectHeadings.js
@@ -32,7 +32,7 @@ const convertShepBibsToDiscoveryBibs = response =>
 
     return {
       data: {
-        bibs,
+        results: bibs,
         next_url: nextUrl,
       },
     };

--- a/src/server/routes/nyplApiClient/index.js
+++ b/src/server/routes/nyplApiClient/index.js
@@ -1,8 +1,8 @@
 import NyplApiClient from '@nypl/nypl-data-api-client';
 import aws from 'aws-sdk';
 
-import config from '../../../app/data/appConfig.js';
-import logger from '../../../../logger.js';
+import config from '../../../app/data/appConfig';
+import logger from '../../../../logger';
 
 const appEnvironment = process.env.APP_ENV || 'production';
 const kmsEnvironment = process.env.KMS_ENV || 'encrypted';

--- a/test/unit/utils.test.js
+++ b/test/unit/utils.test.js
@@ -432,6 +432,7 @@ describe('getReqParams', () => {
         sortQuery: '',
         fieldQuery: '',
         filters: {},
+        perPage: '50',
       });
     });
   });
@@ -447,6 +448,7 @@ describe('getReqParams', () => {
         sortQuery: '',
         fieldQuery: '',
         filters: {},
+        perPage: '50',
       });
     });
 
@@ -460,6 +462,7 @@ describe('getReqParams', () => {
         sortQuery: '',
         fieldQuery: '',
         filters: {},
+        perPage: '50',
       });
     });
 
@@ -473,6 +476,7 @@ describe('getReqParams', () => {
         sortQuery: '',
         fieldQuery: '',
         filters: {},
+        perPage: '50',
       });
     });
 
@@ -486,6 +490,7 @@ describe('getReqParams', () => {
         sortQuery: '',
         fieldQuery: 'author',
         filters: {},
+        perPage: '50',
       });
     });
 
@@ -499,6 +504,7 @@ describe('getReqParams', () => {
         sortQuery: 'title_asc',
         fieldQuery: '',
         filters: {},
+        perPage: '50',
       });
     });
 
@@ -512,6 +518,7 @@ describe('getReqParams', () => {
         sortQuery: '',
         fieldQuery: '',
         filters: 'filters[owner]=orgs%3A1000',
+        perPage: '50',
       });
     });
   });


### PR DESCRIPTION
**What's this do?**
Currently, rendering the bibs on the SHEP show page with data from Discovery API is fully implemented. I have not yet implemented the logic for making the SHEP API call instead. Could use suggestions on how to handle this. Like how big of a bib count discrepancy should we allow for? Do we want to try to make both calls at the same time?

We also probably want to implement a different way of getting the label/`subjectLiteral` besides waiting for the `context` query to return.

Some changes, particularly in the `constructor` are just stylistic/trying to make things work. Feel free to ask to revert these changes.

Generally, there is a lot of room for cleanup.

**Did someone actually run this code to verify it works?**
PR author did. Show page seems to be working, except for the call to SHEP API.