### PR TITLE
SCC-2022 Styling tweaks

### DIFF
--- a/src/app/components/SubjectHeading/NeighboringHeadingsBox.jsx
+++ b/src/app/components/SubjectHeading/NeighboringHeadingsBox.jsx
@@ -37,7 +37,7 @@ class NeighboringHeadingsBox extends React.Component {
         tableHeaderText="Neighboring Subject Headings"
         tfootContent={
           <tr>
-            <td>
+            <td colSpan="4">
               <Link
                 to={linkUrl}
                 className="toIndex"

--- a/src/client/styles/components/SubjectHeadings.scss
+++ b/src/client/styles/components/SubjectHeadings.scss
@@ -150,9 +150,3 @@ thead .subjectHeadingRow {
 #sort-by-label {
   width: 160px;
 }
-
-.shepcontainer {
-  #titles {
-    font-size: 1.2rem;
-  }
-}

--- a/src/client/styles/components/SubjectHeadings/BibsList.scss
+++ b/src/client/styles/components/SubjectHeadings/BibsList.scss
@@ -10,13 +10,15 @@
   }
 }
 
+.shepcontainer {
+  #titles {
+    font-size: 1.2rem;
+    font-weight: 400;
+  }
+}
+
 @media (min-width: 966px) {
   .bibsList {
     min-height: 22rem;
-  }
-
-  #titles {
-    font-weight: 400;
-    font-family: Milo-Light;
   }
 }

--- a/src/client/styles/components/SubjectHeadings/SubjectHeading.scss
+++ b/src/client/styles/components/SubjectHeadings/SubjectHeading.scss
@@ -74,6 +74,8 @@ tbody .subjectHeadingRow {
 
 .emph {
   color: black;
+  font-size: 14px;
+  font-style: initial;
 
   &:hover {
     color: inherit;

--- a/src/client/styles/components/SubjectHeadings/SubjectHeadingShow.scss
+++ b/src/client/styles/components/SubjectHeadings/SubjectHeadingShow.scss
@@ -1,6 +1,7 @@
 .subjectHeadingsSideBar {
   display: flex;
   flex-direction: column;
+  float: right;
 
   .subjectHeadingsTable {
     min-width: 100%;
@@ -21,9 +22,10 @@
   }
 
   .toIndex {
-    font-size: 14px;
+    font-size: 16px;
     min-height: 32px;
     text-decoration: none;
+    font-weight: 500;
   }
 
   .toIndex:hover {
@@ -59,6 +61,7 @@
 
   h4 {
     font-size: 16px;
+    font-weight: 500;
   }
 
   .subjectHeadingLabelContainer {


### PR DESCRIPTION
**What's this do?**
Changes to font sizes and some other small fixes I noticed (position of show page side boxes before the bibs list loads, the width of the "Explore more in subject heading index" element, font-family for the "Titles" header on the show page).

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SCC-2022

**Dependencies for merging? Releasing to production?**
I applied the font sizes Ellen requested for mobile for all widths. I think it looks good, but I can I also change this to just be on mobile. If the latter, should I make it for the tablet width and phone width or just phone?

**Did someone actually run this code to verify it works?**
PR author did.