### PR TITLE
Add minimal changes to loading process in HoldRequestPage

### DIFF
--- a/src/app/actions/Actions.js
+++ b/src/app/actions/Actions.js
@@ -65,6 +65,10 @@ class Actions {
   updateDrbbResults(data) {
     return data;
   }
+
+  updateLastLoaded(data) {
+    return data;
+  }
 }
 
 export default alt.createActions(Actions);

--- a/src/app/components/HoldRequest/HoldRequest.jsx
+++ b/src/app/components/HoldRequest/HoldRequest.jsx
@@ -365,13 +365,18 @@ class HoldRequest extends React.Component {
 
     const searchUrl = basicQuery(this.props)({});
 
+    if (this.state.isLoading) {
+      return (
+        <LoadingLayer
+          status={this.state.isLoading}
+          title="Requesting"
+        />
+      );
+    }
+
     return (
       <DocumentTitle title="Item Request | Shared Collection Catalog | NYPL">
         <div>
-          <LoadingLayer
-            status={this.state.isLoading}
-            title="Requesting"
-          />
           <div className="nypl-request-page-header">
             <div className="nypl-full-width-wrapper">
               <div className="row">

--- a/src/app/components/HoldRequest/HoldRequest.jsx
+++ b/src/app/components/HoldRequest/HoldRequest.jsx
@@ -53,7 +53,7 @@ class HoldRequest extends React.Component {
       delivery: defaultDelivery,
       checkedLocNum,
       serverRedirect: true,
-      isLoading: !Store.getState().lastLoaded.pathname.includes('hold'),
+      isLoading: this.isLoading(),
     }, { patron: PatronStore.getState() });
 
     // change all the components :(
@@ -62,6 +62,8 @@ class HoldRequest extends React.Component {
     this.submitRequest = this.submitRequest.bind(this);
     this.checkEligibility = this.checkEligibility.bind(this);
     this.conditionallyRedirect = this.conditionallyRedirect.bind(this);
+    this.isLoading = this.isLoading.bind(this);
+    this.requireUser = this.requireUser.bind(this);
   }
 
 
@@ -74,7 +76,6 @@ class HoldRequest extends React.Component {
       title.focus();
     }
     if (this.state.serverRedirect) this.setState({ serverRedirect: false });
-    this.timeoutId = setTimeout(() => { Actions.updateLoadingStatus(false); }, 5000);
   }
 
   componentWillUnmount() {
@@ -82,7 +83,7 @@ class HoldRequest extends React.Component {
   }
 
   onChange() {
-    this.setState({ patron: PatronStore.getState(), isLoading: !Store.getState().lastLoaded.pathname.includes('hold') });
+    this.setState({ patron: PatronStore.getState(), isLoading: this.isLoading() });
   }
 
   onRadioSelect(e, i) {
@@ -91,6 +92,11 @@ class HoldRequest extends React.Component {
       delivery: e.target.value,
       checkedLocNum: i,
     });
+  }
+
+  isLoading() {
+    const patron = PatronStore.getState();
+    return !patron || !patron.id || !Store.getState().lastLoaded.pathname.includes(this.props.location.pathname);
   }
 
   /**
@@ -181,7 +187,6 @@ class HoldRequest extends React.Component {
 
   conditionallyRedirect() {
     return this.checkEligibility().then((eligibility) => {
-      clearTimeout(this.timeoutId);
       if (!eligibility.eligibility) {
         const bib = (this.props.bib && !_isEmpty(this.props.bib)) ?
           this.props.bib : null;

--- a/src/app/components/HoldRequest/HoldRequest.jsx
+++ b/src/app/components/HoldRequest/HoldRequest.jsx
@@ -53,6 +53,7 @@ class HoldRequest extends React.Component {
       delivery: defaultDelivery,
       checkedLocNum,
       serverRedirect: true,
+      isLoading: !Store.getState().lastLoaded.pathname.includes('hold'),
     }, { patron: PatronStore.getState() });
 
     // change all the components :(
@@ -67,6 +68,7 @@ class HoldRequest extends React.Component {
   componentDidMount() {
     this.requireUser();
     this.conditionallyRedirect();
+    Store.listen(this.onChange);
     const title = document.getElementById('item-title');
     if (title) {
       title.focus();
@@ -75,8 +77,12 @@ class HoldRequest extends React.Component {
     this.timeoutId = setTimeout(() => { Actions.updateLoadingStatus(false); }, 5000);
   }
 
+  componentWillUnmount() {
+    Store.unlisten(this.onChange);
+  }
+
   onChange() {
-    this.setState({ patron: PatronStore.getState() });
+    this.setState({ patron: PatronStore.getState(), isLoading: !Store.getState().lastLoaded.pathname.includes('hold') });
   }
 
   onRadioSelect(e, i) {
@@ -358,7 +364,7 @@ class HoldRequest extends React.Component {
       <DocumentTitle title="Item Request | Shared Collection Catalog | NYPL">
         <div>
           <LoadingLayer
-            status={Store.state.isLoading}
+            status={this.state.isLoading}
             title="Requesting"
           />
           <div className="nypl-request-page-header">

--- a/src/app/components/HoldRequest/HoldRequest.jsx
+++ b/src/app/components/HoldRequest/HoldRequest.jsx
@@ -275,6 +275,37 @@ class HoldRequest extends React.Component {
   }
 
   render() {
+    if (this.isLoading()) {
+      return (
+        <React.Fragment>
+          <LoadingLayer
+            status={this.isLoading()}
+            title="Requesting"
+          />
+          <div>
+            <div className="nypl-request-page-header">
+              <div className="nypl-full-width-wrapper">
+                <div className="row">
+                  <div className="nypl-column-full">
+                    <Breadcrumbs
+                      type="hold"
+                    />
+                    <h1 id="item-title" tabIndex="0" id="mainContent">Item Request</h1>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div className="nypl-full-width-wrapper">
+              <div className="row">
+                <div className="nypl-column-three-quarters" />
+              </div>
+            </div>
+          </div>
+        </React.Fragment>
+      );
+    }
+
     const { closedLocations, holdRequestNotification } = AppConfigStore.getState();
     const { serverRedirect } = this.state;
     const searchKeywords = this.props.searchKeywords;
@@ -358,15 +389,6 @@ class HoldRequest extends React.Component {
     }
 
     const searchUrl = basicQuery(this.props)({});
-
-    if (this.isLoading()) {
-      return (
-        <LoadingLayer
-          status={this.isLoading()}
-          title="Requesting"
-        />
-      );
-    }
 
     return (
       <DocumentTitle title="Item Request | Shared Collection Catalog | NYPL">

--- a/src/app/components/HoldRequest/HoldRequest.jsx
+++ b/src/app/components/HoldRequest/HoldRequest.jsx
@@ -53,7 +53,6 @@ class HoldRequest extends React.Component {
       delivery: defaultDelivery,
       checkedLocNum,
       serverRedirect: true,
-      isLoading: this.isLoading(),
     }, { patron: PatronStore.getState() });
 
     // change all the components :(
@@ -70,7 +69,6 @@ class HoldRequest extends React.Component {
   componentDidMount() {
     this.requireUser();
     this.conditionallyRedirect();
-    Store.listen(this.onChange);
     const title = document.getElementById('item-title');
     if (title) {
       title.focus();
@@ -78,12 +76,8 @@ class HoldRequest extends React.Component {
     if (this.state.serverRedirect) this.setState({ serverRedirect: false });
   }
 
-  componentWillUnmount() {
-    Store.unlisten(this.onChange);
-  }
-
   onChange() {
-    this.setState({ patron: PatronStore.getState(), isLoading: this.isLoading() });
+    this.setState({ patron: PatronStore.getState() });
   }
 
   onRadioSelect(e, i) {
@@ -365,10 +359,10 @@ class HoldRequest extends React.Component {
 
     const searchUrl = basicQuery(this.props)({});
 
-    if (this.state.isLoading) {
+    if (this.isLoading()) {
       return (
         <LoadingLayer
-          status={this.state.isLoading}
+          status={this.isLoading()}
           title="Requesting"
         />
       );

--- a/src/app/stores/Store.js
+++ b/src/app/stores/Store.js
@@ -21,6 +21,7 @@ class Store {
       updateIsEddRequestable: Actions.updateIsEddRequestable,
       updateSubjectHeading: Actions.updateSubjectHeading,
       updateDrbbResults: Actions.updateDrbbResults,
+      updateLastLoaded: Actions.updateLastLoaded,
     });
 
     this.state = {
@@ -45,6 +46,7 @@ class Store {
       isEddRequestable: false,
       subjectHeading: null,
       drbbResults: {},
+      lastLoaded: '',
     };
   }
 
@@ -112,6 +114,10 @@ class Store {
 
   updateDrbbResults(data) {
     this.setState({ drbbResults: data });
+  }
+
+  updateLastLoaded(data) {
+    this.setState({ lastLoaded: data });
   }
 }
 

--- a/src/app/utils/dataLoaderUtil.js
+++ b/src/app/utils/dataLoaderUtil.js
@@ -118,9 +118,11 @@ function loadDataForRoutes(location, req, routeMethods, realRes) {
     Actions.updateLoadingStatus(true);
     const successCb = (response) => {
       actions.forEach(action => action(response.data));
+      Actions.updateLastLoaded(location);
       Actions.updateLoadingStatus(false);
     };
     const errorCb = (error) => {
+      Actions.updateLastLoaded(location);
       Actions.updateLoadingStatus(false);
       console.error(
         errorMessage,
@@ -144,6 +146,7 @@ function loadDataForRoutes(location, req, routeMethods, realRes) {
     return ajaxCall(apiRoute(matchData, route), successCb, errorCb);
   }
 
+  Actions.updateLastLoaded(location);
   return new Promise(resolve => resolve());
 }
 

--- a/src/server/ApiRoutes/User.js
+++ b/src/server/ApiRoutes/User.js
@@ -16,6 +16,7 @@ function eligibility(req, res) {
   if (!req.patronTokenResponse || !req.patronTokenResponse.decodedPatron
      || !req.patronTokenResponse.decodedPatron.sub) {
     res.send(JSON.stringify({ eligibility: true }));
+    return;
   }
   const id = req.patronTokenResponse.decodedPatron.sub;
   nyplApiClient().then(client => client.get(`/patrons/${id}/hold-request-eligibility`, { cache: false }))


### PR DESCRIPTION
**What's this do?**
Since there has been some disussion of whether the other scc-2200 PR is too large of a change, this is a more minimal approach to scc-2200. Instead of adding a new `Content` component, this branch only adds the `lastLoaded` field in the `Store`, and updates the `HoldRequest` page so that the `LoadingLayer` is turned on/off depending on whether the `lastLoaded` matches the current page.

**Why are we doing this? (w/ JIRA link if applicable)**
We are trying to avoid incorrect information getting displayed before the loading layer turns on, or before the user is redirected to log in.

**What's this NOT do?**

This branch doesn't change the text that displays under the loading layer, so you can still see messages like 'Item not available' under the loading layer while it loads. This would be easy to change but we need to settle on the copy if we want to change the text.

**How should this be tested? / Do these changes have associated tests?**
Navigate to a `HoldRequest` page. You should not see any incorrect information displayed without a loading layer. If you are not logged in, you should not see anything above the loading layer before you are redirected.

**Dependencies for merging? Releasing to production?**
NA

**Has the application documentation been updated for these changes?**
NA

**Did someone actually run this code to verify it works?**
PR author tested locally.
