### PR TITLE
Truncate titles over 92 characters long on whitespace

### DIFF
--- a/src/app/components/Drbb/DrbbResult.jsx
+++ b/src/app/components/Drbb/DrbbResult.jsx
@@ -10,6 +10,9 @@ import {
   formatUrl,
   generateStreamedReaderUrl,
 } from '../../utils/researchNowUtils';
+import {
+  truncateStringOnWhitespace,
+} from '../../utils/utils';
 
 const DrbbResult = (props) => {
   const { work } = props;
@@ -123,7 +126,7 @@ const DrbbResult = (props) => {
         to={`${drbbFrontEnd}/work?recordType=editions&workId=${work.uuid}`}
         className="drbb-result-title"
       >
-        {title}
+        {truncateStringOnWhitespace(title, 92)}
       </Link>
       {agents && agents.length ? authorship() : null}
       { readOnlineLinkElement() }

--- a/src/app/utils/utils.js
+++ b/src/app/utils/utils.js
@@ -448,6 +448,23 @@ function displayContext({ searchKeywords, selectedFilters, field, count }) {
   return clauses.length ? `for ${clauses.join(' and ')}` : '';
 }
 
+/**
+ * truncateStringOnWhitespace(str, maxLength)
+ * Return a version of the string shortened to the provided maxLength param. This includes
+ * the three characters for the ellipsis that is appended. If the string is shorter than the
+ * max length it is returned as is. If the string contains no whitespace before the max
+ * length it is truncated at that point regardless of word breaks.
+ * @param {string} str - The string to be shortened (or returned without change)
+ * @param {int} maxLength - The maximum length of the returned string to be applied
+ */
+const truncateStringOnWhitespace = (str, maxLength) => {
+  if (str.length < maxLength) { return str; }
+  const truncStr = str.substr(0, maxLength - 3);
+  const truncArray = truncStr.split(/\s+/).slice(0, -1);
+  if (truncArray.length === 0) { return `${truncStr}...`; }
+  return `${truncArray.join(' ')}...`;
+};
+
 export {
   trackDiscovery,
   ajaxCall,
@@ -463,4 +480,5 @@ export {
   getAggregatedElectronicResources,
   getUpdatedFilterValues,
   displayContext,
+  truncateStringOnWhitespace,
 };

--- a/test/unit/DrbbResult.test.js
+++ b/test/unit/DrbbResult.test.js
@@ -70,4 +70,17 @@ describe('DrbbResult', () => {
       expect(component.type()).to.be.null;
     });
   });
+
+  describe('work with long title', () => {
+    let component;
+    before(() => {
+      const longTitleWork = workData.data;
+      longTitleWork.title = 'Life in India; or, Madras, the Neilgherries, and Calcutta. Written for the American Sunday-School Union.';
+      component = shallow(<DrbbResult work={longTitleWork} />);
+    });
+
+    it('should truncate the title', () => {
+      expect(component.find('Link').first().render().text()).to.equal('Life in India; or, Madras, the Neilgherries, and Calcutta. Written for the American...');
+    });
+  });
 });

--- a/test/unit/utils.test.js
+++ b/test/unit/utils.test.js
@@ -16,6 +16,7 @@ import {
   basicQuery,
   getReqParams,
   getAggregatedElectronicResources,
+  truncateStringOnWhitespace,
 } from '../../src/app/utils/utils';
 
 /**
@@ -643,5 +644,29 @@ describe('getAggregatedElectronicResources', () => {
           },
         ]);
     });
+  });
+});
+
+describe('truncateStringOnWhitespace()', () => {
+  it('Should return a short title as-is', () => {
+    expect(truncateStringOnWhitespace('Test Title', 25)).to.equal('Test Title');
+  });
+
+  it('Should truncate a long title when break lands in the middle of a word', () => {
+    const truncStr = truncateStringOnWhitespace('Longer Title Here To Become Shorter', 25);
+    expect(truncStr).to.equal('Longer Title Here To...');
+    expect(truncStr.length).to.be.lessThan(26);
+  });
+
+  it('Should truncate a long title when break lands on a whitespace', () => {
+    const truncStr = truncateStringOnWhitespace('Longer Title Break On Whitespace', 25);
+    expect(truncStr).to.equal('Longer Title Break On...');
+    expect(truncStr.length).to.be.lessThan(26);
+  });
+
+  it('Should truncate single word title regardless of whitespace', () => {
+    const truncStr = truncateStringOnWhitespace('ThisIsAOneWordTitleWhichCouldExistOutThere', 25);
+    expect(truncStr).to.equal('ThisIsAOneWordTitleWhi...');
+    expect(truncStr.length).to.be.lessThan(26);
   });
 });


### PR DESCRIPTION
**What's this do?**
This is something I had in my notes app to do, but kept forgetting about. Has not come up in any reviews. The max character value came from Ellen.

**Did someone actually run this code to verify it works?**
PR author did.