### PR TITLE
Convert context for media to new API to update dynamically

### DIFF
--- a/src/app/components/Application/Application.jsx
+++ b/src/app/components/Application/Application.jsx
@@ -13,7 +13,9 @@ import DataLoader from '../DataLoader/DataLoader';
 
 import { breakpoints } from '../../data/constants';
 
-class Application extends React.Component {
+export const MediaContext = React.createContext('desktop');
+
+export class Application extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
@@ -21,12 +23,6 @@ class Application extends React.Component {
       patron: props.patron,
     };
     this.submitFeedback = this.submitFeedback.bind(this);
-  }
-
-  getChildContext() {
-    return {
-      media: this.state.media,
-    };
   }
 
   componentDidMount() {
@@ -73,27 +69,29 @@ class Application extends React.Component {
     );
 
     return (
-      <DocumentTitle title="Shared Collection Catalog | NYPL">
-        <div className="app-wrapper">
-          <Header
-            navData={navConfig.current}
-            patron={this.state.patron}
-            skipNav={{ target: 'mainContent' }}
-          />
-          <LoadingLayer
-            title="Loading"
-            loading={this.props.loading}
-          />
-          <DataLoader
-            location={this.context.router.location}
-            key={JSON.stringify(dataLocation)}
-          >
-            {React.cloneElement(this.props.children)}
-          </DataLoader>
-          <Footer />
-          <Feedback submit={this.submitFeedback} />
-        </div>
-      </DocumentTitle>
+      <MediaContext.Provider value={this.state.media}>
+        <DocumentTitle title="Shared Collection Catalog | NYPL">
+          <div className="app-wrapper">
+            <Header
+              navData={navConfig.current}
+              patron={this.state.patron}
+              skipNav={{ target: 'mainContent' }}
+            />
+            <LoadingLayer
+              title="Loading"
+              loading={this.props.loading}
+            />
+            <DataLoader
+              location={this.context.router.location}
+              key={JSON.stringify(dataLocation)}
+            >
+              {React.cloneElement(this.props.children)}
+            </DataLoader>
+            <Footer />
+            <Feedback submit={this.submitFeedback} />
+          </div>
+        </DocumentTitle>
+      </MediaContext.Provider>
     );
   }
 }
@@ -110,10 +108,6 @@ Application.defaultProps = {
 
 Application.contextTypes = {
   router: PropTypes.object,
-};
-
-Application.childContextTypes = {
-  media: PropTypes.string,
 };
 
 export default withRouter(connect(({ patron, loading }) => ({ patron, loading }))(Application));

--- a/src/app/components/FilterPopup/FilterPopup.jsx
+++ b/src/app/components/FilterPopup/FilterPopup.jsx
@@ -624,6 +624,7 @@ const mapStateToProps = (state) => {
     },
     searchResults,
     searchKeywords,
+    selectedFilters,
   } = state;
 
   const apiFilters = (
@@ -637,6 +638,7 @@ const mapStateToProps = (state) => {
     filters: apiFilters,
     totalResults: searchResults.totalResults,
     searchKeywords,
+    selectedFilters,
   });
 };
 

