### PR TITLE
Check for existence of items

### DIFF
--- a/src/app/components/Drbb/DrbbResult.jsx
+++ b/src/app/components/Drbb/DrbbResult.jsx
@@ -55,16 +55,19 @@ const DrbbResult = (props) => {
 
   const selectEdition = () => (editions.find(edition => (
     edition && edition.items && edition.items[0].links && edition.items[0].links.length
-  )));
+  ))) || editions[0];
 
   const edition = selectEdition();
+  const { items } = edition;
 
   const readOnlineLinkElement = () => {
+    if (!items) return null;
+
     const editionWithTitle = edition;
     editionWithTitle.title = edition.title || work.title;
 
     let selectedLink;
-    const selectedItem = edition.items.find(item => item.links.find((link) => {
+    const selectedItem = items.find(item => item.links.find((link) => {
       selectedLink = link;
       return (!link.local && !link.download) || (link.local && link.download);
     }));
@@ -89,6 +92,8 @@ const DrbbResult = (props) => {
   };
 
   const downloadLinkElement = () => {
+    if (!items) return null;
+
     let downloadLink;
     edition.items.find(item => item.links.find((link) => {
       downloadLink = link;

--- a/test/unit/DrbbResult.test.js
+++ b/test/unit/DrbbResult.test.js
@@ -26,6 +26,20 @@ describe('DrbbResult', () => {
     it('should have links to authors', () => {
       expect(component.find('.drbb-result-author')).to.have.length(authors.length);
     });
+
+    describe('edition with no items', () => {
+      before(() => {
+        const workWithItemsNull = workData.data;
+        let { editions } = workWithItemsNull;
+        editions = [editions[0]];
+        editions[0].items = null;
+
+        component = shallow(<DrbbResult work={workWithItemsNull} />);
+      });
+      it('should still render', () => {
+        expect(component.find('li')).to.have.length(1);
+      });
+    });
   });
 
   describe('without work prop', () => {
@@ -35,6 +49,6 @@ describe('DrbbResult', () => {
 
     it('should return `null`', () => {
       expect(component.type()).to.be.null;
-    })
+    });
   });
 });


### PR DESCRIPTION
I just found this bug on QA `discovery-front-end` using production ResearchNow API. Proper checks for the existences of `items` were missing.