### PR TITLE
Fix bugs in destructureFilters

### DIFF
--- a/src/app/components/Filters/SelectedFilters.jsx
+++ b/src/app/components/Filters/SelectedFilters.jsx
@@ -74,7 +74,6 @@ class SelectedFilters extends React.Component {
       selectedFilters,
     } = this.props;
 
-
     if (_isEmpty(selectedFilters)) {
       return null;
     }
@@ -136,7 +135,6 @@ class SelectedFilters extends React.Component {
         }
       }
     });
-
 
     if (!filtersToRender.length && !datesToRender.length) {
       return null;

--- a/src/app/utils/dataLoaderUtil.js
+++ b/src/app/utils/dataLoaderUtil.js
@@ -73,7 +73,6 @@ const routesGenerator = location => ({
     apiRoute: (matchData, route) => route.replace(':bibId-:itemId', matchData[1]),
     serverParams: (matchData, req) => {
       const params = matchData[1].match(/\w+/g);
-      console.log('params: ', params[0], params[1]);
       if (params[0]) req.params.bibId = params[0];
       if (params[1]) req.params.itemId = params[1];
     },

--- a/src/app/utils/utils.js
+++ b/src/app/utils/utils.js
@@ -76,10 +76,7 @@ function destructureFilters(filters, apiFilters) {
       key.substring(8, key.length - 1) : key.substring(8, key.length - 4);
 
     if (id === 'dateAfter' || id === 'dateBefore') {
-      selectedFilters[id] = {
-        label: value,
-        value,
-      };
+      selectedFilters[id] = value;
     } else if (_isArray(value) && value.length) {
       if (!selectedFilters[id]) {
         selectedFilters[id] = [];
@@ -111,15 +108,7 @@ function destructureFilters(filters, apiFilters) {
         }
       }
     }
-    if (key.includes('filters[subjectLiteral]')) {
-      selectedFilters.subjectLiteral = selectedFilters.subjectLiteral || [];
-      selectedFilters.subjectLiteral.push({
-        value: value,
-        label: value,
-      })
-    }
   });
-
   return selectedFilters;
 }
 

--- a/test/unit/utils.test.js
+++ b/test/unit/utils.test.js
@@ -148,6 +148,30 @@ describe('createAppHistory', () => {
  * destructureFilters
  */
 describe('destructureFilters', () => {
+  const apiFilters = { '@context':
+   'http://discovery-api-qa.us-east-1.elasticbeanstalk.com/api/v0.1/discovery/context_all.jsonld',
+  '@type': 'itemList',
+  itemListElement:
+   [
+     { '@type': 'nypl:Aggregation',
+       '@id': 'res:subjectLiteral',
+       id: 'subjectLiteral',
+       field: 'subjectLiteral',
+       values: [
+         {
+           count: 130,
+           label: 'Animals -- Fiction.',
+           value: 'Animals -- Fiction.',
+         },
+         {
+           count: 89,
+           label: 'Awards.',
+           value: 'Awards.',
+         },
+       ],
+     },
+   ],
+  totalResults: 665 };
   describe('Default call', () => {
     it('should return an empty object', () => {
       const filters = destructureFilters();
@@ -155,12 +179,46 @@ describe('destructureFilters', () => {
     });
   });
 
-  // describe('No filters from the API', () => {
-  // it('should return an empty object', () => {
-  //   const filters = destructureFilters();
-  //   expect(filters).to.eql({});
-  // });
-  // });
+  describe('No filters from the API', () => {
+    it('should return an empty object for aggregations with no values', () => {
+      const filters = { 'filters[subjectLiteral][0]': 'Animals -- Fiction.', 'filters[subjectLiteral][1]': 'Awards.' };
+      expect(destructureFilters(filters, {})).to.eql({});
+    });
+  });
+
+  describe('Date filters', () => {
+    const filters = { 'filters[dateBefore]': '2000', 'filters[dateAfter]': '1900' };
+    const expectedReturnValue = { dateBefore: '2000', dateAfter: '1900' };
+    it('should return object with dateBefore and dateAfter when they are passed', () => {
+      expect(destructureFilters(filters, apiFilters)).to.eql(expectedReturnValue);
+    });
+  });
+
+  describe('Filters with value of type array', () => {
+    const filters = { 'filters[subjectLiteral][0]': ['Animals -- Fiction.', 'Awards.'] };
+    const expectedReturnValue = {
+      subjectLiteral: [
+        { value: 'Animals -- Fiction.', label: 'Animals -- Fiction.' },
+        { value: 'Awards.', label: 'Awards.' },
+      ],
+    };
+    it('should return value/label pairs in an array under the appropriate key', () => {
+      expect(destructureFilters(filters, apiFilters)).to.eql(expectedReturnValue);
+    });
+  });
+
+  describe('Filters with value of type string', () => {
+    const filters = { 'filters[subjectLiteral][0]': 'Animals -- Fiction.', 'filters[subjectLiteral][1]': 'Awards.' };
+    const expectedReturnValue = {
+      subjectLiteral: [
+        { value: 'Animals -- Fiction.', label: 'Animals -- Fiction.' },
+        { value: 'Awards.', label: 'Awards.' },
+      ],
+    };
+    it('should return value/label pairs in an array under the appropriate key', () => {
+      expect(destructureFilters(filters, apiFilters)).to.eql(expectedReturnValue);
+    });
+  });
 });
 
 /**


### PR DESCRIPTION
NOTE: It looks like this is actually a bug in production. Steps to reproduce: 1. Search for a term (e.g. dogs) 2. Add some dates (e.g. 1901 to 2000). 3. Click 'clear filters' 4. Press the back button. The dates do not appear. It looks like the existing methods for handling these filters were inconsistent, which is why we are now seeing a problem (i.e. the dataloader is now applying the wrong method, but consistently).

**What's this do?**
Fixes bugs in the selected filters. Currently we are seeing `subjectLiteral` filters more than once and `dateBefore|After` filters not at all. This branch fixes these issues by making some changes to the `destructureFilters` utility method:

- Change type of value for dateBefore and dateAfter to string
- Remove extra handling of subjectLiteral filters

It seems to fix the problem but I am not sure why we started having this problem. @EdwinGuzman can you weigh in on whether these changes make sense and/or if there are special cases we need to check?
 
**Why are we doing this? (w/ JIRA link if applicable)**
See above

**How should this be tested? / Do these changes have associated tests?**
Select some filters on a search results page. You should see date and subject literal filters displayed properly.

**Dependencies for merging? Releasing to production?**
[Description of any watchouts, dependencies, or issues we should be aware of goes here]

**Has the application documentation been updated for these changes?**

**Did someone actually run this code to verify it works?**
PR author tested locally.