### PR TITLE
Bibs list refactor

### DIFF
--- a/src/app/components/Pagination/Pagination.jsx
+++ b/src/app/components/Pagination/Pagination.jsx
@@ -32,16 +32,15 @@ class Pagination extends React.Component {
       subjectIndexPage,
     } = this.props;
     if (!page) return null;
-    if (type == 'Next' && subjectShowPage && !hasNext) return null;
+    if (type === 'Next' && subjectShowPage && !hasNext) return null;
     const intPage = parseInt(page, 10);
     const pageNum = type === 'Next' ? intPage + 1 : intPage - 1;
     const svg = type === 'Next' ? <RightWedgeIcon /> : <LeftWedgeIcon />;
-    const subjectHeadingPage = subjectShowPage || subjectIndexPage;
 
     let url;
     let apiUrl;
     let localUrl;
-    if (subjectHeadingPage && shepNavigation) {
+    if (shepNavigation) {
       if (!shepNavigation[type.toLowerCase()]) return null;
       url = type === 'Next' ? shepNavigation.next : shepNavigation.previous;
     } else {

--- a/src/app/components/Pagination/Pagination.jsx
+++ b/src/app/components/Pagination/Pagination.jsx
@@ -122,6 +122,7 @@ Pagination.propTypes = {
   subjectShowPage: PropTypes.bool,
   shepNavigation: PropTypes.object,
   subjectIndexPage: PropTypes.bool,
+  hasNext: PropTypes.bool,
 };
 
 Pagination.defaultProps = {

--- a/src/app/components/SubjectHeading/BibsList.jsx
+++ b/src/app/components/SubjectHeading/BibsList.jsx
@@ -47,19 +47,19 @@ class BibsList extends React.Component {
           results,
           bibsSource,
           page,
-          totalResults,
         } = res.data;
+        const totalResults = res.data.totalResults || this.state.totalResults;
         const newState = {
           bibsSource,
-          bibPage: page,
+          bibPage: parseInt(page, 10),
           componentLoading: false,
+          totalResults,
         };
         if (bibsSource === 'discoveryApi') {
           newState.results = results;
           this.setState(newState, cb);
         } else if (bibsSource === 'shepApi') {
           newState.nextUrl = res.data.next_url;
-          newState.totalResults = this.props.shepBibCount;
           this.setState((prevState) => {
             newState.results = prevState.results.concat(res.data.newResults);
             return newState;
@@ -120,7 +120,7 @@ class BibsList extends React.Component {
           nextUrl: res.data.next_url,
           componentLoading: false,
           bibsSource: 'shepApi',
-          bibPage: newPage,
+          bibPage: parseInt(newPage, 10),
         }, () => window.scrollTo(0, 300));
       })
       .catch(
@@ -144,28 +144,21 @@ class BibsList extends React.Component {
     const {
       bibsSource,
       bibPage,
-      results,
       nextUrl,
       totalResults,
     } = this.state;
 
+    const lastPage = Math.ceil(totalResults / this.perPage);
+
     const paginationProps = {
       perPage: this.perPage,
       ariaControls: 'nypl-results-list',
+      updatePage: this.updateBibPage,
+      total: parseInt(totalResults, 10),
+      page: bibPage,
+      hasNext: (bibPage < lastPage || nextUrl),
+      subjectShowPage: true,
     };
-
-    if (bibsSource === 'discoveryApi') {
-      paginationProps.total = totalResults;
-      paginationProps.page = parseInt(bibPage, 10);
-      paginationProps.updatePage = this.updateBibPage;
-    } else if (bibsSource === 'shepApi') {
-      const lastPage = Math.ceil(results.length / this.perPage);
-      paginationProps.total = this.props.shepBibCount;
-      paginationProps.updatePage = this.updateShepBibPage;
-      paginationProps.hasNext = (bibPage < lastPage || nextUrl);
-      paginationProps.page = parseInt(bibPage, 10);
-      paginationProps.shepBibs = true;
-    }
 
     return (
       <Pagination

--- a/src/app/components/SubjectHeading/BibsList.jsx
+++ b/src/app/components/SubjectHeading/BibsList.jsx
@@ -114,13 +114,12 @@ class BibsList extends React.Component {
 
     return axios(nextUrl)
       .then((res) => {
-        const results = this.state.results.concat(res.data.bibs);
+        const results = this.state.results.concat(res.data.results);
         this.setState({
           results,
           nextUrl: res.data.next_url,
           componentLoading: false,
-          bibsSource: 'shepApi',
-          bibPage: parseInt(newPage, 10),
+          bibPage: newPage,
         }, () => window.scrollTo(0, 300));
       })
       .catch(

--- a/src/app/components/SubjectHeading/BibsList.jsx
+++ b/src/app/components/SubjectHeading/BibsList.jsx
@@ -29,7 +29,6 @@ class BibsList extends React.Component {
     this.changeBibSorting = this.changeBibSorting.bind(this);
     this.fetchBibs = this.fetchBibs.bind(this);
     this.pagination = this.pagination.bind(this);
-    this.permittedMargin = 0.2;
   }
 
   componentDidMount() {
@@ -141,7 +140,6 @@ class BibsList extends React.Component {
 
   pagination() {
     const {
-      bibsSource,
       bibPage,
       nextUrl,
       totalResults,
@@ -168,9 +166,7 @@ class BibsList extends React.Component {
 
   render() {
     const {
-      bibPage,
       results,
-      nextUrl,
       bibsSource,
       totalResults,
     } = this.state;
@@ -230,6 +226,7 @@ class BibsList extends React.Component {
 BibsList.propTypes = {
   label: PropTypes.string,
   shepBibCount: PropTypes.number,
+  uuid: PropTypes.string,
 };
 
 BibsList.contextTypes = {

--- a/src/app/components/SubjectHeading/SubjectHeadingShow.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeadingShow.jsx
@@ -53,6 +53,7 @@ class SubjectHeadingShow extends React.Component {
           contextHeadings: this.processContextHeadings(subject_headings, uuid),
           mainHeading: {
             label,
+            uuid,
           },
           totalBibs: bib_count,
           contextIsLoading: false,

--- a/src/app/components/SubjectHeading/SubjectHeadingShow.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeadingShow.jsx
@@ -1,12 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import axios from 'axios';
-import { Link } from 'react-router';
 
 import SubjectHeadingsTable from './SubjectHeadingsTable';
 import NeighboringHeadingsBox from './NeighboringHeadingsBox';
 import BibsList from './BibsList';
-import LocalLoadingLayer from './LocalLoadingLayer';
 import Range from '../../models/Range';
 import appConfig from '../../data/appConfig';
 import Actions from '../../actions/Actions';
@@ -19,8 +17,6 @@ class SubjectHeadingShow extends React.Component {
       mainHeading: {
         uuid: this.props.params.subjectHeadingUuid,
       },
-      shepBibs: [],
-      bibsLoaded: false,
       contextError: null,
       contextIsLoading: true,
       contextHeadings: [],
@@ -105,7 +101,6 @@ class SubjectHeadingShow extends React.Component {
 
   generateFullContextUrl() {
     const uuid = this.props.params.subjectHeadingUuid;
-    const linkFromLabel = this.getTopLevelLabel();
     const path = this.props.location.pathname.replace(/\/subject_headings.*/, '');
     return `${path}/subject_headings?linked=${uuid}`;
   }

--- a/src/server/ApiRoutes/SubjectHeading.js
+++ b/src/server/ApiRoutes/SubjectHeading.js
@@ -1,8 +1,11 @@
+import axios from 'axios';
+
 import {
   getReqParams,
 } from '../../app/utils/utils';
 import nyplApiClient from '../routes/nyplApiClient';
 import logger from '../../../logger';
+import appConfig from '@appConfig'
 
 const nyplApiClientCall = query => nyplApiClient()
   .then((client) => {
@@ -32,6 +35,52 @@ const bibsAjax = (req, res) => {
   const { subjectLiteral } = req.params;
   const { page, perPage, sort, order } = getReqParams(req.query);
   const shepApiBibCount = req.query.shep_bib_count;
+  const bibsSource = req.query.source;
+
+  const shepApiBibsCall = () => {
+    const stringifiedSortParams = `sort=${sort}&sort_direction=${order}`;
+    const queryUrl = `${appConfig.baseUrl}/api/subjectHeadings/subject_headings/${subjectLiteral}/bibs?${stringifiedSortParams}`;
+
+    return axios(queryUrl)
+      .then((response) => {
+        const newResults = response.data.bibs;
+        return response.json({
+          newResults,
+          nextUrl: response.data.next_url,
+          bibsSource: 'shepApi',
+          bibPage: page,
+        });
+      })
+      .catch(
+        (err) => {
+          // eslint-disable-next-line no-console
+          console.error('error: ', err);
+        },
+      );
+  };
+
+  const useDiscoveryResults = (discoveryApiBibCount) => {
+    if (shepApiBibCount === 0) return true;
+    if (discoveryApiBibCount === 0) return false;
+    const discrepancy = Math.abs(shepApiBibCount - discoveryApiBibCount);
+
+    return discrepancy < (shepApiBibCount * 0.2);
+  };
+
+  const processData = (data) => {
+    console.log(data);
+    const { totalResults } = data;
+    if (bibsSource === 'discoveryApi' || useDiscoveryResults(totalResults)) {
+      return res.json({
+        results: data.itemListElement,
+        page,
+        totalResults,
+        bibsSource: 'discoveryApi'
+      });
+    }
+    console.log("making shep api call");
+    return shepApiBibsCall();
+  };
 
   fetchBibs(
     page,
@@ -40,7 +89,7 @@ const bibsAjax = (req, res) => {
     order,
     subjectLiteral,
     shepApiBibCount,
-    data => res.json({ ...data, page }),
+    data => processData(data),
     error => res.json(error),
   );
 };

--- a/src/server/ApiRoutes/SubjectHeading.js
+++ b/src/server/ApiRoutes/SubjectHeading.js
@@ -47,7 +47,7 @@ const bibsAjax = (req, res) => {
         const newResults = response.data.results;
         return res.json({
           newResults,
-          nextUrl: response.data.next_url,
+          next_url: response.data.next_url,
           bibsSource: 'shepApi',
           page,
           totalResults: shepApiBibCount,

--- a/src/server/ApiRoutes/SubjectHeading.js
+++ b/src/server/ApiRoutes/SubjectHeading.js
@@ -1,17 +1,12 @@
-import axios from 'axios';
-
 import {
   getReqParams,
 } from '../../app/utils/utils';
 import nyplApiClient from '../routes/nyplApiClient';
 import logger from '../../../logger';
-import appConfig from '../../app/data/appConfig';
 import SubjectHeadings from './SubjectHeadings';
 
 const nyplApiClientCall = query => nyplApiClient()
-  .then((client) => {
-    return client.get(`/discovery/resources${query}`, { cache: false });
-  })
+  .then(client => client.get(`/discovery/resources${query}`, { cache: false }))
   .catch(console.error);
 
 function fetchBibs(page, perPage, sortBy, order, subjectLiteral, shepApiBibCount, cb, errorcb) {
@@ -76,7 +71,7 @@ const bibsAjax = (req, res) => {
         results: data.itemListElement,
         page,
         totalResults,
-        bibsSource: 'discoveryApi'
+        bibsSource: 'discoveryApi',
       });
     }
 

--- a/src/server/ApiRoutes/SubjectHeading.js
+++ b/src/server/ApiRoutes/SubjectHeading.js
@@ -5,7 +5,8 @@ import {
 } from '../../app/utils/utils';
 import nyplApiClient from '../routes/nyplApiClient';
 import logger from '../../../logger';
-import appConfig from '@appConfig'
+import appConfig from '../../app/data/appConfig';
+import SubjectHeadings from './SubjectHeadings';
 
 const nyplApiClientCall = query => nyplApiClient()
   .then((client) => {
@@ -39,16 +40,17 @@ const bibsAjax = (req, res) => {
 
   const shepApiBibsCall = () => {
     const stringifiedSortParams = `sort=${sort}&sort_direction=${order}`;
-    const queryUrl = `${appConfig.baseUrl}/api/subjectHeadings/subject_headings/${subjectLiteral}/bibs?${stringifiedSortParams}`;
+    const queryUrl = `/subject_headings/${req.query.shep_uuid}/bibs?${stringifiedSortParams}`;
 
-    return axios(queryUrl)
+    return SubjectHeadings.shepApiCall(queryUrl)
       .then((response) => {
-        const newResults = response.data.bibs;
-        return response.json({
+        const newResults = response.data.results;
+        return res.json({
           newResults,
           nextUrl: response.data.next_url,
           bibsSource: 'shepApi',
-          bibPage: page,
+          page,
+          totalResults: shepApiBibCount,
         });
       })
       .catch(
@@ -68,7 +70,6 @@ const bibsAjax = (req, res) => {
   };
 
   const processData = (data) => {
-    console.log(data);
     const { totalResults } = data;
     if (bibsSource === 'discoveryApi' || useDiscoveryResults(totalResults)) {
       return res.json({
@@ -78,7 +79,7 @@ const bibsAjax = (req, res) => {
         bibsSource: 'discoveryApi'
       });
     }
-    console.log("making shep api call");
+
     return shepApiBibsCall();
   };
 

--- a/src/server/ApiRoutes/SubjectHeadings.js
+++ b/src/server/ApiRoutes/SubjectHeadings.js
@@ -56,7 +56,7 @@ const shepApiCall = (path, queryParams) => {
     url: `${appConfig.shepApi}${path}`,
     params: queryParams,
   }).then((response) => {
-    if (/\/bibs$/.test(path)) {
+    if (/\/bibs/.test(path)) {
       return convertShepBibsToDiscoveryBibs(response);
     }
 

--- a/src/server/ApiRoutes/SubjectHeadings.js
+++ b/src/server/ApiRoutes/SubjectHeadings.js
@@ -32,7 +32,7 @@ const convertShepBibsToDiscoveryBibs = response =>
 
     return {
       data: {
-        bibs,
+        results: bibs,
         next_url: nextUrl,
       },
     };

--- a/test/unit/utils.test.js
+++ b/test/unit/utils.test.js
@@ -432,6 +432,7 @@ describe('getReqParams', () => {
         sortQuery: '',
         fieldQuery: '',
         filters: {},
+        perPage: '50',
       });
     });
   });
@@ -447,6 +448,7 @@ describe('getReqParams', () => {
         sortQuery: '',
         fieldQuery: '',
         filters: {},
+        perPage: '50',
       });
     });
 
@@ -460,6 +462,7 @@ describe('getReqParams', () => {
         sortQuery: '',
         fieldQuery: '',
         filters: {},
+        perPage: '50',
       });
     });
 
@@ -473,6 +476,7 @@ describe('getReqParams', () => {
         sortQuery: '',
         fieldQuery: '',
         filters: {},
+        perPage: '50',
       });
     });
 
@@ -486,6 +490,7 @@ describe('getReqParams', () => {
         sortQuery: '',
         fieldQuery: 'author',
         filters: {},
+        perPage: '50',
       });
     });
 
@@ -499,6 +504,7 @@ describe('getReqParams', () => {
         sortQuery: 'title_asc',
         fieldQuery: '',
         filters: {},
+        perPage: '50',
       });
     });
 
@@ -512,6 +518,7 @@ describe('getReqParams', () => {
         sortQuery: '',
         fieldQuery: '',
         filters: 'filters[owner]=orgs%3A1000',
+        perPage: '50',
       });
     });
   });


### PR DESCRIPTION
**What's this do?**
This PR moves more of the logic for the `BibsList` data fetching to the server side routing.

**Dependencies for merging? Releasing to production?**
This PR is merging into `server-shep-routes`. PR #1311 has `server-shep-routes` merging into `shep-development`

**Did someone actually run this code to verify it works?**
PR author did. I checked "Pottery" and subject headings from the index "Aach (Germany)" through "Aachen (Ggermany)". "Labor movement -- Germany" gets its bibs using SHEP API and has pagination.