### PR TITLE
SCC-2125/Bug fix for when there are no authors

### DIFF
--- a/src/app/components/Drbb/DrbbResult.jsx
+++ b/src/app/components/Drbb/DrbbResult.jsx
@@ -31,7 +31,7 @@ const DrbbResult = (props) => {
   const authorship = () => {
     const authors = agents.filter(agent => agent.roles.includes('author'));
 
-    if (!authors) return null;
+    if (!authors || !authors.length) return null;
     const authorLinks = authors.map((agent, i) => [
       (i > 0 ? ', ' : null),
       <Link

--- a/test/unit/DrbbResult.test.js
+++ b/test/unit/DrbbResult.test.js
@@ -8,26 +8,30 @@ import workData from '../fixtures/work-detail.json';
 
 describe('DrbbResult', () => {
   describe('with work prop', () => {
-    let component;
-    const authors = workData.data.agents.filter(agent => agent.roles.includes('author'));
-    before(() => {
-      component = shallow(<DrbbResult work={workData.data} />);
-    });
 
-    it('Should render an `li`', () => {
-      expect(component.find('li')).to.have.length(1);
-    });
+    describe('work with all data', () => {
+      let component;
+      const authors = workData.data.agents.filter(agent => agent.roles.includes('author'));
+      before(() => {
+        component = shallow(<DrbbResult work={workData.data} />);
+      });
 
-    it('should have a link with .drbb-result-title class', () => {
-      expect(component.find('Link').first().render().text()).to.equal(workData.data.title);
-    });
+      it('should render an `li`', () => {
+        expect(component.find('li')).to.have.length(1);
+      });
 
-    it('should have links to authors', () => {
-      expect(component.find('.drbb-result-author')).to.have.length(authors.length);
-      expect(component.find('.drbb-result-author').is('Link')).to.equal(true);
+      it('should have a link with .drbb-result-title class', () => {
+        expect(component.find('Link').first().render().text()).to.equal(workData.data.title);
+      });
+
+      it('should have links to authors', () => {
+        expect(component.find('.drbb-result-author')).to.have.length(authors.length);
+        expect(component.find('.drbb-result-author').is('Link')).to.equal(true);
+      });
     });
 
     describe('edition with no items', () => {
+      let component;
       before(() => {
         const workWithItemsNull = workData.data;
         let { editions } = workWithItemsNull;
@@ -38,6 +42,20 @@ describe('DrbbResult', () => {
       });
       it('should still render', () => {
         expect(component.find('li')).to.have.length(1);
+      });
+    });
+
+    describe('work with no authors', () => {
+      let component;
+      before(() => {
+        const workWithNoAuthors = workData.data;
+        const { agents } = workWithNoAuthors;
+        workWithNoAuthors.agents = agents.filter(agent => !agent.roles.includes('author'));
+        component = shallow(<DrbbResult work={workWithNoAuthors} />);
+      });
+
+      it('should not have a .drbb-authorship element', () => {
+        expect(component.find('.drbb-authorship')).to.have.length(0);
       });
     });
   });


### PR DESCRIPTION
**What's this do?**
I was just checking for the truthiness of `authors`. But there also needs to be a check for length.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SCC-2125

**How should this be tested? / Do these changes have associated tests?**
Added 1 unit test. It's not perfect, because I am relying on the element classname.

**Did someone actually run this code to verify it works?**
PR author did.