### PR TITLE
Hold request with redux no appdata

### DIFF
--- a/server.js
+++ b/server.js
@@ -10,8 +10,6 @@ import cookieParser from 'cookie-parser';
 import bodyParser from 'body-parser';
 import { Provider } from 'react-redux';
 
-import configureStore from './src/app/stores/configureStore';
-import initialState from './src/app/stores/InitialState';
 import appConfig from './src/app/data/appConfig';
 import dataLoaderUtil from '@dataLoaderUtil';
 import webpackConfig from './webpack.config';
@@ -23,6 +21,7 @@ import initializePatronTokenAuth from './src/server/routes/auth';
 import { getPatronData } from './src/server/routes/api';
 import nyplApiClient from './src/server/routes/nyplApiClient';
 import logger from './logger';
+import store from './src/app/stores/Store';
 
 const ROOT_PATH = __dirname;
 const INDEX_PATH = path.resolve(ROOT_PATH, 'src/client');
@@ -92,7 +91,6 @@ app.get('/*', (req, res, next) => {
 });
 
 app.get('/*', (req, res) => {
-  console.log('res.data', res.data);
   const appRoutes = (req.url).indexOf(appConfig.baseUrl) !== -1 ? routes.client : routes.server;
 
   match({ routes: appRoutes, location: req.url }, (error, redirectLocation, renderProps) => {
@@ -104,8 +102,6 @@ app.get('/*', (req, res) => {
       if (!res.data) {
         res.data = {};
       }
-      const appData = Object.assign(initialState, res.data);
-      const store = configureStore(appData);
       application = ReactDOMServer.renderToString(
         <Provider store={store}>
           <RouterContext {...renderProps} />
@@ -117,7 +113,7 @@ app.get('/*', (req, res) => {
         .status(200)
         .render('index', {
           application,
-          appData: JSON.stringify(appData).replace(/</g, '\\u003c'),
+          appData: JSON.stringify(store.getState()).replace(/</g, '\\u003c'),
           appTitle: title,
           favicon: appConfig.favIconPath,
           webpackPort: WEBPACK_DEV_PORT,

--- a/src/app/components/Application/Application.jsx
+++ b/src/app/components/Application/Application.jsx
@@ -12,7 +12,6 @@ import LoadingLayer from '../LoadingLayer/LoadingLayer';
 import DataLoader from '../DataLoader/DataLoader';
 
 import { breakpoints } from '../../data/constants';
-import store from '../../stores/Store';
 
 class Application extends React.Component {
   constructor(props) {
@@ -33,7 +32,6 @@ class Application extends React.Component {
   componentDidMount() {
     window.addEventListener('resize', this.onWindowResize.bind(this));
     this.onWindowResize();
-    window.store = store; // this is just useful for debugging, but we'd get rid of it in production
   }
 
   onWindowResize() {

--- a/src/app/components/Application/Application.jsx
+++ b/src/app/components/Application/Application.jsx
@@ -12,6 +12,7 @@ import LoadingLayer from '../LoadingLayer/LoadingLayer';
 import DataLoader from '../DataLoader/DataLoader';
 
 import { breakpoints } from '../../data/constants';
+import store from '../../stores/Store';
 
 class Application extends React.Component {
   constructor(props) {
@@ -32,6 +33,7 @@ class Application extends React.Component {
   componentDidMount() {
     window.addEventListener('resize', this.onWindowResize.bind(this));
     this.onWindowResize();
+    window.store = store; // this is just useful for debugging, but we'd get rid of it in production
   }
 
   onWindowResize() {

--- a/src/app/components/HoldRequest/HoldRequest.jsx
+++ b/src/app/components/HoldRequest/HoldRequest.jsx
@@ -24,6 +24,8 @@ import {
   basicQuery,
 } from '../../utils/utils';
 
+import store from '../../stores/Store';
+
 class HoldRequest extends React.Component {
   constructor(props) {
     super(props);
@@ -61,8 +63,8 @@ class HoldRequest extends React.Component {
 
 
   componentDidMount() {
-    // this.requireUser();
-    // this.conditionallyRedirect();
+    this.requireUser();
+    this.conditionallyRedirect();
     const title = document.getElementById('item-title');
     if (title) {
       title.focus();
@@ -256,7 +258,6 @@ class HoldRequest extends React.Component {
   }
 
   render() {
-    console.log('HoldRequest patron', this.props.patron);
     const { closedLocations, holdRequestNotification } = this.props;
     const searchKeywords = this.props.searchKeywords;
     const bib = (this.props.bib && !_isEmpty(this.props.bib)) ?

--- a/src/app/components/HoldRequest/HoldRequest.jsx
+++ b/src/app/components/HoldRequest/HoldRequest.jsx
@@ -24,8 +24,6 @@ import {
   basicQuery,
 } from '../../utils/utils';
 
-import store from '../../stores/Store';
-
 class HoldRequest extends React.Component {
   constructor(props) {
     super(props);

--- a/src/app/stores/Reducers.js
+++ b/src/app/stores/Reducers.js
@@ -29,7 +29,7 @@ function appReducer(state = initialState, action) {
     case Actions.UPDATE_PATRON_DATA:
       return { ...state, patron: action.payload };
     case Actions.UPDATE_DELIVERY_LOCATIONS:
-      return { ...state, deliveryLocation: action.payload };
+      return { ...state, deliveryLocations: action.payload };
     case Actions.SET_APP_CONFIG:
       return { ...state, appConfig };
     default:

--- a/src/app/stores/Store.js
+++ b/src/app/stores/Store.js
@@ -1,11 +1,12 @@
 /* eslint-disable no-underscore-dangle */
 import configureStore from './configureStore';
+import initialState from './InitialState';
 
 const preloadedState = global && global.window && global.window.__PRELOADED_STATE__;
 if (preloadedState) {
   delete global.window.__PRELOADED_STATE__;
 }
 
-const store = configureStore(preloadedState);
+const store = configureStore(preloadedState || initialState);
 
 export default store;

--- a/src/app/utils/dataLoaderUtil.js
+++ b/src/app/utils/dataLoaderUtil.js
@@ -106,10 +106,7 @@ function loadDataForRoutes(location, req, routeMethods, realRes) {
         };
         return routeMethods[pathType](req, res);
       })
-        .then(({ data }) => {
-          realRes.data = { ...realRes.data, ...data };
-          return realRes;
-        })
+        .then(successCb)
         .catch(errorCb);
     }
     console.log('making ajaxCall');

--- a/src/server/routes/api/index.js
+++ b/src/server/routes/api/index.js
@@ -4,6 +4,11 @@ import { isEmpty as _isEmpty } from 'underscore';
 import nyplApiClient from '../nyplApiClient';
 import logger from '../../../../logger';
 
+import store from '../../../app/stores/Store';
+import { updatePatronData } from '../../../app/actions/Actions';
+
+const { dispatch } = store;
+
 export function getPatronData(req, res, next) {
   if (req.patronTokenResponse.isTokenValid
     && req.patronTokenResponse.decodedPatron
@@ -17,26 +22,26 @@ export function getPatronData(req, res, next) {
           .then((response) => {
             if (_isEmpty(response)) {
               // Data is empty for the Patron
-              res.data = {
-                patron: {
-                  id: '',
-                  names: [],
-                  barcodes: [],
-                  emails: [],
-                  loggedIn: false,
-                },
+              const patron = {
+                id: '',
+                names: [],
+                barcodes: [],
+                emails: [],
+                loggedIn: false,
               };
+
+              dispatch(updatePatronData(patron));
             } else {
               // Data exists for the Patron
-              res.data = {
-                patron: {
-                  id: response.data.id,
-                  names: response.data.names,
-                  barcodes: response.data.barCodes,
-                  emails: response.data.emails,
-                  loggedIn: true,
-                },
+              const patron = {
+                id: response.data.id,
+                names: response.data.names,
+                barcodes: response.data.barCodes,
+                emails: response.data.emails,
+                loggedIn: true,
               };
+
+              dispatch(updatePatronData(patron));
             }
 
             // Continue next function call
@@ -46,20 +51,20 @@ export function getPatronData(req, res, next) {
             logger.error(
               'Error attemping to make server side fetch call to patrons in getPatronData' +
               `, /patrons/${userId}`,
-              error
+              error,
             );
-            res.data = {
-              patron: {
-                id: '',
-                names: [],
-                barcodes: [],
-                emails: [],
-                loggedIn: false,
-              },
+            const patron = {
+              id: '',
+              names: [],
+              barcodes: [],
+              emails: [],
+              loggedIn: false,
             };
+
+            dispatch(updatePatronData(patron));
             // Continue next function call
             next();
-          })
+          }),
       );
   }
 


### PR DESCRIPTION
**What's this do?**
This is an example of what the code might look like if we call actions directly on the server side instead of passing around res.data. Personally I feel this is a more straightforward approach that increases consistency (and hence reduces the room for unexpected behavior). For example in the `dataLoaderUtil` we get to call the same `successCb` regardless of whether navigation is occurring server side or client side.

**Did someone actually run this code to verify it works?**
PR author tested locally.
