### PR TITLE
RENO-1275: Update dgx-react-footer to v0.5.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## CHANGE LOG
 
+### 1.6.6
+- Updating @nypl/dgx-react-footer to 0.5.6.
+
 ### 1.6.5
 - Updating @nypl/dgx-react-footer to 0.5.5.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## Discovery
 
 ### Version
-> 1.6.5
+> 1.6.6
 
 ### Shared Collection Catalog
 [![GitHub version](https://badge.fury.io/gh/nypl-discovery%2Fdiscovery-front-end.svg)](https://badge.fury.io/gh/nypl-discovery%2Fdiscovery-front-end)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nypl-discovery",
-  "version": "1.6.5",
+  "version": "1.6.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -954,9 +954,9 @@
         "@nypl/dgx-svg-icons": "0.3.7",
         "axios": "0.9.1",
         "classnames": "2.1.3",
-        "dgx-feature-flags": "git+https://git@bitbucket.org/NYPL/dgx-feature-flags.git#master",
-        "dgx-react-ga": "git+https://git@bitbucket.org/NYPL/dgx-react-ga.git#master",
-        "dgx-skip-navigation-link": "git+https://git@bitbucket.org/NYPL/dgx-skip-navigation-link.git#master",
+        "dgx-feature-flags": "git+https://git@bitbucket.org/NYPL/dgx-feature-flags.git#27568b5f49f0fb853ce229b02c553e06955d3bf2",
+        "dgx-react-ga": "git+https://git@bitbucket.org/NYPL/dgx-react-ga.git#1908e78bd8704b815ec37030d0f8040f8b3cbb95",
+        "dgx-skip-navigation-link": "git+https://git@bitbucket.org/NYPL/dgx-skip-navigation-link.git#20ed457bb7b3c9505357d6df15119f64a9930d8a",
         "focus-trap-react": "3.0.3",
         "moment": "2.19.3",
         "prop-types": "15.5.10",
@@ -1049,18 +1049,18 @@
       }
     },
     "@nypl/dgx-react-footer": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/@nypl/dgx-react-footer/-/dgx-react-footer-0.5.5.tgz",
-      "integrity": "sha512-BOFwAcX2jvMviA/5FY1/wrH5Zfaqqkiy2hUwBsPLjQtHcpKakfmUlbJEb3CbxwsrzkpDYO4rcK9jxX0rVZtUQQ==",
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/@nypl/dgx-react-footer/-/dgx-react-footer-0.5.6.tgz",
+      "integrity": "sha512-E/Nc93V3t1v4HSsFjpug6wtDWf7vlc/lpA3IdKDe5R14y2vrLXLaMX8NpQeet6f5qA2cEBZp9cWWpSCG1ZgW5A==",
       "requires": {
-        "@nypl/dgx-svg-icons": "0.3.11",
+        "@nypl/dgx-svg-icons": "0.3.12",
         "system-font-css": "^2.0.2"
       },
       "dependencies": {
         "@nypl/dgx-svg-icons": {
-          "version": "0.3.11",
-          "resolved": "https://registry.npmjs.org/@nypl/dgx-svg-icons/-/dgx-svg-icons-0.3.11.tgz",
-          "integrity": "sha512-DdL/kGqFEmvUM5WO6ETWv2H03ZjDH6/XV21WqTIG6FomkkdxEfTaJqFwHUkNRq+XxMOEDG/FIP+JPqthxy+msQ=="
+          "version": "0.3.12",
+          "resolved": "https://registry.npmjs.org/@nypl/dgx-svg-icons/-/dgx-svg-icons-0.3.12.tgz",
+          "integrity": "sha512-Co92hdOAL04STAKLa2JFQPdo/As3NDDVsPf1aiAfMPLzMKr4T8914V+0fMmLRZ7QL9xVOuCWU2vgo4pUgE0DxA=="
         }
       }
     },
@@ -4775,7 +4775,7 @@
       "from": "git+https://git@bitbucket.org/NYPL/dgx-feature-flags.git#master",
       "requires": {
         "alt-utils": "1.0.0",
-        "dgx-alt-center": "git+https://bitbucket.org/NYPL/dgx-alt-center.git#master",
+        "dgx-alt-center": "git+https://bitbucket.org/NYPL/dgx-alt-center.git#f00bd9ea99925072d561ac0041fecd0b07174432",
         "immutable": "3.7.6"
       }
     },
