### PR TITLE
SCC-2163/ limit SHEP api calls

### DIFF
--- a/src/server/ApiRoutes/Bib.js
+++ b/src/server/ApiRoutes/Bib.js
@@ -12,7 +12,7 @@ const nyplApiClientCall = (query) => {
 
 const shepApiCall = bibId => axios(`${appConfig.shepApi}/bibs/${bibId}/subject_headings`);
 
-function fetchBib(bibId, cb, errorcb) {
+function fetchBib(bibId, cb, errorcb, options = { fetchSubjectHeadingData: true }) {
   return Promise.all([
     nyplApiClientCall(bibId),
     nyplApiClientCall(`${bibId}.annotated-marc`),
@@ -28,7 +28,7 @@ function fetchBib(bibId, cb, errorcb) {
       return data;
     })
     .then((data) => {
-      if (data.subjectLiteral && data.subjectLiteral.length) {
+      if (options.fetchSubjectHeadingData && data.subjectLiteral && data.subjectLiteral.length) {
         return shepApiCall(bibId)
           .then((shepRes) => {
             data.subjectHeadingData = shepRes.data.subject_headings;

--- a/src/server/ApiRoutes/Hold.js
+++ b/src/server/ApiRoutes/Hold.js
@@ -254,6 +254,7 @@ function confirmRequestServer(req, res, next) {
             };
             next();
           },
+          { fetchSubjectHeadingData: false },
         );
       }
 
@@ -326,6 +327,7 @@ function newHoldRequest(req, res) {
       );
     },
     bibResponseError => res.json(bibResponseError),
+    { fetchSubjectHeadingData: false },
   );
 }
 
@@ -362,6 +364,7 @@ function newHoldRequestServerEdd(req, res, next) {
       };
       next();
     },
+    { fetchSubjectHeadingData: false },
   );
 }
 


### PR DESCRIPTION
**What's this do?**
Prevent superfluous calls to SHEP API for HoldRequest and HoldConfirmation page

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SCC-2163
This helps when developing locally, since pages will load faster if SHEP API is not also running locally.

**Did someone actually run this code to verify it works?**
PR author did. If you do, Search Result -> Hold Request -> Item Details, the SHEP API call is made for that last step 👍 (As long as it is indeed an item with subject headings)