### PR TITLE
Fix client side redirect for patron login, esp. for timeout

### DIFF
--- a/src/app/actions/Actions.js
+++ b/src/app/actions/Actions.js
@@ -128,6 +128,7 @@ export const updateSearchResultsPage = data => dispatch => new Promise(() => {
   dispatch(updateSearchKeywords(searchKeywords));
   if (page) dispatch(updatePage(page));
   if (sortBy) dispatch(updateSortBy(sortBy));
+  return data;
 });
 
 export const updateBibPage = ({ bib }) => dispatch => new Promise(() => dispatch(updateBib(bib)));
@@ -137,4 +138,5 @@ export const updateHoldRequestPage = data => dispatch => new Promise(() => {
   dispatch(updateBib(bib));
   dispatch(updateDeliveryLocations(deliveryLocations));
   dispatch(updateIsEddRequestable(isEddRequestable));
+  return data;
 });

--- a/src/app/components/HoldRequest/HoldRequest.jsx
+++ b/src/app/components/HoldRequest/HoldRequest.jsx
@@ -114,6 +114,12 @@ class HoldRequest extends React.Component {
       Object.fromEntries(formData.entries()),
     )
       .then((response) => {
+        const { data } = response;
+        if (data.redirect) {
+          const fullUrl = encodeURIComponent(window.location.href);
+          window.location.replace(`${appConfig.loginUrl}?redirect_uri=${fullUrl}`);
+          return;
+        };
         this.context.router.push(response.data);
       })
       .catch((error) => {

--- a/src/app/stores/Reducers.js
+++ b/src/app/stores/Reducers.js
@@ -6,7 +6,7 @@ function appReducer(state = initialState, action) {
   switch (action.type) {
     case Actions.RESET_STATE:
       // Reset state except appConfig and patron
-      return { ...initialState, appConfig: state.appConfig, patron: state.patron };
+      return { ...initialState, appConfig: state.appConfig, patron: state.patron, loading: false };
     case Actions.UPDATE_LOADING_STATUS:
       return { ...state, loading: action.payload };
     case Actions.UPDATE_SEARCH_RESULTS:

--- a/src/server/ApiRoutes/Hold.js
+++ b/src/server/ApiRoutes/Hold.js
@@ -175,14 +175,15 @@ function getDeliveryLocations(barcode, patronId, cb, errorCb) {
  */
 function confirmRequestServer(req, res, next) {
   const bibId = req.params.bibId || '';
-  const loggedIn = User.requireUser(req, res);
+  const requireUser = User.requireUser(req, res);
+  const { redirect } = requireUser;
   const requestId = req.query.requestId || '';
   const searchKeywords = req.query.q || '';
   const errorStatus = req.query.errorStatus ? req.query.errorStatus : null;
   const errorMessage = req.query.errorMessage ? req.query.errorMessage : null;
   const error = _extend({}, { errorStatus, errorMessage });
 
-  if (!loggedIn) return false;
+  if (redirect) return false;
 
   if (!requestId) {
     res.data = {
@@ -290,7 +291,8 @@ function confirmRequestServer(req, res, next) {
  * @return {function}
  */
 function newHoldRequest(req, res, resolve) {
-  const redirect = User.requireUser(req, res).redirect;
+  const requireUser = User.requireUser(req, res);
+  const { redirect } = requireUser;
   if (redirect) return resolve({ redirect });
 
   const bibId = req.params.bibId || '';
@@ -336,12 +338,13 @@ function newHoldRequest(req, res, resolve) {
 
 function newHoldRequestServerEdd(req, res, next) {
   const { dispatch } = global.store;
-  const loggedIn = User.requireUser(req, res);
+  const requireUser = User.requireUser(req, res);
+  const { redirect } = requireUser;
   const error = req.query.error ? JSON.parse(req.query.error) : {};
   const form = req.query.form ? JSON.parse(req.query.form) : {};
   const bibId = req.params.bibId || '';
 
-  if (!loggedIn) return false;
+  if (redirect) return false;
 
   // Retrieve item
   return Bib.fetchBib(
@@ -385,8 +388,9 @@ function newHoldRequestServerEdd(req, res, next) {
 function createHoldRequestServer(req, res, pickedUpBibId = '', pickedUpItemId = '') {
   res.respond = req.body.serverRedirect === 'false' ? res.json : res.redirect;
   // Ensure user is logged in
-  const loggedIn = User.requireUser(req, res);
-  if (!loggedIn) return false;
+  const requireUser = User.requireUser(req, res);
+  const { redirect } = requireUser;
+  if (redirect) return res.json({ redirect: true });
 
   // NOTE: pickedUpItemId and pickedUpBibId are coming from the EDD form function below:
   const itemId = req.params.itemId || pickedUpItemId;
@@ -471,9 +475,10 @@ function eddServer(req, res) {
   }
 
   // Ensure user is logged in
-  const loggedIn = User.requireUser(req);
+  const requireUser = User.requireUser(req, res);
+  const { redirect } = requireUser;
 
-  if (!loggedIn) return false;
+  if (redirect) return false;
 
   return postHoldAPI(
     req,

--- a/src/server/ApiRoutes/Hold.js
+++ b/src/server/ApiRoutes/Hold.js
@@ -290,8 +290,8 @@ function confirmRequestServer(req, res, next) {
  * @return {function}
  */
 function newHoldRequest(req, res, resolve) {
-  const loggedIn = User.requireUser(req, res);
-  if (!loggedIn) return false;
+  const redirect = User.requireUser(req, res).redirect;
+  if (redirect) return resolve({ redirect });
 
   const bibId = req.params.bibId || '';
   const patronId = req.patronTokenResponse.decodedPatron ?

--- a/src/server/ApiRoutes/User.js
+++ b/src/server/ApiRoutes/User.js
@@ -6,10 +6,10 @@ function requireUser(req, res) {
     !req.patronTokenResponse.decodedPatron || !req.patronTokenResponse.decodedPatron.sub) {
     // redirect to login
     const fullUrl = encodeURIComponent(`${req.protocol}://${req.get('host')}${req.originalUrl}`);
-    if (fullUrl.includes('%2Fapi%2F')) {
-      return { redirect: true };
+    if (!fullUrl.includes('%2Fapi%2F')) {
+      res.redirect(`${appConfig.loginUrl}?redirect_uri=${fullUrl}`);
     }
-    return res.redirect(`${appConfig.loginUrl}?redirect_uri=${fullUrl}`);
+    return { redirect: true };
   }
   return { redirect: false };
 }

--- a/src/server/ApiRoutes/User.js
+++ b/src/server/ApiRoutes/User.js
@@ -5,11 +5,13 @@ function requireUser(req, res) {
   if (!req.patronTokenResponse || !req.patronTokenResponse.isTokenValid ||
     !req.patronTokenResponse.decodedPatron || !req.patronTokenResponse.decodedPatron.sub) {
     // redirect to login
-    const fullUrl = encodeURIComponent(`${req.protocol}://${req.get('host')}${req.originalUrl}`.replace('/api', ''));
-    res.redirect(`${appConfig.loginUrl}?redirect_uri=${fullUrl}`);
-    return false;
+    const fullUrl = encodeURIComponent(`${req.protocol}://${req.get('host')}${req.originalUrl}`);
+    if (fullUrl.includes('%2Fapi%2F')) {
+      return { redirect: true };
+    }
+    return res.redirect(`${appConfig.loginUrl}?redirect_uri=${fullUrl}`);
   }
-  return true;
+  return { redirect: false };
 }
 
 function eligibility(req, res) {

--- a/test/unit/User.test.js
+++ b/test/unit/User.test.js
@@ -50,10 +50,10 @@ describe('If requireUser does not receive valid value from "req.patronTokenRespo
     requireUser.restore();
   });
 
-  it('should return false', () => {
+  it('should return { redirect: true }', () => {
     requireUser(renderMockReq(mockPatronTokenResponse), mockRes);
 
-    expect(requireUser.returnValues[0]).to.equal(false);
+    expect(requireUser.returnValues[0].redirect).to.equal(true);
   });
 });
 
@@ -71,10 +71,10 @@ describe('If requireUser does not receive valid value from "req.patronTokenRespo
       requireUser.restore();
     });
 
-    it('should return false', () => {
+    it('should return { redirect: true }', () => {
       requireUser(renderMockReq(mockPatronTokenResponse), mockRes);
 
-      expect(requireUser.returnValues[0]).to.equal(false);
+      expect(requireUser.returnValues[0].redirect).to.equal(true);
     });
   },
 );
@@ -104,10 +104,10 @@ describe('If requireUser does not receive valid value from "req.patronTokenRespo
       requireUser.restore();
     });
 
-    it('should return false', () => {
+    it('should return { redirect: true }', () => {
       requireUser(renderMockReq(mockPatronTokenResponse), mockRes);
 
-      expect(requireUser.returnValues[0]).to.equal(false);
+      expect(requireUser.returnValues[0].redirect).to.equal(true);
     });
   },
 );
@@ -126,10 +126,10 @@ describe('If requireUser does not receive valid value from "req.patronTokenRespo
     requireUser.restore();
   });
 
-  it('should return false', () => {
+  it('should return { redirect: true }', () => {
     requireUser(renderMockReq(mockPatronTokenResponse), mockRes);
 
-    expect(requireUser.returnValues[0]).to.equal(false);
+    expect(requireUser.returnValues[0].redirect).to.equal(true);
   });
 });
 
@@ -144,9 +144,9 @@ describe('If requireUser receives all valid values from "req"', () => {
     requireUser.restore();
   });
 
-  it('should return true', () => {
-    requireUser({ patronTokenResponse: mockPatronTokenResponse }, mockRes);
+  it('should return { redirect: false }', () => {
+    requireUser(renderMockReq(mockPatronTokenResponse), mockRes);
 
-    expect(requireUser.returnValues[0]).to.equal(true);
+    expect(requireUser.returnValues[0].redirect).to.equal(false);
   });
 });


### PR DESCRIPTION
**What's this do?**
This is an approximation of the work from #1471 with the new work done for the Redux implementation/simplifying the dataLoader.

**Why are we doing this? (w/ JIRA link if applicable)**
If a user is logged in on an SCC page, then logged out elsewhere, SCC will still behave as if the user is logged in.

**How should this be tested? / Do these changes have associated tests?**
Open an SCC page while logged in. In a different window, logout. In the first window, try to request an item. User should be redirected to login page.

**Did someone actually run this code to verify it works?**
I did.

**Note**
I found more cases that are not covered in this PR. But as discussed in standup, let's not handle that here or in the Redux refactor in general. These cases would come from being on a HoldRequest page, using JS, while logged in and then being logged out elsewhere and either doing an EDD or physical delivery.