--- a/src/app/components/Filters/SelectedFilters.jsx
+++ b/src/app/components/Filters/SelectedFilters.jsx
@@ -260,7 +260,6 @@ class SelectedFilters extends React.Component {
 SelectedFilters.propTypes = {
   selectedFilters: PropTypes.object,
   createAPIQuery: PropTypes.func,
-  dropdownOpen: PropTypes.bool,
 };
 
 SelectedFilters.defaultProps = {

--- a/src/app/components/SearchResults/SearchResultsContainer.jsx
+++ b/src/app/components/SearchResults/SearchResultsContainer.jsx
@@ -1,30 +1,24 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
-import { withRouter } from 'react-router';
+import { useSelector } from 'react-redux';
 
 import ResultsList from '../ResultsList/ResultsList';
 import Pagination from '../Pagination/Pagination';
 import DrbbContainer from '../Drbb/DrbbContainer';
 import {
-  basicQuery,
   trackDiscovery,
   displayContext,
 } from '../../utils/utils';
 import appConfig from '../../data/appConfig';
+import { MediaContext } from '../Application/Application';
 
-// Renders the ResultsList containing the search results and the Pagination component
-const SearchResultsContainer = (props, context) => {
-  const {
-    searchResults,
-    searchKeywords,
-    page,
-    features,
-    createAPIQuery,
-  } = props;
-  const {
-    media,
-  } = context;
+// Renders ResultsList and Pagination components
+const SearchResultsContainer = (props) => {
+  const searchResults = useSelector(state => state.searchResults);
+  const features = useSelector(state => state.appConfig.features);
+  const searchKeywords = useSelector(state => state.searchKeywords);
+  const page = useSelector(state => state.page);
+  const { createAPIQuery } = props;
   const includeDrbb = features.includes('drb-integration');
 
   const results = searchResults ? searchResults.itemListElement : [];
@@ -40,8 +34,7 @@ const SearchResultsContainer = (props, context) => {
   const noResultElementForDrbbIntegration = includeDrbb ?
     (
       <div
-        className={
-          `nypl-results-summary no-scc-results drbb-integration`}
+        className="nypl-results-summary no-scc-results drbb-integration"
       >
         There are no results {displayContext(props)} from Shared Collection Catalog.
       </div>) : null;
@@ -49,62 +42,50 @@ const SearchResultsContainer = (props, context) => {
   const hasResults = results && totalResults;
 
   return (
-    <React.Fragment>
-      <div className="nypl-row">
-        <div
-          className="nypl-column-full"
-          role="region"
-          aria-describedby="results-description"
-        >
-          {
-            hasResults ?
-              <ResultsList
-                results={results}
-                searchKeywords={searchKeywords}
-              /> :
-              noResultElementForDrbbIntegration
-          }
-          { includeDrbb && media === 'desktop' ? <DrbbContainer /> : null}
-          {
-            hasResults ?
-              <Pagination
-                ariaControls="nypl-results-list"
-                total={totalResults}
-                perPage={50}
-                page={parseInt(page, 10)}
-                createAPIQuery={createAPIQuery}
-                updatePage={updatePage}
-              /> : null
-          }
-          { includeDrbb && ['tablet', 'mobile'].includes(media) ? <DrbbContainer /> : null}
-        </div>
-      </div>
-    </React.Fragment>
+    <MediaContext.Consumer>
+      { media => (
+        <React.Fragment>
+          <div className="nypl-row">
+            <div
+              className="nypl-column-full"
+              role="region"
+              aria-describedby="results-description"
+            >
+              {
+                hasResults ?
+                  <ResultsList
+                    results={results}
+                    searchKeywords={searchKeywords}
+                  /> :
+                  noResultElementForDrbbIntegration
+              }
+              { includeDrbb && media === 'desktop' ? <DrbbContainer /> : null}
+              {
+                hasResults ?
+                  <Pagination
+                    ariaControls="nypl-results-list"
+                    total={totalResults}
+                    perPage={50}
+                    page={parseInt(page, 10)}
+                    createAPIQuery={createAPIQuery}
+                    updatePage={updatePage}
+                  /> : null
+              }
+              { includeDrbb && ['tablet', 'mobile'].includes(media) ? <DrbbContainer /> : null}
+            </div>
+          </div>
+        </React.Fragment>
+      )}
+    </MediaContext.Consumer>
   );
 };
 
 SearchResultsContainer.propTypes = {
-  searchResults: PropTypes.object,
-  searchKeywords: PropTypes.string,
-  page: PropTypes.string,
-  features: PropTypes.array,
   createAPIQuery: PropTypes.func,
-};
-
-SearchResultsContainer.defaultProps = {
-  page: '1',
 };
 
 SearchResultsContainer.contextTypes = {
   router: PropTypes.object,
-  media: PropTypes.string,
 };
 
-const mapStateToProps = state => ({
-  searchResults: state.searchResults,
-  features: state.appConfig.features,
-  searchKeywords: state.searchKeywords,
-  page: state.page,
-});
-
-export default withRouter(connect(mapStateToProps)(SearchResultsContainer));
+export default SearchResultsContainer;

--- a/src/app/components/SubjectHeading/SubjectHeading.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeading.jsx
@@ -6,6 +6,7 @@ import { Link } from 'react-router';
 import SubjectHeadingsTableBody from './SubjectHeadingsTableBody';
 import Range from '../../models/Range';
 import appConfig from '../../data/appConfig';
+import { MediaContext } from '../Application/Application';
 
 class SubjectHeading extends React.Component {
   constructor(props) {
@@ -156,19 +157,19 @@ class SubjectHeading extends React.Component {
       seeMoreText,
       seeMoreLinkUrl,
       indentation,
+      container,
+      location,
     } = this.props;
 
     const {
-      location: {
-        pathname,
-        search,
-        query: {
-          filter,
-        },
+      pathname,
+      search,
+      query: {
+        filter,
       },
-    } = this.context.router;
+    } = location;
 
-    const { container, media } = this.context;
+    const { media } = this.context;
 
     const {
       label,
@@ -300,6 +301,7 @@ SubjectHeading.propTypes = {
   seeMoreText: PropTypes.string,
   seeMoreLinkUrl: PropTypes.string,
   preOpen: PropTypes.bool,
+  container: PropTypes.string,
 };
 
 SubjectHeading.defaultProps = {
@@ -307,10 +309,7 @@ SubjectHeading.defaultProps = {
   preOpen: false,
 };
 
-SubjectHeading.contextTypes = {
-  router: PropTypes.object,
-  container: PropTypes.string,
-  media: PropTypes.string,
-};
+// with new context API, class components may only subscribe to one context
+SubjectHeading.contextType = MediaContext;
 
 export default SubjectHeading;

--- a/src/app/components/SubjectHeading/SubjectHeadingsTableBody.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeadingsTableBody.jsx
@@ -125,8 +125,7 @@ class SubjectHeadingsTableBody extends React.Component {
       preOpen,
       marginSize
     } = this.props;
-
-
+    const { container, router } = this.context;
     const { location } = this.context.router;
 
     if (listItem.button) {
@@ -157,6 +156,8 @@ class SubjectHeadingsTableBody extends React.Component {
         seeMoreLinkUrl={seeMoreLinkUrl}
         direction={direction}
         preOpen={preOpen}
+        container={container}
+        router={router}
       />
     );
   }

--- a/src/app/pages/SubjectHeadingsIndexPage.jsx
+++ b/src/app/pages/SubjectHeadingsIndexPage.jsx
@@ -20,7 +20,7 @@ const SubjectHeadingsIndexPage = (props) => {
   const breadcrumbUrls = {}
   const searchUrl = basicQuery(props)({});
   if (searchUrl) breadcrumbUrls.searchUrl = searchUrl;
-  if (props.bib.uri) breadcrumbUrls.bibUrl = `/bib/${props.bib.uri}`;
+  if (props.bib && props.bib.uri) breadcrumbUrls.bibUrl = `/bib/${props.bib.uri}`;
 
   const bannerInnerHtml = filter ? <span key="bannerText">Subject Headings containing <em>{filter}</em></span> : <span key="bannerText">Subject Headings</span>
 

--- a/src/app/stores/InitialState.js
+++ b/src/app/stores/InitialState.js
@@ -15,7 +15,7 @@ const initialState = {
   filters: [],
   page: '1',
   sortBy: 'relevance',
-  loading: false,
+  loading: true,
   field: 'all',
   deliveryLocations: [],
   isEddRequestable: false,

--- a/src/server/ApiRoutes/Bib.js
+++ b/src/server/ApiRoutes/Bib.js
@@ -31,7 +31,7 @@ function fetchBib(bibId, cb, errorcb, options = { fetchSubjectHeadingData: true 
       if (options.fetchSubjectHeadingData && bib.subjectLiteral && bib.subjectLiteral.length) {
         return shepApiCall(bibId)
           .then((shepRes) => {
-            bib.subjectHeadingData = shepRes.bib.subject_headings;
+            bib.subjectHeadingData = shepRes.data.subject_headings;
             return { bib };
           })
           .catch((error) => {


### PR DESCRIPTION
**What's this do?**
Fragment PR for the Redux upgrade. It seems that with Redux implemented, the legacy context API is not properly changing context dynamically. This is only a problem for the 'media' context, I believe. The 'container' context (for SHEP pages) and 'router' should not change without a page reload.

**Why are we doing this? (w/ JIRA link if applicable)**
[Quick blurb about why the code is needed and Jira link goes here / Do these changes meet the business requirements of the story?]

**How should this be tested? / Do these changes have associated tests?**
With this change, the `Application` tests will passed for the _unconnected_ component. I have a separate draft PR with the test changes I have gotten through..

**Did someone actually run this code to verify it works?**
PR author did