### PR TITLE
Scc 2200

### DIFF
--- a/src/app/actions/Actions.js
+++ b/src/app/actions/Actions.js
@@ -65,6 +65,10 @@ class Actions {
   updateDrbbResults(data) {
     return data;
   }
+
+  updateLastLoaded(data) {
+    return data;
+  }
 }
 
 export default alt.createActions(Actions);

--- a/src/app/components/Application/Application.jsx
+++ b/src/app/components/Application/Application.jsx
@@ -16,6 +16,7 @@ import {
 import { breakpoints } from '../../data/constants';
 import DataLoader from '../DataLoader/DataLoader';
 import Content from '../Content/Content';
+import LoadingLayer from '../LoadingLayer/LoadingLayer';
 
 class Application extends React.Component {
   constructor(props) {
@@ -72,6 +73,13 @@ class Application extends React.Component {
     this.setState({ data: Store.getState() });
   }
 
+  loadingLayerText() {
+    const pathname = this.context.router.location.pathname;
+    if (pathname.includes('search')) return 'Searching';
+    if (pathname.includes('request')) return 'Requesting';
+    return 'Loading';
+  }
+
   render() {
     const dataLocation = Object.assign(
       {},
@@ -95,13 +103,16 @@ class Application extends React.Component {
             location={this.context.router.location}
             next={Store.next}
             key={JSON.stringify(dataLocation)}
+          />
+          <LoadingLayer
+            status={Store.getState().isLoading}
+            title={this.loadingLayerText()}
+          />
+          <Content
+            location={this.context.router.location}
           >
-            <Content
-              location={this.context.router.location}
-            >
-              {React.cloneElement(this.props.children, this.state.data)}
-            </Content>
-          </DataLoader>
+            {React.cloneElement(this.props.children, this.state.data)}
+          </Content>
           <Footer />
           <Feedback location={this.props.location} />
         </div>

--- a/src/app/components/Application/Application.jsx
+++ b/src/app/components/Application/Application.jsx
@@ -75,8 +75,8 @@ class Application extends React.Component {
 
   loadingLayerText() {
     const pathname = this.context.router.location.pathname;
-    if (pathname.includes('search')) return 'Searching';
-    if (pathname.includes('request')) return 'Requesting';
+    if (pathname.includes('/search')) return 'Searching';
+    if (pathname.includes('/request')) return 'Requesting';
     return 'Loading';
   }
 
@@ -107,6 +107,7 @@ class Application extends React.Component {
           <LoadingLayer
             status={Store.getState().isLoading}
             title={this.loadingLayerText()}
+            key={this.loadingLayerText()}
           />
           <Content
             location={this.context.router.location}

--- a/src/app/components/Application/Application.jsx
+++ b/src/app/components/Application/Application.jsx
@@ -15,6 +15,7 @@ import {
 
 import { breakpoints } from '../../data/constants';
 import DataLoader from '../DataLoader/DataLoader';
+import Content from '../Content/Content';
 
 class Application extends React.Component {
   constructor(props) {
@@ -95,7 +96,11 @@ class Application extends React.Component {
             next={Store.next}
             key={JSON.stringify(dataLocation)}
           >
-            {React.cloneElement(this.props.children, this.state.data)}
+            <Content
+              location={this.context.router.location}
+            >
+              {React.cloneElement(this.props.children, this.state.data)}
+            </Content>
           </DataLoader>
           <Footer />
           <Feedback location={this.props.location} />

--- a/src/app/components/BibPage/BibPage.jsx
+++ b/src/app/components/BibPage/BibPage.jsx
@@ -132,10 +132,6 @@ const BibPage = (props) => {
   return (
     <DocumentTitle title="Item Details | Shared Collection Catalog | NYPL">
       <main className="main-page">
-        <LoadingLayer
-          status={ Store.getState().isLoading}
-          title="Searching"
-        />
         <div className="nypl-page-header">
           <div className="nypl-full-width-wrapper">
             <div className="nypl-row">

--- a/src/app/components/Content/Content.jsx
+++ b/src/app/components/Content/Content.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+class Content extends React.Component {
+  shouldComponentUpdate(nextProps) {
+    const {
+      location,
+      loaded,
+    } = nextProps;
+    console.log('Content: ', location, loaded, location === loaded);
+    return location === loaded;
+  }
+  render() {
+    return (
+      <React.Fragment>{this.props.children}</React.Fragment>
+    );
+  }
+}
+
+export default Content;

--- a/src/app/components/Content/Content.jsx
+++ b/src/app/components/Content/Content.jsx
@@ -6,7 +6,6 @@ class Content extends React.Component {
       location,
       loaded,
     } = nextProps;
-    console.log('Content: ', location, loaded, location === loaded);
     return location === loaded;
   }
   render() {

--- a/src/app/components/Content/Content.jsx
+++ b/src/app/components/Content/Content.jsx
@@ -1,13 +1,41 @@
 import React from 'react';
+import Store from '@Store';
 
 class Content extends React.Component {
-  shouldComponentUpdate(nextProps) {
+  constructor(props) {
+    super(props);
+    this.state = {
+      loaded: Store.getState().lastLoaded,
+    };
+    this.onChange = this.onChange.bind(this);
+  }
+
+  componentDidMount() {
+    Store.listen(this.onChange);
+  }
+
+  shouldComponentUpdate(nextProps, nextState) {
     const {
       location,
-      loaded,
     } = nextProps;
+
+    const {
+      loaded,
+    } = nextState;
+
     return location === loaded;
   }
+
+  componentWillUnmount() {
+    Store.unlisten(this.onChange);
+  }
+
+  onChange() {
+    this.setState({
+      loaded: Store.getState().lastLoaded,
+    });
+  }
+
   render() {
     return (
       <React.Fragment>{this.props.children}</React.Fragment>

--- a/src/app/components/DataLoader/DataLoader.jsx
+++ b/src/app/components/DataLoader/DataLoader.jsx
@@ -23,7 +23,6 @@ class DataLoader extends React.Component {
   }
 
   render() {
-    console.log('updated: ', this.state, 'location: ', this.props.location, this.props.location === this.state.loaded);
     return (
       <Content
         location={this.props.location}

--- a/src/app/components/DataLoader/DataLoader.jsx
+++ b/src/app/components/DataLoader/DataLoader.jsx
@@ -9,7 +9,7 @@ class DataLoader extends React.Component {
     const lastLoaded = Store.getState().lastLoaded;
     const { location } = this.props;
     const relevantFields = ['pathname', 'query', 'search'];
-    if (relevantFields.some(field =>
+    if (!lastLoaded || relevantFields.some(field =>
       JSON.stringify(lastLoaded[field]) !== JSON.stringify(location[field]))
     ) {
       dataLoaderUtil.loadDataForRoutes(location);

--- a/src/app/components/DataLoader/DataLoader.jsx
+++ b/src/app/components/DataLoader/DataLoader.jsx
@@ -2,34 +2,23 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import dataLoaderUtil from '@dataLoaderUtil';
 import Content from '../Content/Content';
+import Store from '../../stores/Store';
 
 class DataLoader extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      loaded: null,
-    };
-    this.updateState = this.updateState.bind(this);
-  }
-
   componentDidMount() {
-    dataLoaderUtil.loadDataForRoutes(this.props.location, null, null, null, this.updateState);
-  }
-
-  updateState(loaded) {
-    this.setState({
-      loaded,
-    });
+    const lastLoaded = Store.getState().lastLoaded;
+    const { location } = this.props;
+    const relevantFields = ['pathname', 'query', 'search'];
+    if (relevantFields.some(field =>
+      JSON.stringify(lastLoaded[field]) !== JSON.stringify(location[field]))
+    ) {
+      dataLoaderUtil.loadDataForRoutes(location);
+    }
   }
 
   render() {
     return (
-      <Content
-        location={this.props.location}
-        loaded={this.state.loaded}
-      >
-        <React.Fragment>{this.props.children}</React.Fragment>
-      </Content>
+      <React.Fragment>{this.props.children}</React.Fragment>
     );
   }
 }

--- a/src/app/components/DataLoader/DataLoader.jsx
+++ b/src/app/components/DataLoader/DataLoader.jsx
@@ -1,16 +1,36 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import dataLoaderUtil from '@dataLoaderUtil';
+import Content from '../Content/Content';
 
 class DataLoader extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      loaded: null,
+    };
+    this.updateState = this.updateState.bind(this);
+  }
 
   componentDidMount() {
-    dataLoaderUtil.loadDataForRoutes(this.props.location);
+    dataLoaderUtil.loadDataForRoutes(this.props.location, null, null, null, this.updateState);
+  }
+
+  updateState(loaded) {
+    this.setState({
+      loaded,
+    });
   }
 
   render() {
+    console.log('updated: ', this.state, 'location: ', this.props.location, this.props.location === this.state.loaded);
     return (
-      <React.Fragment>{this.props.children}</React.Fragment>
+      <Content
+        location={this.props.location}
+        loaded={this.state.loaded}
+      >
+        <React.Fragment>{this.props.children}</React.Fragment>
+      </Content>
     );
   }
 }

--- a/src/app/components/HoldRequest/HoldRequest.jsx
+++ b/src/app/components/HoldRequest/HoldRequest.jsx
@@ -65,7 +65,6 @@ class HoldRequest extends React.Component {
 
 
   componentDidMount() {
-    // this.requireUser();
     this.conditionallyRedirect();
     const title = document.getElementById('item-title');
     if (title) {
@@ -133,24 +132,6 @@ class HoldRequest extends React.Component {
           `${path}?errorMessage=${error}${searchKeywordsQueryPhysical}${fromUrlQuery}`,
         );
       });
-  }
-
-  /**
-   * requireUser()
-   * Redirects the patron to OAuth log in page if he/she hasn't been logged in yet.
-   *
-   * @return {Boolean}
-   */
-  requireUser() {
-    if (this.state.patron && this.state.patron.id) {
-      return true;
-    }
-
-    const fullUrl = encodeURIComponent(window.location.href);
-    console.log('Hold request: ', `${appConfig.loginUrl}?redirect_uri=${fullUrl}`);
-    window.location.replace(`${appConfig.loginUrl}?redirect_uri=${fullUrl}`);
-
-    return false;
   }
 
   /**

--- a/src/app/components/HoldRequest/HoldRequest.jsx
+++ b/src/app/components/HoldRequest/HoldRequest.jsx
@@ -339,10 +339,6 @@ class HoldRequest extends React.Component {
     return (
       <DocumentTitle title="Item Request | Shared Collection Catalog | NYPL">
         <div>
-          <LoadingLayer
-            status={Store.state.isLoading}
-            title="Requesting"
-          />
           <div className="nypl-request-page-header">
             <div className="nypl-full-width-wrapper">
               <div className="row">

--- a/src/app/components/HoldRequest/HoldRequest.jsx
+++ b/src/app/components/HoldRequest/HoldRequest.jsx
@@ -65,7 +65,7 @@ class HoldRequest extends React.Component {
 
 
   componentDidMount() {
-    this.requireUser();
+    // this.requireUser();
     this.conditionallyRedirect();
     const title = document.getElementById('item-title');
     if (title) {
@@ -147,6 +147,7 @@ class HoldRequest extends React.Component {
     }
 
     const fullUrl = encodeURIComponent(window.location.href);
+    console.log('Hold request: ', `${appConfig.loginUrl}?redirect_uri=${fullUrl}`);
     window.location.replace(`${appConfig.loginUrl}?redirect_uri=${fullUrl}`);
 
     return false;

--- a/src/app/components/SccContainer/SccContainer.jsx
+++ b/src/app/components/SccContainer/SccContainer.jsx
@@ -12,10 +12,6 @@ const SccContainer = (props) => {
   const { includeDrbb } = appConfig;
   return (
     <main className="main-page">
-      <LoadingLayer
-        status={Store.getState().isLoading}
-        title={props.loadingLayerText}
-      />
       <div className="nypl-page-header">
         <div className={`nypl-full-width-wrapper filter-page${includeDrbb ? ' drbb-integration' : ''}`}>
           <div className="nypl-row">

--- a/src/app/stores/Store.js
+++ b/src/app/stores/Store.js
@@ -21,6 +21,7 @@ class Store {
       updateIsEddRequestable: Actions.updateIsEddRequestable,
       updateSubjectHeading: Actions.updateSubjectHeading,
       updateDrbbResults: Actions.updateDrbbResults,
+      updateLastLoaded: Actions.updateLastLoaded,
     });
 
     this.state = {
@@ -45,6 +46,7 @@ class Store {
       isEddRequestable: false,
       subjectHeading: null,
       drbbResults: {},
+      lastLoaded: null,
     };
   }
 
@@ -112,6 +114,10 @@ class Store {
 
   updateDrbbResults(data) {
     this.setState({ drbbResults: data });
+  }
+
+  updateLastLoaded(data) {
+    this.setState({ lastLoaded: data });
   }
 }
 

--- a/src/app/utils/dataLoaderUtil.js
+++ b/src/app/utils/dataLoaderUtil.js
@@ -86,10 +86,11 @@ const routesGenerator = location => ({
     },
     actions: [
       (data) => {
-        console.dir(`new action data: ${data}`);
+        console.dir(`new action data: ${encodeURIComponent(data)}`);
         if (typeof data === 'string' && data.includes('redirect_uri')) {
           globalState.updateState = false;
-          window.location.replace(encodeURIComponent(data));
+          const fullUrl = encodeURIComponent(window.location.href);
+          window.location.replace(`${appConfig.loginUrl}?redirect_uri=${fullUrl}`);
         }
       },
       data => Actions.updateBib(data.bib),

--- a/src/app/utils/dataLoaderUtil.js
+++ b/src/app/utils/dataLoaderUtil.js
@@ -133,8 +133,10 @@ function loadDataForRoutes(location, req, routeMethods, realRes) {
     Actions.updateLoadingStatus(true);
     const successCb = (response) => {
       actions.forEach(action => action(response.data));
-      Actions.updateLoadingStatus(false);
-      if (globalState.updateState) Actions.updateLastLoaded(location);
+      if (globalState.updateState) {
+        Actions.updateLastLoaded(location);
+        Actions.updateLoadingStatus(false);
+      }
       globalState.updateState = true;
     };
     const errorCb = (error) => {

--- a/src/app/utils/dataLoaderUtil.js
+++ b/src/app/utils/dataLoaderUtil.js
@@ -115,7 +115,7 @@ const matchingPathData = (location) => {
     || { matchData: null, pathType: null };
 };
 
-function loadDataForRoutes(location, req, routeMethods, realRes, updateState) {
+function loadDataForRoutes(location, req, routeMethods, realRes) {
   const routes = routesGenerator(location);
   const {
     matchData,
@@ -134,12 +134,12 @@ function loadDataForRoutes(location, req, routeMethods, realRes, updateState) {
     const successCb = (response) => {
       actions.forEach(action => action(response.data));
       Actions.updateLoadingStatus(false);
-      if (updateState && globalState.updateState) updateState(location);
+      if (globalState.updateState) Actions.updateLastLoaded(location);
       globalState.updateState = true;
     };
     const errorCb = (error) => {
       Actions.updateLoadingStatus(false);
-      if (updateState) updateState(location);
+      Actions.updateLastLoaded(location);
       console.error(
         errorMessage,
         error,
@@ -161,6 +161,7 @@ function loadDataForRoutes(location, req, routeMethods, realRes, updateState) {
     }
     return ajaxCall(apiRoute(matchData, route), successCb, errorCb);
   }
+  Actions.updateLastLoaded(location);
 
   return new Promise(resolve => resolve());
 }

--- a/src/app/utils/dataLoaderUtil.js
+++ b/src/app/utils/dataLoaderUtil.js
@@ -86,7 +86,6 @@ const routesGenerator = location => ({
     },
     actions: [
       (data) => {
-        console.dir(`new action data: ${encodeURIComponent(data)}`);
         if (typeof data === 'string' && data.includes('redirect_uri')) {
           globalState.updateState = false;
           const fullUrl = encodeURIComponent(window.location.href);
@@ -160,7 +159,6 @@ function loadDataForRoutes(location, req, routeMethods, realRes, updateState) {
         .then(successCb)
         .catch(errorCb);
     }
-    console.log('apiRoute: ', apiRoute(matchData, route));
     return ajaxCall(apiRoute(matchData, route), successCb, errorCb);
   }
 

--- a/src/server/ApiRoutes/Hold.js
+++ b/src/server/ApiRoutes/Hold.js
@@ -464,7 +464,7 @@ function eddServer(req, res) {
   }
 
   // Ensure user is logged in
-  const loggedIn = User.requireUser(req);
+  const loggedIn = User.requireUser(req, res);
 
   if (!loggedIn) return false;
 

--- a/src/server/ApiRoutes/User.js
+++ b/src/server/ApiRoutes/User.js
@@ -2,20 +2,16 @@ import appConfig from '../../app/data/appConfig';
 import nyplApiClient from '../../server/routes/nyplApiClient';
 
 function requireUser(req, res) {
-  console.log('requireUser: ', req);
   res.respond = req.originalUrl.includes('clientRedirect') ? res.json : res.redirect;
   if (!req.patronTokenResponse || !req.patronTokenResponse.isTokenValid ||
     !req.patronTokenResponse.decodedPatron || !req.patronTokenResponse.decodedPatron.sub) {
     // redirect to login
     let fullUrl;
     if (!req.originalUrl.includes('clientRedirect')) {
-      console.log('require user if clause');
       fullUrl = encodeURIComponent(`${req.protocol}://${req.get('host')}${req.originalUrl}`);
     } else {
-      console.log('require user else clause ', req.query.clientRedirect);
       fullUrl = req.query.clientRedirect;
     }
-    console.log('user responding: ', `${appConfig.loginUrl}?redirect_uri=${fullUrl}`);
     res.respond(`${appConfig.loginUrl}?redirect_uri=${fullUrl}`);
     return false;
   }

--- a/src/server/ApiRoutes/User.js
+++ b/src/server/ApiRoutes/User.js
@@ -2,7 +2,7 @@ import appConfig from '../../app/data/appConfig';
 import nyplApiClient from '../../server/routes/nyplApiClient';
 
 function requireUser(req, res) {
-  const respond = req.originalUrl.includes('clientRedirect') ? res.json : res.redirect;
+  const respond = (req.originalUrl.includes('clientRedirect') ? res.json : res.redirect).bind(res);
   if (!req.patronTokenResponse || !req.patronTokenResponse.isTokenValid ||
     !req.patronTokenResponse.decodedPatron || !req.patronTokenResponse.decodedPatron.sub) {
     // redirect to login

--- a/src/server/ApiRoutes/User.js
+++ b/src/server/ApiRoutes/User.js
@@ -2,19 +2,28 @@ import appConfig from '../../app/data/appConfig';
 import nyplApiClient from '../../server/routes/nyplApiClient';
 
 function requireUser(req, res) {
+  console.log('requireUser: ', req);
+  res.respond = req.originalUrl.includes('clientRedirect') ? res.json : res.redirect;
   if (!req.patronTokenResponse || !req.patronTokenResponse.isTokenValid ||
     !req.patronTokenResponse.decodedPatron || !req.patronTokenResponse.decodedPatron.sub) {
     // redirect to login
-    const fullUrl = encodeURIComponent(`${req.protocol}://${req.get('host')}${req.originalUrl}`);
-    res.redirect(`${appConfig.loginUrl}?redirect_uri=${fullUrl}`);
+    let fullUrl;
+    if (!req.originalUrl.includes('clientRedirect')) {
+      console.log('require user if clause');
+      fullUrl = encodeURIComponent(`${req.protocol}://${req.get('host')}${req.originalUrl}`);
+    } else {
+      console.log('require user else clause ', req.query.clientRedirect);
+      fullUrl = req.query.clientRedirect;
+    }
+    console.log('user responding: ', `${appConfig.loginUrl}?redirect_uri=${fullUrl}`);
+    res.respond(`${appConfig.loginUrl}?redirect_uri=${fullUrl}`);
     return false;
   }
   return true;
 }
 
 function eligibility(req, res) {
-  if (!req.patronTokenResponse || !req.patronTokenResponse.decodedPatron
-     || !req.patronTokenResponse.decodedPatron.sub) {
+  if (!req.patronTokenResponse || !req.patronTokenResponse.decodedPatron || !req.patronTokenResponse.decodedPatron.sub) {
     res.send(JSON.stringify({ eligibility: true }));
   }
   const id = req.patronTokenResponse.decodedPatron.sub;

--- a/src/server/ApiRoutes/User.js
+++ b/src/server/ApiRoutes/User.js
@@ -2,7 +2,7 @@ import appConfig from '../../app/data/appConfig';
 import nyplApiClient from '../../server/routes/nyplApiClient';
 
 function requireUser(req, res) {
-  res.respond = req.originalUrl.includes('clientRedirect') ? res.json : res.redirect;
+  const respond = req.originalUrl.includes('clientRedirect') ? res.json : res.redirect;
   if (!req.patronTokenResponse || !req.patronTokenResponse.isTokenValid ||
     !req.patronTokenResponse.decodedPatron || !req.patronTokenResponse.decodedPatron.sub) {
     // redirect to login
@@ -12,7 +12,7 @@ function requireUser(req, res) {
     } else {
       fullUrl = req.query.clientRedirect;
     }
-    res.respond(`${appConfig.loginUrl}?redirect_uri=${fullUrl}`);
+    respond(`${appConfig.loginUrl}?redirect_uri=${fullUrl}`);
     return false;
   }
   return true;

--- a/test/unit/Content.test.js
+++ b/test/unit/Content.test.js
@@ -1,0 +1,37 @@
+/* eslint-env mocha */
+import React from 'react';
+import sinon from 'sinon';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+
+import Content from './../../src/app/components/Content/Content';
+
+describe('Content', () => {
+  let wrapper;
+  let children;
+  let shouldComponentUpdate;
+
+  before(() => {
+    children = (<div />);
+    wrapper = shallow(<Content>{children}</Content>);
+    shouldComponentUpdate = wrapper.instance().shouldComponentUpdate;
+  });
+
+  it('should render children', () => {
+    expect(wrapper.find('div')).to.have.lengthOf(1);
+  });
+
+  it('should not update if loaded prop doesn\'t match location', () => {
+    expect(shouldComponentUpdate({
+      location: 1,
+      loaded: 2,
+    })).to.equal(false);
+  });
+
+  it('should update when loaded prop matches location', () => {
+    expect(shouldComponentUpdate({
+      location: 1,
+      loaded: 1,
+    })).to.equal(true);
+  });
+});

--- a/test/unit/Content.test.js
+++ b/test/unit/Content.test.js
@@ -22,16 +22,14 @@ describe('Content', () => {
   });
 
   it('should not update if loaded prop doesn\'t match location', () => {
-    expect(shouldComponentUpdate({
-      location: 1,
-      loaded: 2,
-    })).to.equal(false);
+    expect(
+      shouldComponentUpdate({ location: 1 }, { lastLoaded: 2 }),
+    ).to.equal(false);
   });
 
   it('should update when loaded prop matches location', () => {
-    expect(shouldComponentUpdate({
-      location: 1,
-      loaded: 1,
-    })).to.equal(true);
+    expect(
+      shouldComponentUpdate({ location: 1 }, { loaded: 1 }),
+    ).to.equal(true);
   });
 });

--- a/test/unit/DataLoader.test.js
+++ b/test/unit/DataLoader.test.js
@@ -5,24 +5,59 @@ import { expect } from 'chai';
 import { shallow } from 'enzyme';
 
 import DataLoader from './../../src/app/components/DataLoader/DataLoader';
+import Content from './../../src/app/components/Content/Content';
 import dataLoaderUtil from '@dataLoaderUtil';
 
-describe('DataLoader', () => {
+describe.only('DataLoader', () => {
   let dataLoaderUtilSpy;
   const location = { pathname: '', search: '' };
   let wrapper;
+  let component;
   before(() => {
     const children = (<div />);
     dataLoaderUtilSpy = sinon.spy(dataLoaderUtil, 'loadDataForRoutes');
-    wrapper = shallow(<DataLoader location={location} children={children} />);
+    component = (<DataLoader location={location} children={children} />);
+    wrapper = shallow(component);
   });
   after(() => {
     dataLoaderUtilSpy.restore();
   });
+  it('should initialize loaded to null', () => {
+    expect(wrapper.state().loaded).to.equal(null);
+  })
   it('should call dataLoaderUtil with location', () => {
     expect(dataLoaderUtilSpy.calledWith(location)).to.equal(true);
   });
+  it('should call dataLoaderUtil with updateState', () => {
+    expect(dataLoaderUtilSpy.firstCall.args[4].name).to.equal('bound updateState');
+  });
   it('should render the children', () => {
     expect(wrapper.find('div')).to.have.lengthOf(1);
+  });
+  it('should render the content', () => {
+    expect(wrapper.find(Content)).to.have.lengthOf(1);
+  });
+  it('should pass the location prop to content', () => {
+    expect(wrapper.find(Content).props().location).to.equal(wrapper.props().location);
+  });
+  it('should pass the loaded slice of state to content', () => {
+    expect(wrapper.find(Content).props().loaded).to.equal(wrapper.state().loaded);
+  });
+  it('should pass the children to content', () => {
+    expect(wrapper.find(Content).props().children).to.equal(wrapper.props().children);
+  });
+
+  describe('updateState', () => {
+    let setStateSpy;
+    before(() => {
+      setStateSpy = sinon.spy(wrapper.instance(), 'setState');
+    });
+    after(() => {
+      setStateSpy.restore();
+    });
+    it('should call setState with input', () => {
+      wrapper.instance().updateState('fake');
+      expect(setStateSpy.firstCall.args).to.deep.equal([{ loaded: 'fake' }]);
+    });
   });
 });

--- a/test/unit/DataLoader.test.js
+++ b/test/unit/DataLoader.test.js
@@ -13,51 +13,23 @@ describe('DataLoader', () => {
   const location = { pathname: '', search: '' };
   let wrapper;
   let component;
+
   before(() => {
     const children = (<div />);
     dataLoaderUtilSpy = sinon.spy(dataLoaderUtil, 'loadDataForRoutes');
     component = (<DataLoader location={location} children={children} />);
     wrapper = shallow(component);
   });
+
   after(() => {
     dataLoaderUtilSpy.restore();
   });
-  it('should initialize loaded to null', () => {
-    expect(wrapper.state().loaded).to.equal(null);
-  })
+
   it('should call dataLoaderUtil with location', () => {
     expect(dataLoaderUtilSpy.calledWith(location)).to.equal(true);
   });
-  it('should call dataLoaderUtil with updateState', () => {
-    expect(dataLoaderUtilSpy.firstCall.args[4].name).to.equal('bound updateState');
-  });
+
   it('should render the children', () => {
     expect(wrapper.find('div')).to.have.lengthOf(1);
-  });
-  it('should render the content', () => {
-    expect(wrapper.find(Content)).to.have.lengthOf(1);
-  });
-  it('should pass the location prop to content', () => {
-    expect(wrapper.find(Content).props().location).to.equal(wrapper.props().location);
-  });
-  it('should pass the loaded slice of state to content', () => {
-    expect(wrapper.find(Content).props().loaded).to.equal(wrapper.state().loaded);
-  });
-  it('should pass the children to content', () => {
-    expect(wrapper.find(Content).props().children).to.equal(wrapper.props().children);
-  });
-
-  describe('updateState', () => {
-    let setStateSpy;
-    before(() => {
-      setStateSpy = sinon.spy(wrapper.instance(), 'setState');
-    });
-    after(() => {
-      setStateSpy.restore();
-    });
-    it('should call setState with input', () => {
-      wrapper.instance().updateState('fake');
-      expect(setStateSpy.firstCall.args).to.deep.equal([{ loaded: 'fake' }]);
-    });
   });
 });

--- a/test/unit/DataLoader.test.js
+++ b/test/unit/DataLoader.test.js
@@ -8,7 +8,7 @@ import DataLoader from './../../src/app/components/DataLoader/DataLoader';
 import Content from './../../src/app/components/Content/Content';
 import dataLoaderUtil from '@dataLoaderUtil';
 
-describe.only('DataLoader', () => {
+describe('DataLoader', () => {
   let dataLoaderUtilSpy;
   const location = { pathname: '', search: '' };
   let wrapper;

--- a/test/unit/HoldRequest.test.js
+++ b/test/unit/HoldRequest.test.js
@@ -109,49 +109,6 @@ describe('HoldRequest', () => {
     });
   });
 
-  describe('After being rendered, <HoldRequest>', () => {
-    let component;
-    let requireUser;
-
-    before(() => {
-      requireUser = sinon.spy(HoldRequest.prototype, 'requireUser');
-      component = mount(<HoldRequest />, { attachTo: document.body });
-      component.setState({ redirect: false });
-    });
-
-    after(() => {
-      requireUser.restore();
-      component.unmount();
-    });
-
-    // TODO: This should check the state and not that the function was called.
-    it('should check if the patron is logged in.', () => {
-      expect(requireUser.calledOnce).to.equal(true);
-    });
-  });
-
-  describe('If the patron is not logged in, <HoldRequest>', () => {
-    let component;
-    let requireUser;
-
-    before(() => {
-      Actions.updatePatronData({});
-      requireUser = sinon.spy(HoldRequest.prototype, 'requireUser');
-      component = mount(<HoldRequest />, { attachTo: document.body });
-      component.setState({ redirect: false });
-    });
-
-    after(() => {
-      requireUser.restore();
-      component.unmount();
-    });
-
-    it('should redirect the patron to OAuth log in page.', () => {
-      component.setState({ patron: {} });
-      expect(requireUser.returnValues[0]).to.equal(false);
-    });
-  });
-
   describe('If the patron is logged in and the App receives invalid item data, <HoldRequest>',
     () => {
       let component;

--- a/test/unit/User.test.js
+++ b/test/unit/User.test.js
@@ -145,7 +145,7 @@ describe('If requireUser receives all valid values from "req"', () => {
   });
 
   it('should return true', () => {
-    requireUser({ patronTokenResponse: mockPatronTokenResponse }, mockRes);
+    requireUser({ patronTokenResponse: mockPatronTokenResponse, originalUrl: '' }, mockRes);
 
     expect(requireUser.returnValues[0]).to.equal(true);
   });

--- a/test/unit/User.test.js
+++ b/test/unit/User.test.js
@@ -23,14 +23,25 @@ const renderMockReq = data => ({
   originalUrl: '/hold/request/b11995345-i14211097',
   patronTokenResponse: data,
 });
+
+const renderMockReqClient = data => ({
+  get: n => n,
+  protocol: 'http',
+  originalUrl: '/hold/request/b11995345-i14211097?clientRedirect=true',
+  patronTokenResponse: data,
+  query: { clientRedirect: true },
+});
+
 const mockRes = { redirect: () => {} };
 
 describe('If requireUser does not receive valid value from "req.patronTokenResponse"', () => {
   let requireUser;
+  let jsonArg;
 
   before(() => {
     requireUser = sinon.spy(User, 'requireUser');
     mockPatronTokenResponse = {};
+    mockRes.json = (arg) => { jsonArg = arg; };
   });
 
   after(() => {
@@ -55,15 +66,23 @@ describe('If requireUser does not receive valid value from "req.patronTokenRespo
 
     expect(requireUser.returnValues[0]).to.equal(false);
   });
+
+  it('should call res.json for client side redirect', () => {
+    requireUser(renderMockReqClient(mockPatronTokenResponse), mockRes);
+
+    expect(typeof jsonArg).to.equal('string');
+  });
 });
 
 describe('If requireUser does not receive valid value from "req.patronTokenResponse.isTokenValid"',
   () => {
     let requireUser;
+    let jsonArg;
 
     before(() => {
       requireUser = sinon.spy(User, 'requireUser');
       mockPatronTokenResponse.isTokenValid = false;
+      mockRes.json = (arg) => { jsonArg = arg; };
     });
 
     after(() => {
@@ -76,16 +95,24 @@ describe('If requireUser does not receive valid value from "req.patronTokenRespo
 
       expect(requireUser.returnValues[0]).to.equal(false);
     });
+
+    it('should call res.json for client side redirect', () => {
+      requireUser(renderMockReqClient(mockPatronTokenResponse), mockRes);
+
+      expect(typeof jsonArg).to.equal('string');
+    });
   },
 );
 
 describe('If requireUser does not receive valid value from "req.patronTokenResponse.decodedPatron"',
   () => {
     let requireUser;
+    let jsonArg;
 
     before(() => {
       requireUser = sinon.spy(User, 'requireUser');
       mockPatronTokenResponse.decodedPatron = undefined;
+      mockRes.json = (arg) => { jsonArg = arg; };
     });
 
     after(() => {
@@ -109,16 +136,24 @@ describe('If requireUser does not receive valid value from "req.patronTokenRespo
 
       expect(requireUser.returnValues[0]).to.equal(false);
     });
+
+    it('should call json for client side redirect', () => {
+      requireUser(renderMockReqClient(mockPatronTokenResponse), mockRes);
+
+      expect(typeof jsonArg).to.equal('string');
+    });
   },
 );
 
 describe('If requireUser does not receive valid value from "req.patronTokenResponse.' +
   'decodedPatron.sub"', () => {
   let requireUser;
+  let jsonArg;
 
   before(() => {
     requireUser = sinon.spy(User, 'requireUser');
     mockPatronTokenResponse.decodedPatron.sub = undefined;
+    mockRes.json = (arg) => { jsonArg = arg; };
   });
 
   after(() => {
@@ -130,6 +165,12 @@ describe('If requireUser does not receive valid value from "req.patronTokenRespo
     requireUser(renderMockReq(mockPatronTokenResponse), mockRes);
 
     expect(requireUser.returnValues[0]).to.equal(false);
+  });
+
+  it('should call json in case of client side redirect', () => {
+    requireUser(renderMockReqClient(mockPatronTokenResponse), mockRes);
+
+    expect(typeof jsonArg).to.equal('string');
   });
 });
 

--- a/test/unit/dataLoaderUtil.test.js
+++ b/test/unit/dataLoaderUtil.test.js
@@ -18,6 +18,7 @@ describe('dataLoaderUtil', () => {
       let sandbox;
       let mockRouteMethods;
       let mockReq = [];
+      let location;
       before(() => {
         sandbox = sinon.createSandbox();
         axiosSpy = sandbox.spy(axios, 'get');
@@ -26,13 +27,13 @@ describe('dataLoaderUtil', () => {
           search: sandbox.spy(),
           hold: sandbox.spy(),
         };
-        actionsSpy = [];
+        actionsSpy = {};
         Object.keys(Actions).forEach((key) => {
           if (typeof Actions[key] === 'function') {
-            actionsSpy.push(sandbox.spy(Actions, key));
+            actionsSpy[key] = sandbox.spy(Actions, key);
           }
         });
-        const location = {
+        location = {
           pathname: '',
           search: '',
         };
@@ -41,7 +42,7 @@ describe('dataLoaderUtil', () => {
       after(() => {
         sandbox.restore();
       });
-      it('should not call any function', () => {
+      it('should not call any function except to update last loaded', () => {
         const {
           bib,
           search,
@@ -51,9 +52,15 @@ describe('dataLoaderUtil', () => {
         expect(bib.getCalls()).to.have.lengthOf(0);
         expect(search.getCalls()).to.have.lengthOf(0);
         expect(hold.getCalls()).to.have.lengthOf(0);
-        actionsSpy.forEach((spy) => {
-          expect(spy.getCalls()).to.have.lengthOf(0);
+        Object.keys(actionsSpy).forEach((key) => {
+          expect(actionsSpy[key].getCalls()).to.have.lengthOf(key === 'updateLastLoaded' ? 1 : 0);
         });
+      });
+
+      it('should update last loaded with the location', () => {
+        expect(actionsSpy.updateLastLoaded.getCalls()).to.have.lengthOf(1);
+        expect(actionsSpy.updateLastLoaded.getCalls()[0].args).to.have.lengthOf(1);
+        expect(actionsSpy.updateLastLoaded.getCalls()[0].args[0]).to.equal(location);
       });
     });
     describe('bib path', () => {
@@ -64,6 +71,7 @@ describe('dataLoaderUtil', () => {
       let sandbox;
       let axiosSpy;
       let mockReq;
+      let location;
       before(() => {
         bibResponse = [];
         mockRouteMethods = {
@@ -80,7 +88,7 @@ describe('dataLoaderUtil', () => {
             actionsSpy[key] = sandbox.spy(Actions, key);
           }
         });
-        const location = {
+        location = {
           pathname: '/research/collections/shared-collection-catalog/bib/b000000',
           search: '',
         };
@@ -112,9 +120,14 @@ describe('dataLoaderUtil', () => {
           ),
         ).to.equal(true);
       });
+      it('should update last loaded', () => {
+        expect(actionsSpy.updateLastLoaded.getCalls()).to.have.lengthOf(1);
+        expect(actionsSpy.updateLastLoaded.getCalls()[0].args).to.have.lengthOf(1);
+        expect(actionsSpy.updateLastLoaded.getCalls()[0].args[0]).to.equal(location);
+      });
       it('should not update any other field in the Store', () => {
         Object.keys(actionsSpy).forEach((key) => {
-          if (key !== 'updateBib' && key !== 'updateLoadingStatus') {
+          if (key !== 'updateBib' && key !== 'updateLoadingStatus' && key !== 'updateLastLoaded') {
             expect(actionsSpy[key].getCalls()).to.have.lengthOf(0);
           }
         });
@@ -239,6 +252,11 @@ describe('dataLoaderUtil', () => {
           ),
         ).to.equal(true);
       });
+      it('should update last loaded', () => {
+        expect(actionsSpy.updateLastLoaded.getCalls()).to.have.lengthOf(1);
+        expect(actionsSpy.updateLastLoaded.getCalls()[0].args).to.have.lengthOf(1);
+        expect(actionsSpy.updateLastLoaded.getCalls()[0].args[0]).to.equal(location);
+      });
       it('should not update any other fields in the Store', () => {
         Object.keys(actionsSpy).forEach((key) => {
           if (![
@@ -249,6 +267,7 @@ describe('dataLoaderUtil', () => {
             'updateSearchResults',
             'updateSelectedFilters',
             'updateSortBy',
+            'updateLastLoaded',
           ]
             .includes(key)) {
             expect(actionsSpy[key].getCalls()).to.have.lengthOf(0);
@@ -334,6 +353,11 @@ describe('dataLoaderUtil', () => {
           ),
         ).to.equal(true);
       });
+      it('should update last loaded', () => {
+        expect(actionsSpy.updateLastLoaded.getCalls()).to.have.lengthOf(1);
+        expect(actionsSpy.updateLastLoaded.getCalls()[0].args).to.have.lengthOf(1);
+        expect(actionsSpy.updateLastLoaded.getCalls()[0].args[0]).to.equal(location);
+      });
       it('should not update any other fields', () => {
         Object.keys(actionsSpy).forEach((key) => {
           if (![
@@ -341,6 +365,7 @@ describe('dataLoaderUtil', () => {
             'updateIsEddRequestable',
             'updateBib',
             'updateDeliveryLocations',
+            'updateLastLoaded',
           ]
             .includes(key)) {
             expect(actionsSpy[key].getCalls()).to.have.lengthOf(0);
@@ -354,16 +379,17 @@ describe('dataLoaderUtil', () => {
       let axiosSpy;
       let actionsSpy;
       let sandbox;
+      let location;
       before(() => {
         sandbox = sinon.createSandbox();
         axiosSpy = sandbox.spy(axios, 'get');
         actionsSpy = [];
         Object.keys(Actions).forEach((key) => {
           if (typeof Actions[key] === 'function') {
-            actionsSpy.push(sandbox.spy(Actions, key));
+            actionsSpy[key] = sandbox.spy(Actions, key);
           }
         });
-        const location = {
+        location = {
           pathname: '',
           search: '',
         };
@@ -372,11 +398,17 @@ describe('dataLoaderUtil', () => {
       after(() => {
         sandbox.restore();
       });
-      it('should not call any function', () => {
+      it('should not call any function except to update last loaded', () => {
         expect(axiosSpy.getCalls()).to.have.lengthOf(0);
-        actionsSpy.forEach((spy) => {
-          expect(spy.getCalls()).to.have.lengthOf(0);
+        Object.keys(actionsSpy).forEach((key) => {
+          const spy = actionsSpy[key];
+          expect(spy.getCalls()).to.have.lengthOf(key === 'updateLastLoaded' ? 1 : 0);
         });
+      });
+      it('should update last loaded', () => {
+        expect(actionsSpy.updateLastLoaded.getCalls()).to.have.lengthOf(1);
+        expect(actionsSpy.updateLastLoaded.getCalls()[0].args).to.have.lengthOf(1);
+        expect(actionsSpy.updateLastLoaded.getCalls()[0].args[0]).to.equal(location);
       });
     });
     describe('bib path', () => {
@@ -386,6 +418,7 @@ describe('dataLoaderUtil', () => {
         let bibResponse;
         let actionsSpy;
         let sandbox;
+        let location;
         before(() => {
           bibResponse = [];
           mock = new MockAdapter(axios);
@@ -400,7 +433,7 @@ describe('dataLoaderUtil', () => {
               actionsSpy[key] = sandbox.spy(Actions, key);
             }
           });
-          const location = {
+          location = {
             pathname: '/research/collections/shared-collection-catalog/bib/b000000',
             search: '',
           };
@@ -427,12 +460,18 @@ describe('dataLoaderUtil', () => {
           expect(actionsSpy.updateLoadingStatus.secondCall.args).to.have.lengthOf(1);
           expect(actionsSpy.updateLoadingStatus.secondCall.args[0]).to.equal(false);
         });
+        it('should update last loaded', () => {
+          expect(actionsSpy.updateLastLoaded.getCalls()).to.have.lengthOf(1);
+          expect(actionsSpy.updateLastLoaded.getCalls()[0].args).to.have.lengthOf(1);
+          expect(actionsSpy.updateLastLoaded.getCalls()[0].args[0]).to.equal(location);
+        });
         it('should make no other updates to the Store', () => {
           expect(actionsSpy.updateLoadingStatus.calledTwice).to.equal(true);
           Object.keys(actionsSpy).forEach((key) => {
             if (![
               'updateLoadingStatus',
               'updateBib',
+              'updateLastLoaded',
             ]
               .includes(key)) {
               expect(actionsSpy[key].getCalls()).to.have.lengthOf(0);
@@ -447,6 +486,7 @@ describe('dataLoaderUtil', () => {
         let actionsSpy;
         let sandbox;
         let consoleSpy;
+        let location;
         before(() => {
           bibResponse = [];
           mock = new MockAdapter(axios);
@@ -462,7 +502,7 @@ describe('dataLoaderUtil', () => {
               actionsSpy[key] = sandbox.spy(Actions, key);
             }
           });
-          const location = {
+          location = {
             pathname: '/research/collections/shared-collection-catalog/bib/b000000',
             search: '',
           };
@@ -492,11 +532,17 @@ describe('dataLoaderUtil', () => {
           expect(actionsSpy.updateLoadingStatus.secondCall.args).to.have.lengthOf(1);
           expect(actionsSpy.updateLoadingStatus.secondCall.args[0]).to.equal(false);
         });
+        it('should update last loaded', () => {
+          expect(actionsSpy.updateLastLoaded.getCalls()).to.have.lengthOf(1);
+          expect(actionsSpy.updateLastLoaded.getCalls()[0].args).to.have.lengthOf(1);
+          expect(actionsSpy.updateLastLoaded.getCalls()[0].args[0]).to.equal(location);
+        });
         it('should make no other updates', () => {
           expect(actionsSpy.updateLoadingStatus.calledTwice).to.equal(true);
           Object.keys(actionsSpy).forEach((key) => {
             if (![
               'updateLoadingStatus',
+              'updateLastLoaded',
             ]
               .includes(key)) {
               expect(actionsSpy[key].getCalls()).to.have.lengthOf(0);
@@ -613,6 +659,11 @@ describe('dataLoaderUtil', () => {
           expect(actionsSpy.updateLoadingStatus.secondCall.args).to.have.lengthOf(1);
           expect(actionsSpy.updateLoadingStatus.secondCall.args[0]).to.equal(false);
         });
+        it('should update last loaded', () => {
+          expect(actionsSpy.updateLastLoaded.getCalls()).to.have.lengthOf(1);
+          expect(actionsSpy.updateLastLoaded.getCalls()[0].args).to.have.lengthOf(1);
+          expect(actionsSpy.updateLastLoaded.getCalls()[0].args[0]).to.equal(location);
+        });
         it('should make no other updates to the Store', () => {
           expect(actionsSpy.updateLoadingStatus.calledTwice).to.equal(true);
           Object.keys(actionsSpy).forEach((key) => {
@@ -624,6 +675,7 @@ describe('dataLoaderUtil', () => {
               'updateSearchResults',
               'updateSelectedFilters',
               'updateSortBy',
+              'updateLastLoaded',
             ]
               .includes(key)) {
               expect(actionsSpy[key].getCalls()).to.have.lengthOf(0);
@@ -691,11 +743,17 @@ describe('dataLoaderUtil', () => {
           expect(actionsSpy.updateLoadingStatus.secondCall.args).to.have.lengthOf(1);
           expect(actionsSpy.updateLoadingStatus.secondCall.args[0]).to.equal(false);
         });
+        it('should update last loaded', () => {
+          expect(actionsSpy.updateLastLoaded.getCalls()).to.have.lengthOf(1);
+          expect(actionsSpy.updateLastLoaded.getCalls()[0].args).to.have.lengthOf(1);
+          expect(actionsSpy.updateLastLoaded.getCalls()[0].args[0]).to.equal(location);
+        });
         it('should make no other updates', () => {
           expect(actionsSpy.updateLoadingStatus.calledTwice).to.equal(true);
           Object.keys(actionsSpy).forEach((key) => {
             if (![
               'updateLoadingStatus',
+              'updateLastLoaded',
             ]
               .includes(key)) {
               expect(actionsSpy[key].getCalls()).to.have.lengthOf(0);
@@ -778,6 +836,11 @@ describe('dataLoaderUtil', () => {
           expect(actionsSpy.updateLoadingStatus.secondCall.args).to.have.lengthOf(1);
           expect(actionsSpy.updateLoadingStatus.secondCall.args[0]).to.equal(false);
         });
+        it('should update last loaded', () => {
+          expect(actionsSpy.updateLastLoaded.getCalls()).to.have.lengthOf(1);
+          expect(actionsSpy.updateLastLoaded.getCalls()[0].args).to.have.lengthOf(1);
+          expect(actionsSpy.updateLastLoaded.getCalls()[0].args[0]).to.equal(location);
+        });
         it('should make no other updates', () => {
           expect(actionsSpy.updateLoadingStatus.calledTwice).to.equal(true);
           Object.keys(actionsSpy).forEach((key) => {
@@ -786,11 +849,52 @@ describe('dataLoaderUtil', () => {
               'updateDeliveryLocations',
               'updateIsEddRequestable',
               'updateBib',
+              'updateLastLoaded',
             ]
               .includes(key)) {
               expect(actionsSpy[key].getCalls()).to.have.lengthOf(0);
             }
           });
+        });
+      });
+      describe('successful call with redirect', () => {
+        let mock;
+        let holdRequestResponse;
+        let actionsSpy;
+        let sandbox;
+        let location;
+        let replaceSpy;
+        before(() => {
+          global.savedWindow = global.window;
+          global.window = { location: { href: ' fakefakefake', replace: () => {} } };
+          holdRequestResponse = 'redirect_uri';
+          mock = new MockAdapter(axios);
+          mock
+            .onGet(/.*/)
+            .reply(200, holdRequestResponse);
+          sandbox = sinon.createSandbox();
+          replaceSpy = sandbox.spy(global.window.location, 'replace');
+          actionsSpy = {};
+          Object.keys(Actions).forEach((key) => {
+            if (typeof Actions[key] === 'function') {
+              actionsSpy[key] = sandbox.spy(Actions, key);
+            }
+          });
+          location = {
+            pathname: '/research/collections/shared-collection-catalog/hold/request/b1000-i1000',
+            search: '',
+          };
+          dataLoaderUtil.loadDataForRoutes(location);
+        });
+        after(() => {
+          global.window = global.savedWindow;
+          sandbox.restore();
+        });
+        it('should redirect', () => {
+          expect(replaceSpy.calledOnce).to.equal(true);
+        });
+        it('should not update last loaded', () => {
+          expect(actionsSpy.updateLastLoaded.notCalled).to.equal(true);
         });
       });
       describe('unsuccessful call', () => {
@@ -853,11 +957,17 @@ describe('dataLoaderUtil', () => {
           expect(actionsSpy.updateLoadingStatus.secondCall.args).to.have.lengthOf(1);
           expect(actionsSpy.updateLoadingStatus.secondCall.args[0]).to.equal(false);
         });
+        it('should update last loaded', () => {
+          expect(actionsSpy.updateLastLoaded.getCalls()).to.have.lengthOf(1);
+          expect(actionsSpy.updateLastLoaded.getCalls()[0].args).to.have.lengthOf(1);
+          expect(actionsSpy.updateLastLoaded.getCalls()[0].args[0]).to.equal(location);
+        });
         it('should make no other updates', () => {
           expect(actionsSpy.updateLoadingStatus.calledTwice).to.equal(true);
           Object.keys(actionsSpy).forEach((key) => {
             if (![
               'updateLoadingStatus',
+              'updateLastLoaded',
             ]
               .includes(key)) {
               expect(actionsSpy[key].getCalls()).to.have.lengthOf(0);

--- a/test/unit/dataLoaderUtil.test.js
+++ b/test/unit/dataLoaderUtil.test.js
@@ -713,6 +713,8 @@ describe('dataLoaderUtil', () => {
         let sandbox;
         let location;
         before(() => {
+          global.savedWindow = global.window;
+          global.window = { location: { href: ' fakefakefake' } };
           holdRequestResponse = {
             bib: [],
             deliveryLocations: [],
@@ -737,12 +739,13 @@ describe('dataLoaderUtil', () => {
           dataLoaderUtil.loadDataForRoutes(location);
         });
         after(() => {
+          global.window = global.savedWindow;
           sandbox.restore();
         });
         it('should make api call to /api/hold/request with the correct parameters', () => {
           expect(axiosSpy.calledOnce).to.equal(true);
           expect(axiosSpy.firstCall.args).to.have.lengthOf(1);
-          expect(axiosSpy.firstCall.args[0]).to.equal('/research/collections/shared-collection-catalog/api/hold/request/b1000-i1000');
+          expect(axiosSpy.firstCall.args[0]).to.equal('/research/collections/shared-collection-catalog/api/hold/request/b1000-i1000?clientRedirect=%20fakefakefake');
         });
         it('should update bib in the Store', () => {
           expect(actionsSpy.updateBib.calledOnce).to.equal(true);
@@ -799,6 +802,8 @@ describe('dataLoaderUtil', () => {
         let location;
         let consoleSpy;
         before(() => {
+          global.savedWindow = global.window;
+          global.window = { location: { href: ' fakefakefake' } };
           holdRequestResponse = {
             bib: [],
             deliveryLocations: [],
@@ -824,12 +829,13 @@ describe('dataLoaderUtil', () => {
           dataLoaderUtil.loadDataForRoutes(location);
         });
         after(() => {
+          global.window = global.savedWindow;
           sandbox.restore();
         });
         it('should make api call to /api/hold/request with the correct parameters', () => {
           expect(axiosSpy.calledOnce).to.equal(true);
           expect(axiosSpy.firstCall.args).to.have.lengthOf(1);
-          expect(axiosSpy.firstCall.args[0]).to.equal('/research/collections/shared-collection-catalog/api/hold/request/b1000-i1000');
+          expect(axiosSpy.firstCall.args[0]).to.equal('/research/collections/shared-collection-catalog/api/hold/request/b1000-i1000?clientRedirect=%20fakefakefake');
         });
         it('should log an error', () => {
           expect(consoleSpy.calledOnce).to.equal(true);


### PR DESCRIPTION
**What's this do?**
- Adds a `Content` component which blocks the content from updating until the `DataLoader` is finished loading data
- Moves the authorization redirect from the `HoldRequest` component to `dataLoaderUtil`. Previously, when an unauthorized user tried to navigate to a `HoldRequest` page, this would trigger an api call, which would error. The current version changes the api to respond with a message to redirect, instead of an error. Since the api call now returns a message to redirect, the `dataLoaderUtil` can handle the redirect, and an extra redirect in the `HoldRequest` component is not necessary.  
- Changes `requireUser` so that it only redirects in case of server-side rendering. Otherwise, it responds with a url to redirect to.
- adds a `lastLoaded` field to the `Store` so that we don't see an extra loading layer on the first page load (this is caused by the `dataLoader` being triggered client-side after it has already run server-side. This is an issue for e.g. redirects back to the `HoldRequest` page)

**What's this NOT do?**
There is still an issue of incorrect or incomplete information being displayed below the loading layer. It is not clear if this matters to us. If so, there are a couple of different ways to solve that issue. This PR is set up to facilitate the following further refactor, which would solve that issue:

- Move the `Content` component out of the `DataLoader`
- Move the loading layers for various components outside of `Content`

These two steps would allow the loading layer for a page to display while the data is loading, but before the component is displayed.

Alternatively, each component could have a default view for while it is loading.
 Because we need to decide whether this issue matters and if so, what approach we want, I think this should be a separate ticket.

**Why are we doing this? (w/ JIRA link if applicable)**
Right now we have confusing behavior where there can be a lag between navigating to a page and either being redirected or the data being loaded. In the meantime, users can be shown incorrect information. The current PR fixes this by 1. Moving redirect behavior out of `componentDidMount`, 2. adding a `shouldComponentUpdate` that can pause loading the next page until the right data is available.

**How should this be tested? / Do these changes have associated tests?**
Navigate to a hold request page. If you are not logged in, you should be immediately redirected to the auth page, and then redirected back to the correct hold request page. If you are logged in, you should be immediately shown the correct information. There should be no flash of incorrect information in either case.

**Dependencies for merging? Releasing to production?**
NA

**Has the application documentation been updated for these changes?**
NA

**Did someone actually run this code to verify it works?**
PR author tested locally.
