### PR TITLE
Extract feature refactor

### DIFF
--- a/src/app/data/appConfig.js
+++ b/src/app/data/appConfig.js
@@ -1,6 +1,12 @@
-import { extractFeatures } from '../utils/utils';
+const extractFeatures = (featuresString) => {
+  if (typeof featuresString !== 'string') return [];
+  return featuresString.split(',').reduce((features, feature) => {
+    if (feature.length) features.push(feature.trim());
+    return features;
+  }, []);
+};
 
-export default {
+const appConfig = {
   appTitle: 'NYPL | Discovery',
   appName: 'discovery',
   displayTitle: 'Shared Collection Catalog',
@@ -57,4 +63,9 @@ export default {
   features: extractFeatures(process.env.FEATURES),
   includeDrbb: /true/i.test(process.env.INCLUDE_DRBB),
   generalResearchEmail: process.env.GENERAL_RESEARCH_EMAIL,
+};
+
+export default {
+  extractFeatures,
+  ...appConfig,
 };

--- a/src/app/utils/utils.js
+++ b/src/app/utils/utils.js
@@ -465,19 +465,6 @@ const truncateStringOnWhitespace = (str, maxLength) => {
   return `${truncArray.join(' ')}...`;
 };
 
-/**
- * extractFeatures
- * Takes comma-delimited list of values as a string and returns array of strings.
- * @param {string} featuresString The comma-delimited list of features.
- */
-const extractFeatures = (featuresString) => {
-  if (typeof featuresString !== 'string') return [];
-  return featuresString.split(',').reduce((features, feature) => {
-    if (feature.length) features.push(feature.trim());
-    return features;
-  }, []);
-};
-
 export {
   trackDiscovery,
   ajaxCall,
@@ -494,5 +481,4 @@ export {
   getUpdatedFilterValues,
   displayContext,
   truncateStringOnWhitespace,
-  extractFeatures,
 };

--- a/test/unit/AppConfigStore.test.js
+++ b/test/unit/AppConfigStore.test.js
@@ -30,4 +30,29 @@ describe('AppConfigStore', () => {
       expect(getFeatures()).to.deep.equal(['several', 'other', 'features']);
     });
   });
+
+  /**
+   * extractFeatures()
+   */
+  describe(('extractFeatures'), () => {
+    it('handles non-string parameters', () => {
+      expect(appConfig.extractFeatures()).to.deep.equal([]);
+      expect(appConfig.extractFeatures(undefined)).to.deep.equal([]);
+      expect(appConfig.extractFeatures(null)).to.deep.equal([]);
+      expect(appConfig.extractFeatures(-1)).to.deep.equal([]);
+      expect(appConfig.extractFeatures(Math.PI)).to.deep.equal([]);
+    });
+
+    it('handles malformed features String', () => {
+      expect(appConfig.extractFeatures(',,dasdfksdjfdsf,,').length).to.deep.equal(1);
+    });
+
+    it('returns array of values', () => {
+      expect(appConfig.extractFeatures('several,other,features')).to.deep.equal(['several', 'other', 'features']);
+    });
+
+    it('strips whitespace', () => {
+      expect(appConfig.extractFeatures('several ,other  , foo  , features')).to.deep.equal(['several', 'other', 'foo', 'features']);
+    });
+  });
 });

--- a/test/unit/utils.test.js
+++ b/test/unit/utils.test.js
@@ -17,7 +17,6 @@ import {
   getReqParams,
   getAggregatedElectronicResources,
   truncateStringOnWhitespace,
-  extractFeatures,
 } from '../../src/app/utils/utils';
 
 /**
@@ -669,30 +668,5 @@ describe('truncateStringOnWhitespace()', () => {
     const truncStr = truncateStringOnWhitespace('ThisIsAOneWordTitleWhichCouldExistOutThere', 25);
     expect(truncStr).to.equal('ThisIsAOneWordTitleWhi...');
     expect(truncStr.length).to.be.lessThan(26);
-  });
-});
-
-/**
- * extractFeatures()
- */
-describe(('extractFeatures'), () => {
-  it('handles non-string parameters', () => {
-    expect(extractFeatures()).to.deep.equal([]);
-    expect(extractFeatures(undefined)).to.deep.equal([]);
-    expect(extractFeatures(null)).to.deep.equal([]);
-    expect(extractFeatures(-1)).to.deep.equal([]);
-    expect(extractFeatures(Math.PI)).to.deep.equal([]);
-  });
-
-  it('handles malformed features String', () => {
-    expect(extractFeatures(',,dasdfksdjfdsf,,').length).to.deep.equal(1);
-  });
-
-  it('returns array of values', () => {
-    expect(extractFeatures('several,other,features')).to.deep.equal(['several', 'other', 'features']);
-  });
-
-  it('strips whitespace', () => {
-    expect(extractFeatures('several ,other  , foo  , features')).to.deep.equal(['several', 'other', 'foo', 'features']);
   });
 });


### PR DESCRIPTION
**What's this do?**
Refactors the way extracting features from `process.ENV.FEATURES` is handled to eliminate importing from the `utils` file. This seems to cause a circular dependency. This somehow relates to the "Submit" button not disappearing next to the "Sort by" drop down. Also, the perpetual `Uncaught TypeError: at is not a function` in the console is resolved with this change. 

**Did someone actually run this code to verify it works?**
PR author did. Fixes issues mentioned in description.