### PR TITLE
SCC-2068 documentation for ResearchNow API compared to Discovery API

### DIFF
--- a/discoveryApiResearchNowApiMapping.md
+++ b/discoveryApiResearchNowApiMapping.md
@@ -43,7 +43,7 @@
 ## API Parameters Comparison
 This table lists, in the first column, the frontend features related to searching and search filters available from the frontend. The 2nd and 3rd column list out the Discovery API and ResearchNow API parameters that correlate to that frontend functionality.
 
-Single quotes (') are used for frontend terminology. Italics used to describe frontend feature. Code styling is used for parameters the respective APIs except. Doubles quotes are used for keys in Parameters that take an object. (")
+Single quotes (') are used for frontend terminology. Italics are used to describe frontend features. Code styling (e.g. `filters`) is used for the parameters the respective APIs except.
 
 |Discovery front end|Discovery API |ResearchNow API|
 |-------------------|--------------|---------------|
@@ -52,19 +52,19 @@ Single quotes (') are used for frontend terminology. Italics used to describe fr
 |<ul>'All Fields'   |<ul>"all"     |<ul>"keyword"|
 |<ul>'Title'            |<ul>"title"        |<ul>"title"       |
 |<ul>'Author/Contributor'|<ul>"contributor" |<ul>"author"      |
-|<ul>'Standard Number'|<ul>"standard_number"|<ul> 'standard_number'|
-|_Search page filters_|`filters`     |`filters`      |
-|<ul>'Format'       |<ul>"materialType"|<ul>_N/A_|
-|<ul><li>'Date':<ul><li>'Start Year'<li>'End Year'| <ul><br>"dateAfter"<br>"dateBefore" |`years`:<ul>"start"<br>"end"|
-|<ul>'Language'|<ul>"language"|<ul>`language`|
+|<ul>'Standard Number'|<ul>"standard_number"|<ul> "standard_number"|
+|_Search page filters_|`filters`     |      |
+|<ul>'Format'       |<ul>`filters[materialType]`|<ul>N/A|
+|<ul>'Date':<ul><li>'Start Year'<li>'End Year'| <ul><br>`filters[dateAfter]`<br>`filters[dateBefore]` |<br><ul>`years[start]`<br>`years[end]`|
+|<ul>'Language'|<ul>`filters[language]`|<ul>`language`|
 |_Filters linked to from a bib page_|
-|<ul>'Author'|<ul>"creatorLiteral"|<ul>use `field` "author"|
-|<ul>'Additional Authors'|<ul>"creatorLiteral"|<ul>use `field` "author"|
-|<ul>'Subject'    |<ul>"subjectLiteral"|<ul>use `field` "subject"|
+|<ul>'Author'|<ul>`filters[creatorLiteral]`|<ul>`field[author]`|
+|<ul>'Additional Authors'|<ul>`filters[creatorLiteral]`|<ul>`field[author]`|
+|<ul>'Subject'    |<ul>`filters[subjectLiteral]`|<ul> `field[subject]`|
 |_Pagination_     |`page`      | `page`        |
 |                   |`per_page`|`per_page`|
-|Sorting            |`sort`        |`sort` "field" |
-|                   |`sort_direction`|"direction"  |
+|_Sorting_            |`sort`        |`sort[field]` |
+|                   |`sort_direction`|`sort[direction]`  |
 
 ## API Response Structure
 ### Discovery API

--- a/discoveryApiResearchNowApiMapping.md
+++ b/discoveryApiResearchNowApiMapping.md
@@ -1,0 +1,63 @@
+# Discovery API - ResearchNow API mapping
+## Discovery API
+[Github](https://github.com/NYPL-discovery/discovery-api/blob/master/README.md#searching)
+### Parameters
+[GET `/v0.1/discovery/resources`](https://platformdocs.nypl.org/#/discovery/get_v0_1_discovery_resources)
+* `q` string
+* `page` string
+* `per_page` integer
+* `sort` integer
+ * 'relevance', 'title', 'creator', 'date'
+* `sort_direction` string
+ * 'asc', 'desc'
+ * title defaults to asc, date defaults to desc, creator defaults to asc, relevance is fixed desc
+* `search_scope` string
+ * 'all', 'title', 'contributor', 'subject', 'series', 'callnumber', 'standard_number'
+* `filters` string
+ * 'owner’, 'subjectLiteral’, 'holdingLocation’, 'deliveryLocation’, 'language', 'materialType', 'mediaType’, 'carrierType’, 'publisher’, 'contributor’, 'creator’, 'issuance’, 'createdYear’, 'dateAfter', or 'dateBefore'
+ * Specify a hash of filters to apply, where keys are from terms above
+
+## ResearchNow API
+[Github](https://github.com/NYPL/sfr-ingest-pipeline/tree/development/app/sfr-search-api#searching)
+### Parameters
+[GET `/v0.1/research-now/v3/search-api`](https://dev-platformdocs.nypl.org/#/research-now/get_v0_1_research_now_v3_search_api)
+* **`field`** (required) string
+ * Keyword, Title, Author, StandardNumber(ISBN, ISSN, LCCN and OCLC) and Subject
+ * Defaults to Keyword
+* **`query`** (required) string
+* `recordType`
+ * Internal record type to return with the work. Either instances or editions.
+* `page` integer
+* `per_page` integer
+* `sort`
+* `language`
+* `years`
+ * This should be formatted as {"start": year, "end": year}.
+
+<style>
+  table ul {
+    list-style: none;
+  }
+</style>
+
+## Comparison
+|Discovery front end|Discovery API |ResearchNow API|
+|-------------------|--------------|---------------|
+|_Search field_     |`q`           |`query`        |
+|_Search field dropdown_|`search_scope`|`field`|
+|<ul>'All Fields'   |<ul>"all"     |<ul>"keyword"|
+|<ul>'Title'            |<ul>"title"        |<ul>"title"       |
+|<ul>'Author/Contributor'|<ul>"contributor" |<ul>"author"      |
+|<ul>'Standard Number'|<ul>"standard_number"|<ul> 'standard_number'|
+|_Search page filters_|`filters`     |`filters`      |
+|<ul>'Format'       |<ul>"materialType"|<ul>_N/A_|
+|<ul><li>'Date':<ul><li>'Start Year'<li>'End Year'| <ul><br>"dateAfter"<br>"dateBefore" |`years`:<ul>"start"<br>"end"|
+|<ul>'Language'|<ul>"language"|<ul>`language`|
+|_Filters linked to from a bib page_|
+|<ul>'Author'|<ul>"creatorLiteral"|<ul>use `field` 'author'|
+|<ul>'Additional Authors'|<ul>"creatorLiteral"|<ul>use `field` 'author'|
+|<ul>'Subject'    |<ul>"subjectLiteral"|<ul>use `field` 'subject'|
+|_Pagination_     |`page`      | `page`        |
+|                   |`per_page`|`per_page`|
+|Sorting            |`sort`        |`sort` "field" |
+|                   |`sort_direction`|"direction"  |

--- a/discoveryApiResearchNowApiMapping.md
+++ b/discoveryApiResearchNowApiMapping.md
@@ -34,11 +34,11 @@
 * `years`
  * This should be formatted as {"start": year, "end": year}.
 
-<style>
+<!-- <style>
   table ul {
     list-style: none;
   }
-</style>
+</style> -->
 
 ## API Parameters Comparison
 This table lists, in the first column, the frontend features related to searching and search filters available from the frontend. The 2nd and 3rd column list out the Discovery API and ResearchNow API parameters that correlate to that frontend functionality.

--- a/discoveryApiResearchNowApiMapping.md
+++ b/discoveryApiResearchNowApiMapping.md
@@ -7,32 +7,32 @@
 * `page` string
 * `per_page` integer
 * `sort` integer
- * 'relevance', 'title', 'creator', 'date'
+  * "relevance", "title", "creator", "date"
 * `sort_direction` string
- * 'asc', 'desc'
- * title defaults to asc, date defaults to desc, creator defaults to asc, relevance is fixed desc
+  * "asc", "desc"
+  * title defaults to asc, date defaults to desc, creator defaults to asc, relevance is fixed desc
 * `search_scope` string
- * 'all', 'title', 'contributor', 'subject', 'series', 'callnumber', 'standard_number'
+  * "all", "title", "contributor", "subject", "series", "callnumber", "standard_number"
 * `filters` string
- * 'owner’, 'subjectLiteral’, 'holdingLocation’, 'deliveryLocation’, 'language', 'materialType', 'mediaType’, 'carrierType’, 'publisher’, 'contributor’, 'creator’, 'issuance’, 'createdYear’, 'dateAfter', or 'dateBefore'
- * Specify a hash of filters to apply, where keys are from terms above
+  * "owner", "subjectLiteral", "holdingLocation", "deliveryLocation", "language", "materialType", "mediaType", "carrierType", "publisher", "contributor", "creator", "issuance", "createdYear", "dateAfte"', or "dateBefore"
+  * Specify a hash of filters to apply, where keys are from terms above
 
 ## ResearchNow API
 [Github](https://github.com/NYPL/sfr-ingest-pipeline/tree/development/app/sfr-search-api#searching)
 ### Parameters
 [GET `/v0.1/research-now/v3/search-api`](https://dev-platformdocs.nypl.org/#/research-now/get_v0_1_research_now_v3_search_api)
 * **`field`** (required) string
- * Keyword, Title, Author, StandardNumber(ISBN, ISSN, LCCN and OCLC) and Subject
- * Defaults to Keyword
+  * "keyword", "title", "author", "standard_number" (ISBN, ISSN, LCCN and OCLC) and "subject"
+  * Defaults to "keyword"
 * **`query`** (required) string
 * `recordType`
- * Internal record type to return with the work. Either instances or editions.
+  * Internal record type to return with the work. Either instances or editions.
 * `page` integer
 * `per_page` integer
 * `sort`
 * `language`
 * `years`
- * This should be formatted as {"start": year, "end": year}.
+  * This should be formatted as {"start": year, "end": year}.
 
 <!-- <style>
   table ul {

--- a/discoveryApiResearchNowApiMapping.md
+++ b/discoveryApiResearchNowApiMapping.md
@@ -14,25 +14,32 @@
 * `search_scope` string
   * "all", "title", "contributor", "subject", "series", "callnumber", "standard_number"
 * `filters` string
-  * "owner", "subjectLiteral", "holdingLocation", "deliveryLocation", "language", "materialType", "mediaType", "carrierType", "publisher", "contributor", "creator", "issuance", "createdYear", "dateAfte"', or "dateBefore"
+  * "owner", "subjectLiteral", "holdingLocation", "deliveryLocation", "language", "materialType", "mediaType", "carrierType", "publisher", "contributor", "creator", "issuance", "createdYear", "dateAfter"', or "dateBefore"
   * Specify a hash of filters to apply, where keys are from terms above
 
 ## ResearchNow API
 [Github](https://github.com/NYPL/sfr-ingest-pipeline/tree/development/app/sfr-search-api#searching)
-### Parameters
 [GET `/v0.1/research-now/v3/search-api`](https://dev-platformdocs.nypl.org/#/research-now/get_v0_1_research_now_v3_search_api)
-* **`field`** (required) string
+[POST `/v0.1/research-now/v3/search-api`](https://dev-platformdocs.nypl.org/#/research-now/post_v0_1_research_now_v3_search_api)
+### Parameters
+* `queries` array of objects
+  * Objects for the queries are formatted as `{"field": filter, "value": value}`
+* `filters` array of objects
+  * Objects for the filters are formatted as `{"filter": filter, "value": value}`
+* `field` string
   * "keyword", "title", "author", "standardNumber" (ISBN, ISSN, LCCN and OCLC) and "subject"
-  * Defaults to "keyword"
-* **`query`** (required) string
+* `query` string
 * `recordType`
   * Internal record type to return with the work. Either instances or editions.
 * `page` integer
 * `per_page` integer
-* `sort`
+* `sort` array of objects
+  * Objects are formatted as `{"field": field, "dir": dir}`
 * `language`
 * `years`
-  * This should be formatted as {"start": year, "end": year}.
+  * This should be formatted as `{"start": year, "end": year}`.
+
+For the DRBB/SCC integration, the DRBB data is fetched using a POST request with a body containing `page`, `per_page`, `filters` (years, languages), and `queries` (author/contributor, subject).
 
 <!-- <style>
   table ul {
@@ -47,15 +54,15 @@ Single quotes (') are used for frontend terminology. Italics are used to describ
 
 |Discovery front end|Discovery API |ResearchNow API|
 |-------------------|--------------|---------------|
-|_Search field_ |`q`           |`query`        |
-|_Search field dropdown_|`search_scope`|`field`|
+|_Search field_ |`q`           |`queries`, "value"       |
+|_Search field dropdown_|`search_scope`|`queries`, "field"|
 |<ul>'All Fields'   |<ul>"all"     |<ul>"keyword"|
 |<ul>'Title'       |<ul>"title"  |<ul>"title"       |
 |<ul>'Author/Contributor'|<ul>"contributor" |<ul>"author"|
 |<ul>'Standard Number'|<ul>"standard_number"|<ul> "standardNumber"|
 |_Search page filters_|`filters`     ||
 |<ul>'Format'       |<ul>`filters[materialType]`|<ul>N/A*|
-|<ul>'Date':<ul><li>'Start Year'<li>'End Year'| <ul><br>`filters[dateAfter]`<br>`filters[dateBefore]` |<br><ul>`years[start]`<br>`years[end]`|
+|<ul>'Date':<ul><li>'Start Year'<li>'End Year'| <ul><br>`filters[dateAfter]`<br>`filters[dateBefore]` |`filters`<br><ul>`years[start]`<br>`years[end]`|
 |<ul>'Language'|<ul>`filters[language]`|<ul>`language`|
 |_Filters linked to from a bib page_|
 |<ul>'Author'|<ul>`filters[creatorLiteral]`|<ul>`field[author]`|

--- a/discoveryApiResearchNowApiMapping.md
+++ b/discoveryApiResearchNowApiMapping.md
@@ -40,7 +40,11 @@
   }
 </style>
 
-## Comparison
+## API Parameters Comparison
+This table lists, in the first column, the frontend features related to searching and search filters available from the frontend. The 2nd and 3rd column list out the Discovery API and ResearchNow API parameters that correlate to that frontend functionality.
+
+Single quotes (') are used for frontend terminology. Italics used to describe frontend feature. Code styling is used for parameters the respective APIs except. Doubles quotes are used for keys in Parameters that take an object. (")
+
 |Discovery front end|Discovery API |ResearchNow API|
 |-------------------|--------------|---------------|
 |_Search field_     |`q`           |`query`        |
@@ -54,10 +58,379 @@
 |<ul><li>'Date':<ul><li>'Start Year'<li>'End Year'| <ul><br>"dateAfter"<br>"dateBefore" |`years`:<ul>"start"<br>"end"|
 |<ul>'Language'|<ul>"language"|<ul>`language`|
 |_Filters linked to from a bib page_|
-|<ul>'Author'|<ul>"creatorLiteral"|<ul>use `field` 'author'|
-|<ul>'Additional Authors'|<ul>"creatorLiteral"|<ul>use `field` 'author'|
-|<ul>'Subject'    |<ul>"subjectLiteral"|<ul>use `field` 'subject'|
+|<ul>'Author'|<ul>"creatorLiteral"|<ul>use `field` "author"|
+|<ul>'Additional Authors'|<ul>"creatorLiteral"|<ul>use `field` "author"|
+|<ul>'Subject'    |<ul>"subjectLiteral"|<ul>use `field` "subject"|
 |_Pagination_     |`page`      | `page`        |
 |                   |`per_page`|`per_page`|
 |Sorting            |`sort`        |`sort` "field" |
 |                   |`sort_direction`|"direction"  |
+
+## API Response Structure
+### Discovery API
+``` json
+{
+  "@context": "string",
+  "@type": "itemList",
+  "itemListElement": [
+    {
+      "@type": "searchResult",
+      "result": {
+        "@type": [
+          "string"
+        ],
+        "@id": "string",
+        "carrierType": [
+          {
+            "@type": "string",
+            "@id": "string",
+            "prefLabel": "string"
+          }
+        ],
+        "creatorLiteral": [
+          "string"
+        ],
+        "contributorLiteral": [
+          "string"
+        ],
+        "created": "string",
+        "createdYear": 0,
+        "dateStartYear": 0,
+        "depiction": "string",
+        "description": "string",
+        "endYear": 0,
+        "extent": [
+          "string"
+        ],
+        "holdingCount": 0,
+        "issuance": [
+          {
+            "@type": "string",
+            "@id": "string",
+            "prefLabel": "string"
+          }
+        ],
+        "items": [
+          {
+            "@id": "string",
+            "accessMessage": [
+              {
+                "@type": "string",
+                "@id": "string",
+                "prefLabel": "string"
+              }
+            ],
+            "deliveryLocation": [
+              {
+                "@type": "string",
+                "@id": "string",
+                "prefLabel": "string"
+              }
+            ],
+            "holdingLocation": [
+              {
+                "@type": "string",
+                "@id": "string",
+                "prefLabel": "string"
+              }
+            ],
+            "idBarcode": "string",
+            "identifier": [
+              "string"
+            ],
+            "owner": [
+              {
+                "@type": "string",
+                "@id": "string",
+                "prefLabel": "string"
+              }
+            ],
+            "requestable": [
+              true
+            ],
+            "eddRequestable": true,
+            "shelfMark": [
+              "string"
+            ],
+            "status": [
+              {
+                "@type": "string",
+                "@id": "string",
+                "prefLabel": "string"
+              }
+            ],
+            "uri": "string"
+          }
+        ],
+        "^id": "string",
+        "language": [
+          {
+            "@type": "string",
+            "@id": "string",
+            "prefLabel": "string"
+          }
+        ],
+        "materialType": [
+          {
+            "@type": "string",
+            "@id": "string",
+            "prefLabel": "string"
+          }
+        ],
+        "mediaType": [
+          {
+            "@type": "string",
+            "@id": "string",
+            "prefLabel": "string"
+          }
+        ],
+        "note": [
+          {
+            "@type": "bf:Note",
+            "noteType": "string",
+            "label": "string"
+          }
+        ],
+        "numAvailable": 0,
+        "placeOfPublication": [
+          "string"
+        ],
+        "prefLabel": [
+          "string"
+        ],
+        "roles:ROLE": [
+          "string"
+        ],
+        "startYear": 0,
+        "subject": [
+          {
+            "@type": "string",
+            "@id": "string",
+            "prefLabel": "string"
+          }
+        ],
+        "suppressed": true,
+        "title": [
+          "string"
+        ],
+        "titleDisplay": [
+          "string"
+        ],
+        "type": [
+          "nypl:Item"
+        ],
+        "uri": "string"
+      }
+    }
+  ]
+}
+```
+
+### ResearchNow API
+``` json
+{
+  "status": 0,
+  "timestamp": "2020-06-01T20:30:37.458Z",
+  "responseType": "string",
+  "data": {
+    "totalWorks": 0,
+    "facets": {
+      "facet": [
+        {
+          "value": "string",
+          "count": 0
+        }
+      ]
+    },
+    "paging": {
+      "prev_page_sort": [
+        "string"
+      ],
+      "next_page_sort": [
+        "string"
+      ]
+    },
+    "works": [
+      {
+        "date_modified": "2020-06-01T20:30:37.458Z",
+        "date_created": "2020-06-01T20:30:37.458Z",
+        "id": 0,
+        "uuid": "string",
+        "title": "string",
+        "sort_title": "string",
+        "sub_title": [
+          "string"
+        ],
+        "medium": "string",
+        "series": "string",
+        "series_position": 0,
+        "edition_count": 0,
+        "edition_range": "string",
+        "sort": [
+          "string"
+        ],
+        "agents": [
+          {
+            "name": "string",
+            "sort_name": "string",
+            "viaf": "string",
+            "lcnaf": "string",
+            "role": "string",
+            "birth_date_display": "string",
+            "death_date_display": "string"
+          }
+        ],
+        "alt_titles": [
+          "string"
+        ],
+        "instances": [
+          {
+            "date_modified": "2020-06-01T20:30:37.458Z",
+            "date_created": "2020-06-01T20:30:37.458Z",
+            "id": 0,
+            "title": "string",
+            "sort_title": "string",
+            "sub_title": "string",
+            "pub_place": "string",
+            "edition": "string",
+            "edition_statement": "string",
+            "volume": "string",
+            "table_of_contents": "string",
+            "copyright_date": "string",
+            "extent": "string",
+            "summary": "string",
+            "work_id": 0,
+            "edition_id": 0,
+            "agents": [
+              {
+                "name": "string",
+                "sort_name": "string",
+                "viaf": "string",
+                "lcnaf": "string",
+                "role": "string",
+                "birth_date_display": "string",
+                "death_date_display": "string"
+              }
+            ],
+            "items": [
+              {
+                "source": "string",
+                "content_type": "string",
+                "modified": "2020-06-01T20:30:37.458Z",
+                "drm": "string",
+                "links": [
+                  {
+                    "url": "string",
+                    "media_type": "string",
+                    "content": "string",
+                    "thumbnail": "string",
+                    "local": true,
+                    "download": true,
+                    "images": true,
+                    "ebook": true
+                  }
+                ]
+              }
+            ],
+            "languages": [
+              {
+                "language": "string",
+                "iso_2": "string",
+                "iso_3": "string"
+              }
+            ],
+            "identifiers": [
+              {
+                "id_type": "string",
+                "identifier": "string"
+              }
+            ]
+          }
+        ],
+        "languages": [
+          {
+            "language": "string",
+            "iso_2": "string",
+            "iso_3": "string"
+          }
+        ],
+        "editions": [
+          {
+            "date_modified": "2020-06-01T20:30:37.460Z",
+            "date_created": "2020-06-01T20:30:37.460Z",
+            "id": 0,
+            "publication_place": "string",
+            "publication_date": "string",
+            "edition": "string",
+            "edition_statement": "string",
+            "volume": "string",
+            "table_of_contents": "string",
+            "extent": "string",
+            "summary": "string",
+            "work_id": 0,
+            "agents": [
+              {
+                "name": "string",
+                "sort_name": "string",
+                "viaf": "string",
+                "lcnaf": "string",
+                "role": "string",
+                "birth_date_display": "string",
+                "death_date_display": "string"
+              }
+            ],
+            "items": [
+              {
+                "source": "string",
+                "content_type": "string",
+                "modified": "2020-06-01T20:30:37.461Z",
+                "drm": "string",
+                "links": [
+                  {
+                    "url": "string",
+                    "media_type": "string",
+                    "content": "string",
+                    "thumbnail": "string",
+                    "local": true,
+                    "download": true,
+                    "images": true,
+                    "ebook": true
+                  }
+                ]
+              }
+            ],
+            "languages": [
+              {
+                "language": "string",
+                "iso_2": "string",
+                "iso_3": "string"
+              }
+            ]
+          }
+        ],
+        "identifiers": [
+          {
+            "id_type": "string",
+            "identifier": "string"
+          }
+        ],
+        "subjects": [
+          {
+            "subject": "string",
+            "authority": "string",
+            "uri": "string"
+          }
+        ],
+        "measurements": [
+          {
+            "quantity": "string",
+            "value": 0,
+            "weight": 0,
+            "taken_at": "2020-06-01T20:30:37.461Z"
+          }
+        ]
+      }
+    ]
+  }
+}
+```

--- a/discoveryApiResearchNowApiMapping.md
+++ b/discoveryApiResearchNowApiMapping.md
@@ -22,7 +22,7 @@
 ### Parameters
 [GET `/v0.1/research-now/v3/search-api`](https://dev-platformdocs.nypl.org/#/research-now/get_v0_1_research_now_v3_search_api)
 * **`field`** (required) string
-  * "keyword", "title", "author", "standard_number" (ISBN, ISSN, LCCN and OCLC) and "subject"
+  * "keyword", "title", "author", "standardNumber" (ISBN, ISSN, LCCN and OCLC) and "subject"
   * Defaults to "keyword"
 * **`query`** (required) string
 * `recordType`
@@ -47,14 +47,14 @@ Single quotes (') are used for frontend terminology. Italics are used to describ
 
 |Discovery front end|Discovery API |ResearchNow API|
 |-------------------|--------------|---------------|
-|_Search field_     |`q`           |`query`        |
+|_Search field_ |`q`           |`query`        |
 |_Search field dropdown_|`search_scope`|`field`|
 |<ul>'All Fields'   |<ul>"all"     |<ul>"keyword"|
-|<ul>'Title'            |<ul>"title"        |<ul>"title"       |
-|<ul>'Author/Contributor'|<ul>"contributor" |<ul>"author"      |
+|<ul>'Title'       |<ul>"title"  |<ul>"title"       |
+|<ul>'Author/Contributor'|<ul>"contributor" |<ul>"author"|
 |<ul>'Standard Number'|<ul>"standard_number"|<ul> "standard_number"|
-|_Search page filters_|`filters`     |      |
-|<ul>'Format'       |<ul>`filters[materialType]`|<ul>N/A|
+|_Search page filters_|`filters`     ||
+|<ul>'Format'       |<ul>`filters[materialType]`|<ul>N/A*|
 |<ul>'Date':<ul><li>'Start Year'<li>'End Year'| <ul><br>`filters[dateAfter]`<br>`filters[dateBefore]` |<br><ul>`years[start]`<br>`years[end]`|
 |<ul>'Language'|<ul>`filters[language]`|<ul>`language`|
 |_Filters linked to from a bib page_|
@@ -65,6 +65,8 @@ Single quotes (') are used for frontend terminology. Italics are used to describ
 |                   |`per_page`|`per_page`|
 |_Sorting_            |`sort`        |`sort[field]` |
 |                   |`sort_direction`|`sort[direction]`  |
+
+\* ResearchNow's `format` parameter does not correspond to the `materialType` in Discovery API. The former relates to digital formats (pdf, epub, and html). The latter to physical material type.
 
 ## API Response Structure
 ### Discovery API

--- a/discoveryApiResearchNowApiMapping.md
+++ b/discoveryApiResearchNowApiMapping.md
@@ -44,7 +44,7 @@ For the DRBB/SCC integration, the DRBB data is fetched using a POST request with
 ## Example Translation
 A GET request to the Discovery API endpoint detailed above with this query
 ```
-?q=hello&filters[subjectLiteral][0]=United%20States&sort=title&sort_direction=asc&search_scope=title&page=1
+?q=hello&filters[subjectLiteral][0]=United%20States&sort=title&sort_direction=asc&search_scope=title&page=1&filters[language][0]=lang%3Aeng&filters[language][1]=lang%3Ager&filters[dateAfter]=1993&filters[dateBefore]=2020
 ```
 would translate to a POST request with this body for ResearchNow's search endpoint:
 ``` json
@@ -54,7 +54,15 @@ would translate to a POST request with this body for ResearchNow's search endpoi
 		{"field":"subject","query":"United States"}
 	],
 	"page":0,
-	"sort":[{"field":"title","dir":"asc"}]
+	"sort":[{"field":"title","dir":"asc"}],
+  "filters":[
+    {"field":"language","value":"eng"},
+    {"field":"language","value":"ger"},
+    {"field":"years","value":{
+      "start": 1993,
+      "end": 2020,
+    }},
+  ]}
 }
 ```
 
@@ -71,10 +79,10 @@ Single quotes (') are used for frontend terminology. Italics are used to describ
 
 |Discovery front end|Discovery API |ResearchNow API|
 |-------------------|--------------|---------------|
-|_Search field_ |`q`           |`queries`, "value"       |
+|_Search field_     |`q`           |`queries`, "value"|
 |_Search field dropdown_|`search_scope`|`queries`, "field"|
-|<ul>'All Fields'   |<ul>"all"     |<ul>"keyword"|
-|<ul>'Title'       |<ul>"title"  |<ul>"title"       |
+|<ul>'All Fields'   |<ul>"all"     |<ul>"keyword"  |
+|<ul>'Title'        |<ul>"title"   |<ul>"title"    |
 |<ul>'Author/Contributor'|<ul>"contributor" |<ul>"author"|
 |<ul>'Standard Number'|<ul>"standard_number"|<ul> "standardNumber"|
 |_Search page filters_|`filters`     ||

--- a/discoveryApiResearchNowApiMapping.md
+++ b/discoveryApiResearchNowApiMapping.md
@@ -52,7 +52,7 @@ Single quotes (') are used for frontend terminology. Italics are used to describ
 |<ul>'All Fields'   |<ul>"all"     |<ul>"keyword"|
 |<ul>'Title'       |<ul>"title"  |<ul>"title"       |
 |<ul>'Author/Contributor'|<ul>"contributor" |<ul>"author"|
-|<ul>'Standard Number'|<ul>"standard_number"|<ul> "standard_number"|
+|<ul>'Standard Number'|<ul>"standard_number"|<ul> "standardNumber"|
 |_Search page filters_|`filters`     ||
 |<ul>'Format'       |<ul>`filters[materialType]`|<ul>N/A*|
 |<ul>'Date':<ul><li>'Start Year'<li>'End Year'| <ul><br>`filters[dateAfter]`<br>`filters[dateBefore]` |<br><ul>`years[start]`<br>`years[end]`|

--- a/discoveryApiResearchNowApiMapping.md
+++ b/discoveryApiResearchNowApiMapping.md
@@ -35,7 +35,7 @@
 * `per_page` integer
 * `sort` array of objects
   * Objects are formatted as `{"field": field, "dir": dir}`
-* `language`
+* `language` array of languages
 * `years`
   * This should be formatted as `{"start": year, "end": year}`.
 
@@ -63,11 +63,11 @@ Single quotes (') are used for frontend terminology. Italics are used to describ
 |_Search page filters_|`filters`     ||
 |<ul>'Format'       |<ul>`filters[materialType]`|<ul>N/A*|
 |<ul>'Date':<ul><li>'Start Year'<li>'End Year'| <ul><br>`filters[dateAfter]`<br>`filters[dateBefore]` |`filters`<br><ul>`years[start]`<br>`years[end]`|
-|<ul>'Language'|<ul>`filters[language]`|<ul>`language`|
+|<ul>'Language'|<ul>`filters[language]`|<ul>`filters` `language`|
 |_Filters linked to from a bib page_|
-|<ul>'Author'|<ul>`filters[creatorLiteral]`|<ul>`field[author]`|
-|<ul>'Additional Authors'|<ul>`filters[creatorLiteral]`|<ul>`field[author]`|
-|<ul>'Subject'    |<ul>`filters[subjectLiteral]`|<ul> `field[subject]`|
+|<ul>'Author'|<ul>`filters[creatorLiteral]`|<ul>`queries` `"field":"author"`|
+|<ul>'Additional Authors'|<ul>`filters[creatorLiteral]`|<ul>`queries` `"field":"author"`|
+|<ul>'Subject'    |<ul>`filters[subjectLiteral]`|<ul>`queries` `"field":"subject"`|
 |_Pagination_     |`page`      | `page`        |
 |                   |`per_page`|`per_page`|
 |_Sorting_            |`sort`        |`sort[field]` |

--- a/discoveryApiResearchNowApiMapping.md
+++ b/discoveryApiResearchNowApiMapping.md
@@ -31,7 +31,7 @@
 * `query` string
 * `recordType`
   * Internal record type to return with the work. Either instances or editions.
-* `page` integer
+* `page` integer (0 indexed)
 * `per_page` integer
 * `sort` array of objects
   * Objects are formatted as `{"field": field, "dir": dir}`
@@ -40,6 +40,23 @@
   * This should be formatted as `{"start": year, "end": year}`.
 
 For the DRBB/SCC integration, the DRBB data is fetched using a POST request with a body containing `page`, `per_page`, `filters` (years, languages), and `queries` (author/contributor, subject).
+
+## Example Translation
+A GET request to the Discovery API endpoint detailed above with this query
+```
+?q=hello&filters[subjectLiteral][0]=United%20States&sort=title&sort_direction=asc&search_scope=title&page=1
+```
+would translate to a POST request with this body for ResearchNow's search endpoint:
+``` json
+{
+	"queries":[
+		{"field":"title","query":"hello"},
+		{"field":"subject","query":"United States"}
+	],
+	"page":0,
+	"sort":[{"field":"title","dir":"asc"}]
+}
+```
 
 <!-- <style>
   table ul {


### PR DESCRIPTION
**What's this do?**
Reference this link to read the doc without the markdown syntax: https://github.com/NYPL-discovery/discovery-front-end/blob/SCC-2068/discoveryApiResearchNowApiMapping.md

This doc that lays out the parameters that the ResearchNow API and Discovery API accept, respectively, and how they correlate to SCC's frontend functionality.

These are the default filters or "validFilters" as they are referred to in Paul's open PR #1309. This new doc covers all of these and how they compare in ResearchNow. Discovery API does allow for more filtering, as listed out in the parameters. 
``` 
defaultFilters: {
    materialType: [],
    language: [],
    dateAfter: '',
    dateBefore: '',
    subjectLiteral: [],
    creatorLiteral: [],
}
```

**JIRA link**
https://jira.nypl.org/browse/SCC-2068
