### PR TITLE
Simple fix for login redirect LoadingLayer

### DIFF
--- a/src/app/components/HoldRequest/HoldRequest.jsx
+++ b/src/app/components/HoldRequest/HoldRequest.jsx
@@ -55,6 +55,8 @@ class HoldRequest extends React.Component {
       serverRedirect: true,
     }, { patron: PatronStore.getState() });
 
+    this.userLoggedIn = this.state.patron && this.state.patron.id;
+
     // change all the components :(
     this.onChange = this.onChange.bind(this);
     this.onRadioSelect = this.onRadioSelect.bind(this);
@@ -142,7 +144,7 @@ class HoldRequest extends React.Component {
    * @return {Boolean}
    */
   requireUser() {
-    if (this.state.patron && this.state.patron.id) {
+    if (this.userLoggedIn) {
       return true;
     }
 
@@ -270,6 +272,10 @@ class HoldRequest extends React.Component {
   }
 
   render() {
+    if (!this.userLoggedIn) return (
+      <LoadingLayer status />
+    );
+
     const { closedLocations, holdRequestNotification } = AppConfigStore.getState();
     const { serverRedirect } = this.state;
     const searchKeywords = this.props.searchKeywords;


### PR DESCRIPTION
**What's this do?**
This makes sure the LoadingLayer is rendered when redirecting a user. This is really all we need. There could be some more work to make the page behind the LoadingLayer look more consistent with the rest of the SCC experience. This is just a patch.

The component is really complicated. Fundamentally, we are rendering the wrong thing initially. So, I would like to do more code/logic cleanup before making any bigger changes. But this approach prevents the LoadingLayer from disappearing too quickly or the wrong information from being shown, behind the LoadingLayer or fully visible.

**Has the application documentation been updated for these changes?**

**Did someone actually run this code to verify it works?**