@@ -6728,8 +6728,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": false,
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "optional": true
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
         },
         "aproba": {
           "version": "1.2.0",
@@ -6750,14 +6749,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "resolved": false,
-          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "optional": true
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": false,
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6772,20 +6769,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "resolved": false,
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "optional": true
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": false,
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "optional": true
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": false,
-          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "optional": true
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6902,8 +6896,7 @@
         "inherits": {
           "version": "2.0.4",
           "resolved": false,
-          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-          "optional": true
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
         },
         "ini": {
           "version": "1.3.5",
@@ -6915,7 +6908,6 @@
           "version": "1.0.0",
           "resolved": false,
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6930,7 +6922,6 @@
           "version": "3.0.4",
           "resolved": false,
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -6938,14 +6929,12 @@
         "minimist": {
           "version": "0.0.8",
           "resolved": false,
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "optional": true
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         },
         "minipass": {
           "version": "2.9.0",
           "resolved": false,
           "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -6964,7 +6953,6 @@
           "version": "0.5.1",
           "resolved": false,
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -7054,8 +7042,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "resolved": false,
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "optional": true
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
         },
         "object-assign": {
           "version": "4.1.1",
@@ -7067,7 +7054,6 @@
           "version": "1.4.0",
           "resolved": false,
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -7153,8 +7139,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "resolved": false,
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "optional": true
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -7190,7 +7175,6 @@
           "version": "1.0.2",
           "resolved": false,
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7210,7 +7194,6 @@
           "version": "3.0.1",
           "resolved": false,
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -7254,14 +7237,12 @@
         "wrappy": {
           "version": "1.0.2",
           "resolved": false,
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "optional": true
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         },
         "yallist": {
           "version": "3.1.1",
           "resolved": false,
-          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-          "optional": true
+          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
         }
       }
     },
@@ -9891,8 +9872,7 @@
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
           "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "browser-stdout": {
           "version": "1.3.1",
@@ -9905,8 +9885,7 @@
           "version": "5.3.1",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
           "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "cliui": {
           "version": "5.0.0",
@@ -9989,8 +9968,7 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "js-yaml": {
           "version": "3.13.1",
@@ -10061,8 +10039,7 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
           "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "request": {
           "version": "2.88.2",
@@ -10110,7 +10087,6 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
           "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
           "dev": true,
-          "optional": true,
           "requires": {
             "emoji-regex": "^7.0.1",
             "is-fullwidth-code-point": "^2.0.0",
@@ -10122,7 +10098,6 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^4.1.0"
           }
@@ -10187,7 +10162,6 @@
           "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
           "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
           "dev": true,
-          "optional": true,
           "requires": {
             "camelcase": "^5.0.0",
             "decamelize": "^1.2.0"
@@ -17198,8 +17172,7 @@
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
           "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "camelcase": {
           "version": "5.3.1",
@@ -17231,8 +17204,7 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "require-main-filename": {
           "version": "2.0.0",
@@ -17246,7 +17218,6 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
           "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
           "dev": true,
-          "optional": true,
           "requires": {
             "emoji-regex": "^7.0.1",
             "is-fullwidth-code-point": "^2.0.0",
@@ -17258,7 +17229,6 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^4.1.0"
           }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nypl-discovery",
-  "version": "1.6.5",
+  "version": "1.6.6",
   "description": "Isomorphic React App for NYPL Research Catalog.",
   "main": "index.js",
   "scripts": {
@@ -79,7 +79,7 @@
     "@babel/register": "^7.7.7",
     "@nypl/design-toolkit": "^0.1.38",
     "@nypl/dgx-header-component": "git+https://git@github.com/NYPL/dgx-header-component#reactupdate",
-    "@nypl/dgx-react-footer": "0.5.5",
+    "@nypl/dgx-react-footer": "0.5.6",
     "@nypl/dgx-svg-icons": "0.2.5",
     "@nypl/nypl-data-api-client": "0.2.5",
     "alt": "^0.18.6",

--- a/src/client/styles/main.scss
+++ b/src/client/styles/main.scss
@@ -106,12 +106,6 @@ li, p {
   max-width: 100%;
 }
 
-@media only screen and (min-width: 768px) {
-  .footer {
-    padding: 15px 0 30px !important;
-  }
-}
-
 // Override for the omnisearch div to work as a fieldset and
 // allow focus on the search button.
 div.nypl-omnisearch {


### PR DESCRIPTION
[Related Jira ticket](https://jira.nypl.org/browse/RENO-1275)

**This PR does the following:**
- Updates dgx-react-footer to v0.5.6

Note: Tested locally. I saw a couple of warnings/errors that I did not see on the `development` environment, but they do not seem related to this footer work (which displayed as expected).
