### PR TITLE
Convert feedback form from Google Suite to Airtable

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -14,3 +14,5 @@ export SET INCLUDE_DRBB=true
 export SET INCLUDE_ON_SITE_EDD=false
 
 export SET GENERAL_RESEARCH_EMAIL=example@nypl.com
+export SET AIRTABLE_API_KEY=[secret]
+export SET FEEDBACK_FORM_URL=https://[fqdn airtable]/v0/[spreadsheet id]/Feedback

--- a/src/app/components/Application/Application.jsx
+++ b/src/app/components/Application/Application.jsx
@@ -26,6 +26,7 @@ class Application extends React.Component {
     };
     this.onChange = this.onChange.bind(this);
     this.shouldStoreUpdate = this.shouldStoreUpdate.bind(this);
+    this.submitFeedback = this.submitFeedback.bind(this);
   }
 
   getChildContext() {
@@ -71,6 +72,14 @@ class Application extends React.Component {
     this.setState({ data: Store.getState() });
   }
 
+  submitFeedback(callback, e) {
+    e.preventDefault();
+    const { pathname, hash, search } = this.context.router.location;
+    const currentURL = `${pathname}${hash}${search}`;
+
+    callback(currentURL);
+  }
+
   render() {
     const dataLocation = Object.assign(
       {},
@@ -98,7 +107,7 @@ class Application extends React.Component {
             {React.cloneElement(this.props.children, this.state.data)}
           </DataLoader>
           <Footer />
-          <Feedback location={this.props.location} />
+          <Feedback submit={this.submitFeedback} />
         </div>
       </DocumentTitle>
     );

--- a/src/app/components/Feedback/Feedback.jsx
+++ b/src/app/components/Feedback/Feedback.jsx
@@ -27,19 +27,20 @@ class Feedback extends React.Component {
       }, initialFields),
     };
 
+    this.commentText = React.createRef();
+
     this.onSubmitForm = this.onSubmitForm.bind(this);
     this.toggleForm = this.toggleForm.bind(this);
     this.deactivateForm = this.deactivateForm.bind(this);
   }
 
   onSubmitForm(e) {
+    e.preventDefault();
     const { fields } = this.state;
     if (!fields.Feedback && !fields.Feedback.length) {
       this.commentText.current.focus();
     } else {
-      e.preventDefault();
       this.postForm();
-
       this.setState({
         showForm: false,
         fields: Object.assign({ URL: this.currentURL }, initialFields),
@@ -93,6 +94,15 @@ class Feedback extends React.Component {
 
     return (
       <div className="feedback">
+        <button
+          className="feedback-button"
+          onClick={() => this.toggleForm()}
+          aria-haspopup="true"
+          aria-expanded={showForm}
+          aria-controls="feedback-menu"
+        >
+        Feedback
+        </button>
         <FocusTrap
           focusTrapOptions={{
             onDeactivate: this.deactivateForm,
@@ -100,15 +110,6 @@ class Feedback extends React.Component {
           }}
           active={showForm}
         >
-          <button
-            className="feedback-button"
-            onClick={() => this.toggleForm()}
-            aria-haspopup="true"
-            aria-expanded={showForm}
-            aria-controls="feedback-menu"
-          >
-            Feedback
-          </button>
           <div
             role="menu"
             className={`feedback-form-container${showForm ? ' active' : ''}`}
@@ -127,6 +128,7 @@ class Feedback extends React.Component {
                   id="feedback-textarea-comment"
                   name="Feedback"
                   value={fields.Feedback}
+                  ref={this.commentText}
                   rows="5"
                   aria-required="true"
                   tabIndex="0"

--- a/src/app/components/Feedback/Feedback.jsx
+++ b/src/app/components/Feedback/Feedback.jsx
@@ -32,6 +32,7 @@ class Feedback extends React.Component {
     this.onSubmitForm = this.onSubmitForm.bind(this);
     this.toggleForm = this.toggleForm.bind(this);
     this.deactivateForm = this.deactivateForm.bind(this);
+    this.handleInputChange = this.handleInputChange.bind(this);
   }
 
   onSubmitForm(e) {
@@ -117,7 +118,7 @@ class Feedback extends React.Component {
           >
             <form
               target="hidden_feedback_iframe"
-              onSubmit={e => this.onSubmitForm(e)}
+              onSubmit={this.onSubmitForm}
             >
               <div>
                 <label htmlFor="feedback-textarea-comment">
@@ -132,7 +133,7 @@ class Feedback extends React.Component {
                   rows="5"
                   aria-required="true"
                   tabIndex="0"
-                  onChange={e => this.handleInputChange(e)}
+                  onChange={this.handleInputChange}
                 />
               </div>
               <div>
@@ -142,7 +143,7 @@ class Feedback extends React.Component {
                   name="Email"
                   type="email"
                   value={fields.Email}
-                  onChange={e => this.handleInputChange(e)}
+                  onChange={this.handleInputChange}
                 />
               </div>
               <input

--- a/src/app/components/Feedback/Feedback.jsx
+++ b/src/app/components/Feedback/Feedback.jsx
@@ -35,10 +35,6 @@ class Feedback extends React.Component {
       this.commentText.current.focus();
     } else {
       this.postForm(url);
-      this.setState({
-        showForm: false,
-        fields: initialFields(),
-      });
       trackDiscovery('Feedback', 'Submit');
     }
   }
@@ -52,8 +48,13 @@ class Feedback extends React.Component {
       data: {
         fields,
       },
+    }).then(() => {
+      this.setState({
+        showForm: false,
+        fields: initialFields(),
       // eslint-disable-next-line no-alert
-    }).then(() => alert('Thank you, your feedback has been submitted.')).catch(console.error);
+      }, alert('Thank you, your feedback has been submitted.'));
+    }).catch(console.error);
   }
 
   toggleForm() {

--- a/src/app/components/Feedback/Feedback.jsx
+++ b/src/app/components/Feedback/Feedback.jsx
@@ -7,24 +7,18 @@ import axios from 'axios';
 import { trackDiscovery } from '../../utils/utils';
 import appConfig from '../../data/appConfig';
 
-const initialFields = {
+const initialFields = () => ({
   Email: '',
   Feedback: '',
-};
+});
 
 class Feedback extends React.Component {
   constructor(props) {
     super(props);
 
-    this.currentURL = (this.props.location.pathname +
-    this.props.location.hash +
-    this.props.location.search);
-
     this.state = {
       showForm: false,
-      fields: Object.assign({
-        URL: this.currentURL,
-      }, initialFields),
+      fields: initialFields(),
     };
 
     this.commentText = React.createRef();
@@ -35,23 +29,23 @@ class Feedback extends React.Component {
     this.handleInputChange = this.handleInputChange.bind(this);
   }
 
-  onSubmitForm(e) {
-    e.preventDefault();
+  onSubmitForm(url) {
     const { fields } = this.state;
     if (!fields.Feedback && !fields.Feedback.length) {
       this.commentText.current.focus();
     } else {
-      this.postForm();
+      this.postForm(url);
       this.setState({
         showForm: false,
-        fields: Object.assign({ URL: this.currentURL }, initialFields),
+        fields: initialFields(),
       });
       trackDiscovery('Feedback', 'Submit');
     }
   }
 
-  postForm() {
+  postForm(url) {
     const { fields } = this.state;
+    fields.URL = url;
     axios({
       method: 'POST',
       url: appConfig.feedbackFormUrl,
@@ -91,7 +85,7 @@ class Feedback extends React.Component {
       showForm,
       fields,
     } = this.state;
-    const currentURL = fields.URL;
+    const { submit } = this.props;
 
     return (
       <div className="feedback">
@@ -102,7 +96,7 @@ class Feedback extends React.Component {
           aria-expanded={showForm}
           aria-controls="feedback-menu"
         >
-        Feedback
+          Feedback
         </button>
         <FocusTrap
           focusTrapOptions={{
@@ -118,7 +112,7 @@ class Feedback extends React.Component {
           >
             <form
               target="hidden_feedback_iframe"
-              onSubmit={this.onSubmitForm}
+              onSubmit={e => submit(this.onSubmitForm, e)}
             >
               <div>
                 <label htmlFor="feedback-textarea-comment">
@@ -146,12 +140,6 @@ class Feedback extends React.Component {
                   onChange={this.handleInputChange}
                 />
               </div>
-              <input
-                id="feedback-input-url"
-                name="entry.1973652282"
-                value={currentURL}
-                type="hidden"
-              />
               <input name="fvv" value="1" type="hidden" />
 
               <button
@@ -173,7 +161,7 @@ class Feedback extends React.Component {
 }
 
 Feedback.propTypes = {
-  location: PropTypes.object,
+  submit: PropTypes.func,
 };
 
 export default Feedback;

--- a/src/app/components/Feedback/Feedback.jsx
+++ b/src/app/components/Feedback/Feedback.jsx
@@ -48,13 +48,9 @@ class Feedback extends React.Component {
     fields.URL = url;
     axios({
       method: 'POST',
-      url: appConfig.feedbackFormUrl,
+      url: `${appConfig.baseUrl}/api/feedback`,
       data: {
         fields,
-      },
-      headers: {
-        Authorization: `Bearer ${appConfig.airtableApiKey}`,
-        'Content-Type': 'application/json',
       },
       // eslint-disable-next-line no-alert
     }).then(() => alert('Thank you, your feedback has been submitted.')).catch(console.error);
@@ -144,7 +140,7 @@ class Feedback extends React.Component {
 
               <button
                 className={`cancel-button ${!showForm ? 'hidden' : ''}`}
-                onClick={e => this.closeForm(e)}
+                onClick={e => this.deactivateForm(e)}
                 aria-expanded={!showForm}
                 aria-controls="feedback-menu"
               >

--- a/src/app/data/appConfig.js
+++ b/src/app/data/appConfig.js
@@ -63,6 +63,8 @@ const appConfig = {
   features: extractFeatures(process.env.FEATURES),
   includeDrbb: /true/i.test(process.env.INCLUDE_DRBB),
   generalResearchEmail: process.env.GENERAL_RESEARCH_EMAIL,
+  airtableApiKey: process.env.AIRTABLE_API_KEY,
+  feedbackFormUrl: process.env.FEEDBACK_FORM_URL,
 };
 
 export default {

--- a/src/server/ApiRoutes/ApiRoutes.js
+++ b/src/server/ApiRoutes/ApiRoutes.js
@@ -3,6 +3,7 @@ import express from 'express';
 import User from './User';
 import Hold from './Hold';
 import Search from './Search';
+import Feedback from './Feedback';
 import appConfig from '../../app/data/appConfig';
 import SubjectHeading from './SubjectHeading';
 import SubjectHeadings from './SubjectHeadings';
@@ -45,15 +46,19 @@ router
 router
   .route(`${appConfig.baseUrl}/api/subjectHeading/:subjectLiteral/`)
   .get(SubjectHeading.bibsAjax);
+
 /**
  * This wildcard route proxies the following SHEP API routes:
  *  * /api/subjectHeadings/{UUID}/context => /api/v0.1/subject_headings/{UUID}/context
  *  * /api/subjectHeadings/{UUID}/bibs => /api/v0.1/subject_headings/{UUID}/bibs
  *  * /api/subjectHeadings/{UUID}/related => /api/v0.1/subject_headings/{UUID}/related
  */
-
 router
   .route(`${appConfig.baseUrl}/api/subjectHeadings*`)
   .get(SubjectHeadings.proxyRequest);
+
+router
+  .route(`${appConfig.baseUrl}/api/feedback*`)
+  .post(Feedback.post);
 
 export default router;

--- a/src/server/ApiRoutes/Feedback.js
+++ b/src/server/ApiRoutes/Feedback.js
@@ -1,0 +1,22 @@
+import axios from 'axios';
+
+import appConfig from '../../app/data/appConfig';
+
+export default {
+  post: (req, res) => {
+    if (!req.body) return res.json({ error: 'Malformed request' });
+    if (!req.body.fields) return res.json({ error: 'Request body missing `field` key' });
+    const { fields } = req.body;
+    return axios({
+      method: 'POST',
+      url: appConfig.feedbackFormUrl,
+      data: {
+        fields,
+      },
+      headers: {
+        Authorization: `Bearer ${appConfig.airtableApiKey}`,
+        'Content-Type': 'application/json',
+      },
+    }).then(postResp => res.json(postResp.data)).catch(error => res.json({ error }));
+  },
+};

--- a/src/server/ApiRoutes/Feedback.js
+++ b/src/server/ApiRoutes/Feedback.js
@@ -4,8 +4,9 @@ import appConfig from '../../app/data/appConfig';
 
 export default {
   post: (req, res) => {
-    if (!req.body) return res.json({ error: 'Malformed request' });
-    if (!req.body.fields) return res.json({ error: 'Request body missing `field` key' });
+    if (!req.body) return res.status(400).json({ error: 'Malformed request' });
+    if (!req.body.fields) return res.status(400).json({ error: 'Request body missing `field` key' });
+
     const { fields } = req.body;
     return axios({
       method: 'POST',
@@ -17,6 +18,8 @@ export default {
         Authorization: `Bearer ${appConfig.airtableApiKey}`,
         'Content-Type': 'application/json',
       },
-    }).then(postResp => res.json(postResp.data)).catch(error => res.json({ error }));
+    }).then((postResp) => {
+      return res.json(postResp.data);
+    }).catch(error => res.status(500).json({ error }));
   },
 };


### PR DESCRIPTION
**What's this do?**
Revamp to Feedback form.
This PR contains a switch from Google Suite to Airtable. I find Airtable's API is simpler and easier to work with. Also, this is closer to what DRB implemented.

There are a couple things going on with this particular bug and fixing it that made me frustrated with the Google Suite implementation. The bug here is mostly that `this.refs.commentText.value` was always returning false. Therefore, the submission never triggered the success alert and closing the form. PR #1431 fixes this bug with minimal other changes. I think this breaking change came out of the React upgrade. 

Currently, there is no error handling. If I post to the Google API url, but with a bad form ID, with the simple bug fix, the user is still told their submission was successful.
There is also this confusing output in the console: `Uncaught Could not establish connection. Receiving end does not exist.` on QA and Production. 

Feel free to debate this switch. I had completed all the work for this switch before Edwin had provided the urls to the feedback form and spreadsheet.

**Why are we doing this? (w/ JIRA link if applicable)**
Feedback appears to be broken, leading to users to submit of the same feedback multiple times and probably get annoyed.

**Did someone actually run this code to verify it works?**
PR author did