### PR TITLE
URL enabled feature flag capability

### DIFF
--- a/src/app/data/appConfig.js
+++ b/src/app/data/appConfig.js
@@ -1,10 +1,4 @@
-const extractFeatures = (featuresString) => {
-  if (typeof featuresString !== 'string') return [];
-  return featuresString.split(',').reduce((features, feature) => {
-    if (feature.length) features.push(feature.trim());
-    return features;
-  }, []);
-};
+import extractFeatures from '../utils/extractFeatures';
 
 const appConfig = {
   appTitle: 'NYPL | Discovery',
@@ -66,7 +60,4 @@ const appConfig = {
   feedbackFormUrl: process.env.FEEDBACK_FORM_URL,
 };
 
-export default {
-  extractFeatures,
-  ...appConfig,
-};
+export default appConfig;

--- a/src/app/utils/dataLoaderUtil.js
+++ b/src/app/utils/dataLoaderUtil.js
@@ -27,7 +27,11 @@ const routePaths = {
 
 const routesGenerator = location => ({
   bib: {
-    apiRoute: (matchData, route) => `${route}?bibId=${matchData[1]}`,
+    apiRoute: (matchData, route) => `${route}${
+      (
+        location.search && location.search.length
+      ) ? `${location.search}&` : '?'
+    }bibId=${matchData[1]}`,
     serverParams: (matchData, req) => { req.query.bibId = matchData[1]; },
     actions: [Actions.updateBib],
     errorMessage: 'Error attempting to make an ajax request to fetch a bib record from ResultsList',
@@ -106,7 +110,6 @@ function loadDataForRoutes(location, req, routeMethods, realRes) {
     matchData,
     pathType,
   } = matchingPathData(location);
-
   if (routes[pathType]) {
     const {
       apiRoute,

--- a/src/app/utils/dataLoaderUtil.js
+++ b/src/app/utils/dataLoaderUtil.js
@@ -27,11 +27,7 @@ const routePaths = {
 
 const routesGenerator = location => ({
   bib: {
-    apiRoute: (matchData, route) => `${route}${
-      (
-        location.search && location.search.length
-      ) ? `${location.search}&` : '?'
-    }bibId=${matchData[1]}`,
+    apiRoute: (matchData, route) => `${route}?bibId=${matchData[1]}${location.query.features ? `&features=${location.query.features}` : ''}`,
     serverParams: (matchData, req) => { req.query.bibId = matchData[1]; },
     actions: [Actions.updateBib],
     errorMessage: 'Error attempting to make an ajax request to fetch a bib record from ResultsList',

--- a/src/app/utils/extractFeatures.js
+++ b/src/app/utils/extractFeatures.js
@@ -1,0 +1,9 @@
+const extractFeatures = (featuresString) => {
+  if (typeof featuresString !== 'string') return [];
+  return featuresString.split(',').reduce((features, feature) => {
+    if (feature.length) features.push(feature.trim());
+    return features;
+  }, []);
+};
+
+export default extractFeatures;

--- a/test/unit/AppConfigStore.test.js
+++ b/test/unit/AppConfigStore.test.js
@@ -4,6 +4,7 @@ import { mock } from 'sinon';
 
 import AppConfigStore from '../../src/app/stores/AppConfigStore';
 import appConfig from '../../src/app/data/appConfig';
+import extractFeatures from '../../src/app/utils/extractFeatures';
 
 describe('AppConfigStore', () => {
   let appConfigMock;
@@ -36,23 +37,23 @@ describe('AppConfigStore', () => {
    */
   describe(('extractFeatures'), () => {
     it('handles non-string parameters', () => {
-      expect(appConfig.extractFeatures()).to.deep.equal([]);
-      expect(appConfig.extractFeatures(undefined)).to.deep.equal([]);
-      expect(appConfig.extractFeatures(null)).to.deep.equal([]);
-      expect(appConfig.extractFeatures(-1)).to.deep.equal([]);
-      expect(appConfig.extractFeatures(Math.PI)).to.deep.equal([]);
+      expect(extractFeatures()).to.deep.equal([]);
+      expect(extractFeatures(undefined)).to.deep.equal([]);
+      expect(extractFeatures(null)).to.deep.equal([]);
+      expect(extractFeatures(-1)).to.deep.equal([]);
+      expect(extractFeatures(Math.PI)).to.deep.equal([]);
     });
 
     it('handles malformed features String', () => {
-      expect(appConfig.extractFeatures(',,dasdfksdjfdsf,,').length).to.deep.equal(1);
+      expect(extractFeatures(',,dasdfksdjfdsf,,').length).to.deep.equal(1);
     });
 
     it('returns array of values', () => {
-      expect(appConfig.extractFeatures('several,other,features')).to.deep.equal(['several', 'other', 'features']);
+      expect(extractFeatures('several,other,features')).to.deep.equal(['several', 'other', 'features']);
     });
 
     it('strips whitespace', () => {
-      expect(appConfig.extractFeatures('several ,other  , foo  , features')).to.deep.equal(['several', 'other', 'foo', 'features']);
+      expect(extractFeatures('several ,other  , foo  , features')).to.deep.equal(['several', 'other', 'foo', 'features']);
     });
   });
 });

--- a/test/unit/dataLoaderUtil.test.js
+++ b/test/unit/dataLoaderUtil.test.js
@@ -36,6 +36,7 @@ describe('dataLoaderUtil', () => {
         location = {
           pathname: '',
           search: '',
+          query: {},
         };
         dataLoaderUtil.loadDataForRoutes(location, mockReq, mockRouteMethods);
       });
@@ -91,6 +92,7 @@ describe('dataLoaderUtil', () => {
         location = {
           pathname: '/research/collections/shared-collection-catalog/bib/b000000',
           search: '',
+          query: {},
         };
         mockReq = { query: {} };
         dataLoaderUtil.loadDataForRoutes(location, mockReq, mockRouteMethods);
@@ -307,6 +309,7 @@ describe('dataLoaderUtil', () => {
         });
         location = {
           pathname: '/research/collections/shared-collection-catalog/hold/request/',
+          query: {},
         };
         dataLoaderUtil.loadDataForRoutes(location, mockReq, mockRouteMethods);
       });
@@ -392,6 +395,7 @@ describe('dataLoaderUtil', () => {
         location = {
           pathname: '',
           search: '',
+          query: {},
         };
         dataLoaderUtil.loadDataForRoutes(location);
       });
@@ -436,6 +440,7 @@ describe('dataLoaderUtil', () => {
           location = {
             pathname: '/research/collections/shared-collection-catalog/bib/b000000',
             search: '',
+            query: {},
           };
           dataLoaderUtil.loadDataForRoutes(location);
         });
@@ -505,6 +510,7 @@ describe('dataLoaderUtil', () => {
           location = {
             pathname: '/research/collections/shared-collection-catalog/bib/b000000',
             search: '',
+            query: {},
           };
           dataLoaderUtil.loadDataForRoutes(location);
         });
@@ -793,6 +799,7 @@ describe('dataLoaderUtil', () => {
           location = {
             pathname: '/research/collections/shared-collection-catalog/hold/request/b1000-i1000',
             search: '',
+            query: {},
           };
           dataLoaderUtil.loadDataForRoutes(location);
         });
@@ -889,6 +896,7 @@ describe('dataLoaderUtil', () => {
           location = {
             pathname: '/research/collections/shared-collection-catalog/hold/request/b1000-i1000',
             search: '',
+            query: {},
           };
           dataLoaderUtil.loadDataForRoutes(location);
         });


### PR DESCRIPTION
**What's this do?**
This allows for enabling the feature flag through a URL search param. That aspect was not too difficult to implement. The weird part here is a workaround for adding the param to all URLs linked to from within the url-enabled-feature environment. This works better than I expected. It does not work for no-JS though.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SCC-2216

**How should this be tested? / Do these changes have associated tests?**
If this seems like a reasonable approach, will write tests tomorrow.
Example path: `/research/collections/shared-collection-catalog/?features=on-site-edd`

**Did someone actually run this code to verify it works?**
PR author did