### PR TITLE
SCC-2067/ 

### DIFF
--- a/src/client/styles/components/ShepContainer.scss
+++ b/src/client/styles/components/ShepContainer.scss
@@ -47,10 +47,18 @@
     }
   }
 
-  .nypl-row.container-row {
-    @include media($mobile-breakpoint) {
-      padding-right: 0px;
-      padding-left: 10px;
+  .nypl-row {
+    margin: 0;
+
+    &.container-row {
+      @include media($mobile-breakpoint) {
+        padding-left: 10px;
+        padding-right: 0;
+      }
+
+      @include media(770px) {
+        padding: 2%;
+      }
     }
   }
 }

--- a/src/client/styles/components/SubjectHeadings/SubjectHeadingShow.scss
+++ b/src/client/styles/components/SubjectHeadings/SubjectHeadingShow.scss
@@ -98,3 +98,10 @@
     min-width: auto;
   }
 }
+
+@include media($xtrasmall-breakpoint) {
+  .subjectHeadingsSideBar {
+    float: left;
+    width: unset;
+  }
+}


### PR DESCRIPTION
**What's this do?**
This fixes the weird margin and padding that were especially noticeable in the mobile view, except for cases in which a subject heading has an especially long word, eg. "Versicherungsgesellschaft" which is in a heading on the default index page... We are waiting on feedback for how to handle this case.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SCC-2067

**Did someone actually run this code to verify it works?**
PR author did