### PR TITLE
SCC-2152/Truncate item tables on results lists instead of not displaying them

### DIFF
--- a/src/app/components/ResultsList/ResultsList.jsx
+++ b/src/app/components/ResultsList/ResultsList.jsx
@@ -14,6 +14,11 @@ import ItemTable from '../Item/ItemTable';
 import appConfig from '../../data/appConfig';
 
 class ResultsList extends React.Component {
+  constructor() {
+    super();
+    this.itemTableLimit = 3;
+  }
+
   getBibTitle(bib) {
     if (!bib.titleDisplay || !bib.titleDisplay.length) {
       const author = bib.creatorLiteral && bib.creatorLiteral.length ?
@@ -56,9 +61,9 @@ class ResultsList extends React.Component {
       result.publicationStatement[0] : '';
     const items = LibraryItem.getItems(result);
     const totalItems = items.length;
-    const hasRequestTable = items.length === 1;
+    const hasRequestTable = items.length > 0;
 
-    let bibUrl = `${appConfig.baseUrl}/bib/${bibId}`;
+    const bibUrl = `${appConfig.baseUrl}/bib/${bibId}`;
 
     return (
       <li key={i} className={`nypl-results-item ${hasRequestTable ? 'has-request' : ''}`}>
@@ -84,7 +89,7 @@ class ResultsList extends React.Component {
         {
           hasRequestTable &&
           <ItemTable
-            items={items}
+            items={items.slice(0, this.itemTableLimit)}
             bibId={bibId}
             id={null}
             searchKeywords={this.props.searchKeywords}

--- a/test/fixtures/resultsBibs.js
+++ b/test/fixtures/resultsBibs.js
@@ -60,6 +60,24 @@ const resultsBibs = [
             '@value': 21106086,
           },
         },
+        {
+          '@id': 'res:i21106099',
+          uri: 'i21106086',
+          identifier: ['urn:SierraNypl:21106086'],
+          idNyplSourceId: {
+            '@type': 'SierraNypl',
+            '@value': 21106086,
+          },
+        },
+        {
+          '@id': 'res:i21106025',
+          uri: 'i21106086',
+          identifier: ['urn:SierraNypl:21106086'],
+          idNyplSourceId: {
+            '@type': 'SierraNypl',
+            '@value': 21106086,
+          },
+        },
       ],
     },
   },

--- a/test/unit/ResultsList.test.js
+++ b/test/unit/ResultsList.test.js
@@ -2,7 +2,7 @@
 import React from 'react';
 import { expect } from 'chai';
 import { shallow, mount } from 'enzyme';
-import { mock } from 'sinon';
+import { mock as sinonMock } from 'sinon';
 import MockAdapter from 'axios-mock-adapter';
 import axios from 'axios';
 
@@ -344,7 +344,7 @@ describe('ResultsList', () => {
     let appConfigMock;
 
     before(() => {
-      appConfigMock = mock(appConfig);
+      appConfigMock = sinonMock(appConfig);
     });
 
     describe('without integration', () => {

--- a/test/unit/ResultsList.test.js
+++ b/test/unit/ResultsList.test.js
@@ -118,13 +118,12 @@ describe('ResultsList', () => {
       expect(component.find('li').length).to.equal(15);
     });
 
-    // Only renders the table if the bib has only ONE item:
-    it('should render one table for each single-item bib (2)', () => {
-      expect(component.find('table').length).to.equal(2);
+    it('should render one table for each bib', () => {
+      expect(component.find('table').length).to.equal(3);
     });
   });
 
-  describe('Rendering with one bib and two items', () => {
+  describe('Rendering with one bib and four items', () => {
     const bib = resultsBibs[0];
     let component;
 
@@ -161,11 +160,15 @@ describe('ResultsList', () => {
     it('should have a total items description', () => {
       const yearPublished = component.find('.nypl-results-info');
       expect(yearPublished.length).to.equal(1);
-      expect(yearPublished.text()).to.equal('2 items');
+      expect(yearPublished.text()).to.equal('4 items');
     });
 
-    it('should not have a table', () => {
-      expect(component.find('table').length).to.equal(0);
+    it('should have a table', () => {
+      expect(component.find('table').length).to.equal(1);
+    });
+
+    it('table should only render three rows', () => {
+      expect(component.find('table').find('ItemTableRow').length).to.equal(3);
     });
   });
 


### PR DESCRIPTION
**What's this do?**
Instead of not rendering the `ItemTable` for bibs with more than one item, now a truncated table with a maximum of 3 items is rendered.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SCC-2152

I did check in with Edwin on Slack about the original implementation and he can't remember the why, but it was indeed intentional. This detail has not come up in three years, however definitely a nice change for the new on-site EED work and serials work. There may be further design changes for how to indicate when the list is truncated.

**How should this be tested? / Do these changes have associated tests?**
Made necessary changes in tests. Changed one test to test the truncation.

**Did someone actually run this code to verify it works?**
PR author did.

**Merging**
This should also be merged into `on-site-edd-development` branch.