### PR TITLE
SCC-2210: Move "Electronic Delivery" info above "Physical Delivery"

### DIFF
--- a/src/app/components/HoldConfirmation/HoldConfirmation.jsx
+++ b/src/app/components/HoldConfirmation/HoldConfirmation.jsx
@@ -315,7 +315,11 @@ class HoldConfirmation extends React.Component {
           <p id="delivery-location">
             The item will be delivered to: {this.renderLocationInfo(deliveryLocation)}
           </p>
-
+          <h3 id="electronic-delivery">Electronic Delivery</h3>
+          <p>
+            If you selected electronic delivery,
+            you will receive an email when the item is available to download.
+          </p>
           <h3 id="physical-delivery">Physical Delivery</h3>
           <p>
             Please log into your library account to check for updates. The item will be
@@ -334,11 +338,6 @@ class HoldConfirmation extends React.Component {
             call 917-ASK-NYPL (<a href="tel:19172756975">917-275-6975</a>).
           </p>
 
-          <h3 id="electronic-delivery">Electronic Delivery</h3>
-          <p>
-            If you selected electronic delivery, you will receive an email when the item is
-            available to download.
-          </p>
           {this.renderBackToClassicLink()}
           {this.renderBackToSearchLink()}
           {this.renderStartOverLink()}


### PR DESCRIPTION
**What's this do?**
Simple edit to the HoldConfirmation page to move the "Electronic Delivery" info above the "Physical Delivery" info.

**Did someone actually run this code to verify it works?**
PR author did.