### PR TITLE
SCC-2108 Implement layout for mobile view

### DIFF
--- a/src/app/components/Application/Application.jsx
+++ b/src/app/components/Application/Application.jsx
@@ -29,7 +29,6 @@ class Application extends React.Component {
     };
     this.onChange = this.onChange.bind(this);
     this.shouldStoreUpdate = this.shouldStoreUpdate.bind(this);
-    this.checkMedia = this.checkMedia.bind(this);
   }
 
   getChildContext() {
@@ -70,12 +69,9 @@ class Application extends React.Component {
         });
       }
     });
-    const style = {
-      xtrasmallBreakPoint: '483px',
-    };
-    const mediaMatcher = window.matchMedia(`(max-width: ${style.xtrasmallBreakPoint})`);
-    this.checkMedia(mediaMatcher);
-    mediaMatcher.addListener(this.checkMedia);
+
+    window.addEventListener('resize', this.onWindowResize.bind(this));
+    this.onWindowResize();
   }
 
   shouldStoreUpdate() {
@@ -86,16 +82,25 @@ class Application extends React.Component {
     Store.unlisten(this.onChange);
   }
 
-  onChange() {
-    this.setState({ data: Store.getState() });
+  onWindowResize() {
+    const { media } = this.state;
+    const style = {
+      xtrasmallBreakPoint: 483,
+      tablet: 870,
+    };
+    const { innerWidth } = window;
+
+    if (innerWidth <= style.xtrasmallBreakPoint) {
+      if (media !== 'mobile') this.setState({ media: 'mobile' });
+    } else if (innerWidth <= style.tablet) {
+      if (media !== 'tablet') this.setState({ media: 'tablet' });
+    } else {
+      if (media !== 'desktop') this.setState({ media: 'desktop' });
+    }
   }
 
-  checkMedia(media) {
-    if (media && media.matches) {
-      this.setState({ media: 'mobile' });
-    } else {
-      this.setState({ media: 'desktop' });
-    }
+  onChange() {
+    this.setState({ data: Store.getState() });
   }
 
   render() {

--- a/src/app/components/Application/Application.jsx
+++ b/src/app/components/Application/Application.jsx
@@ -17,6 +17,7 @@ import {
 } from '../../utils/utils';
 import Actions from '../../actions/Actions';
 import appConfig from '../../data/appConfig';
+import { breakpoints } from '../../data/constants';
 import DataLoader from '../DataLoader/DataLoader';
 
 class Application extends React.Component {
@@ -84,15 +85,15 @@ class Application extends React.Component {
 
   onWindowResize() {
     const { media } = this.state;
-    const style = {
-      xtrasmallBreakPoint: 483,
-      tablet: 870,
-    };
     const { innerWidth } = window;
+    const {
+      xtrasmall,
+      tablet,
+    } = breakpoints;
 
-    if (innerWidth <= style.xtrasmallBreakPoint) {
+    if (innerWidth <= xtrasmall) {
       if (media !== 'mobile') this.setState({ media: 'mobile' });
-    } else if (innerWidth <= style.tablet) {
+    } else if (innerWidth <= tablet) {
       if (media !== 'tablet') this.setState({ media: 'tablet' });
     } else {
       if (media !== 'desktop') this.setState({ media: 'desktop' });

--- a/src/app/components/Drbb/DrbbContainer.jsx
+++ b/src/app/components/Drbb/DrbbContainer.jsx
@@ -43,15 +43,6 @@ class DrbbContainer extends React.Component {
       });
   }
 
-  promo() {
-    return (
-      <img
-        alt="digital-research-book"
-        src={require('../../../client/assets/drbb_promo.png').default}
-      />
-    );
-  }
-
   content() {
     const {
       works,
@@ -84,7 +75,7 @@ class DrbbContainer extends React.Component {
           { works.map(work => <DrbbResult key={work.id} work={work} />) }
         </ul>,
         <Link
-          className="drbb-description"
+          className="drbb-description drbb-frontend-link"
           to={{
             pathname: `${appConfig.drbbFrontEnd[appConfig.environment]}/search?`,
             search: researchNowQueryString,
@@ -106,7 +97,10 @@ class DrbbContainer extends React.Component {
         key="drbb-link"
       >
         <div className="drbb-promo">
-          { this.promo() }
+          <img
+            alt="digital-research-book"
+            src={require('../../../client/assets/drbb_promo.png').default}
+          />
         </div>
         See results from Digital Research Books Beta
       </Link>

--- a/src/app/components/ResultsList/ResultsList.jsx
+++ b/src/app/components/ResultsList/ResultsList.jsx
@@ -11,7 +11,6 @@ import Store from '@Store';
 import LibraryItem from '../../utils/item';
 import { trackDiscovery } from '../../utils/utils';
 import ItemTable from '../Item/ItemTable';
-// import DrbbContainer from '../Drbb/DrbbContainer';
 import appConfig from '../../data/appConfig';
 
 class ResultsList extends React.Component {

--- a/src/app/components/SearchResults/SearchResultsContainer.jsx
+++ b/src/app/components/SearchResults/SearchResultsContainer.jsx
@@ -13,16 +13,13 @@ import Actions from '../../actions/Actions';
 import appConfig from '../../data/appConfig';
 
 // Renders the ResultsList containing the search results and the Pagination component
-class SearchResultsContainer extends React.Component {
-  constructor(props) {
-    super();
-    this.includeDrbb = true;
-    this.createAPIQuery = basicQuery(props);
-  }
+const SearchResultsContainer = (props, context) => {
+  const includeDrbb = true;
+  const createAPIQuery = basicQuery(props);
 
-  updatePage(nextPage, pageType) {
+  const updatePage = (nextPage, pageType) => {
     Actions.updateLoadingStatus(true);
-    const apiQuery = this.createAPIQuery({ page: nextPage });
+    const apiQuery = createAPIQuery({ page: nextPage });
 
     trackDiscovery('Pagination - Search Results', `${pageType} - page ${nextPage}`);
     ajaxCall(`${appConfig.baseUrl}/api?${apiQuery}`, (response) => {
@@ -30,56 +27,54 @@ class SearchResultsContainer extends React.Component {
       Actions.updatePage(nextPage.toString());
       setTimeout(() => {
         Actions.updateLoadingStatus(false);
-        this.context.router.push(`${appConfig.baseUrl}/search?${apiQuery}`);
+        context.router.push(`${appConfig.baseUrl}/search?${apiQuery}`);
       }, 500);
     });
-  }
+  };
 
-  render() {
-    const {
-      searchResults,
-      searchKeywords,
-      page,
-    } = this.props;
-    const { media } = this.context;
+  const {
+    searchResults,
+    searchKeywords,
+    page,
+  } = props;
+  const { media } = context;
 
-    const totalResults = searchResults ? searchResults.totalResults : undefined;
-    const results = searchResults ? searchResults.itemListElement : [];
+  const totalResults = searchResults ? searchResults.totalResults : undefined;
+  const results = searchResults ? searchResults.itemListElement : [];
 
-    return (
-      <React.Fragment>
-        <div className="nypl-row">
-          <div
-            className="nypl-column-full"
-            role="region"
-            aria-describedby="results-description"
-          >
-            {
-              !!(results && results.length !== 0) &&
-              <ResultsList
-                results={results}
-                searchKeywords={searchKeywords}
-              />
-            }
-            { this.includeDrbb && media === 'desktop' ? <DrbbContainer /> : null}
-            {
-              !!(totalResults && totalResults !== 0) &&
-              <Pagination
-                ariaControls="nypl-results-list"
-                total={totalResults}
-                perPage={50}
-                page={parseInt(page, 10)}
-                createAPIQuery={this.createAPIQuery}
-                updatePage={this.updatePage}
-              />
-            }
-            { this.includeDrbb && ['tablet', 'mobile'].includes(media) ? <DrbbContainer /> : null}
-          </div>
+  return (
+    <React.Fragment>
+      <div className="nypl-row">
+        <div
+          className="nypl-column-full"
+          role="region"
+          aria-describedby="results-description"
+        >
+          {
+            !!(results && results.length !== 0) &&
+            <ResultsList
+              results={results}
+              searchKeywords={searchKeywords}
+            />
+          }
+          { includeDrbb && media === 'desktop' ? <DrbbContainer /> : null}
+          {
+            !!(totalResults && totalResults !== 0) &&
+            <Pagination
+              ariaControls="nypl-results-list"
+              total={totalResults}
+              perPage={50}
+              page={parseInt(page, 10)}
+              createAPIQuery={createAPIQuery}
+              updatePage={updatePage}
+            />
+          }
+          { includeDrbb && ['tablet', 'mobile'].includes(media) ? <DrbbContainer /> : null}
         </div>
-      </React.Fragment>
-    );
-  }
-}
+      </div>
+    </React.Fragment>
+  );
+};
 
 SearchResultsContainer.propTypes = {
   searchResults: PropTypes.object,

--- a/src/app/components/SearchResults/SearchResultsContainer.jsx
+++ b/src/app/components/SearchResults/SearchResultsContainer.jsx
@@ -73,7 +73,7 @@ class SearchResultsContainer extends React.Component {
                 updatePage={this.updatePage}
               />
             }
-            { this.includeDrbb && media === 'tablet' ? <DrbbContainer /> : null}
+            { this.includeDrbb && ['tablet', 'mobile'].includes(media) ? <DrbbContainer /> : null}
           </div>
         </div>
       </React.Fragment>

--- a/src/app/data/constants.js
+++ b/src/app/data/constants.js
@@ -1,0 +1,8 @@
+const breakpoints = {
+  xtrasmall: 483,
+  tablet: 870,
+};
+
+export {
+  breakpoints,
+};

--- a/src/client/styles/components/Drbb/Drbb.scss
+++ b/src/client/styles/components/Drbb/Drbb.scss
@@ -33,7 +33,7 @@
   font-weight: 450;
 
   a {
-    display: inline-block;
+    display: contents;
     padding: 0;
   }
 }
@@ -135,10 +135,10 @@ a.drbb-download-pdf {
 }
 
 .nypl-results-list.drbb-integration {
-  display: inline-block;
-  width: 60%;
-  padding-right: 10%;
   box-sizing: border-box;
+  display: inline-block;
+  padding-right: 10%;
+  width: 65%;
 
   h3 {
     margin-top: 0;
@@ -156,4 +156,16 @@ a.drbb-download-pdf {
 
 .nypl-results-summary h2 {
   font-size: 22px;
+}
+
+@media(max-width: 800px) {
+  .nypl-results-list.drbb-integration {
+    width: 100%;
+    padding-right: 0;
+  }
+
+  .drbb-container {
+    width: unset;
+    margin-left: 0;
+  }
 }

--- a/src/client/styles/components/Drbb/Drbb.scss
+++ b/src/client/styles/components/Drbb/Drbb.scss
@@ -128,6 +128,10 @@ a.drbb-download-pdf {
   margin: 7px 0;
 }
 
+.drbb-frontend-link {
+  font-size: 14px;
+}
+
 .nypl-full-width-wrapper.drbb-integration {
   margin: unset;
   max-width: unset;
@@ -158,7 +162,7 @@ a.drbb-download-pdf {
   font-size: 22px;
 }
 
-@media(max-width: 800px) {
+@media(max-width: 870px) {
   .nypl-results-list.drbb-integration {
     width: 100%;
     padding-right: 0;

--- a/test/helpers/browser.js
+++ b/test/helpers/browser.js
@@ -22,3 +22,6 @@ Object.keys(document.defaultView).forEach((property) => {
 global.navigator = {
   userAgent: 'node.js',
 };
+
+const noop = () => {};
+require.extensions[".png"] = noop;

--- a/test/unit/Application.test.js
+++ b/test/unit/Application.test.js
@@ -7,6 +7,7 @@ import { stub } from 'sinon';
 import Application from '@Application';
 import { Header, navConfig } from '@nypl/dgx-header-component';
 import { mockRouterContext } from '../helpers/routing';
+import { breakpoints } from '../../src/app/data/constants';
 
 const resizeWindow = (x) => {
   window.innerWidth = x;
@@ -54,18 +55,23 @@ describe('Application', () => {
   });
 
   describe('should set media type in context', () => {
-    it('should set media as "desktop" for screenwidths above 871px', () => {
-      resizeWindow('871');
+    const {
+      tablet,
+      xtrasmall,
+    } = breakpoints;
+
+    it(`should set media as "desktop" for screenwidths above ${tablet}px`, () => {
+      resizeWindow(tablet + 1);
       expect(component.state().media).to.eql('desktop');
     });
-    it('should set media as "tablet" for screenwidths 484-870px', () => {
-      resizeWindow('484');
+    it(`should set media as "tablet" for screenwidths ${xtrasmall + 1}-${tablet}px`, () => {
+      resizeWindow(xtrasmall + 1);
       expect(component.state().media).to.eql('tablet');
-      resizeWindow('870');
+      resizeWindow(tablet);
       expect(component.state().media).to.eql('tablet');
     });
-    it('should set media as "mobile" for screenwidths below 484px', () => {
-      resizeWindow('483');
+    it(`should set media as "mobile" for screenwidths below ${xtrasmall}`, () => {
+      resizeWindow(xtrasmall);
       expect(component.state().media).to.eql('mobile');
     });
   });

--- a/test/unit/Application.test.js
+++ b/test/unit/Application.test.js
@@ -8,6 +8,11 @@ import Application from '@Application';
 import { Header, navConfig } from '@nypl/dgx-header-component';
 import { mockRouterContext } from '../helpers/routing';
 
+const resizeWindow = (x) => {
+  window.innerWidth = x;
+  window.dispatchEvent(new Event('resize'));
+};
+
 describe('Application', () => {
   let component;
   const context = mockRouterContext();
@@ -46,5 +51,22 @@ describe('Application', () => {
 
   it('should render a <Footer /> components', () => {
     expect(component.find('Footer')).to.have.length(1);
+  });
+
+  describe('should set media type in context', () => {
+    it('should set media as "desktop" for screenwidths above 871px', () => {
+      resizeWindow('871');
+      expect(component.state().media).to.eql('desktop');
+    });
+    it('should set media as "tablet" for screenwidths 484-870px', () => {
+      resizeWindow('484');
+      expect(component.state().media).to.eql('tablet');
+      resizeWindow('870');
+      expect(component.state().media).to.eql('tablet');
+    });
+    it('should set media as "mobile" for screenwidths below 484px', () => {
+      resizeWindow('483');
+      expect(component.state().media).to.eql('mobile');
+    });
   });
 });

--- a/test/unit/DrbbContainer.test.js
+++ b/test/unit/DrbbContainer.test.js
@@ -76,7 +76,6 @@ describe('DrbbContainer', () => {
     });
   });
 
-  const promoStub = stub(DrbbContainer.prototype, 'promo');
   describe('no ResearchNow results', () => {
     before(() => {
       context.router.location.search = '?q=noresults';
@@ -91,7 +90,7 @@ describe('DrbbContainer', () => {
       mock.restore();
     });
     it('should display the drbb promo', () => {
-      expect(component.find('.drbb-promo')).to.have.length(1);
+      expect(component.find('img')).to.have.length(1);
     });
   });
 
@@ -110,9 +109,7 @@ describe('DrbbContainer', () => {
     });
 
     it('should display the drbb promo', () => {
-      expect(component.find('.drbb-promo')).to.have.length(1);
+      expect(component.find('img')).to.have.length(1);
     });
   });
-
-  after(() => { promoStub.restore(); });
 });

--- a/test/unit/DrbbResult.test.js
+++ b/test/unit/DrbbResult.test.js
@@ -20,7 +20,7 @@ describe('DrbbResult', () => {
     });
 
     it('should have a link with .drbb-result-title class', () => {
-      expect(component.findWhere(n => n.text() === 'The Blithedale romance, by Nathaniel Hawthorne.')).to.have.length(1);
+      expect(component.find('a'))
     });
 
     it('should have links to authors', () => {

--- a/test/unit/DrbbResult.test.js
+++ b/test/unit/DrbbResult.test.js
@@ -7,12 +7,11 @@ import DrbbResult from './../../src/app/components/Drbb/DrbbResult';
 import workData from '../fixtures/work-detail.json';
 
 describe('DrbbResult', () => {
-  let component;
-
   describe('with work prop', () => {
+    let component;
     const authors = workData.data.agents.filter(agent => agent.roles.includes('author'));
     before(() => {
-      component = shallow(<DrbbResult work={workData.data}/>);
+      component = shallow(<DrbbResult work={workData.data} />);
     });
 
     it('Should render an `li`', () => {
@@ -20,21 +19,23 @@ describe('DrbbResult', () => {
     });
 
     it('should have a link with .drbb-result-title class', () => {
-      expect(component.find('a'))
+      expect(component.find('Link').first().render().text()).to.equal(workData.data.title);
     });
 
     it('should have links to authors', () => {
       expect(component.find('.drbb-result-author')).to.have.length(authors.length);
+      expect(component.find('.drbb-result-author').is('Link')).to.equal(true);
     });
   });
 
   describe('without work prop', () => {
+    let component;
     before(() => {
       component = shallow(<DrbbResult />);
     });
 
     it('should return `null`', () => {
       expect(component.type()).to.be.null;
-    })
+    });
   });
 });

--- a/test/unit/SearchResultsPage.test.js
+++ b/test/unit/SearchResultsPage.test.js
@@ -5,6 +5,7 @@ import { mount } from 'enzyme';
 import PropTypes from 'prop-types';
 
 import SearchResults from '../../src/app/pages/SearchResults';
+import SearchResultsContainer from '../../src/app/components/SearchResults/SearchResultsContainer';
 import { mockRouterContext } from '../helpers/routing';
 
 // Eventually, it would be nice to have mocked data in a different file and imported.
@@ -27,12 +28,13 @@ const searchResults = {
 const context = mockRouterContext();
 const childContextTypes = {
   router: PropTypes.object,
+  media: PropTypes.string,
 };
 
 describe('SearchResultsPage', () => {
-  describe('Component properties', () => {
-    let component;
+  let component;
 
+  describe('Component properties', () => {
     before(() => {
       // Added this empty prop so that the `componentWillMount` method will be skipped.
       // That lifecycle hook is tested later on.
@@ -88,8 +90,6 @@ describe('SearchResultsPage', () => {
   });
 
   describe('With passed search results prop', () => {
-    let component;
-
     before(() => {
       component = mount(
         <SearchResults
@@ -128,8 +128,6 @@ describe('SearchResultsPage', () => {
   });
 
   describe('DOM structure', () => {
-    let component;
-
     before(() => {
       component = mount(
         <SearchResults
@@ -158,6 +156,46 @@ describe('SearchResultsPage', () => {
 
     it('should have four .nypl-full-width-wrapper elements', () => {
       expect(component.find('.nypl-full-width-wrapper')).to.have.length(4);
+    });
+  });
+
+  describe('with DRBB integration', () => {
+    before(() => {
+      context.media = 'desktop';
+      component = mount(
+        <SearchResultsContainer
+          searchKeywords="locofocos"
+          searchResults={searchResults}
+          location={{ search: '' }}
+        />,
+        { context }
+      );
+    });
+
+    it('should render a <DrbbContainer /> component', () => {
+      expect(component.find('DrbbContainer')).to.have.length(1);
+    });
+
+    describe('desktop view', () => {
+      it('should have the DrbbContainer above Pagination', () => {
+        expect(component.find('.nypl-column-full').childAt(1).is('DrbbContainer')).to.eql(true);
+      });
+    });
+
+    describe('tablet/mobile view', () => {
+      before(() => {
+        context.media = 'tablet';
+        component = mount(
+          <SearchResultsContainer
+            searchKeywords="locofocos"
+            searchResults={searchResults}
+            location={{ search: '' }}
+          />,
+          { context });
+      });
+      it('should have the Pagination above the DrbbContainer', () => {
+        expect(component.find('.nypl-column-full').childAt(1).is('Pagination')).to.eql(true);
+      });
     });
   });
 });

--- a/test/unit/SearchResultsPage.test.js
+++ b/test/unit/SearchResultsPage.test.js
@@ -32,9 +32,9 @@ const childContextTypes = {
 };
 
 describe('SearchResultsPage', () => {
-  let component;
-
   describe('Component properties', () => {
+    let component;
+
     before(() => {
       // Added this empty prop so that the `componentWillMount` method will be skipped.
       // That lifecycle hook is tested later on.
@@ -90,6 +90,8 @@ describe('SearchResultsPage', () => {
   });
 
   describe('With passed search results prop', () => {
+    let component;
+
     before(() => {
       component = mount(
         <SearchResults
@@ -128,6 +130,8 @@ describe('SearchResultsPage', () => {
   });
 
   describe('DOM structure', () => {
+    let component;
+
     before(() => {
       component = mount(
         <SearchResults
@@ -160,6 +164,8 @@ describe('SearchResultsPage', () => {
   });
 
   describe('with DRBB integration', () => {
+    let component;
+
     before(() => {
       context.media = 'desktop';
       component = mount(
@@ -168,8 +174,7 @@ describe('SearchResultsPage', () => {
           searchResults={searchResults}
           location={{ search: '' }}
         />,
-        { context }
-      );
+        { context });
     });
 
     it('should render a <DrbbContainer /> component', () => {


### PR DESCRIPTION
**What's this do?**
Most of these changes are for the mobile/tablet view. At screen widths 870px and smaller, the DRBB results go below the SCC ones and below the pagination. This requires changing the order of the components. To use the `media` context we recently added in, I had to turn "SearchResultsContainer" from a functional component into a class component.
870px is the width Ellen wants to try for this feature.

There are also some small styling tweaks and using @hokei's suggestion for the tests to skip certain file types, in this case '.png'.

**How should this be tested? / Do these changes have associated tests?**
There are associated tests. The page layout should change when decreasing the screenwidth.

**Did someone actually run this code to verify it works?**
PR author did.