### PR TITLE
Add notification on search results page

### DIFF
--- a/src/app/components/SccContainer/SccContainer.jsx
+++ b/src/app/components/SccContainer/SccContainer.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 
 import Breadcrumbs from '../Breadcrumbs/Breadcrumbs';
 import LoadingLayer from '../LoadingLayer/LoadingLayer';
+import Notification from '../Notification/Notification';
 
 import Store from '../../stores/Store';
 
@@ -17,6 +18,7 @@ const SccContainer = props => (
         <div className="nypl-row">
           <div className="nypl-column-full">
             <Breadcrumbs type={props.breadcrumbsType} />
+            <Notification notificationType="searchResultsNotification" />
             <h1
               aria-label={props.bannerOptions.ariaLabel || props.bannerOptions.text}
             >


### PR DESCRIPTION
**What's this do?**
Adds a notification to the search results page

**Why are we doing this? (w/ JIRA link if applicable)**
This is currently in production but got lost in shep

**How should this be tested? / Do these changes have associated tests?**
You should see the message on any search results page as long as you have environment variables set. If you are using `.env` add these lines:
```
export SET CLOSED_LOCATIONS="all;Schwarzman;Science;Library for the Performing Arts;Schomburg"
export SET SEARCH_RESULTS_NOTIFICATION="Print and electronic delivery services are unavailable until further notice. Patrons are encouraged to take advantage of the Library's remote research resources: <a href='https://www.nypl.org/about/remote-research-resources'>https://www.nypl.org/about/remote-research-resources</a>"
```

**Dependencies for merging? Releasing to production?**
[Description of any watchouts, dependencies, or issues we should be aware of goes here]

**Has the application documentation been updated for these changes?**

**Did someone actually run this code to verify it works?**
PR author tested locally.
