### PR TITLE
Match `sfr-bookfinder` logic for generating ereader link

### DIFF
--- a/src/app/components/Drbb/DrbbResult.jsx
+++ b/src/app/components/Drbb/DrbbResult.jsx
@@ -8,6 +8,7 @@ import appConfig from '../../data/appConfig';
 import {
   authorQuery,
   formatUrl,
+  generateStreamedReaderUrl,
 } from '../../utils/researchNowUtils';
 
 const DrbbResult = (props) => {
@@ -25,6 +26,7 @@ const DrbbResult = (props) => {
   } = appConfig;
 
   const drbbFrontEnd = appConfig.drbbFrontEnd[environment];
+  const eReader = appConfig.drbbEreader[environment];
 
   const authorship = () => {
     const authors = agents.filter(agent => agent.roles.includes('author'));
@@ -45,7 +47,7 @@ const DrbbResult = (props) => {
       </Link>]);
 
     return (
-      <div className='drbb-authorship'>
+      <div className="drbb-authorship">
         By {authorLinks}
       </div>
     );
@@ -57,7 +59,7 @@ const DrbbResult = (props) => {
 
   const edition = selectEdition();
 
-  const readOnlineLink = () => {
+  const readOnlineLinkElement = () => {
     const editionWithTitle = edition;
     editionWithTitle.title = edition.title || work.title;
 
@@ -69,12 +71,15 @@ const DrbbResult = (props) => {
 
     if (!selectedItem || !selectedLink || !selectedLink.url) return null;
 
+    const eReaderUrl = selectedLink.local ?
+      generateStreamedReaderUrl(selectedLink.url, eReader) : formatUrl(selectedLink.url);
+
     return (
       <Link
         target="_blank"
         to={{
           pathname: `${drbbFrontEnd}/read-online`,
-          search: `?url=${formatUrl(selectedLink.url)}#/edition?editionId=${edition.id}`,
+          search: `?url=${eReaderUrl}`,
         }}
         className="drbb-read-online"
       >
@@ -116,7 +121,7 @@ const DrbbResult = (props) => {
         {title}
       </Link>
       {agents && agents.length ? authorship() : null}
-      { readOnlineLink() }
+      { readOnlineLinkElement() }
       { downloadLinkElement() }
     </li>
   );

--- a/src/app/utils/researchNowUtils.js
+++ b/src/app/utils/researchNowUtils.js
@@ -91,15 +91,15 @@ const authorQuery = author => ({
   showQueries: JSON.stringify([{ query: author.name, field: 'author' }]),
 });
 
-const generateStreamedReaderUrl = (url, eReaderUrl, editionId) => {
-  const base64BookUrl = Buffer.from(url).toString('base64');
+const formatUrl = link => (link.startsWith('http') ? link : `https://${link}`);
+
+const generateStreamedReaderUrl = (url, eReaderUrl) => {
+  const base64BookUrl = Buffer.from(formatUrl(url)).toString('base64');
   const encodedBookUrl = encodeURIComponent(`${base64BookUrl}`);
-  let combined = `${eReaderUrl}/readerNYPL/?url=${eReaderUrl}/pub/${encodedBookUrl}/manifest.json`;
-  combined += `#/edition?editionId=${editionId}`;
-  return combined;
+
+  return encodeURI(`${eReaderUrl}/readerNYPL/?url=${eReaderUrl}/pub/${encodedBookUrl}/manifest.json`);
 };
 
-const formatUrl = link => (link.startsWith('http') ? link : `https://${link}`);
 
 const getQueryString = (initialQuery, cb = input => input) => {
   const query = cb(initialQuery);

--- a/test/unit/researchNowUtils.test.js
+++ b/test/unit/researchNowUtils.test.js
@@ -1,0 +1,31 @@
+/* eslint-env mocha */
+import { expect } from 'chai';
+
+import {
+  createResearchNowQuery,
+  authorQuery,
+  generateStreamedReaderUrl,
+  formatUrl,
+  getResearchNowQueryString,
+} from '../../src/app/utils/researchNowUtils';
+
+describe('generateStreamedReaderUrl', () => {
+  const eReaderUrl = 'eReaderUrl';
+  const referrer = 'referrer';
+  it('should return appropriately formatted webpub-viewer link', () => {
+    const links = [
+      {
+        url: 'https://read-online-url-1',
+        media_type: 'application/pdf',
+        content: null,
+        thumbnail: null,
+        local: true,
+        download: true,
+        images: true,
+        ebook: true,
+      }];
+    const url = generateStreamedReaderUrl(links[0].url, eReaderUrl, referrer);
+    expect(url).to.equal('eReaderUrl/readerNYPL/?url=eReaderUrl'
+    + '/pub/aHR0cHM6Ly9yZWFkLW9ubGluZS11cmwtMQ%253D%253D/manifest.json');
+  });
+});


### PR DESCRIPTION
**What's this do?**
This properly formats the Read Online url for links in which `local` and `download` are both true.
Also, noting here that the eReader url  is double encoded in `sfr-bookfinder-front-end`. 

**How should this be tested? / Do these changes have associated tests?**
Modified the one related test from `sfr-bookfinder-front-end`.

**Did someone actually run this code to verify it works?**
PR author did.