### PR TITLE
NO_REF- inquiry email text and mailto link only for unrequestable items

### DIFF
--- a/src/app/components/Item/ItemTableRow.jsx
+++ b/src/app/components/Item/ItemTableRow.jsx
@@ -48,7 +48,7 @@ class ItemTableRow extends React.Component {
       generalResearchEmail,
     } = AppConfigStore.getState();
     const onSiteEddEnabled = features.includes('on-site-edd');
-    if (item.holdingLocationCode && item.nonRecapNYPL && onSiteEddEnabled) {
+    if (item.holdingLocationCode && item.nonRecapNYPL && !item.requestable && onSiteEddEnabled) {
       if (generalResearchEmail && generalResearchEmail.length) {
         const emailText = `Inquiry about item ${item.id} ${item.callNumber}`;
         return ([

--- a/test/unit/ItemTableRow.test.js
+++ b/test/unit/ItemTableRow.test.js
@@ -193,29 +193,44 @@ describe('ItemTableRow', () => {
       });
     });
 
-    describe('Unrequestable NYPL item', () => {
-      const data = item.full;
-      // SASB location
-      data.holdingLocationCode = 'loc:mal82';
+    describe('with "on-site-edd" feature flag', () => {
       let component;
       let appConfigStoreStub;
       const generalResearchEmail = 'example@nypl.com';
-
       before(() => {
         appConfigStoreStub = stub(AppConfigStore, 'getState').returns({
           generalResearchEmail,
           features: ['on-site-edd'],
+          closedLocations: [],
         });
-        component = shallow(<ItemTableRow item={data} bibId="b12345" />);
       });
       after(() => {
         appConfigStoreStub.restore();
       });
 
-      it('should render `Email for access options` link in the fourth <td> column data', () => {
-        expect(component.find('td').find('a').length).to.equal(1);
-        expect(component.find('td').find('a').text()).to.equal(generalResearchEmail);
-        expect(component.find('td').find('a').props().href).to.include(generalResearchEmail);
+      describe('unrequestable NYPL item', () => {
+        before(() => {
+          const data = item.full;
+          data.holdingLocationCode = 'loc:mal82';
+          component = shallow(<ItemTableRow item={data} bibId="b12345" />);
+        });
+        it('should render `Email for access options` and mailto link in the fourth <td> column data', () => {
+          expect(component.find('td').find('a').length).to.equal(1);
+          expect(component.find('td').find('a').text()).to.equal(generalResearchEmail);
+          expect(component.find('td').find('a').props().href).to.include(generalResearchEmail);
+        });
+      });
+
+      describe('requestable NYPL item', () => {
+        before(() => {
+          const data = item.requestable_nonReCAP_NYPL;
+          data.holdingLocationCode = 'loc:mal82';
+          component = shallow(<ItemTableRow item={data} bibId="b12345" />);
+        });
+        it('should render `Email for access options` and mailto link in the fourth <td> column data', () => {
+          expect(component.find('td').find('div').length).to.equal(0);
+          expect(component.find('td').find('a').length).to.equal(0);
+        });
       });
     });
   });


### PR DESCRIPTION
**What's this do?**
Only render the text and mailto link for inquiring about an unrequestable item.

**Did someone actually run this code to verify it works?**
PR author did