### PR TITLE
Bugfix for adding feature flag to `development`

### DIFF
--- a/server.js
+++ b/server.js
@@ -9,11 +9,11 @@ import Iso from 'iso';
 import webpack from 'webpack';
 import cookieParser from 'cookie-parser';
 import bodyParser from 'body-parser';
-import Store from '@Store';
-import dataLoaderUtil from '@dataLoaderUtil';
 
 import alt from './src/app/alt';
 import appConfig from './src/app/data/appConfig';
+import Store from '@Store';
+import dataLoaderUtil from '@dataLoaderUtil';
 import webpackConfig from './webpack.config';
 import apiRoutes from './src/server/ApiRoutes/ApiRoutes';
 import routeMethods from './src/server/ApiRoutes/RouteMethods';


### PR DESCRIPTION
**What's this do?**
The order of the imports in `server.js` was causing the server build to fail. I think only `dataLoaderUtil` really needed to move. But this order makes sense to me.

**How should this be tested? / Do these changes have associated tests?**
Any suggestions for an automated way to test this? Travis build succeed.
Change is already on the EDD training environment, which had crashed and then came back to life.

**Did someone actually run this code to verify it works?**
PR author did