### PR TITLE
Simplify routes

### DIFF
--- a/server.js
+++ b/server.js
@@ -92,6 +92,7 @@ app.get('/*', (req, res, next) => {
 });
 
 app.get('/*', (req, res) => {
+  console.log('store: ', Store.getState());
   alt.bootstrap(JSON.stringify({
     PatronStore: res.locals.data.PatronStore,
     Store: Store.getState(),

--- a/server.js
+++ b/server.js
@@ -92,7 +92,6 @@ app.get('/*', (req, res, next) => {
 });
 
 app.get('/*', (req, res) => {
-  console.log('store: ', Store.getState());
   alt.bootstrap(JSON.stringify({
     PatronStore: res.locals.data.PatronStore,
     Store: Store.getState(),

--- a/src/app/utils/dataLoaderUtil.js
+++ b/src/app/utils/dataLoaderUtil.js
@@ -2,38 +2,34 @@ import Actions from '@Actions';
 import { ajaxCall, destructureFilters } from '@utils';
 import { pick as _pick } from 'underscore';
 import appConfig from '@appConfig';
-import Store from '@Store';
 
 const pathInstructions = [
   {
-    expression: /\/research\/collections\/shared-collection-catalog\/bib\/([cp]?b\d*)/,
+    expression: 'bib/:bibId',
     pathType: 'bib',
   },
   {
-    expression: /\/research\/collections\/shared-collection-catalog\/search\?(.*)/,
+    expression: 'search',
     pathType: 'search',
   },
   {
-    expression: /\/research\/collections\/shared-collection-catalog\/hold\/request\/([^/]*)/,
+    expression: 'hold/request/:bibId-:itemId',
     pathType: 'holdRequest',
   },
 ];
 
-const routePaths = {
-  bib: `${appConfig.baseUrl}/api/bib`,
-  search: `${appConfig.baseUrl}/api`,
-  holdRequest: `${appConfig.baseUrl}/api/hold/request/:bibId-:itemId`,
-};
+const pathExpressions = pathInstructions.map(({ expression, pathType }) => (
+  {
+    expression: `${appConfig.baseUrl}/${expression.replace(/:\w*/, '\\w*')}`,
+    pathType,
+  }
+));
 
 const routesGenerator = location => ({
   bib: {
-    apiRoute: (matchData, route) => `${route}?bibId=${matchData[1]}`,
-    serverParams: (matchData, req) => { req.query.bibId = matchData[1]; },
     actions: [Actions.updateBib],
-    errorMessage: 'Error attempting to make an ajax request to fetch a bib record from ResultsList',
   },
   search: {
-    apiRoute: (matchData, route) => `${route}?${matchData[1]}`,
     actions: [
       data => Actions.updateSearchResults(data.searchResults),
       () => Actions.updatePage(location.query.page || 1),
@@ -67,87 +63,64 @@ const routesGenerator = location => ({
         if (data.drbbResults) Actions.updateDrbbResults(data.drbbResults);
       },
     ],
-    errorMessage: 'Error attempting to make an ajax request to search',
   },
   holdRequest: {
-    apiRoute: (matchData, route) => route.replace(':bibId-:itemId', matchData[1]),
-    serverParams: (matchData, req) => {
-      const params = matchData[1].match(/\w+/g);
-      console.log('params: ', params[0], params[1]);
-      if (params[0]) req.params.bibId = params[0];
-      if (params[1]) req.params.itemId = params[1];
-    },
     actions: [
       data => Actions.updateBib(data.bib),
       data => Actions.updateDeliveryLocations(data.deliveryLocations),
       data => Actions.updateIsEddRequestable(data.isEddRequestable),
     ],
-    errorMessage: 'Error attempting to make ajax request for hold request',
   },
 });
 
-const matchingPathData = (location) => {
+function loadDataForRoutes(location, req, routeMethods) {
   const {
     pathname,
     search,
   } = location;
-
-  return pathInstructions
-    .map(instruction => ({
-      matchData: (pathname + search).match(instruction.expression),
-      pathType: instruction.pathType,
-    }))
-    .find(pair => pair.matchData)
-    || { matchData: null, pathType: null };
-};
-
-function loadDataForRoutes(location, req, routeMethods) {
   const routes = routesGenerator(location);
-  const {
-    matchData,
-    pathType,
-  } = matchingPathData(location);
-
-  if (routes[pathType]) {
-    const {
-      apiRoute,
-      actions,
-      errorMessage,
-      serverParams,
-    } = routes[pathType];
-    const route = routePaths[pathType];
-    Actions.updateLoadingStatus(true);
-    const successCb = (response) => {
-      actions.forEach(action => action(response.data));
-      Actions.updateLoadingStatus(false);
-    };
-    const errorCb = (error) => {
-      Actions.updateLoadingStatus(false);
-      console.error(
-        errorMessage,
-        error,
+  const fullPath = pathname + search;
+  pathExpressions.forEach(({ expression, pathType }) => {
+    if (fullPath.match(expression)) {
+      const {
+        actions,
+      } = routes[pathType];
+      Actions.updateLoadingStatus(true);
+      const successCb = (response) => {
+        actions.forEach(action => action(response.data));
+        Actions.updateLoadingStatus(false);
+      };
+      const errorCb = (error) => {
+        Actions.updateLoadingStatus(false);
+        console.error(
+          `Error fetching data for ${pathType}`,
+          error,
+        );
+      };
+      if (req) {
+        return new Promise((resolve) => {
+          const res = {
+            json: (data) => {
+              resolve({ data });
+            },
+          };
+          routeMethods[pathType](req, res);
+        })
+          .then(successCb)
+          .catch(errorCb);
+      }
+      return ajaxCall(
+        fullPath.replace(`${appConfig.baseUrl}`, `${appConfig.baseUrl}/api`),
+        successCb,
+        errorCb,
       );
-    };
-    if (req) {
-      if (serverParams) serverParams(matchData, req);
-      return new Promise((resolve) => {
-        const res = {
-          json: (data) => {
-            resolve({ data });
-          },
-        };
-        routeMethods[pathType](req, res);
-      })
-        .then(successCb)
-        .catch(errorCb);
     }
-    return ajaxCall(apiRoute(matchData, route), successCb, errorCb);
-  }
+  });
 
   return new Promise(resolve => resolve());
 }
 
 export default {
   loadDataForRoutes,
-  routePaths,
+  pathInstructions,
 };

--- a/src/app/utils/dataLoaderUtil.js
+++ b/src/app/utils/dataLoaderUtil.js
@@ -101,6 +101,7 @@ function loadDataForRoutes(location, req, routeMethods) {
         );
       };
       if (req) {
+        req.params = Object.assign({}, req.prevParams, req.params);
         return new Promise((resolve) => {
           const res = {
             json: (data) => {

--- a/src/server/ApiRoutes/ApiRoutes.js
+++ b/src/server/ApiRoutes/ApiRoutes.js
@@ -4,7 +4,6 @@ import User from './User';
 import Hold from './Hold';
 import Search from './Search';
 import Bib from './Bib';
-import ResearchNow from './ResearchNow';
 import appConfig from '../../app/data/appConfig';
 import SubjectHeading from './SubjectHeading';
 import SubjectHeadings from './SubjectHeadings';
@@ -35,17 +34,10 @@ router
   .post(Hold.eddServer);
 
 pathInstructions.forEach(({ expression, pathType }) => {
-  console.log('instruction: ', expression, pathType, routeMethods[pathType]);
   router
     .route(`${appConfig.baseUrl}/api/${expression}`)
     .get(routeMethods[pathType]);
 });
-
-
-// router
-//   .route(`${appConfig.baseUrl}/api/research-now`)
-//   .get(ResearchNow.searchAjax);
-
 
 router
   .route(`${appConfig.baseUrl}/api/patronEligibility`)

--- a/src/server/ApiRoutes/ApiRoutes.js
+++ b/src/server/ApiRoutes/ApiRoutes.js
@@ -3,6 +3,8 @@ import express from 'express';
 import User from './User';
 import Hold from './Hold';
 import Search from './Search';
+import Bib from './Bib';
+import ResearchNow from './ResearchNow';
 import appConfig from '../../app/data/appConfig';
 import SubjectHeading from './SubjectHeading';
 import SubjectHeadings from './SubjectHeadings';
@@ -10,7 +12,7 @@ import dataLoaderUtil from '../../app/utils/dataLoaderUtil';
 import routeMethods from './RouteMethods';
 
 const router = express.Router();
-const routePaths = dataLoaderUtil.routePaths;
+const pathInstructions = dataLoaderUtil.pathInstructions;
 
 router
   .route(`${appConfig.baseUrl}/search`)
@@ -32,14 +34,16 @@ router
   .route(`${appConfig.baseUrl}/edd`)
   .post(Hold.eddServer);
 
-Object.keys(routePaths).forEach((routeName) => {
+Object.keys(pathInstructions).forEach(({ expression, pathType }) => {
   router
-    .route(routePaths[routeName])
-    .get(routeMethods[routeName]);
+    .route(`${appConfig.baseUrl}/api/${expression}`)
+    .get(routeMethods[pathType]);
 });
 
 
 router
+  .route(`${appConfig.baseUrl}/api/research-now`)
+  .get(ResearchNow.searchAjax);
 
 
 router

--- a/src/server/ApiRoutes/ApiRoutes.js
+++ b/src/server/ApiRoutes/ApiRoutes.js
@@ -37,6 +37,13 @@ pathInstructions.forEach(({ expression, pathType }) => {
   router
     .route(`${appConfig.baseUrl}/api/${expression}`)
     .get(routeMethods[pathType]);
+
+  router
+    .route(`${appConfig.baseUrl}/${expression}`)
+    .get((req, res, next) => {
+      req.prevParams = req.params;
+      next();
+    });
 });
 
 router

--- a/src/server/ApiRoutes/ApiRoutes.js
+++ b/src/server/ApiRoutes/ApiRoutes.js
@@ -34,16 +34,17 @@ router
   .route(`${appConfig.baseUrl}/edd`)
   .post(Hold.eddServer);
 
-Object.keys(pathInstructions).forEach(({ expression, pathType }) => {
+pathInstructions.forEach(({ expression, pathType }) => {
+  console.log('instruction: ', expression, pathType, routeMethods[pathType]);
   router
     .route(`${appConfig.baseUrl}/api/${expression}`)
     .get(routeMethods[pathType]);
 });
 
 
-router
-  .route(`${appConfig.baseUrl}/api/research-now`)
-  .get(ResearchNow.searchAjax);
+// router
+//   .route(`${appConfig.baseUrl}/api/research-now`)
+//   .get(ResearchNow.searchAjax);
 
 
 router

--- a/src/server/ApiRoutes/Bib.js
+++ b/src/server/ApiRoutes/Bib.js
@@ -47,7 +47,7 @@ function fetchBib(bibId, cb, errorcb) {
 }
 
 function bibSearch(req, res) {
-  const bibId = req.query.bibId || '';
+  const bibId = req.params.bibId || '';
 
   fetchBib(
     bibId,


### PR DESCRIPTION
**What's this do?**
1. Changes the api routes to match the frontend routes they correspond to in a regular way
2. Uses this regularity to remove some of the logic in the `dataLoaderUtil` that was required for matching frontend routes to api routes

**Why are we doing this? (w/ JIRA link if applicable)**
Part of SCC-2123. This should reduce some of the discrepancy between the logic in the server/client/nojs scenarios and make it easier to keep them in sync with each other.

**How should this be tested? / Do these changes have associated tests?**
[Description of any tests that need to be performed once merged goes here]

**Dependencies for merging? Releasing to production?**
[Description of any watchouts, dependencies, or issues we should be aware of goes here]

**Has the application documentation been updated for these changes?**

**Did someone actually run this code to verify it works?**
