### PR TITLE
Remove console log

### DIFF
--- a/src/app/components/SubjectHeading/BibsList.jsx
+++ b/src/app/components/SubjectHeading/BibsList.jsx
@@ -34,7 +34,7 @@ class BibsList extends React.Component {
   componentDidMount() {
     const stringifiedSortParams = `sort=${this.sort}&sort_direction=${this.sortDirection}&per_page=${this.perPage}&shep_bib_count=${this.props.shepBibCount}&shep_uuid=${this.props.uuid}`;
 
-    this.fetchBibs(stringifiedSortParams, () => console.log(this.state));
+    this.fetchBibs(stringifiedSortParams);
   }
 
   fetchBibs(stringifiedSortParams, cb = () => {}) {


### PR DESCRIPTION
Tiny PR to remove the logging of state from the `BibsList` componentDidMount. I used this to see when shep api or discovery api is being used. But we should remove this, at least on QA and Prod.