### PR TITLE
Remove duplicate code causing EDD hold bug

### DIFF
--- a/src/app/components/ElectronicDelivery/ElectronicDeliveryForm.jsx
+++ b/src/app/components/ElectronicDelivery/ElectronicDeliveryForm.jsx
@@ -294,7 +294,6 @@ class ElectronicDeliveryForm extends React.Component {
 
         <input type="hidden" name="bibId" value={this.props.bibId} />
         <input type="hidden" name="itemId" value={this.props.itemId} />
-        <input type="hidden" name="pickupLocation" value="edd" />
         <input type="hidden" name="itemSource" value={this.props.itemSource} />
         <input
           type="hidden"

--- a/test/unit/ElectronicDelivery.test.js
+++ b/test/unit/ElectronicDelivery.test.js
@@ -1,0 +1,21 @@
+/* eslint-env mocha */
+/* eslint-disable react/jsx-filename-extension */
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+
+import ElectronicDeliveryForm from './../../src/app/components/ElectronicDelivery/ElectronicDeliveryForm';
+
+describe('ElectronicDeliveryForm', () => {
+  describe('default form', () => {
+    let component;
+    before(() => {
+      component = shallow(
+        <ElectronicDeliveryForm fromUrl="example.com" />,
+      );
+    });
+    it('should have `pickupLocation` set to `edd`', () => {
+      expect(component.find('input').findWhere(n => n.props().name === 'pickupLocation').length).to.equal(1);
+    });
+  });
+});


### PR DESCRIPTION
**What's this do?**
There was an extra hidden field for to set `pickupLocation` as `edd` on the EDD form. This was causing `pickupLocation` to equal `['edd', 'edd']`. This subsequently led to `docDeliveryData` being set to `null` and a malformed HoldRequest pickupLocation. This is failing silently right now. We get back a 400 response from HoldRequestService. Right now there is no proper error handling and we tell the user their hold was placed. This seems like a bigger issue and could use some product input. But for the time being, this is a small fix to unblock EDD holds from being place.

**Why are we doing this? (w/ JIRA link if applicable)**
Important bug fix. This bug was introduced from navigation refactor.

**How should this be tested? / Do these changes have associated tests?**
I added one test. Seems like this component could use more test coverage.

**Did someone actually run this code to verify it works?**
PR author did