### PR TITLE
Pass data.filters directly

### DIFF
--- a/src/app/components/Application/Application.jsx
+++ b/src/app/components/Application/Application.jsx
@@ -61,8 +61,7 @@ class Application extends React.Component {
         ajaxCall(`${appConfig.baseUrl}/api${decodeURI(search)}`, (response) => {
           const { data } = response;
           if (data.filters && data.searchResults) {
-            const selectedFilters = destructureFilters(urlFilters, data.filters);
-            Actions.updateSelectedFilters(selectedFilters);
+            Actions.updateSelectedFilters(data.filters);
             Actions.updateFilters(data.filters);
             if (data.drbbResults) Actions.updateDrbbResults(data.drbbResults);
             Actions.updateSearchResults(data.searchResults);
@@ -79,7 +78,9 @@ class Application extends React.Component {
   }
 
   shouldStoreUpdate() {
-    return `?${basicQuery({})(Store.getState())}` !== this.context.router.location.search;
+    const { search } = this.context.router.location;
+
+    return `?${basicQuery({})(Store.getState())}` !== search;
   }
 
   componentWillUnmount() {

--- a/src/app/components/Application/Application.jsx
+++ b/src/app/components/Application/Application.jsx
@@ -156,7 +156,6 @@ Application.contextTypes = {
 
 Application.childContextTypes = {
   media: PropTypes.string,
-  includeDrbb: PropTypes.bool,
 };
 
 export default Application;

--- a/src/app/pages/SearchResults.jsx
+++ b/src/app/pages/SearchResults.jsx
@@ -24,7 +24,6 @@ const SearchResults = (props, context) => {
     page,
     field,
     sortBy,
-    drbbResults,
   } = props;
 
   const {

--- a/src/server/ApiRoutes/ResearchNow.js
+++ b/src/server/ApiRoutes/ResearchNow.js
@@ -1,10 +1,8 @@
 import nyplApiClient from '../routes/nyplApiClient';
-
 import {
   createResearchNowQuery,
   getResearchNowQueryString,
 } from '../../app/utils/researchNowUtils';
-import appConfig from '../../app/data/appConfig';
 import logger from '../../../logger';
 
 const nyplApiClientCall = query => nyplApiClient({ apiName: 'drbb' })


### PR DESCRIPTION
`destructureFilters` is ignoring certain filters. It is not used in this similar bit of code: https://github.com/NYPL-discovery/discovery-front-end/blob/development/src/app/components/Search/Search.jsx#L118
I think we should just pass `data.filters` directly, as in the code linked to.