### PR TITLE
Fix path for DRB promo on prod

### DIFF
--- a/src/app/components/Drbb/DrbbContainer.jsx
+++ b/src/app/components/Drbb/DrbbContainer.jsx
@@ -46,7 +46,7 @@ const DrbbContainer = () => {
         <div className="drbb-promo">
           <img
             alt="digital-research-book"
-            src="/src/client/assets/drbb_promo.png"
+            src="./src/client/assets/drbb_promo.png"
           />
         </div>
         Explore Digital Research Books Beta


### PR DESCRIPTION
The previous PR was still pointing to `shep-production`