### PR TITLE
Fix type of false to be string

### DIFF
--- a/src/server/ApiRoutes/Hold.js
+++ b/src/server/ApiRoutes/Hold.js
@@ -445,7 +445,7 @@ function eddServer(req, res) {
   let { fromUrl } = req.body;
   fromUrl = fromUrl ? `&fromUrl=${fromUrl}` : '';
 
-  res.respond = serverRedirect === false ? res.json : res.redirect;
+  res.respond = serverRedirect === 'false' ? res.json : res.redirect;
 
   const searchKeywordsQuery = (searchKeywords) ? `&q=${searchKeywords}` : '';
 


### PR DESCRIPTION
**What's this do?**
Fixes a bug with the edd request form, `false` should have been `'false'`

**Did someone actually run this code to verify it works?**
PR author tested locally.
