### PR TITLE
Add filtering by closedLocation in api methods

### DIFF
--- a/src/server/ApiRoutes/Hold.js
+++ b/src/server/ApiRoutes/Hold.js
@@ -98,6 +98,24 @@ function mapLocationDetails(locations) {
 }
 
 /**
+ * modelDeliveryLocationName(prefLabel, shortName)
+ * Renders the names of the radio input fields of delivery locations except EDD.
+ *
+ * @param {String} prefLabel
+ * @param {String} shortName
+ * @return {String}
+ */
+function modelDeliveryLocationName(prefLabel, shortName) {
+  if (prefLabel && typeof prefLabel === 'string' && shortName) {
+    const deliveryRoom = (prefLabel.split(' - ')[1]) ? ` - ${prefLabel.split(' - ')[1]}` : '';
+
+    return `${shortName}${deliveryRoom}`;
+  }
+
+  return '';
+}
+
+/**
  * getDeliveryLocations(barcode, patronId, cb, errorCb)
  * The function to make a request to get delivery locations of an item.
  *
@@ -117,10 +135,18 @@ function getDeliveryLocations(barcode, patronId, cb, errorCb) {
         barcodeAPIresponse.itemListElement.length &&
         barcodeAPIresponse.itemListElement[0].eddRequestable) ?
         barcodeAPIresponse.itemListElement[0].eddRequestable : false;
-      const deliveryLocationWithAddress = (barcodeAPIresponse &&
+      let deliveryLocationWithAddress = (barcodeAPIresponse &&
           barcodeAPIresponse.itemListElement && barcodeAPIresponse.itemListElement.length &&
           barcodeAPIresponse.itemListElement[0].deliveryLocation) ?
         mapLocationDetails(barcodeAPIresponse.itemListElement[0].deliveryLocation) : [];
+
+      const { closedLocations } = appConfig;
+      deliveryLocationWithAddress = deliveryLocationWithAddress.filter(location =>
+        !closedLocations.some(closedLocation =>
+          modelDeliveryLocationName(location.prefLabel, location.shortName)
+            .startsWith(closedLocation),
+        ),
+      );
 
       cb(
         deliveryLocationWithAddress,


### PR DESCRIPTION
**What's this do?**
- Adds a step to the `getDeliveryLocations` method that filters out closed locations 

**Why are we doing this? (w/ JIRA link if applicable)**
This is scc-2104. We currently have a bug where there are no delivery locations, but the button to submit the form is still available. The reason for this bug is that we are currently filtering out closed locations only in the method to display location options, but there are other things (such as whether to display the button and which messages to display) that also depend on the available locations. This change moves the logic for filtering out locations to the earliest possible stage so as to ensure all these behaviors are consistent.

**How should this be tested? / Do these changes have associated tests?**
Try navigating to a hold request page for an item with no delivery options. There should be no submit button available. For an example of such an item see `Dogs, dogs, dogs! [motion picture]` available at `research/collections/shared-collection-catalog/hold/request/b17111971-i22250263` in production

**Dependencies for merging? Releasing to production?**


**Has the application documentation been updated for these changes?**

**Did someone actually run this code to verify it works?**
PR author tested locally.
