### PR TITLE
SCC-2173/ add feature flag support

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -8,6 +8,8 @@ export SET HOLD_REQUEST_NOTIFICATION="notification"
 export SET CLOSED_LOCATIONS="all;Library for the Performing Arts"
 export SET SEARCH_RESULTS_NOTIFICATION="notification"
 
+export SET FEATURES="first-feature,second-feature,yet-another-feature"
+
 export SET INCLUDE_DRBB=true
 
 export SET LIB_ANSWERS_EMAIL_SASB=example@nypl.com

--- a/src/app/data/appConfig.js
+++ b/src/app/data/appConfig.js
@@ -1,3 +1,5 @@
+import { extractFeatures } from '../utils/utils';
+
 export default {
   appTitle: 'NYPL | Discovery',
   appName: 'discovery',
@@ -52,6 +54,7 @@ export default {
     development: 'https://researchnow-reader.nypl.org',
     production: 'https://digital-research-books-reader.nypl.org',
   },
+  features: extractFeatures(process.env.FEATURES),
   includeDrbb: /true/i.test(process.env.INCLUDE_DRBB),
   libAnswersEmails: {
     sasb: process.env.LIB_ANSWERS_EMAIL_SASB,

--- a/src/app/utils/utils.js
+++ b/src/app/utils/utils.js
@@ -448,6 +448,14 @@ function displayContext({ searchKeywords, selectedFilters, field, count }) {
   return clauses.length ? `for ${clauses.join(' and ')}` : '';
 }
 
+const extractFeatures = (featuresString) => {
+  if (typeof featuresString !== 'string') return [];
+  return featuresString.split(',').reduce((features, feature) => {
+    if (feature.length) features.push(feature.trim());
+    return features;
+  }, []);
+};
+
 export {
   trackDiscovery,
   ajaxCall,
@@ -463,4 +471,5 @@ export {
   getAggregatedElectronicResources,
   getUpdatedFilterValues,
   displayContext,
+  extractFeatures,
 };

--- a/src/app/utils/utils.js
+++ b/src/app/utils/utils.js
@@ -448,6 +448,11 @@ function displayContext({ searchKeywords, selectedFilters, field, count }) {
   return clauses.length ? `for ${clauses.join(' and ')}` : '';
 }
 
+/**
+ * extractFeatures
+ * Takes comma-delimited list of values as a string and returns array of strings.
+ * @param {string} featuresString The comma-delimited list of features.
+ */
 const extractFeatures = (featuresString) => {
   if (typeof featuresString !== 'string') return [];
   return featuresString.split(',').reduce((features, feature) => {

--- a/test/unit/AppConfigStore.test.js
+++ b/test/unit/AppConfigStore.test.js
@@ -1,0 +1,33 @@
+/* eslint-env mocha */
+import { expect } from 'chai';
+import { mock } from 'sinon';
+
+import AppConfigStore from '../../src/app/stores/AppConfigStore';
+import appConfig from '../../src/app/data/appConfig';
+
+describe('AppConfigStore', () => {
+  let appConfigMock;
+  const getFeatures = () => AppConfigStore.getState().features;
+  before(() => {
+    appConfigMock = mock(appConfig);
+  });
+  before(() => {
+    appConfigMock.restore();
+  });
+
+  describe('features', () => {
+    beforeEach(() => {
+      appConfig.features = null;
+    });
+
+    it('handles empty features array', () => {
+      appConfig.features = [];
+      expect(getFeatures()).to.deep.equal([]);
+    });
+
+    it('returns same value in appConfig', () => {
+      appConfig.features = ['several', 'other', 'features'];
+      expect(getFeatures()).to.deep.equal(['several', 'other', 'features']);
+    });
+  });
+});

--- a/test/unit/utils.test.js
+++ b/test/unit/utils.test.js
@@ -16,6 +16,7 @@ import {
   basicQuery,
   getReqParams,
   getAggregatedElectronicResources,
+  extractFeatures,
 } from '../../src/app/utils/utils';
 
 /**
@@ -643,5 +644,30 @@ describe('getAggregatedElectronicResources', () => {
           },
         ]);
     });
+  });
+});
+
+/**
+ * extractFeatures()
+ */
+describe(('extractFeatures'), () => {
+  it('handles non-string parameters', () => {
+    expect(extractFeatures()).to.deep.equal([]);
+    expect(extractFeatures(undefined)).to.deep.equal([]);
+    expect(extractFeatures(null)).to.deep.equal([]);
+    expect(extractFeatures(-1)).to.deep.equal([]);
+    expect(extractFeatures(Math.PI)).to.deep.equal([]);
+  });
+
+  it('handles malformed features String', () => {
+    expect(extractFeatures(',,dasdfksdjfdsf,,').length).to.deep.equal(1);
+  });
+
+  it('returns array of values', () => {
+    expect(extractFeatures('several,other,features')).to.deep.equal(['several', 'other', 'features']);
+  });
+
+  it('strips whitespace', () => {
+    expect(extractFeatures('several ,other  , foo  , features')).to.deep.equal(['several', 'other', 'foo', 'features']);
   });
 });


### PR DESCRIPTION
**What's this do?**
Add feature flag capability. No implementation yet, because I want to merge the same changes into `development` in parallel. Subsequent PR will apply the `on-site-edd` flag on `on-site-edd-development` as needed and for forthcoming work for SCC-2172. Then we can discuss merging the current EDD work into standard branches, because it will be hidden behind the feature flag.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SCC-2173

**How should this be tested? / Do these changes have associated tests?**
I am imagining that we will check `AppConfigStore.getState().includes('feature-name')` to check. There are tests for a new utility processing the value from `process.env.FEATURES` (mocked) and tests for `appConfig` (mocked) -> `AppConfigStore`. Could not test `process.env.FEATURES` (mocked) -> `AppConfigStore`.

**Dependencies for merging? Releasing to production?**
There will be a fraternal twin PR into `development` from a different branch.

**Did someone actually run this code to verify it works?**
The code runs. This is not actually being implemented yet.