### PR TITLE
NO_REF bug fix: `return` in eligibility check to avoid error

### DIFF
--- a/src/server/ApiRoutes/User.js
+++ b/src/server/ApiRoutes/User.js
@@ -15,11 +15,11 @@ function requireUser(req, res) {
 function eligibility(req, res) {
   if (!req.patronTokenResponse || !req.patronTokenResponse.decodedPatron
      || !req.patronTokenResponse.decodedPatron.sub) {
-    res.send(JSON.stringify({ eligibility: true }));
+    return res.send(JSON.stringify({ eligibility: true }));
   }
   const id = req.patronTokenResponse.decodedPatron.sub;
-  nyplApiClient().then(client => client.get(`/patrons/${id}/hold-request-eligibility`, { cache: false }))
-    .then((response) => { res.send(JSON.stringify(response)); });
+  return nyplApiClient().then(client => client.get(`/patrons/${id}/hold-request-eligibility`, { cache: false }))
+    .then(response => res.send(JSON.stringify(response)));
 }
 
 export default { eligibility, requireUser };


### PR DESCRIPTION
**What's this do?**
Return in the eligibility check when `!req.patronTokenResponse || !req.patronTokenResponse.decodedPatron || !req.patronTokenResponse.decodedPatron.sub` to avoid an obvious error.

**How should this be tested? / Do these changes have associated tests?**
Check request button -> login flow before and after change. Error logging goes away.

**Did someone actually run this code to verify it works?**
I did.