### PR TITLE
NO_REF - Fix "1 results" bug, tests for DrbbContainer refactor

### DIFF
--- a/src/app/components/Drbb/DrbbContainer.jsx
+++ b/src/app/components/Drbb/DrbbContainer.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { Link } from 'react-router';
 
 import appConfig from '../../data/appConfig';
@@ -30,16 +29,14 @@ const DrbbContainer = () => {
           target="_blank"
           key="drbb-results-list-link"
         >
-          See {totalWorks.toLocaleString()} results from Digital Research Books Beta
+          See {totalWorks.toLocaleString()} result{totalWorks === 1 ? '' : 's'} from Digital Research Books Beta
         </Link>]);
     }
 
     return (
       <Link
         className="drbb-description"
-        to={{
-          pathname: `${appConfig.drbbFrontEnd[appConfig.environment]}/search?`,
-        }}
+        to={appConfig.drbbFrontEnd[appConfig.environment]}
         target="_blank"
         key="drbb-link"
       >
@@ -57,26 +54,24 @@ const DrbbContainer = () => {
   return (
     <div className="drbb-container">
       <h3 className="drbb-main-header">
-        {hasWorks ? 'Results from ' : 'No results found from '} Digital Research Books Beta
+        {hasWorks ? 'Results from' : 'No results found from'} Digital Research Books Beta
       </h3>
       <p className="drbb-description">
         Digital books for research from multiple sources world wide-
-        all free to read, download, and keep. No Library Card is Required. <span>
+        all free to read, download, and keep. No Library Card is Required.&nbsp;
+        <span>
           <a
             className="link"
-            target="_blanks"
+            target="_blank"
             href={`${appConfig.drbbFrontEnd[appConfig.environment]}/about`}
-          >Read more about the project
+          >
+          Read more about the project
           </a>.
         </span>
       </p>
       { content() }
     </div>
   );
-};
-
-DrbbContainer.contextTypes = {
-  router: PropTypes.object,
 };
 
 export default DrbbContainer;

--- a/test/unit/DrbbContainer.test.js
+++ b/test/unit/DrbbContainer.test.js
@@ -2,67 +2,118 @@
 import React from 'react';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
-import { spy } from 'sinon';
-import MockAdapter from 'axios-mock-adapter';
-import axios from 'axios';
+import { stub } from 'sinon';
 
 import DrbbContainer from './../../src/app/components/Drbb/DrbbContainer';
-import { mockRouterContext } from '../helpers/routing';
+import Store from './../../src/app/stores/Store';
+import appConfig from '../../src/app/data/appConfig';
 
 describe('DrbbContainer', () => {
   let component;
-  const context = mockRouterContext();
+  let storeStub;
+  before(() => {
+    storeStub = stub(Store, 'getState').returns({ drbbResults: {} });
+  });
 
-  let mock;
-  describe('with search params', () => {
+  afterEach(() => {
+    storeStub.restore();
+  });
+
+  describe('all renderings', () => {
     before(() => {
-      context.router.location.search = '?q=dogs';
-      mock = new MockAdapter(axios);
-      mock
-        .onGet('/research/collections/shared-collection-catalog/api/research-now?q=dogs')
-        .reply(200, { works: [{ title: 'work' }], totalWorks: 1000, researchNowQueryString: 'query=dogs' });
-      component = shallow(<DrbbContainer />, { context });
+      component = shallow(<DrbbContainer />);
     });
 
-    after(() => {
-      mock.restore();
+    it('should have an h3', () => {
+      expect(component.find('h3').length).to.equal(1);
+      expect(component.find('h3').text()).to.include('Digital Research Books Beta');
+    });
+
+    it('should have a <p> with a <span> and an <a>', () => {
+      expect(component.find('p').length).to.equal(1);
+      // test that space is rendered before 'Read more...' link
+      expect(component.find('p').text()).to.include('No Library Card is Required. Read more about the project.');
+      expect(component.find('p').find('span').length).to.equal(1);
+      expect(component.find('p').find('span').text()).to.equal('Read more about the project.');
+      expect(component.find('p').find('span').find('a').text()).to.equal('Read more about the project');
+      expect(component.find('p').find('span').find('a').prop('href')).to.equal(`${appConfig.drbbFrontEnd[appConfig.environment]}/about`);
+    });
+  });
+
+  describe('with one result', () => {
+    before(() => {
+      storeStub = stub(Store, 'getState').returns({
+        drbbResults:
+          {
+            works: [{ title: 'work', id: 10 }],
+            totalWorks: 1,
+            researchNowQueryString: 'query=onework',
+          } });
+      component = shallow(<DrbbContainer />);
+    });
+
+    it('h3 text should be "Results from Digital Research Books Beta"', () => {
+      expect(component.find('h3').text()).to.equal('Results from Digital Research Books Beta');
+    });
+    it('should render a <ul>', () => {
+      expect(component.find('ul').length).to.equal(1);
+    });
+    it('should render 1 `DrbbResult`', () => {
+      expect(component.find('DrbbResult').length).to.equal(1);
+    });
+    it('should render a link to the DRBB search results page', () => {
+      expect(component.find('Link').prop('to')).to.deep.equal({
+        pathname: `${appConfig.drbbFrontEnd[appConfig.environment]}/search?`,
+        search: 'query=onework' });
+    });
+    it('link text should have result singular', () => {
+      expect(component.find('Link').render().text()).to.include('See 1 result');
+    });
+  });
+
+  describe('with multiple works', () => {
+    before(() => {
+      storeStub = stub(Store, 'getState').returns({
+        drbbResults:
+          {
+            works: [{ title: 'work', id: 10 }, { title: 'work', id: 11 }],
+            totalWorks: 1000,
+            researchNowQueryString: 'query=multipleworks',
+          } });
+      component = shallow(<DrbbContainer />);
+    });
+
+    it('link text should have results plural and correct thousands separators', () => {
+      expect(component.find('Link').render().text()).to.include('See 1,000 results');
     });
   });
 
   describe('no ResearchNow results', () => {
     before(() => {
-      context.router.location.search = '?q=noresults';
-      mock = new MockAdapter(axios);
-      mock
-        .onGet('/research/collections/shared-collection-catalog/api/research-now?q=noresults')
-        .reply(200, { works: [] });
+      storeStub = stub(Store, 'getState').returns({
+        drbbResults:
+          {
+            works: [],
+            totalWorks: 0,
+            researchNowQueryString: 'query=noworks',
+          } });
       component = shallow(<DrbbContainer />, { context });
-    });
-
-    after(() => {
-      mock.restore();
-    });
-    it('should display the drbb promo', () => {
-      expect(component.find('img')).to.have.length(1);
-    });
-  });
-
-  describe('bad results response', () => {
-    before(() => {
-      context.router.location.search = '?q=badresults';
-      mock = new MockAdapter(axios);
-      mock
-        .onGet('/research/collections/shared-collection-catalog/api/research-now?q=badresults')
-        .reply(200, { notWhatIExpected: 'whatever' });
-      component = shallow(<DrbbContainer />, { context });
-    });
-
-    after(() => {
-      mock.restore();
     });
 
     it('should display the drbb promo', () => {
       expect(component.find('img')).to.have.length(1);
+    });
+
+    it('h3 text should be "No results found from Digital Research Books Beta"', () => {
+      expect(component.find('h3').text()).to.equal('No results found from Digital Research Books Beta');
+    });
+
+    it('link text should be "Explore Digital Research Books Beta"', () => {
+      expect(component.find('Link').render().text()).to.equal('Explore Digital Research Books Beta');
+    });
+
+    it('link text should be "Explore Digital Research Books Beta"', () => {
+      expect(component.find('Link').prop('to')).to.equal(appConfig.drbbFrontEnd[appConfig.environment]);
     });
   });
 });


### PR DESCRIPTION
**What's this do?**
Mostly this is to fix a bug for when there is one result, it says "1 results". I also rewrote the tests for the DrbbContainer since the refactor and did some other cleanup.

**Why are we doing this? (w/ JIRA link if applicable)**
No ticket. Easy bug. Tests are needed.

**How should this be tested? / Do these changes have associated tests?**
Tests for bug. Also, new tests since refactoring to use the Store instead of AJAX.

**Dependencies for merging? Releasing to production?**
I cut this branch from `shep-production`. So, it could eventually be merged into production either separately or with the rest of the work on QA.

**Did someone actually run this code to verify it works?**
PR author did