### PR TITLE
Use server path in fetch and upate

### DIFF
--- a/src/app/components/SubjectHeading/SubjectHeading.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeading.jsx
@@ -103,7 +103,8 @@ class SubjectHeading extends React.Component {
 
   fetchAndUpdate(url) {
     return (element) => {
-      axios(url)
+      const apiUrl = url.replace(/.*\/api\/v0\.1/, `${appConfig.baseUrl}/api/subjectHeadings`);
+      axios(apiUrl)
         .then(
           (resp) => {
             if (resp.data.narrower) {


### PR DESCRIPTION
**What's this do?**
Change the logic in `fetchAndUpdate` to make sure we use the proxied server path rather than calling shep api directly.
We should probably also change the url at the point when it is received, but there are a couple of different places where that happens and it is difficult to test this locally, so I favor this approach as a temporary patch since it should catch everything.

**Why are we doing this? (w/ JIRA link if applicable)**
We need the browser to be able to get items from shep-api (which has restrictive inbound ip rules).

**How should this be tested? / Do these changes have associated tests?**
Unfortunately you still need to be vpn'ed for this to work (if you are hitting production shep). So you can test locally that the `See More` button is working but we'll still have to see if it works in dev.

**Dependencies for merging? Releasing to production?**

**Has the application documentation been updated for these changes?**

**Did someone actually run this code to verify it works?**
PR author tested locally.
