### PR TITLE
SCC-2126/ Give the DRB promo img a max width

### DIFF
--- a/src/client/styles/components/Drbb/Drbb.scss
+++ b/src/client/styles/components/Drbb/Drbb.scss
@@ -122,6 +122,10 @@ a.drbb-download-pdf {
   align-items: center;
   background-color: #f9f8f7;
   border-radius: 4px;
+
+  img {
+    max-width: 80%;
+  }
 }
 
 .drbb-authorship {


### PR DESCRIPTION
**What's this do?**
This just adds a max width to the DRB promo image to keep it from expanding past the container. There is a screenshot in the JIRA ticket linked below.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SCC-2126

**Did someone actually run this code to verify it works?**
PR author did