### PR TITLE
SCC-2116/ fix email

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -9,5 +9,6 @@ export SET CLOSED_LOCATIONS="all;Library for the Performing Arts"
 export SET SEARCH_RESULTS_NOTIFICATION="notification"
 
 export SET INCLUDE_DRBB=true
+export SET INCLUDE_ON_SITE_EDD=false
 
 export SET GENERAL_RESEARCH_EMAIL=example@nypl.com

--- a/.env-sample
+++ b/.env-sample
@@ -10,6 +10,4 @@ export SET SEARCH_RESULTS_NOTIFICATION="notification"
 
 export SET INCLUDE_DRBB=true
 
-export SET LIB_ANSWERS_EMAIL_SASB=example@nypl.com
-export SET LIB_ANSWERS_EMAIL_LPA=example@nypl.com
-export SET LIB_ANSWERS_EMAIL_SC=example@nypl.com
+export SET GENERAL_RESEARCH_EMAIL=example@nypl.com

--- a/src/app/components/Item/ItemTableRow.jsx
+++ b/src/app/components/Item/ItemTableRow.jsx
@@ -66,32 +66,19 @@ class ItemTableRow extends React.Component {
   message() {
     const { item } = this.props;
     if (item.holdingLocationCode && item.nonRecapNYPL) {
-      let holdingLocationEmail;
-      const { libAnswersEmails } = AppConfigStore.getState();
-      switch (item.holdingLocationCode.substring(4, 6)) {
-        case 'ma':
-          holdingLocationEmail = libAnswersEmails.sasb;
-          break;
-        case 'my':
-          holdingLocationEmail = libAnswersEmails.lpa;
-          break;
-        case 'sc':
-          holdingLocationEmail = libAnswersEmails.sc;
-          break;
-        default:
-          holdingLocationEmail = null;
-      }
-      if (holdingLocationEmail) {
+      const { generalResearchEmail } = AppConfigStore.getState();
+
+      if (generalResearchEmail && generalResearchEmail.length) {
         const emailText = `Inquiry about item ${item.id} ${item.callNumber}`;
         return ([
           item.accessMessage.prefLabel,
           <div className="item-email-inquiry">
             Email
             <a
-              href={`mailto:${holdingLocationEmail}?subject=${emailText}&body=${emailText}`}
+              href={`mailto:${generalResearchEmail}?subject=${emailText}&body=${emailText}`}
               target="_blank"
             >
-              { holdingLocationEmail }
+              { generalResearchEmail }
             </a>
             for more information.
           </div>]);

--- a/src/app/components/Item/ItemTableRow.jsx
+++ b/src/app/components/Item/ItemTableRow.jsx
@@ -65,22 +65,23 @@ class ItemTableRow extends React.Component {
 
   message() {
     const { item } = this.props;
-    if (item.holdingLocationCode && item.nonRecapNYPL) {
-      const { generalResearchEmail } = AppConfigStore.getState();
+    const {
+      includeOnSiteEdd,
+      generalResearchEmail,
+    } = AppConfigStore.getState();
+    if (item.holdingLocationCode && item.nonRecapNYPL && includeOnSiteEdd) {
 
       if (generalResearchEmail && generalResearchEmail.length) {
         const emailText = `Inquiry about item ${item.id} ${item.callNumber}`;
         return ([
           item.accessMessage.prefLabel,
           <div className="item-email-inquiry">
-            Email
-            <a
+            Email <a
               href={`mailto:${generalResearchEmail}?subject=${emailText}&body=${emailText}`}
               target="_blank"
             >
               { generalResearchEmail }
-            </a>
-            for more information.
+            </a> for more information.
           </div>]);
       }
     }

--- a/src/app/data/appConfig.js
+++ b/src/app/data/appConfig.js
@@ -53,9 +53,5 @@ export default {
     production: 'https://digital-research-books-reader.nypl.org',
   },
   includeDrbb: /true/i.test(process.env.INCLUDE_DRBB),
-  libAnswersEmails: {
-    sasb: process.env.LIB_ANSWERS_EMAIL_SASB,
-    lpa: process.env.LIB_ANSWERS_EMAIL_LPA,
-    sc: process.env.LIB_ANSWERS_EMAIL_SC,
-  },
+  generalResearchEmail: process.env.GENERAL_RESEARCH_EMAIL,
 };

--- a/src/app/data/appConfig.js
+++ b/src/app/data/appConfig.js
@@ -54,4 +54,5 @@ export default {
   },
   includeDrbb: /true/i.test(process.env.INCLUDE_DRBB),
   generalResearchEmail: process.env.GENERAL_RESEARCH_EMAIL,
+  includeOnSiteEdd: /true/i.test(process.env.INCLUDE_ON_SITE_EDD),
 };

--- a/test.env
+++ b/test.env
@@ -2,3 +2,4 @@ export SET NODE_ENV=test
 export SET HOLD_REQUEST_NOTIFICATION
 export SET CLOSED_LOCATIONS="[]"
 export SET INCLUDE_DRBB=false
+export SET INCLUDE_ON_SITE_EDD=false

--- a/test/unit/ItemTableRow.test.js
+++ b/test/unit/ItemTableRow.test.js
@@ -173,14 +173,13 @@ describe('ItemTableRow', () => {
       data.holdingLocationCode = 'loc:mal82';
       let component;
       let appConfigStoreStub;
-      const libAnswersEmails = {
-        sasb: 'sasbexample@nypl.com',
-        lpa: 'lpaexample@nypl.com',
-        sc: 'scexample@nypl.com',
-      };
+      const generalResearchEmail = 'example@nypl.com';
 
       before(() => {
-        appConfigStoreStub = stub(AppConfigStore, 'getState').returns({ libAnswersEmails });
+        appConfigStoreStub = stub(AppConfigStore, 'getState').returns({
+          generalResearchEmail,
+          includeOnSiteEdd: true,
+        });
         component = shallow(<ItemTableRow item={data} bibId="b12345" />);
       });
       after(() => {
@@ -189,8 +188,8 @@ describe('ItemTableRow', () => {
 
       it('should render `Email for access options` link in the fourth <td> column data', () => {
         expect(component.find('td').find('a').length).to.equal(1);
-        expect(component.find('td').find('a').text()).to.equal('Email for access options');
-        expect(component.find('td').find('a').props().href).to.include(libAnswersEmails.sasb);
+        expect(component.find('td').find('a').text()).to.equal(generalResearchEmail);
+        expect(component.find('td').find('a').props().href).to.include(generalResearchEmail);
       });
     });
   });


### PR DESCRIPTION
**What's this do?**
I had conflated the libanswers emails with emails for inquiring about unrequestable items. I also ended up having to set up the feature flag behavior, as mentioned in planning, to get the tests to behave. I've noticed locally, if an environment variable is removed, the value is being stored somehow. It has to be set as something else. So, the `test.env` seemed to have `GENERAL_RESEARCH_EMAIL` set, because of this caching. 

I'll soon create a separate PR for adding this conditional functionality to the standard branches. I think there could be a little refactoring to make `appConfig` update dynamically. We could use the same convention Paul is establishing for discovery API. Described [here](https://github.com/NYPL-discovery/discovery-api/pull/146#issue-440707945). This would be just one environment variable, `FEATURE`, with kebab style for the features (e.g. `digital-research-books-beta` and `on-site-edd`).

**Why are we doing this? (w/ JIRA link if applicable)**
Fixing my own bug/incorrect business information.

**How should this be tested? / Do these changes have associated tests?**
Fixed tests as needed.

**Dependencies for merging? Releasing to production?**
I will need to swap out environment variables for the edd-training environment.

**Did someone actually run this code to verify it works?**
PR author did.