### PR TITLE
Refactor to fetch DRB results together with SCC and use Store

### DIFF
--- a/server.js
+++ b/server.js
@@ -15,7 +15,6 @@ import appConfig from './src/app/data/appConfig';
 import webpackConfig from './webpack.config';
 import apiRoutes from './src/server/ApiRoutes/ApiRoutes';
 import routes from './src/app/routes/routes';
-import AppConfigStore from './src/app/stores/AppConfigStore';
 
 import initializePatronTokenAuth from './src/server/routes/auth';
 import { getPatronData } from './src/server/routes/api';

--- a/src/app/actions/Actions.js
+++ b/src/app/actions/Actions.js
@@ -61,6 +61,10 @@ class Actions {
   updateSubjectHeading(data) {
     return data;
   }
+
+  updateDrbbResults(data) {
+    return data;
+  }
 }
 
 export default alt.createActions(Actions);

--- a/src/app/components/Application/Application.jsx
+++ b/src/app/components/Application/Application.jsx
@@ -62,6 +62,7 @@ class Application extends React.Component {
             const selectedFilters = destructureFilters(urlFilters, data.filters);
             Actions.updateSelectedFilters(selectedFilters);
             Actions.updateFilters(data.filters);
+            if (data.drbbResults) Actions.updateDrbbResults(data.drbbResults);
             Actions.updateSearchResults(data.searchResults);
             Actions.updatePage(query.page || '1');
             if (qParameter) Actions.updateSearchKeywords(qParameter);

--- a/src/app/components/BibPage/BibDetails.jsx
+++ b/src/app/components/BibPage/BibDetails.jsx
@@ -559,6 +559,7 @@ class BibDetails extends React.Component {
         Actions.updateFilters(response.data.filters ? response.data.filters : {});
       }
       if (response.data.searchResults) {
+        if (response.data.drbbResults) Actions.updateDrbbResults(response.data.drbbResults);
         Actions.updateSearchResults(response.data.searchResults);
       }
       Actions.updateSearchKeywords('');

--- a/src/app/components/Drbb/DrbbContainer.jsx
+++ b/src/app/components/Drbb/DrbbContainer.jsx
@@ -44,7 +44,7 @@ const DrbbContainer = () => {
         <div className="drbb-promo">
           <img
             alt="digital-research-book"
-            src={require('../../../client/assets/drbb_promo.png').default}
+            src="/src/client/assets/drbb_promo.png"
           />
         </div>
         See results from Digital Research Books Beta

--- a/src/app/components/Drbb/DrbbContainer.jsx
+++ b/src/app/components/Drbb/DrbbContainer.jsx
@@ -1,59 +1,19 @@
 import React from 'react';
-import axios from 'axios';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router';
 
 import appConfig from '../../data/appConfig';
 import DrbbResult from './DrbbResult';
 import Store from '../../stores/Store';
-import { getResearchNowQueryString } from '../../utils/researchNowUtils';
 
-class DrbbContainer extends React.Component {
-  constructor(props, context) {
-    super();
-    this.search = context.router.location.search || '';
-    const {
-      works,
-      totalWorks,
-      researchNowQueryString
-    } = Store.getState().drbbResults;
-    this.state = {
-      works,
-      researchNowQueryString,
-      totalWorks,
-    };
-  }
+const DrbbContainer = () => {
+  const {
+    works,
+    totalWorks,
+    researchNowQueryString,
+  } = Store.getState().drbbResults;
 
-  componentDidUpdate() {
-    return getResearchNowQueryString(this.search) !== this.state.researchNowQueryString;
-  }
-
-  content() {
-    const {
-      works,
-      drbbResultsLoading,
-      totalWorks,
-      researchNowQueryString,
-    } = this.state;
-
-    if (drbbResultsLoading) {
-      return (
-        <div className="drbb-loading-layer">
-          <span
-            className="loading-animation loadingLayer-texts-loadingWord"
-          >
-            Loading results
-          </span>
-          <div className="loadingDots">
-            <span />
-            <span />
-            <span />
-            <span />
-          </div>
-        </div>
-      );
-    }
-
+  const content = () => {
     if (works && works.length) {
       return ([
         <ul key="drbb-scc-results-list" className="drbb-list">
@@ -90,26 +50,28 @@ class DrbbContainer extends React.Component {
         See results from Digital Research Books Beta
       </Link>
     );
-  }
+  };
 
-  render() {
-    return (
-      <div className="drbb-container">
-        <h3 className="drbb-main-header">
-          Results from Digital Research Books Beta
-        </h3>
-        <p className="drbb-description">
-          Digital books for research from multiple sources world wide- all free to read, download, and keep. No Library Card is Required. <span><a
+  return (
+    <div className="drbb-container">
+      <h3 className="drbb-main-header">
+        Results from Digital Research Books Beta
+      </h3>
+      <p className="drbb-description">
+        Digital books for research from multiple sources world wide-
+        all free to read, download, and keep. No Library Card is Required. <span>
+          <a
             className="link"
             target="_blanks"
             href={`${appConfig.drbbFrontEnd[appConfig.environment]}/about`}
-          >Read more about the project</a>.</span>
-        </p>
-        { this.content() }
-      </div>
-    );
-  }
-}
+          >Read more about the project
+          </a>.
+        </span>
+      </p>
+      { content() }
+    </div>
+  );
+};
 
 DrbbContainer.contextTypes = {
   router: PropTypes.object,

--- a/src/app/components/Drbb/DrbbContainer.jsx
+++ b/src/app/components/Drbb/DrbbContainer.jsx
@@ -5,42 +5,27 @@ import { Link } from 'react-router';
 
 import appConfig from '../../data/appConfig';
 import DrbbResult from './DrbbResult';
+import Store from '../../stores/Store';
+import { getResearchNowQueryString } from '../../utils/researchNowUtils';
 
 class DrbbContainer extends React.Component {
   constructor(props, context) {
     super();
     this.search = context.router.location.search || '';
+    const {
+      works,
+      totalWorks,
+      researchNowQueryString
+    } = Store.getState().drbbResults;
     this.state = {
-      works: [],
-      drbbResultsLoading: true,
-      researchNowQueryString: '',
+      works,
+      researchNowQueryString,
+      totalWorks,
     };
   }
 
-  componentDidMount() {
-    this.fetchResearchNowResults();
-  }
-
-  fetchResearchNowResults() {
-    axios(`${appConfig.baseUrl}/api/research-now${this.search}`)
-      .then((resp) => {
-        if (!resp.data || !resp.data.works) {
-          this.setState({ drbbResultsLoading: false });
-          return;
-        }
-        this.setState({
-          works: resp.data.works,
-          totalWorks: resp.data.totalWorks,
-          drbbResultsLoading: false,
-          researchNowQueryString: resp.data.researchNowQueryString,
-        });
-      })
-      .catch((resp) => {
-        console.error(resp);
-        this.setState({
-          drbbResultsLoading: false,
-        });
-      });
+  componentDidUpdate() {
+    return getResearchNowQueryString(this.search) !== this.state.researchNowQueryString;
   }
 
   content() {

--- a/src/app/components/FilterPopup/FilterPopup.jsx
+++ b/src/app/components/FilterPopup/FilterPopup.jsx
@@ -261,9 +261,11 @@ class FilterPopup extends React.Component {
     Actions.updateSelectedFilters(filtersToApply);
     ajaxCall(`${appConfig.baseUrl}/api?${apiQuery}`, (response) => {
       if (response.data.searchResults && response.data.filters) {
+        if (response.data.drbbResults) Actions.updateDrbbResults(response.data.drbbResults);
         Actions.updateSearchResults(response.data.searchResults);
         Actions.updateFilters(response.data.filters);
       } else {
+        if (response.data.drbbResults) Actions.updateDrbbResults(response.data.drbbResults);
         Actions.updateSearchResults({});
         Actions.updateFilters({});
       }

--- a/src/app/components/Filters/SelectedFilters.jsx
+++ b/src/app/components/Filters/SelectedFilters.jsx
@@ -62,9 +62,11 @@ class SelectedFilters extends React.Component {
     Actions.updateSelectedFilters(selectedFilters);
     ajaxCall(`${appConfig.baseUrl}/api?${apiQuery}`, (response) => {
       if (response.data.searchResults && response.data.filters) {
+        if (response.data.drbbResults) Actions.updateDrbbResults(response.data.drbbResults);
         Actions.updateSearchResults(response.data.searchResults);
         Actions.updateFilters(response.data.filters);
       } else {
+        if (response.data.drbbResults) Actions.updateDrbbResults(response.data.drbbResults);
         Actions.updateSearchResults({});
         Actions.updateFilters({});
       }
@@ -86,9 +88,11 @@ class SelectedFilters extends React.Component {
     Actions.updateSelectedFilters({});
     ajaxCall(`${appConfig.baseUrl}/api?${apiQuery}`, (response) => {
       if (response.data.searchResults && response.data.filters) {
+        if (response.data.drbbResults) Actions.updateDrbbResults(response.data.drbbResults);
         Actions.updateSearchResults(response.data.searchResults);
         Actions.updateFilters(response.data.filters);
       } else {
+        if (response.data.drbbResults) Actions.updateDrbbResults(response.data.drbbResults);
         Actions.updateSearchResults({});
         Actions.updateFilters({});
       }

--- a/src/app/components/Search/Search.jsx
+++ b/src/app/components/Search/Search.jsx
@@ -116,9 +116,11 @@ class Search extends React.Component {
         if (response.data.searchResults && response.data.filters) {
           Actions.updateSearchResults(response.data.searchResults);
           Actions.updateFilters(response.data.filters);
+          if (response.data.drbbResults) Actions.updateDrbbResults(response.data.drbbResults);
         } else {
           Actions.updateSearchResults({});
           Actions.updateFilters({});
+          if (response.data.drbbResults) Actions.updateDrbbResults(response.data.drbbResults);
         }
         Actions.updateSearchKeywords(userSearchKeywords);
         Actions.updateField(searchField);

--- a/src/app/components/Search/Search.jsx
+++ b/src/app/components/Search/Search.jsx
@@ -114,9 +114,9 @@ class Search extends React.Component {
         // (which would be promoted to the Alt store when results are received
         // below).
         if (response.data.searchResults && response.data.filters) {
+          if (response.data.drbbResults) Actions.updateDrbbResults(response.data.drbbResults);
           Actions.updateSearchResults(response.data.searchResults);
           Actions.updateFilters(response.data.filters);
-          if (response.data.drbbResults) Actions.updateDrbbResults(response.data.drbbResults);
         } else {
           Actions.updateSearchResults({});
           Actions.updateFilters({});

--- a/src/app/components/SearchResults/SearchResultsSorter.jsx
+++ b/src/app/components/SearchResults/SearchResultsSorter.jsx
@@ -63,6 +63,7 @@ class SearchResultsSorter extends React.Component {
     trackDiscovery('Sort by', sortBy);
     Actions.updateLoadingStatus(true);
     ajaxCall(`${appConfig.baseUrl}/api?${apiQuery}`, (response) => {
+      if (response.data.drbbResults) Actions.updateDrbbResults(response.data.drbbResults);
       Actions.updateSearchResults(response.data.searchResults);
       Actions.updateSortBy(sortBy);
       Actions.updateLoadingStatus(false);

--- a/src/app/pages/SearchResults.jsx
+++ b/src/app/pages/SearchResults.jsx
@@ -152,7 +152,7 @@ SearchResults.propTypes = {
   filters: PropTypes.object,
   field: PropTypes.string,
   sortBy: PropTypes.string,
-  drbbResults: PropTypes.string,
+  drbbResults: PropTypes.object,
 };
 
 SearchResults.defaultProps = {

--- a/src/app/pages/SearchResults.jsx
+++ b/src/app/pages/SearchResults.jsx
@@ -14,7 +14,7 @@ import {
   basicQuery,
 } from '../utils/utils';
 
-const SearchResults = (props) => {
+const SearchResults = (props, context) => {
   const {
     searchResults,
     searchKeywords,
@@ -25,6 +25,8 @@ const SearchResults = (props) => {
     location,
     sortBy,
   } = props;
+
+  const { includeDrbb } = context;
 
   const [dropdownOpen, toggleDropdown] = useState(false);
 
@@ -120,13 +122,14 @@ const SearchResults = (props) => {
                     page={parseInt(page, 10)}
                   />
                   {
-                    !!(totalResults && totalResults !== 0) &&
-                    <SearchResultsSorter
-                      sortBy={sortBy}
-                      page={page}
-                      searchKeywords={searchKeywords}
-                      createAPIQuery={createAPIQuery}
-                    />
+                    (totalResults && totalResults !== 0) || (includeDrbb && drbbResults.totalWorks > 0) ?
+                      <SearchResultsSorter
+                        sortBy={sortBy}
+                        page={page}
+                        searchKeywords={searchKeywords}
+                        createAPIQuery={createAPIQuery}
+                      />
+                      : null
                   }
                 </div>
               </div>
@@ -149,10 +152,16 @@ SearchResults.propTypes = {
   filters: PropTypes.object,
   field: PropTypes.string,
   sortBy: PropTypes.string,
+  drbbResults: PropTypes.string,
 };
 
 SearchResults.defaultProps = {
   page: '1',
+  drbbResults: { totalWorks: 0 },
+};
+
+SearchResults.contextTypes = {
+  includeDrbb: PropTypes.bool,
 };
 
 export default SearchResults;

--- a/src/app/stores/Store.js
+++ b/src/app/stores/Store.js
@@ -43,6 +43,7 @@ class Store {
       deliveryLocations: [],
       isEddRequestable: false,
       subjectHeading: null,
+      drbbResults: {},
     };
   }
 
@@ -106,6 +107,10 @@ class Store {
 
   updateSubjectHeading(data) {
     this.setState({ subjectHeading: data });
+  }
+
+  updateDrbbResults(data) {
+    this.setState({ drbbResults: data });
   }
 }
 

--- a/src/app/stores/Store.js
+++ b/src/app/stores/Store.js
@@ -20,6 +20,7 @@ class Store {
       updateDeliveryLocations: Actions.updateDeliveryLocations,
       updateIsEddRequestable: Actions.updateIsEddRequestable,
       updateSubjectHeading: Actions.updateSubjectHeading,
+      updateDrbbResults: Actions.updateDrbbResults,
     });
 
     this.state = {

--- a/src/client/App.jsx
+++ b/src/client/App.jsx
@@ -1,7 +1,7 @@
 /* global loadA11y, window */
 // lines 2 and 3 replace deprecated "babel-polyfill"
-import "core-js/stable";
-import "regenerator-runtime/runtime";
+import 'core-js/stable';
+import 'regenerator-runtime/runtime';
 
 import React from 'react';
 import ReactDOM from 'react-dom';
@@ -15,6 +15,7 @@ import Iso from 'iso';
 import alt from '../app/alt';
 
 import './styles/main.scss';
+import './assets/drbb_promo.png';
 
 import routes from '../app/routes/routes';
 

--- a/src/server/ApiRoutes/ApiRoutes.js
+++ b/src/server/ApiRoutes/ApiRoutes.js
@@ -4,7 +4,6 @@ import Bib from './Bib';
 import User from './User';
 import Hold from './Hold';
 import Search from './Search';
-import ResearchNow from './ResearchNow';
 import appConfig from '../../app/data/appConfig';
 import SubjectHeading from './SubjectHeading';
 import SubjectHeadings from './SubjectHeadings';
@@ -67,10 +66,6 @@ router
 router
   .route(`${appConfig.baseUrl}/api`)
   .get(Search.searchAjax);
-
-router
-  .route(`${appConfig.baseUrl}/api/research-now`)
-  .get(ResearchNow.searchAjax);
 
 router
   .route(`${appConfig.baseUrl}/api/bib`)

--- a/src/server/ApiRoutes/ResearchNow.js
+++ b/src/server/ApiRoutes/ResearchNow.js
@@ -7,13 +7,11 @@ import {
 import appConfig from '../../app/data/appConfig';
 import logger from '../../../logger';
 
-const appEnvironment = process.env.APP_ENV || 'production';
-
 const nyplApiClientCall = query => nyplApiClient({ apiName: 'drbb' })
   .then(client => client.post('', JSON.stringify(query)))
   .catch(console.error);
 
-const searchAjax = (req, res) => {
+const search = (req) => {
   const query = createResearchNowQuery(Object.assign({ per_page: 3 }, req.query));
   const researchNowQueryString = getResearchNowQueryString(req.query);
   return nyplApiClientCall(query)
@@ -21,7 +19,7 @@ const searchAjax = (req, res) => {
       const data = JSON.parse(resp).data;
       if (!data || !data.works) {
         logger.error(resp);
-        return res.json(data);
+        return data;
       }
 
       return {
@@ -34,5 +32,5 @@ const searchAjax = (req, res) => {
 };
 
 export default {
-  searchAjax,
+  search,
 };

--- a/src/server/ApiRoutes/ResearchNow.js
+++ b/src/server/ApiRoutes/ResearchNow.js
@@ -24,11 +24,11 @@ const searchAjax = (req, res) => {
         return res.json(data);
       }
 
-      return res.json({
+      return {
         works: data.works,
         totalWorks: data.totalWorks,
         researchNowQueryString,
-      });
+      };
     })
     .catch(console.error);
 };

--- a/src/server/ApiRoutes/Search.js
+++ b/src/server/ApiRoutes/Search.js
@@ -45,13 +45,13 @@ function search(searchKeywords = '', page, sortBy, order, field, filters, cb, er
 
   const aggregationQuery = `/aggregations?${encodedAggregationsQueryString}`;
   const resultsQuery = `?${encodedResultsQueryString}&per_page=50`;
-  const queryObj = { query: { searchKeywords, sortBy, order, field, filters } };
+  const queryObj = { query: { q: searchKeywords, sortBy, order, field, filters } };
 
   // Need to get both results and aggregations before proceeding.
   Promise.all([
     nyplApiClientCall(resultsQuery),
     nyplApiClientCall(aggregationQuery)])
-    .then(response => ResearchNow.searchAjax(queryObj)
+    .then(response => ResearchNow.search(queryObj)
       .then((drbbResults) => {
         response.push(drbbResults);
         return response;

--- a/src/server/ApiRoutes/Search.js
+++ b/src/server/ApiRoutes/Search.js
@@ -14,6 +14,7 @@ import {
 } from '../../app/utils/utils';
 import nyplApiClient from '../routes/nyplApiClient';
 import logger from '../../../logger';
+import ResearchNow from './ResearchNow';
 
 const createAPIQuery = basicQuery({
   searchKeywords: '',
@@ -44,12 +45,21 @@ function search(searchKeywords = '', page, sortBy, order, field, filters, cb, er
 
   const aggregationQuery = `/aggregations?${encodedAggregationsQueryString}`;
   const resultsQuery = `?${encodedResultsQueryString}&per_page=50`;
+  const queryObj = { query: { searchKeywords, sortBy, order, field, filters } };
 
   // Need to get both results and aggregations before proceeding.
-  Promise.all([nyplApiClientCall(resultsQuery), nyplApiClientCall(aggregationQuery)])
+  Promise.all([
+    nyplApiClientCall(resultsQuery),
+    nyplApiClientCall(aggregationQuery)])
+    .then(response => ResearchNow.searchAjax(queryObj)
+      .then((drbbResults) => {
+        response.push(drbbResults);
+        return response;
+      })
+      .catch(console.error))
     .then((response) => {
-      const [results, aggregations] = response;
-      cb(aggregations, results, page);
+      const [results, aggregations, drbbResults] = response;
+      cb(aggregations, results, page, drbbResults);
     })
     .catch((error) => {
       logger.error('Error making server search call in search function', error);
@@ -67,10 +77,11 @@ function searchAjax(req, res) {
     order,
     fieldQuery,
     filters,
-    (apiFilters, searchResults, pageQuery) => res.json({
+    (apiFilters, searchResults, pageQuery, drbbResults) => res.json({
       filters: apiFilters,
       searchResults,
       pageQuery,
+      drbbResults,
     }),
     error => res.json(error),
   );
@@ -126,7 +137,7 @@ function searchServer(req, res, next) {
     order,
     fieldQuery,
     filters,
-    (apiFilters, data, pageQuery) => {
+    (apiFilters, data, pageQuery, drbbResults) => {
       const selectedFilters = {
         materialType: [],
         language: [],
@@ -209,6 +220,7 @@ function searchServer(req, res, next) {
         sortBy: sort ? `${sort}_${order}` : 'relevance',
         field: fieldQuery,
         error: {},
+        drbbResults,
       };
 
       next();
@@ -229,6 +241,7 @@ function searchServer(req, res, next) {
         sortBy: 'relevance',
         field: 'all',
         error,
+        drbbResults: {},
       };
 
       next();

--- a/test/unit/DrbbContainer.test.js
+++ b/test/unit/DrbbContainer.test.js
@@ -27,10 +27,6 @@ describe('DrbbContainer', () => {
     after(() => {
       mock.restore();
     });
-
-    it('should have `search` property', () => {
-      expect(component.instance().search).to.equal('?q=dogs');
-    });
   });
 
   describe('no ResearchNow results', () => {

--- a/test/unit/DrbbContainer.test.js
+++ b/test/unit/DrbbContainer.test.js
@@ -2,7 +2,7 @@
 import React from 'react';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
-import { spy, stub } from 'sinon';
+import { spy } from 'sinon';
 import MockAdapter from 'axios-mock-adapter';
 import axios from 'axios';
 
@@ -13,33 +13,10 @@ describe('DrbbContainer', () => {
   let component;
   const context = mockRouterContext();
 
-  describe('initial render', () => {
-    before(() => {
-      component = shallow(<DrbbContainer />, {
-        context,
-        disableLifecycleMethods: true,
-      });
-    });
-
-    it('should render the loading component', () => {
-      expect(component.find('.drbb-loading-layer')).to.have.length(1);
-    });
-
-    it('should render three divs', () => {
-      expect(component.find('div')).to.have.length(3);
-    });
-
-    it('should have initial loading state', () => {
-      expect(component.state('drbbResultsLoading')).to.equal(true);
-    });
-  });
-
-  let fetchResearchNowResults;
   let mock;
   describe('with search params', () => {
     before(() => {
       context.router.location.search = '?q=dogs';
-      fetchResearchNowResults = spy(DrbbContainer.prototype, 'fetchResearchNowResults');
       mock = new MockAdapter(axios);
       mock
         .onGet('/research/collections/shared-collection-catalog/api/research-now?q=dogs')
@@ -53,26 +30,6 @@ describe('DrbbContainer', () => {
 
     it('should have `search` property', () => {
       expect(component.instance().search).to.equal('?q=dogs');
-    });
-
-    it('should call `fetchResearchNowResults`', () => {
-      expect(fetchResearchNowResults.calledOnce).to.equal(true);
-    });
-
-    it('should not be loading', () => {
-      expect(component.state('drbbResultsLoading')).to.equal(false);
-      expect(component.find('.drbb-loading-layer')).to.not.be.defined;
-    });
-
-    it('should set state with the fetched results', () => {
-      expect(component.state('works')).to.be.an('array');
-      expect(component.state('works')).to.have.length(1);
-      expect(component.state('totalWorks')).to.equal(1);
-      expect(component.state('researchNowQueryString')).to.equal('query=dogs');
-    });
-
-    it('should render DrbbResult', () => {
-      expect(component.find('DrbbResult').exists()).to.equal(true);
     });
   });
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -125,6 +125,16 @@ if (ENV === 'development') {
     module: {
       rules: [
         {
+          test: /\.(png|jpe?g|gif)$/i,
+          use: [
+            {
+              loader: 'file-loader',
+            },
+          ],
+          include: path.resolve(ROOT_PATH, 'src'),
+          exclude: /node_modules/,
+        },
+        {
           test: /\.jsx?$/,
           exclude: /(node_modules|bower_components)/,
           use: {
@@ -147,16 +157,6 @@ if (ENV === 'development') {
             },
           ],
           include: path.resolve(ROOT_PATH, 'src'),
-        },
-        {
-          test: /\.(png|jpe?g|gif)$/i,
-          use: [
-            {
-              loader: 'file-loader',
-            },
-          ],
-          include: path.resolve(ROOT_PATH, 'src'),
-          exclude: /node_modules/,
         },
       ],
     },
@@ -181,6 +181,15 @@ if (ENV === 'production') {
     module: {
       rules: [
         {
+          test: /\.(png|jpe?g|gif)$/i,
+          include: path.resolve(ROOT_PATH, 'src'),
+          use: [
+            {
+              loader: 'file-loader',
+            },
+          ],
+        },
+        {
           test: /\.jsx?$/,
           exclude: /(node_modules|bower_components)/,
           use: 'babel-loader',
@@ -196,15 +205,6 @@ if (ENV === 'production') {
                 includePaths: sassPaths,
                 importer: globImporter(),
               },
-            },
-          ],
-        },
-        {
-          test: /\.(png|jpe?g|gif)$/i,
-          include: path.resolve(ROOT_PATH, 'src'),
-          use: [
-            {
-              loader: 'file-loader',
             },
           ],
         },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -120,7 +120,7 @@ if (ENV === 'development') {
       modules: [
         'node_modules',
       ],
-      extensions: ['.js', '.jsx', '.scss'],
+      extensions: ['.js', '.jsx', '.scss', '.png'],
     },
     module: {
       rules: [
@@ -155,6 +155,8 @@ if (ENV === 'development') {
               loader: 'file-loader',
             },
           ],
+          include: path.resolve(ROOT_PATH, 'src'),
+          exclude: /node_modules/,
         },
       ],
     },


### PR DESCRIPTION
**What's this do?**
There is a detail of Ellen's designs that requires the knowledge of DRB results on the initial load. Right now, the results are being fetched in `componentDidMount`. This follows the rest of SCC more closely and avoids having the DRB component load while SCC Results have already appeared.. But it conflicts with Daniel's work a bit. Thoughts on this approach? 

Will write better new tests if people think this is a better approach.

**Did someone actually run this code to verify it works?**
PR author did.