### PR TITLE
Change travis `script` to prevent failing silently

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ node_js:
 - '10.17.0'
 install: npm rebuild node-sass && npm install
 before_script: npm run dist
-script: npm test; echo -e "${TRAVIS_BRANCH} ${TRAVIS_COMMIT}"; echo -e "${TRAVIS_BRANCH} ${TRAVIS_COMMIT} \n$(cat travis-record.txt)" > travis-record.txt
+script: npm test
 before_deploy: echo 'All unit tests passed; Successfull built distribution assets; Preparing to
   deploy Discovery Shared Collection Catalog to AWS.'
 deploy:

--- a/test/unit/AdditionalDetailsViewer.test.js
+++ b/test/unit/AdditionalDetailsViewer.test.js
@@ -19,7 +19,7 @@ describe('After Clicking on Button', () => {
 
   // These tests should be changed to be more informative
   it('should display Abbreviated Title', () => {
-    expect(component.find('div').someWhere(item => item.text() === "Abrev. title -- 210 ")).to.equal(false);
+    expect(component.find('div').someWhere(item => item.text() === "Abrev. title -- 210 ")).to.equal(true);
   });
 
   it('should display url fields', () => {

--- a/test/unit/AdditionalDetailsViewer.test.js
+++ b/test/unit/AdditionalDetailsViewer.test.js
@@ -19,7 +19,7 @@ describe('After Clicking on Button', () => {
 
   // These tests should be changed to be more informative
   it('should display Abbreviated Title', () => {
-    expect(component.find('div').someWhere(item => item.text() === "Abrev. title -- 210 ")).to.equal(true);
+    expect(component.find('div').someWhere(item => item.text() === "Abrev. title -- 210 ")).to.equal(false);
   });
 
   it('should display url fields', () => {


### PR DESCRIPTION
**What's this do?**
Remove extra code that was preventing a failing test suite from triggered a failed build.