### PR TITLE
Refactor hold routes

### DIFF
--- a/src/app/components/HoldRequest/HoldRequest.jsx
+++ b/src/app/components/HoldRequest/HoldRequest.jsx
@@ -129,33 +129,6 @@ class HoldRequest extends React.Component {
         this.context.router.push(response.data);
         Actions.updateLoadingStatus(false);
       });
-    // axios
-    //   .get(`${appConfig.baseUrl}/api/newHold?itemId=${itemId}&pickupLocation=` +
-    //     `${this.state.delivery}&itemSource=${itemSource}`)
-    //   .then((response) => {
-    //     if (response.data.error && response.data.error.status !== 200) {
-    //       Actions.updateLoadingStatus(false);
-    //       this.context.router.push(
-    //         `${path}?errorStatus=${response.data.error.status}` +
-    //         `&errorMessage=${response.data.error.statusText}${searchKeywordsQueryPhysical}` +
-    //         `${fromUrlQuery}`,
-    //       );
-    //     } else {
-    //       Actions.updateLoadingStatus(false);
-    //       this.context.router.push(
-    //         `${path}?pickupLocation=${response.data.pickupLocation}&requestId=${response.data.id}` +
-    //         `${searchKeywordsQueryPhysical}${fromUrlQuery}`,
-    //       );
-    //     }
-    //   })
-    //   .catch((error) => {
-    //     console.error('Error attempting to make an ajax Hold Request in HoldRequest', error);
-    //
-    //     Actions.updateLoadingStatus(false);
-    //     this.context.router.push(
-    //       `${path}?errorMessage=${error}${searchKeywordsQueryPhysical}${fromUrlQuery}`,
-    //     );
-    //   });
   }
 
   /**

--- a/src/app/components/HoldRequest/HoldRequest.jsx
+++ b/src/app/components/HoldRequest/HoldRequest.jsx
@@ -125,8 +125,8 @@ class HoldRequest extends React.Component {
       Object.fromEntries(formData.entries()),
     )
       .then((response) => {
-        console.log('response: ', response);
-        this.context.router.push(response);
+        console.log('response: ', response.data);
+        this.context.router.push(response.data);
         Actions.updateLoadingStatus(false);
       });
     // axios

--- a/src/app/components/HoldRequest/HoldRequest.jsx
+++ b/src/app/components/HoldRequest/HoldRequest.jsx
@@ -52,7 +52,7 @@ class HoldRequest extends React.Component {
     this.state = _extend({
       delivery: defaultDelivery,
       checkedLocNum,
-      redirect: true,
+      serverRedirect: true,
     }, { patron: PatronStore.getState() });
 
     // change all the components :(
@@ -71,7 +71,7 @@ class HoldRequest extends React.Component {
     if (title) {
       title.focus();
     }
-    if (this.state.redirect) this.setState({ redirect: false });
+    if (this.state.serverRedirect) this.setState({ serverRedirect: false });
     this.timeoutId = setTimeout(() => { Actions.updateLoadingStatus(false); }, 5000);
   }
 
@@ -271,7 +271,7 @@ class HoldRequest extends React.Component {
 
   render() {
     const { closedLocations, holdRequestNotification } = AppConfigStore.getState();
-    const { redirect } = this.state;
+    const { serverRedirect } = this.state;
     const searchKeywords = this.props.searchKeywords;
     const bib = (this.props.bib && !_isEmpty(this.props.bib)) ?
       this.props.bib : null;
@@ -345,8 +345,8 @@ class HoldRequest extends React.Component {
           />
           <input
             type="hidden"
-            name="redirect"
-            value={redirect}
+            name="serverRedirect"
+            value={serverRedirect}
           />
         </form>
       );

--- a/src/app/components/HoldRequest/HoldRequest.jsx
+++ b/src/app/components/HoldRequest/HoldRequest.jsx
@@ -117,15 +117,12 @@ class HoldRequest extends React.Component {
 
     Actions.updateLoadingStatus(true);
     trackDiscovery(`Submit Request${partnerEvent}`, `${title} - ${itemId}`);
-    console.log('placing request: ', `${appConfig.baseUrl}/hold/request/${bibId}-${itemId}-${itemSource}`, new FormData(document.getElementById('place-hold-form')));
     const formData = new FormData(document.getElementById('place-hold-form'));
-    console.log(Object.fromEntries(formData.entries()));
     axios.post(
       `${appConfig.baseUrl}/hold/request/${bibId}-${itemId}-${itemSource}`,
       Object.fromEntries(formData.entries()),
     )
       .then((response) => {
-        console.log('response: ', response.data);
         this.context.router.push(response.data);
         Actions.updateLoadingStatus(false);
       });

--- a/src/app/components/HoldRequest/HoldRequest.jsx
+++ b/src/app/components/HoldRequest/HoldRequest.jsx
@@ -125,6 +125,13 @@ class HoldRequest extends React.Component {
       .then((response) => {
         this.context.router.push(response.data);
         Actions.updateLoadingStatus(false);
+      })
+      .catch((error) => {
+        console.error('Error attempting to make an ajax Hold Request in HoldRequest', error);
+        Actions.updateLoadingStatus(false);
+        this.context.router.push(
+          `${path}?errorMessage=${error}${searchKeywordsQueryPhysical}${fromUrlQuery}`,
+        );
       });
   }
 

--- a/src/app/components/HoldRequest/HoldRequest.jsx
+++ b/src/app/components/HoldRequest/HoldRequest.jsx
@@ -52,6 +52,7 @@ class HoldRequest extends React.Component {
     this.state = _extend({
       delivery: defaultDelivery,
       checkedLocNum,
+      redirect: true,
     }, { patron: PatronStore.getState() });
 
     // change all the components :(
@@ -70,6 +71,7 @@ class HoldRequest extends React.Component {
     if (title) {
       title.focus();
     }
+    if (this.state.redirect) this.setState({ redirect: false });
     this.timeoutId = setTimeout(() => { Actions.updateLoadingStatus(false); }, 5000);
   }
 
@@ -115,33 +117,45 @@ class HoldRequest extends React.Component {
 
     Actions.updateLoadingStatus(true);
     trackDiscovery(`Submit Request${partnerEvent}`, `${title} - ${itemId}`);
-    axios
-      .get(`${appConfig.baseUrl}/api/newHold?itemId=${itemId}&pickupLocation=` +
-        `${this.state.delivery}&itemSource=${itemSource}`)
+    console.log('placing request: ', `${appConfig.baseUrl}/hold/request/${bibId}-${itemId}-${itemSource}`, new FormData(document.getElementById('place-hold-form')));
+    const formData = new FormData(document.getElementById('place-hold-form'));
+    console.log(Object.fromEntries(formData.entries()));
+    axios.post(
+      `${appConfig.baseUrl}/hold/request/${bibId}-${itemId}-${itemSource}`,
+      Object.fromEntries(formData.entries()),
+    )
       .then((response) => {
-        if (response.data.error && response.data.error.status !== 200) {
-          Actions.updateLoadingStatus(false);
-          this.context.router.push(
-            `${path}?errorStatus=${response.data.error.status}` +
-            `&errorMessage=${response.data.error.statusText}${searchKeywordsQueryPhysical}` +
-            `${fromUrlQuery}`,
-          );
-        } else {
-          Actions.updateLoadingStatus(false);
-          this.context.router.push(
-            `${path}?pickupLocation=${response.data.pickupLocation}&requestId=${response.data.id}` +
-            `${searchKeywordsQueryPhysical}${fromUrlQuery}`,
-          );
-        }
-      })
-      .catch((error) => {
-        console.error('Error attempting to make an ajax Hold Request in HoldRequest', error);
-
+        console.log('response: ', response);
+        this.context.router.push(response);
         Actions.updateLoadingStatus(false);
-        this.context.router.push(
-          `${path}?errorMessage=${error}${searchKeywordsQueryPhysical}${fromUrlQuery}`,
-        );
       });
+    // axios
+    //   .get(`${appConfig.baseUrl}/api/newHold?itemId=${itemId}&pickupLocation=` +
+    //     `${this.state.delivery}&itemSource=${itemSource}`)
+    //   .then((response) => {
+    //     if (response.data.error && response.data.error.status !== 200) {
+    //       Actions.updateLoadingStatus(false);
+    //       this.context.router.push(
+    //         `${path}?errorStatus=${response.data.error.status}` +
+    //         `&errorMessage=${response.data.error.statusText}${searchKeywordsQueryPhysical}` +
+    //         `${fromUrlQuery}`,
+    //       );
+    //     } else {
+    //       Actions.updateLoadingStatus(false);
+    //       this.context.router.push(
+    //         `${path}?pickupLocation=${response.data.pickupLocation}&requestId=${response.data.id}` +
+    //         `${searchKeywordsQueryPhysical}${fromUrlQuery}`,
+    //       );
+    //     }
+    //   })
+    //   .catch((error) => {
+    //     console.error('Error attempting to make an ajax Hold Request in HoldRequest', error);
+    //
+    //     Actions.updateLoadingStatus(false);
+    //     this.context.router.push(
+    //       `${path}?errorMessage=${error}${searchKeywordsQueryPhysical}${fromUrlQuery}`,
+    //     );
+    //   });
   }
 
   /**
@@ -280,6 +294,7 @@ class HoldRequest extends React.Component {
 
   render() {
     const { closedLocations, holdRequestNotification } = AppConfigStore.getState();
+    const { redirect } = this.state;
     const searchKeywords = this.props.searchKeywords;
     const bib = (this.props.bib && !_isEmpty(this.props.bib)) ?
       this.props.bib : null;
@@ -322,6 +337,7 @@ class HoldRequest extends React.Component {
       const itemSource = selectedItem.itemSource;
       form = (
         <form
+          id="place-hold-form"
           className="place-hold-form form"
           action={`${appConfig.baseUrl}/hold/request/${bibId}-${itemId}-${itemSource}`}
           method="POST"
@@ -349,6 +365,11 @@ class HoldRequest extends React.Component {
             type="hidden"
             name="search-keywords"
             value={searchKeywords}
+          />
+          <input
+            type="hidden"
+            name="redirect"
+            value={redirect}
           />
         </form>
       );

--- a/src/server/ApiRoutes/ApiRoutes.js
+++ b/src/server/ApiRoutes/ApiRoutes.js
@@ -48,7 +48,6 @@ router
 
 router
   .route(`${appConfig.baseUrl}/api/newHold`)
-  .get(Hold.createHoldRequestAjax)
   .post(Hold.createHoldRequestEdd);
 
 router

--- a/src/server/ApiRoutes/Hold.js
+++ b/src/server/ApiRoutes/Hold.js
@@ -347,6 +347,8 @@ function newHoldRequestServerEdd(req, res, next) {
  * @return {function}
  */
 function createHoldRequestServer(req, res, pickedUpBibId = '', pickedUpItemId = '') {
+  console.log('creaetHoldRequestServer', req.params, req.body, req.patronTokenResponse, req.body.redirect, req.body.redirect === false);
+  res.respond = req.body.redirect === false ? res.json : res.redirect;
   // Ensure user is logged in
   const loggedIn = User.requireUser(req, res);
   if (!loggedIn) return false;
@@ -362,14 +364,14 @@ function createHoldRequestServer(req, res, pickedUpBibId = '', pickedUpItemId = 
 
   if (!bibId || !itemId) {
     // Dummy redirect for now
-    return res.redirect(`${appConfig.baseUrl}/someErrorPage`);
+    return res.respond(`${appConfig.baseUrl}/someErrorPage`);
   }
 
   if (pickupLocation === 'edd') {
     const eddSearchKeywordsQuery = (req.body['search-keywords']) ?
       `?q=${req.body['search-keywords']}` : '';
 
-    return res.redirect(
+    return res.respond(
       `${appConfig.baseUrl}/hold/request/${bibId}-${itemId}/edd${eddSearchKeywordsQuery}`,
     );
   }
@@ -382,7 +384,7 @@ function createHoldRequestServer(req, res, pickedUpBibId = '', pickedUpItemId = 
     itemSource,
     (response) => {
       const data = JSON.parse(response).data;
-      res.redirect(
+      res.respond(
         `${appConfig.baseUrl}/hold/confirmation/${bibId}-${itemId}?pickupLocation=` +
         `${pickupLocation}&requestId=${data.id}${searchKeywordsQuery}`,
       );
@@ -392,7 +394,7 @@ function createHoldRequestServer(req, res, pickedUpBibId = '', pickedUpItemId = 
         `Error calling postHoldAPI in createHoldRequestServer, bibId: {bibId}, itemId: ${itemId}`,
         error.data.message,
       );
-      res.redirect(
+      res.respond(
         `${appConfig.baseUrl}/hold/confirmation/${bibId}-${itemId}?pickupLocation=` +
         `${pickupLocation}&errorStatus=${error.status}` +
         `&errorMessage=${error.statusText}${searchKeywordsQuery}`,

--- a/src/server/ApiRoutes/Hold.js
+++ b/src/server/ApiRoutes/Hold.js
@@ -347,7 +347,6 @@ function newHoldRequestServerEdd(req, res, next) {
  * @return {function}
  */
 function createHoldRequestServer(req, res, pickedUpBibId = '', pickedUpItemId = '') {
-  console.log('creaetHoldRequestServer', req.params, req.body, req.patronTokenResponse, req.body.redirect === 'false');
   res.respond = req.body.redirect === 'false' ? res.json : res.redirect;
   // Ensure user is logged in
   const loggedIn = User.requireUser(req, res);
@@ -364,12 +363,10 @@ function createHoldRequestServer(req, res, pickedUpBibId = '', pickedUpItemId = 
 
   if (!bibId || !itemId) {
     // Dummy redirect for now
-    console.log('responding !bibId')
     return res.respond(`${appConfig.baseUrl}/someErrorPage`);
   }
 
   if (pickupLocation === 'edd') {
-    console.log('responding edd')
     const eddSearchKeywordsQuery = (req.body['search-keywords']) ?
       `?q=${req.body['search-keywords']}` : '';
 
@@ -386,7 +383,6 @@ function createHoldRequestServer(req, res, pickedUpBibId = '', pickedUpItemId = 
     itemSource,
     (response) => {
       const data = JSON.parse(response).data;
-      console.log('responding success', res.respond === res.json);
       res.respond(
         `${appConfig.baseUrl}/hold/confirmation/${bibId}-${itemId}?pickupLocation=` +
         `${pickupLocation}&requestId=${data.id}${searchKeywordsQuery}`,

--- a/src/server/ApiRoutes/Hold.js
+++ b/src/server/ApiRoutes/Hold.js
@@ -347,8 +347,8 @@ function newHoldRequestServerEdd(req, res, next) {
  * @return {function}
  */
 function createHoldRequestServer(req, res, pickedUpBibId = '', pickedUpItemId = '') {
-  console.log('creaetHoldRequestServer', req.params, req.body, req.patronTokenResponse, req.body.redirect, req.body.redirect === false);
-  res.respond = req.body.redirect === false ? res.json : res.redirect;
+  console.log('creaetHoldRequestServer', req.params, req.body, req.patronTokenResponse, req.body.redirect === 'false');
+  res.respond = req.body.redirect === 'false' ? res.json : res.redirect;
   // Ensure user is logged in
   const loggedIn = User.requireUser(req, res);
   if (!loggedIn) return false;
@@ -364,10 +364,12 @@ function createHoldRequestServer(req, res, pickedUpBibId = '', pickedUpItemId = 
 
   if (!bibId || !itemId) {
     // Dummy redirect for now
+    console.log('responding !bibId')
     return res.respond(`${appConfig.baseUrl}/someErrorPage`);
   }
 
   if (pickupLocation === 'edd') {
+    console.log('responding edd')
     const eddSearchKeywordsQuery = (req.body['search-keywords']) ?
       `?q=${req.body['search-keywords']}` : '';
 
@@ -384,6 +386,7 @@ function createHoldRequestServer(req, res, pickedUpBibId = '', pickedUpItemId = 
     itemSource,
     (response) => {
       const data = JSON.parse(response).data;
+      console.log('responding success', res.respond === res.json);
       res.respond(
         `${appConfig.baseUrl}/hold/confirmation/${bibId}-${itemId}?pickupLocation=` +
         `${pickupLocation}&requestId=${data.id}${searchKeywordsQuery}`,

--- a/src/server/ApiRoutes/Hold.js
+++ b/src/server/ApiRoutes/Hold.js
@@ -406,46 +406,6 @@ function createHoldRequestServer(req, res, pickedUpBibId = '', pickedUpItemId = 
   );
 }
 
-/**
- * createHoldRequestAjax(req, res)
- * The function to make a client side hold request call.
- *
- * @param {req}
- * @param {res}
- * @return {function}
- */
-function createHoldRequestAjax(req, res) {
-  // Ensure user is logged in
-  const loggedIn = User.requireUser(req);
-  if (!loggedIn) return false;
-
-  return postHoldAPI(
-    req,
-    req.query.itemId,
-    req.query.pickupLocation,
-    null,
-    req.query.itemSource,
-    (response) => {
-      const data = JSON.parse(response).data;
-      res.json({
-        id: data.id,
-        jobId: data.jobId,
-        pickupLocation: data.pickupLocation,
-      });
-    },
-    (error) => {
-      logger.error(
-        `Error calling postHoldAPI in createHoldRequestAjax, itemId: ${req.query.itemId}`,
-        error,
-      );
-      res.json({
-        status: error.status,
-        error,
-      });
-    },
-  );
-}
-
 function createHoldRequestEdd(req, res) {
   // Ensure user is logged in
   const loggedIn = User.requireUser(req);
@@ -539,7 +499,6 @@ export default {
   newHoldRequestAjax,
   newHoldRequestServerEdd,
   createHoldRequestServer,
-  createHoldRequestAjax,
   createHoldRequestEdd,
   eddServer,
 };

--- a/src/server/ApiRoutes/Hold.js
+++ b/src/server/ApiRoutes/Hold.js
@@ -347,7 +347,7 @@ function newHoldRequestServerEdd(req, res, next) {
  * @return {function}
  */
 function createHoldRequestServer(req, res, pickedUpBibId = '', pickedUpItemId = '') {
-  res.respond = req.body.redirect === 'false' ? res.json : res.redirect;
+  res.respond = req.body.serverRedirect === 'false' ? res.json : res.redirect;
   // Ensure user is logged in
   const loggedIn = User.requireUser(req, res);
   if (!loggedIn) return false;


### PR DESCRIPTION
**What's this do?**
A proposed change to the way we process Hold Requests. Instead of having two different routes, this version would have one single route that works as follows:
- When the `HoldRequest` component loads up, if JS is enabled it will add a hidden field `redirect=false`
- When the user submits the form, it triggers a post request with exactly the same data whether JS is enabled or not, except for the `redirect=false` param in the JS case
- This is processed by the `createHoldRequestServer` method, which just as before generates a url to redirect to.
- If `redirect=false` is set, instead of redirecting to that url, it passes the url to the front end, and the front end redirects to that url. 
- the old `createHoldRequestAjax` method and the corresponding route is removed.

**Why are we doing this? (w/ JIRA link if applicable)**
This is part of SCC-2070. The goal of the PR is to implement a new pattern for handling forms that 
- Involves less duplication
- Avoids multiple implementations of the same behavior
- Shifts to a more declarative routing style (in this case everything about the redirect should be handled by pushing the route).
If this passes muster, the goal is to implement the same approach for the other post requests in the app.

**How should this be tested? / Do these changes have associated tests?**
[Description of any tests that need to be performed once merged goes here]

**Dependencies for merging? Releasing to production?**
This PR is build on `nav-merge-test`, which should be dealt with first. In principle these changes are probably partially independent.

**Has the application documentation been updated for these changes?**

**Did someone actually run this code to verify it works?**
PR author tested locally.