### PR TITLE
Disable redirect when api route needs auth

### DIFF
--- a/src/app/utils/dataLoaderUtil.js
+++ b/src/app/utils/dataLoaderUtil.js
@@ -80,7 +80,8 @@ const routesGenerator = location => ({
       (data) => {
         if (data.redirect) {
           const fullUrl = encodeURIComponent(window.location.href);
-          window.location.replace(`${appConfig.loginUrl}?redirect_uri=${fullUrl}`);
+          console.error('API response indicates we should redirect to login page, but front-end disagrees.')
+          // window.location.replace(`${appConfig.loginUrl}?redirect_uri=${fullUrl}`);
         }
       },
       data => (data.redirect ? null : Actions.updateBib(data.bib)),


### PR DESCRIPTION
**What's this do?**
Revert principal effect of recent login hotfix: When server-side api route indicates that an auth is required and responds with `redirect: true`, the front-end should now silently ignore it - until we better understand the issue. 

**Why are we doing this? (w/ JIRA link if applicable)**
[Quick blurb about why the code is needed and Jira link goes here / Do these changes meet the business requirements of the story?]

**How should this be tested? / Do these changes have associated tests?**
[Description of any tests that need to be performed once merged goes here]

**Dependencies for merging? Releasing to production?**
[Description of any watchouts, dependencies, or issues we should be aware of goes here]

**Has the application documentation been updated for these changes?**

**Did someone actually run this code to verify it works?**
