### PR TITLE
NOREF Fix path for DRB promo on prod

### DIFF
--- a/src/app/components/Drbb/DrbbContainer.jsx
+++ b/src/app/components/Drbb/DrbbContainer.jsx
@@ -46,7 +46,7 @@ const DrbbContainer = () => {
         <div className="drbb-promo">
           <img
             alt="digital-research-book"
-            src="/src/client/assets/drbb_promo.png"
+            src="./src/client/assets/drbb_promo.png"
           />
         </div>
         Explore Digital Research Books Beta


### PR DESCRIPTION
**What's this do?**
Bug fix for the `img` `src` for the DRB promo. This bug only shows on prod. This url for the image is live on prod: https://www.nypl.org/research/collections/shared-collection-catalog/src/client/assets/drbb_promo.png

**Did someone actually run this code to verify it works?**
PR author did