### PR TITLE
Begin implementing programmatic addition of apiRoutes

### DIFF
--- a/server.js
+++ b/server.js
@@ -10,7 +10,7 @@ import webpack from 'webpack';
 import cookieParser from 'cookie-parser';
 import bodyParser from 'body-parser';
 import Store from '@Store';
-import loadDataForRoutes from '@dataLoaderUtil';
+import { loadDataForRoutes } from '@dataLoaderUtil';
 
 import alt from './src/app/alt';
 import appConfig from './src/app/data/appConfig';
@@ -89,10 +89,11 @@ app.get('/*', (req, res, next) => {
     search: '',
   };
 
-  loadDataForRoutes(location, next).then(() => next());
+  loadDataForRoutes(location, req).then(() => next());
 });
 
 app.get('/*', (req, res) => {
+  console.log('get slash: ', Store.getState());
   alt.bootstrap(JSON.stringify({
     PatronStore: res.locals.data.PatronStore,
     Store: Store.getState(),

--- a/src/app/components/DataLoader/DataLoader.jsx
+++ b/src/app/components/DataLoader/DataLoader.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import loadDataForRoutes from '@dataLoaderUtil';
+import { loadDataForRoutes } from '@dataLoaderUtil';
 
 class DataLoader extends React.Component {
 

--- a/src/server/ApiRoutes/ApiRoutes.js
+++ b/src/server/ApiRoutes/ApiRoutes.js
@@ -1,12 +1,12 @@
 import express from 'express';
 
-import Bib from './Bib';
 import User from './User';
 import Hold from './Hold';
 import Search from './Search';
 import appConfig from '../../app/data/appConfig';
 import SubjectHeading from './SubjectHeading';
 import SubjectHeadings from './SubjectHeadings';
+import { routeConfig } from '../../app/utils/dataLoaderUtil';
 
 const router = express.Router();
 
@@ -30,17 +30,16 @@ router
   .route(`${appConfig.baseUrl}/edd`)
   .post(Hold.eddServer);
 
-router
-  .route(`${appConfig.baseUrl}/api`)
-  .get(Search.searchAjax);
-
-router
-  .route(`${appConfig.baseUrl}/api/bib`)
-  .get(Bib.bibSearchAjax);
-
-router
-  .route(`${appConfig.baseUrl}/api/hold/request/:bibId-:itemId`)
-  .get(Hold.newHoldRequestAjax);
+console.log('routeConfig: ', routeConfig);
+Object.values(routeConfig).forEach((routeData) => {
+  const {
+    route,
+    method,
+  } = routeData;
+  router
+    .route(route)
+    .get(method);
+});
 
 router
   .route(`${appConfig.baseUrl}/api/patronEligibility`)


### PR DESCRIPTION
This implements the strategy for avoiding http requests in `server` that Paul and I were discussing. For some reason I can't figure out it is having compile issues. They have something to do with the import statements in `dataLoaderUtil` since they go away when I comment out the imports related to `ApiRoutes`, but I don't see the problem. Can anyone figure out what the issue is?
