### PR TITLE
Scc 1947

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16788,7 +16788,7 @@
     "webpack-dev-middleware": {
       "version": "1.12.2",
       "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.12.2.tgz",
-      "integrity": "sha512-FCrqPy1yy/sN6U/SaEZcHKRXGlqU0DUaEBL45jkUYoB8foVb6wCnbIJ1HKIx+qUFTW+3JpVcCJCxZ8VATL4e+A==",
+      "integrity": "sha1-+PwRIM47T8VoDO7LQ9d3lmshEF4=",
       "dev": true,
       "requires": {
         "memory-fs": "~0.4.1",

--- a/src/app/components/SubjectHeading/SubjectHeading.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeading.jsx
@@ -29,10 +29,8 @@ class SubjectHeading extends React.Component {
     };
     this.toggleOpen = this.toggleOpen.bind(this);
     this.updateSubjectHeading = this.updateSubjectHeading.bind(this);
-    this.addMore = this.addMore.bind(this);
     this.generateUrl = this.generateUrl.bind(this);
     this.updateSort = this.updateSort.bind(this);
-    this.fetchInitial = this.fetchInitial.bind(this);
   }
 
   componentDidMount() {
@@ -77,43 +75,6 @@ class SubjectHeading extends React.Component {
     } else {
       this.updateSubjectHeading({ open: false });
     }
-  }
-
-  addMore(element, data) {
-    this.setState((prevState) => {
-      const { narrower } = prevState;
-      data.narrower.forEach(
-        (child) => { child.indentation = (this.props.subjectHeading.indentation || 0) + 1; }
-      );
-
-      narrower.splice(-1, 1, ...data.narrower);
-
-      if (data.next_url) {
-        narrower.splice(narrower.length, 1, {
-          button: 'next',
-          updateParent: this.fetchAndUpdate(data.next_url),
-          indentation: (this.props.subjectHeading.indentation || 0) + 1,
-          noEllipse: true,
-        });
-      }
-
-      return { narrower };
-    });
-  }
-
-  fetchAndUpdate(url) {
-    return (element) => {
-      axios(url)
-        .then(
-          (resp) => {
-            if (resp.data.narrower) {
-              this.addMore(element, resp.data);
-            } else {
-              element.hide();
-            }
-          },
-        ).catch((resp) => { console.error(resp); });
-    };
   }
 
   addEmphasis(string) {
@@ -173,12 +134,7 @@ class SubjectHeading extends React.Component {
           if (!narrower) return;
           narrower.forEach((child) => {child.indentation = (indentation || 0) + 1; });
           if (next_url) {
-            narrower.push({
-              button: 'next',
-              updateParent: this.fetchAndUpdate(next_url),
-              indentation: (indentation || 0) + 1,
-              noEllipse: true,
-            });
+            this.setState({ nextUrl: next_url });
           }
           this.updateSubjectHeading(
             Object.assign(
@@ -227,6 +183,7 @@ class SubjectHeading extends React.Component {
       sortBy,
       direction,
       range,
+      nextUrl,
     } = this.state;
 
     const {
@@ -324,6 +281,7 @@ class SubjectHeading extends React.Component {
             seeMoreLinkUrl={seeMoreLinkUrl}
             preOpen={false}
             marginSize={marginSize}
+            nextUrl={nextUrl}
           />
           : null}
       </React.Fragment>

--- a/src/app/components/SubjectHeading/SubjectHeadingsTableBody.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeadingsTableBody.jsx
@@ -46,7 +46,8 @@ class SubjectHeadingsTableBody extends React.Component {
       nextUrl,
       subjectHeadings,
     } = this.state;
-    axios(nextUrl)
+    const apiUrl = nextUrl.replace(/.*\/api\/v0\.1/, `${appConfig.baseUrl}/api/subjectHeadings`);
+    axios(apiUrl)
       .then(
         (resp) => {
           const {

--- a/src/app/components/SubjectHeading/SubjectHeadingsTableBody.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeadingsTableBody.jsx
@@ -13,16 +13,19 @@ class SubjectHeadingsTableBody extends React.Component {
     super(props);
     const {
       subjectHeadings,
+      nextUrl,
     } = props;
 
     this.state = {
       subjectHeadings,
       range: this.initialRange(props),
+      nextUrl,
     };
     this.updateRange = this.updateRange.bind(this);
     this.listItemsInRange = this.listItemsInRange.bind(this);
     this.listItemsInInterval = this.listItemsInInterval.bind(this);
     this.tableRow = this.tableRow.bind(this);
+    this.fetchAndUpdate = this.fetchAndUpdate.bind(this);
   }
 
   initialRange(props) {
@@ -36,6 +39,32 @@ class SubjectHeadingsTableBody extends React.Component {
     intervalElement[endpoint] += increment;
     rangeElement.normalize();
     this.setState(prevState => prevState);
+  }
+
+  fetchAndUpdate() {
+    const {
+      nextUrl,
+      subjectHeadings,
+    } = this.state;
+    axios(nextUrl)
+      .then(
+        (resp) => {
+          const {
+            data: {
+              narrower,
+              next_url,
+            },
+          } = resp;
+          if (narrower) {
+            this.setState({
+              subjectHeadings: subjectHeadings.concat(narrower),
+              nextUrl: next_url,
+            });
+          } else {
+            this.setState({ nextUrl: false });
+          }
+        },
+      ).catch((resp) => { console.error(resp); });
   }
 
   listItemsInRange() {
@@ -52,7 +81,7 @@ class SubjectHeadingsTableBody extends React.Component {
 
   listItemsInInterval(interval, index, lastIndex) {
     const { indentation } = this.props;
-    const { subjectHeadings, range } = this.state;
+    const { subjectHeadings, range, nextUrl } = this.state;
     const { container } = this.context;
     const { start, end } = interval;
     const subjectHeadingsInInterval = subjectHeadings.filter((el, i) => i >= start && i <= end);
@@ -70,6 +99,14 @@ class SubjectHeadingsTableBody extends React.Component {
         indentation,
         noEllipse: index === lastIndex,
         updateParent: () => this.updateRange(range, interval, 'end', 10),
+      });
+    }
+    if (end === Infinity && nextUrl) {
+      subjectHeadingsInInterval.push({
+        button: isContext ? 'contextMore' : 'next',
+        indentation,
+        noEllipse: true,
+        updateParent: this.fetchAndUpdate,
       });
     }
     return subjectHeadingsInInterval;


### PR DESCRIPTION
**What's this do?**
Refactors the `SubjectHeading` and `SubjectHeadingsTableBody` components so that fetching more subject headings is only handled by one component, and only in one way. 

**Why are we doing this? (w/ JIRA link if applicable)**
This is part of SCC-1947. Until now we had two different components using two different strategies for implementing the 'See more' button. The approach in the `SubjectHeading` component involved a storing a list that mixed buttons and child components, which was complicated to work with, so I've gotten rid of that one.

**How should this be tested? / Do these changes have associated tests?**
This should only affect the `See More` button, so any component with that will be a good one to test.

**Dependencies for merging? Releasing to production?**
[Description of any watchouts, dependencies, or issues we should be aware of goes here]

**Has the application documentation been updated for these changes?**

**Did someone actually run this code to verify it works?**
PR author tested locally.
