### PR TITLE
Drbb scc integration

### DIFF
--- a/discoveryApiResearchNowApiMapping.md
+++ b/discoveryApiResearchNowApiMapping.md
@@ -1,0 +1,470 @@
+# Discovery API - ResearchNow API mapping
+## Discovery API
+[Github](https://github.com/NYPL-discovery/discovery-api/blob/master/README.md#searching)
+### Parameters
+[GET `/v0.1/discovery/resources`](https://platformdocs.nypl.org/#/discovery/get_v0_1_discovery_resources)
+* `q` string
+* `page` string
+* `per_page` integer
+* `sort` integer
+  * "relevance", "title", "creator", "date"
+* `sort_direction` string
+  * "asc", "desc"
+  * title defaults to asc, date defaults to desc, creator defaults to asc, relevance is fixed desc
+* `search_scope` string
+  * "all", "title", "contributor", "subject", "series", "callnumber", "standard_number"
+* `filters` string
+  * "owner", "subjectLiteral", "holdingLocation", "deliveryLocation", "language", "materialType", "mediaType", "carrierType", "publisher", "contributor", "creator", "issuance", "createdYear", "dateAfter"', or "dateBefore"
+  * Specify a hash of filters to apply, where keys are from terms above
+
+## ResearchNow API
+[Github](https://github.com/NYPL/sfr-ingest-pipeline/tree/development/app/sfr-search-api#searching)
+[GET `/v0.1/research-now/v3/search-api`](https://dev-platformdocs.nypl.org/#/research-now/get_v0_1_research_now_v3_search_api)
+[POST `/v0.1/research-now/v3/search-api`](https://dev-platformdocs.nypl.org/#/research-now/post_v0_1_research_now_v3_search_api)
+### Parameters
+* `queries` array of objects
+  * Objects for the queries are formatted as `{"field": filter, "value": value}`
+* `filters` array of objects
+  * Objects for the filters are formatted as `{"filter": filter, "value": value}`
+* `field` string
+  * "keyword", "title", "author", "standardNumber" (ISBN, ISSN, LCCN and OCLC) and "subject"
+* `query` string
+* `recordType`
+  * Internal record type to return with the work. Either instances or editions.
+* `page` integer (0 indexed)
+* `per_page` integer
+* `sort` array of objects
+  * Objects are formatted as `{"field": field, "dir": dir}`
+* `language` array of languages
+* `years`
+  * This should be formatted as `{"start": year, "end": year}`.
+
+For the DRBB/SCC integration, the DRBB data is fetched using a POST request with a body containing `page`, `per_page`, `filters` (years, languages), and `queries` (author/contributor, subject).
+
+## Example Translation
+A GET request to the Discovery API endpoint detailed above with this query
+```
+?q=hello&filters[subjectLiteral][0]=United%20States&sort=title&sort_direction=asc&search_scope=title&page=1&filters[language][0]=lang%3Aeng&filters[language][1]=lang%3Ager&filters[dateAfter]=1993&filters[dateBefore]=2020
+```
+would translate to a POST request with this body for ResearchNow's search endpoint:
+``` json
+{
+	"queries":[
+		{"field":"title","query":"hello"},
+		{"field":"subject","query":"United States"}
+	],
+	"page":0,
+	"sort":[{"field":"title","dir":"asc"}],
+  "filters":[
+    {"field":"language","value":"eng"},
+    {"field":"language","value":"ger"},
+    {"field":"years","value":{
+      "start": 1993,
+      "end": 2020,
+    }},
+  ]}
+}
+```
+
+<!-- <style>
+  table ul {
+    list-style: none;
+  }
+</style> -->
+
+## API Parameters Comparison
+This table lists, in the first column, the frontend features related to searching and search filters available from the frontend. The 2nd and 3rd column list out the Discovery API and ResearchNow API parameters that correlate to that frontend functionality.
+
+Single quotes (') are used for frontend terminology. Italics are used to describe frontend features. Code styling (e.g. `filters`) is used for the parameters the respective APIs except.
+
+|Discovery front end|Discovery API |ResearchNow API|
+|-------------------|--------------|---------------|
+|_Search field_     |`q`           |`queries`, "value"|
+|_Search field dropdown_|`search_scope`|`queries`, "field"|
+|<ul>'All Fields'   |<ul>"all"     |<ul>"keyword"  |
+|<ul>'Title'        |<ul>"title"   |<ul>"title"    |
+|<ul>'Author/Contributor'|<ul>"contributor" |<ul>"author"|
+|<ul>'Standard Number'|<ul>"standard_number"|<ul> "standardNumber"|
+|_Search page filters_|`filters`     ||
+|<ul>'Format'       |<ul>`filters[materialType]`|<ul>N/A*|
+|<ul>'Date':<ul><li>'Start Year'<li>'End Year'| <ul><br>`filters[dateAfter]`<br>`filters[dateBefore]` |`filters`<br><ul>`years[start]`<br>`years[end]`|
+|<ul>'Language'|<ul>`filters[language]`|<ul>`filters` `language`|
+|_Filters linked to from a bib page_|
+|<ul>'Author'|<ul>`filters[creatorLiteral]`|<ul>`queries` `"field":"author"`|
+|<ul>'Additional Authors'|<ul>`filters[creatorLiteral]`|<ul>`queries` `"field":"author"`|
+|<ul>'Subject'    |<ul>`filters[subjectLiteral]`|<ul>`queries` `"field":"subject"`|
+|_Pagination_     |`page`      | `page`        |
+|                   |`per_page`|`per_page`|
+|_Sorting_            |`sort`        |`sort[field]` |
+|                   |`sort_direction`|`sort[direction]`  |
+
+\* ResearchNow's `format` parameter does not correspond to the `materialType` in Discovery API. The former relates to digital formats (pdf, epub, and html). The latter to physical material type.
+
+## API Response Structure
+### Discovery API
+``` json
+{
+  "@context": "string",
+  "@type": "itemList",
+  "itemListElement": [
+    {
+      "@type": "searchResult",
+      "result": {
+        "@type": [
+          "string"
+        ],
+        "@id": "string",
+        "carrierType": [
+          {
+            "@type": "string",
+            "@id": "string",
+            "prefLabel": "string"
+          }
+        ],
+        "creatorLiteral": [
+          "string"
+        ],
+        "contributorLiteral": [
+          "string"
+        ],
+        "created": "string",
+        "createdYear": 0,
+        "dateStartYear": 0,
+        "depiction": "string",
+        "description": "string",
+        "endYear": 0,
+        "extent": [
+          "string"
+        ],
+        "holdingCount": 0,
+        "issuance": [
+          {
+            "@type": "string",
+            "@id": "string",
+            "prefLabel": "string"
+          }
+        ],
+        "items": [
+          {
+            "@id": "string",
+            "accessMessage": [
+              {
+                "@type": "string",
+                "@id": "string",
+                "prefLabel": "string"
+              }
+            ],
+            "deliveryLocation": [
+              {
+                "@type": "string",
+                "@id": "string",
+                "prefLabel": "string"
+              }
+            ],
+            "holdingLocation": [
+              {
+                "@type": "string",
+                "@id": "string",
+                "prefLabel": "string"
+              }
+            ],
+            "idBarcode": "string",
+            "identifier": [
+              "string"
+            ],
+            "owner": [
+              {
+                "@type": "string",
+                "@id": "string",
+                "prefLabel": "string"
+              }
+            ],
+            "requestable": [
+              true
+            ],
+            "eddRequestable": true,
+            "shelfMark": [
+              "string"
+            ],
+            "status": [
+              {
+                "@type": "string",
+                "@id": "string",
+                "prefLabel": "string"
+              }
+            ],
+            "uri": "string"
+          }
+        ],
+        "^id": "string",
+        "language": [
+          {
+            "@type": "string",
+            "@id": "string",
+            "prefLabel": "string"
+          }
+        ],
+        "materialType": [
+          {
+            "@type": "string",
+            "@id": "string",
+            "prefLabel": "string"
+          }
+        ],
+        "mediaType": [
+          {
+            "@type": "string",
+            "@id": "string",
+            "prefLabel": "string"
+          }
+        ],
+        "note": [
+          {
+            "@type": "bf:Note",
+            "noteType": "string",
+            "label": "string"
+          }
+        ],
+        "numAvailable": 0,
+        "placeOfPublication": [
+          "string"
+        ],
+        "prefLabel": [
+          "string"
+        ],
+        "roles:ROLE": [
+          "string"
+        ],
+        "startYear": 0,
+        "subject": [
+          {
+            "@type": "string",
+            "@id": "string",
+            "prefLabel": "string"
+          }
+        ],
+        "suppressed": true,
+        "title": [
+          "string"
+        ],
+        "titleDisplay": [
+          "string"
+        ],
+        "type": [
+          "nypl:Item"
+        ],
+        "uri": "string"
+      }
+    }
+  ]
+}
+```
+
+### ResearchNow API
+``` json
+{
+  "status": 0,
+  "timestamp": "2020-06-01T20:30:37.458Z",
+  "responseType": "string",
+  "data": {
+    "totalWorks": 0,
+    "facets": {
+      "facet": [
+        {
+          "value": "string",
+          "count": 0
+        }
+      ]
+    },
+    "paging": {
+      "prev_page_sort": [
+        "string"
+      ],
+      "next_page_sort": [
+        "string"
+      ]
+    },
+    "works": [
+      {
+        "date_modified": "2020-06-01T20:30:37.458Z",
+        "date_created": "2020-06-01T20:30:37.458Z",
+        "id": 0,
+        "uuid": "string",
+        "title": "string",
+        "sort_title": "string",
+        "sub_title": [
+          "string"
+        ],
+        "medium": "string",
+        "series": "string",
+        "series_position": 0,
+        "edition_count": 0,
+        "edition_range": "string",
+        "sort": [
+          "string"
+        ],
+        "agents": [
+          {
+            "name": "string",
+            "sort_name": "string",
+            "viaf": "string",
+            "lcnaf": "string",
+            "role": "string",
+            "birth_date_display": "string",
+            "death_date_display": "string"
+          }
+        ],
+        "alt_titles": [
+          "string"
+        ],
+        "instances": [
+          {
+            "date_modified": "2020-06-01T20:30:37.458Z",
+            "date_created": "2020-06-01T20:30:37.458Z",
+            "id": 0,
+            "title": "string",
+            "sort_title": "string",
+            "sub_title": "string",
+            "pub_place": "string",
+            "edition": "string",
+            "edition_statement": "string",
+            "volume": "string",
+            "table_of_contents": "string",
+            "copyright_date": "string",
+            "extent": "string",
+            "summary": "string",
+            "work_id": 0,
+            "edition_id": 0,
+            "agents": [
+              {
+                "name": "string",
+                "sort_name": "string",
+                "viaf": "string",
+                "lcnaf": "string",
+                "role": "string",
+                "birth_date_display": "string",
+                "death_date_display": "string"
+              }
+            ],
+            "items": [
+              {
+                "source": "string",
+                "content_type": "string",
+                "modified": "2020-06-01T20:30:37.458Z",
+                "drm": "string",
+                "links": [
+                  {
+                    "url": "string",
+                    "media_type": "string",
+                    "content": "string",
+                    "thumbnail": "string",
+                    "local": true,
+                    "download": true,
+                    "images": true,
+                    "ebook": true
+                  }
+                ]
+              }
+            ],
+            "languages": [
+              {
+                "language": "string",
+                "iso_2": "string",
+                "iso_3": "string"
+              }
+            ],
+            "identifiers": [
+              {
+                "id_type": "string",
+                "identifier": "string"
+              }
+            ]
+          }
+        ],
+        "languages": [
+          {
+            "language": "string",
+            "iso_2": "string",
+            "iso_3": "string"
+          }
+        ],
+        "editions": [
+          {
+            "date_modified": "2020-06-01T20:30:37.460Z",
+            "date_created": "2020-06-01T20:30:37.460Z",
+            "id": 0,
+            "publication_place": "string",
+            "publication_date": "string",
+            "edition": "string",
+            "edition_statement": "string",
+            "volume": "string",
+            "table_of_contents": "string",
+            "extent": "string",
+            "summary": "string",
+            "work_id": 0,
+            "agents": [
+              {
+                "name": "string",
+                "sort_name": "string",
+                "viaf": "string",
+                "lcnaf": "string",
+                "role": "string",
+                "birth_date_display": "string",
+                "death_date_display": "string"
+              }
+            ],
+            "items": [
+              {
+                "source": "string",
+                "content_type": "string",
+                "modified": "2020-06-01T20:30:37.461Z",
+                "drm": "string",
+                "links": [
+                  {
+                    "url": "string",
+                    "media_type": "string",
+                    "content": "string",
+                    "thumbnail": "string",
+                    "local": true,
+                    "download": true,
+                    "images": true,
+                    "ebook": true
+                  }
+                ]
+              }
+            ],
+            "languages": [
+              {
+                "language": "string",
+                "iso_2": "string",
+                "iso_3": "string"
+              }
+            ]
+          }
+        ],
+        "identifiers": [
+          {
+            "id_type": "string",
+            "identifier": "string"
+          }
+        ],
+        "subjects": [
+          {
+            "subject": "string",
+            "authority": "string",
+            "uri": "string"
+          }
+        ],
+        "measurements": [
+          {
+            "quantity": "string",
+            "value": 0,
+            "weight": 0,
+            "taken_at": "2020-06-01T20:30:37.461Z"
+          }
+        ]
+      }
+    ]
+  }
+}
+```

--- a/src/app/components/Drbb/DrbbContainer.jsx
+++ b/src/app/components/Drbb/DrbbContainer.jsx
@@ -5,7 +5,6 @@ import { Link } from 'react-router';
 
 import appConfig from '../../data/appConfig';
 import DrbbItem from './DrbbItem';
-import { getResearchNowQueryString } from '../../utils/researchNowUtils';
 
 class DrbbContainer extends React.Component {
   constructor(props, context) {

--- a/src/app/components/Drbb/DrbbContainer.jsx
+++ b/src/app/components/Drbb/DrbbContainer.jsx
@@ -1,0 +1,123 @@
+import React from 'react';
+import axios from 'axios';
+import PropTypes from 'prop-types';
+import { Link } from 'react-router';
+
+import appConfig from '../../data/appConfig';
+import DrbbItem from './DrbbItem';
+import { getResearchNowQueryString } from '../../utils/researchNowUtils';
+
+class DrbbContainer extends React.Component {
+  constructor(props, context) {
+    super();
+    this.search = context.router.location.search || '';
+    this.query = context.router.location.query || {};
+    this.state = {
+      works: [],
+      drbbResultsLoading: true,
+      researchNowQueryString: '',
+    };
+  }
+
+  componentDidMount() {
+    this.fetchResearchNowResults();
+  }
+
+  fetchResearchNowResults() {
+    axios(`${appConfig.baseUrl}/api/research-now${this.search}`)
+      .then((resp) => {
+        if (!resp.data || !resp.data.works) {
+          this.setState({ drbbResultsLoading: false });
+          return;
+        }
+        this.setState({
+          works: resp.data.works,
+          totalWorks: resp.data.totalWorks,
+          drbbResultsLoading: false,
+          researchNowQueryString: resp.data.researchNowQueryString,
+        });
+      })
+      .catch(console.error);
+  }
+
+  content() {
+    const {
+      works,
+      drbbResultsLoading,
+      totalWorks,
+      researchNowQueryString,
+    } = this.state;
+
+    if (drbbResultsLoading) {
+      return (
+        <div className="drr-loading-layer">
+          <span
+            className="loading-animation loadingLayer-texts-loadingWord"
+          >
+            Loading results
+          </span>
+          <div className="loadingDots">
+            <span />
+            <span />
+            <span />
+            <span />
+          </div>
+        </div>
+      );
+    }
+
+    if (works && works.length) {
+      return ([
+        <ul key="drbb-scc-results-list" className="drbb-list">
+          { works.map(work => <DrbbItem key={work.id} work={work} />) }
+        </ul>,
+        <Link
+          className="drbb-description"
+          to={{
+            pathname: `${appConfig.drbbFrontEnd[appConfig.environment]}/search?`,
+            search: researchNowQueryString,
+          }}
+          target="_blank"
+          key="drbb-results-list-link"
+        >
+          See {totalWorks} results from Digital Research Books Beta
+        </Link>]);
+    }
+    return (
+      <Link
+        className="drbb-description"
+        to={{
+          pathname: `${appConfig.drbbFrontEnd[appConfig.environment]}/search?`,
+        }}
+        target="_blank"
+        key="drbb-link"
+      >
+        See results from Digital Research Books Beta
+      </Link>
+    );
+  }
+
+  render() {
+    return (
+      <div className="drbb-container">
+        <h3 className="drbb-main-header">
+          Results from Digital Research Books Beta
+        </h3>
+        <p className="drbb-description">
+          Find millions of digital books for research from multiple sources world-wide--all free to read, download, and keep. No library card required. This is an early beta test, so we want your feedback! <a
+            className="link"
+            target="_blanks"
+            href={`${appConfig.drbbFrontEnd[appConfig.environment]}/about`}
+          >Read more about the project</a>.
+        </p>
+        { this.content() }
+      </div>
+    );
+  }
+}
+
+DrbbContainer.contextTypes = {
+  router: PropTypes.object,
+};
+
+export default DrbbContainer;

--- a/src/app/components/Drbb/DrbbItem.jsx
+++ b/src/app/components/Drbb/DrbbItem.jsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Link } from 'react-router';
+
+import appConfig from '../../data/appConfig';
+import {
+  authorQuery,
+  formatUrl,
+} from '../../utils/researchNowUtils';
+
+const DrbbItem = (props) => {
+  const { work } = props;
+  const {
+    agents,
+    title,
+    editions,
+  } = work;
+
+  const {
+    environment,
+  } = appConfig;
+
+  const drbbFrontEnd = appConfig.drbbFrontEnd[environment];
+
+  const edition = editions[0];
+  const item = edition.items[0];
+
+  const authorship = () => {
+    const authors = agents.map((agent, i) => [
+      (i > 0 ? ', ' : null),
+      <Link
+        to={{
+          pathname: `${drbbFrontEnd}/search`,
+          query: authorQuery(agent),
+        }}
+        className="drbb-result-author"
+        key={agent.viaf ? `author-${agent.viaf}` : `author-${agent.name}`}
+        target="_blank"
+      >
+        {agent.name}
+      </Link>]);
+
+    return (
+      <div>
+        By {authors}
+      </div>
+    );
+  };
+
+  const readOnlineLink = () => {
+    const editionWithTitle = edition;
+    editionWithTitle.title = edition.title || work.title;
+
+    const selectedLink = item.links.find(link => (
+      (!link.local && !link.download) || (link.local && link.download)
+    ));
+    if (!selectedLink || !selectedLink.url) return null;
+
+    return (
+      <Link
+        target="_blank"
+        to={{
+          pathname: `${drbbFrontEnd}/read-online`,
+          search: `?url=${formatUrl(selectedLink.url)}#/edition?editionId=${edition.id}`,
+        }}
+        className="drbb-read-online"
+      >
+        Read Online
+      </Link>
+    );
+  };
+
+  return (
+    <li className="drbb-item">
+      <Link
+        target="_blank"
+        to={`${drbbFrontEnd}/work?recordType=editions&workId=${work.uuid}`}
+        className="drbb-result-title"
+      >
+        {title}
+      </Link>
+      {agents && agents.length ? authorship() : null}
+      { readOnlineLink() }
+      <Link
+        target="_blank"
+        to={`${drbbFrontEnd}/work?recordType=editions&workId=${work.uuid}`}
+        className="drbb-download-pdf"
+      >
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+          <path d="M8 0C3.6 0 0 3.6 0 8s3.6 8 8 8 8-3.6 8-8-3.6-8-8-8zm0 15.3C4 15.3.7 12 .7 8S4 .7 8 .7 15.3 4 15.3 8 12 15.3 8 15.3z" />
+          <path d="M11.3 8.2c-.2-.2-.5-.2-.7 0l-2.2 2.2V4.5h-.9v5.9L5.3 8.2c-.1-.2-.4-.2-.6 0s-.2.5 0 .7l3 3c.2.2.5.2.7 0l3-3c.1-.2.1-.5-.1-.7z" />
+        </svg>
+        Download PDF
+      </Link>
+    </li>
+  );
+};
+
+DrbbItem.propTypes = {
+  work: PropTypes.object,
+};
+
+export default DrbbItem;

--- a/src/app/components/ResultsList/ResultsList.jsx
+++ b/src/app/components/ResultsList/ResultsList.jsx
@@ -11,6 +11,7 @@ import Store from '@Store';
 import LibraryItem from '../../utils/item';
 import { trackDiscovery } from '../../utils/utils';
 import ItemTable from '../Item/ItemTable';
+// import DrbbContainer from '../Drbb/DrbbContainer';
 import appConfig from '../../data/appConfig';
 
 class ResultsList extends React.Component {
@@ -103,12 +104,14 @@ class ResultsList extends React.Component {
     }
 
     resultsElm = results.map((bib, i) => this.generateBibLi(bib, i));
+    const includeDrbb = true;
 
     return (
       <ul
         id="nypl-results-list"
         className={`nypl-results-list ${Store.getState().isLoading ? 'hide-results-list ' : ''}`}
       >
+        {/* includeDrbb ? <DrbbContainer /> : null */}
         {resultsElm}
       </ul>
     );

--- a/src/app/components/SccContainer/SccContainer.jsx
+++ b/src/app/components/SccContainer/SccContainer.jsx
@@ -31,7 +31,7 @@ const SccContainer = props => (
       { props.secondaryExtraBannerElement }
     </div>
     { props.extraRow }
-    <div className="nypl-full-width-wrapper">
+    <div className="nypl-full-width-wrapper drbb-integration">
       { props.mainContent }
     </div>
   </main>

--- a/src/app/components/SearchResults/SearchResultsContainer.jsx
+++ b/src/app/components/SearchResults/SearchResultsContainer.jsx
@@ -3,13 +3,13 @@ import PropTypes from 'prop-types';
 
 import ResultList from '../ResultsList/ResultsList';
 import Pagination from '../Pagination/Pagination';
+import DrbbContainer from '../Drbb/DrbbContainer';
 import {
   basicQuery,
   ajaxCall,
   trackDiscovery,
 } from '../../utils/utils';
 import Actions from '../../actions/Actions';
-import Store from '@Store'
 import appConfig from '../../data/appConfig';
 
 // Renders the ResultsList containing the search results and the Pagination component
@@ -38,6 +38,8 @@ const SearchResultsContainer = (props) => {
     });
   };
 
+  const includeDrbb = true;
+
   return (
     <React.Fragment>
       <div className="nypl-row">
@@ -53,6 +55,7 @@ const SearchResultsContainer = (props) => {
               searchKeywords={searchKeywords}
             />
           }
+          {includeDrbb ? <DrbbContainer /> : null}
           {
             !!(totalResults && totalResults !== 0) &&
             <Pagination

--- a/src/app/data/appConfig.js
+++ b/src/app/data/appConfig.js
@@ -6,9 +6,16 @@ export default {
   favIconPath: '//d2znry4lg8s0tq.cloudfront.net/images/favicon.ico',
   port: 3001,
   webpackDevServerPort: 3000,
+  environment: process.env.APP_ENV || 'production',
   api: {
-    development: process.env.PLATFORM_API_BASE_URL || 'https://dev-platform.nypl.org/api/v0.1',
-    production: process.env.PLATFORM_API_BASE_URL || 'https://platform.nypl.org/api/v0.1',
+    discovery: {
+      development: process.env.PLATFORM_API_BASE_URL || 'https://qa-platform.nypl.org/api/v0.1',
+      production: process.env.PLATFORM_API_BASE_URL || 'https://platform.nypl.org/api/v0.1'
+    },
+    drbb: {
+      development: 'https://dev-platform.nypl.org/api/v0.1/research-now/v3/search-api',
+      production: 'https://digital-research-books-api.nypl.org/v3/sfr/search',
+    },
   },
   shepApi: process.env.SHEP_API,
   loginUrl: 'https://login.nypl.org/auth/login',
@@ -37,4 +44,12 @@ export default {
   ).map(location => (location === 'all' ? '' : location)),
   holdRequestNotification: process.env.HOLD_REQUEST_NOTIFICATION,
   searchResultsNotification: process.env.SEARCH_RESULTS_NOTIFICATION,
+  drbbFrontEnd: {
+    development: 'http://sfr-front-end-development.us-east-1.elasticbeanstalk.com',
+    production: 'https://digital-research-books-beta.nypl.org',
+  },
+  drbbEreader: {
+    development: 'https://researchnow-reader.nypl.org',
+    production: 'https://digital-research-books-reader.nypl.org',
+  },
 };

--- a/src/app/utils/researchNowUtils.js
+++ b/src/app/utils/researchNowUtils.js
@@ -1,0 +1,131 @@
+/*
+  `createResearchNowQuery()` currently handles:
+  `search_scope`, `dateAfter`, `dateBefore`,
+  `contributorLiteral`, `subjectLiteral`, `language`,
+  sorting, and pagination
+*/
+
+/* eslint-disable camelcase */
+
+const mapSearchScope = {
+  all: 'keyword',
+  contributor: 'author',
+  standard_number: 'standardNumber',
+  title: 'title',
+  date: 'date',
+};
+
+const filterObj = (field, value) => ({ field, value });
+const queryObj = (field, query) => ({ field, query });
+
+const mapFilters = (filters = {}) => {
+  const researchNowFilters = [];
+
+  const years = {};
+  if (filters.dateAfter) years.start = filters.dateAfter;
+  if (filters.dateBefore) years.end = filters.dateBefore;
+  if (years.start || years.end) researchNowFilters.push(filterObj('years', years));
+  if (filters.language) {
+    const languages = filters.language.map(lang => lang.replace('lang:', ''));
+    languages.forEach(language => researchNowFilters.push(filterObj('language', language)));
+  }
+
+  return researchNowFilters;
+};
+
+const createResearchNowQuery = (params) => {
+  const {
+    q,
+    sort,
+    sort_direction,
+    filters,
+    search_scope,
+    per_page,
+  } = params;
+
+  const mainQuery = queryObj(
+    mapSearchScope[search_scope] || 'keyword',
+    q || '*');
+
+  const query = {
+    queries: [mainQuery],
+    page: 0,
+  };
+
+  if (sort) {
+    query.sort = [{ field: sort }];
+    if (sort_direction) query.sort[0].dir = sort_direction;
+  }
+
+  if (per_page) query.per_page = per_page;
+
+  console.log('researchNowQuery', query);
+
+  if (!filters) return query;
+
+  const {
+    subjectLiteral,
+    contributorLiteral,
+    language,
+    dateAfter,
+    dateBefore,
+  } = filters;
+
+  if (subjectLiteral) {
+    subjectLiteral.forEach(subject => query.queries.push(queryObj('subject', subject)));
+  }
+  if (contributorLiteral) query.queries.push(queryObj('author', contributorLiteral));
+
+  if (language || dateAfter || dateBefore) {
+    query.filters = mapFilters({ dateAfter, dateBefore, language });
+  }
+  console.log(query);
+
+  return query;
+};
+
+const getAuthorIdentifier = author => (author.viaf && ['viaf', 'viaf']) || (author.lcnaf && ['lcnaf', 'lcnaf']) || ['name', 'author'];
+
+const authorQuery = author => ({
+  queries: JSON.stringify([{
+    query: author[getAuthorIdentifier(author)[0]],
+    field: getAuthorIdentifier(author)[1],
+  }]),
+  showQueries: JSON.stringify([{ query: author.name, field: 'author' }]),
+});
+
+const generateStreamedReaderUrl = (url, eReaderUrl, editionId) => {
+  const base64BookUrl = Buffer.from(url).toString('base64');
+  const encodedBookUrl = encodeURIComponent(`${base64BookUrl}`);
+  let combined = `${eReaderUrl}/readerNYPL/?url=${eReaderUrl}/pub/${encodedBookUrl}/manifest.json`;
+  combined += `#/edition?editionId=${editionId}`;
+  return combined;
+};
+
+const formatUrl = link => (link.startsWith('http') ? link : `https://${link}`);
+
+const getQueryString = (initialQuery, cb = input => input) => {
+  const query = cb(initialQuery)
+  return (query && Object.keys(query)
+    .map(key => [key, query[key]]
+      .map((o) => {
+        let ret = o;
+        if (typeof o === 'object') {
+          ret = JSON.stringify(o);
+        }
+        return encodeURIComponent(ret);
+      })
+      .join('='))
+    .join('&')
+  );
+};
+
+const getResearchNowQueryString = query => getQueryString(query, createResearchNowQuery);
+
+export {
+  createResearchNowQuery,
+  authorQuery,
+  generateStreamedReaderUrl,
+  formatUrl,
+  getResearchNowQueryString,
+};

--- a/src/client/styles/components/Drbb/Drbb.scss
+++ b/src/client/styles/components/Drbb/Drbb.scss
@@ -1,0 +1,105 @@
+// $drbb-default-padding: 0 5px;
+
+.drbb-container {
+  border: 1px solid #d7d4d0;
+  border-radius: 8px;
+  float: right;
+  margin: auto;
+  margin-left: 15px;
+  padding: 10px;
+  padding-bottom: 25px;
+  width: 30%;
+
+  .loadingLayer-texts-loadingWord {
+    margin-bottom: unset;
+    text-transform: initial;
+  }
+
+  .loadingDots {
+    margin-top: unset;
+  }
+}
+
+.drbb-main-header {
+  font-size: 1.4375rem;
+  margin: 0 0 10px;
+}
+
+.drbb-main-header,
+.drbb-description {
+  padding: 0 5px;
+}
+
+.nypl-results-list {
+  display: inline-block;
+  width: 65%;
+}
+
+.drbb-description {
+  font-size: 12px;
+
+  a {
+    display: inline-block;
+    padding: 0;
+  }
+}
+
+.drbb-item {
+  background-color: #f9f8f7;
+  border-radius: 4px;
+  font-size: 14px;
+  margin: 20px 0;
+  padding: 5% 8%;
+}
+
+.drbb-list {
+  list-style: none;
+}
+
+.drr-loading-layer {
+  height: 135px;
+  padding-top: 35px;
+  text-align: center;
+}
+
+.nypl-full-width-wrapper.drbb-integration {
+  padding-left: 30px;
+  padding-right: 30px;
+}
+
+.drbb-result-author {
+  display: inline;
+}
+
+.drbb-result-title {
+  display: block;
+}
+
+a.drbb-read-online {
+  background-color: #fff;
+  border: 0.08333rem solid #d0343a;
+  border-radius: 0.13333rem;
+  color: #d0343a;
+  cursor: pointer;
+  display: inline-block;
+  font-size: 0.8rem;
+  font-weight: normal;
+  letter-spacing: 0.06rem;
+  text-decoration: none;
+  padding: 2% 3%;
+}
+
+a.drbb-download-pdf {
+  float: right;
+  color: #000000;
+  fill: currentColor;
+  padding: 2% 0;
+
+  svg {
+    padding-left: 5px;
+  }
+}
+
+.drbb-read-online, .drbb-download-pdf {
+  margin: 2% 0;
+}

--- a/src/server/ApiRoutes/ApiRoutes.js
+++ b/src/server/ApiRoutes/ApiRoutes.js
@@ -4,6 +4,7 @@ import Bib from './Bib';
 import User from './User';
 import Hold from './Hold';
 import Search from './Search';
+import ResearchNow from './ResearchNow';
 import appConfig from '../../app/data/appConfig';
 import SubjectHeading from './SubjectHeading';
 import SubjectHeadings from './SubjectHeadings';
@@ -66,6 +67,10 @@ router
 router
   .route(`${appConfig.baseUrl}/api`)
   .get(Search.searchAjax);
+
+router
+  .route(`${appConfig.baseUrl}/api/research-now`)
+  .get(ResearchNow.searchAjax);
 
 router
   .route(`${appConfig.baseUrl}/api/bib`)

--- a/src/server/ApiRoutes/ResearchNow.js
+++ b/src/server/ApiRoutes/ResearchNow.js
@@ -1,0 +1,37 @@
+import nyplApiClient from '../routes/nyplApiClient';
+
+import {
+  createResearchNowQuery,
+  getResearchNowQueryString,
+} from '../../app/utils/researchNowUtils';
+import appConfig from '../../app/data/appConfig';
+import logger from '../../../logger';
+
+const appEnvironment = process.env.APP_ENV || 'production';
+
+const nyplApiClientCall = query => nyplApiClient({ apiName: 'drbb' })
+  .then(client => client.post('', JSON.stringify(query)))
+  .catch(console.error);
+
+const searchAjax = (req, res) => {
+  const query = createResearchNowQuery(Object.assign({ per_page: 3 }, req.query));
+  const researchNowQueryString = getResearchNowQueryString(req.query);
+  return nyplApiClientCall(query)
+    .then((resp) => {
+      const data = JSON.parse(resp).data;
+      if (!data || !data.works) {
+        logger.error(resp);
+        return res.json(data);
+      }
+      return res.json({
+        works: data.works,
+        totalWorks: data.totalWorks,
+        researchNowQueryString,
+      });
+    })
+    .catch(console.error);
+};
+
+export default {
+  searchAjax,
+};

--- a/test/unit/AdditionalDetailsViewer.test.js
+++ b/test/unit/AdditionalDetailsViewer.test.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { expect } from 'chai';
-import Enzyme, { mount } from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import { mount } from 'enzyme';
 
 // Import the component that is going to be tested
 import AdditionalDetailsViewer from './../../src/app/components/BibPage/AdditionalDetailsViewer';

--- a/test/unit/SearchResultsPage.test.js
+++ b/test/unit/SearchResultsPage.test.js
@@ -2,8 +2,10 @@
 import React from 'react';
 import { expect } from 'chai';
 import { mount } from 'enzyme';
+import PropTypes from 'prop-types';
 
 import SearchResults from '../../src/app/pages/SearchResults';
+import { mockRouterContext } from '../helpers/routing';
 
 // Eventually, it would be nice to have mocked data in a different file and imported.
 const searchResults = {
@@ -22,6 +24,11 @@ const searchResults = {
   totalResults: 2,
 };
 
+const context = mockRouterContext();
+const childContextTypes = {
+  router: PropTypes.object,
+};
+
 describe('SearchResultsPage', () => {
   describe('Component properties', () => {
     let component;
@@ -34,7 +41,10 @@ describe('SearchResultsPage', () => {
           searchResults={{}}
           location={{ search: '' }}
         />,
-        { attachTo: document.body }
+        { attachTo: document.body,
+          context,
+          childContextTypes,
+        },
       );
     });
 
@@ -87,7 +97,7 @@ describe('SearchResultsPage', () => {
           searchResults={searchResults}
           location={{ search: '' }}
         />,
-        { attachTo: document.body }
+        { attachTo: document.body, context, childContextTypes }
       );
     });
 
@@ -127,7 +137,7 @@ describe('SearchResultsPage', () => {
           searchResults={searchResults}
           location={{ search: '' }}
         />,
-        { attachTo: document.body }
+        { attachTo: document.body, context, childContextTypes }
       );
     });
 

--- a/test/unit/SubjectHeadingIndex.test.js
+++ b/test/unit/SubjectHeadingIndex.test.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 import React from 'react';
 import { expect } from 'chai';
-import { shallow, mount } from 'enzyme';
+import { mount } from 'enzyme';
 
 import SubjectHeadingsIndex from '@SubjectHeadingsIndex';
 import { mockRouterContext } from '../helpers/routing';


### PR DESCRIPTION
**What's this do?**
Initial changes to implement current design for SCC-DRBB integration:
https://www.figma.com/file/lFjCBO6eq3afZFwxnNJS74/Subject-Heading-Explorer?node-id=860%3A3
This PR is to get something on to development to have something to send around and refer to.

API comparison doc: https://github.com/NYPL-discovery/discovery-front-end/blob/shep-development/discoveryApiResearchNowApiMapping.md

**To come/still in progress**
* The "Download PDF" button currently still needs some styling tweaks and to point to the right URL.
* The DRBB "Read Online" link is buggy right now :(
* <s>The "See {totalWorks} results from Digital Research Books Beta" link is not working.</s> Implemented with commit 0f55c0b
* Mobile view.
* DRBB promo (coming from Ellen) for if there are no matching results in DRBB
* Test coverage