### PR TITLE
SCC-2228 Add "Journal Title" as a search option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## CHANGE LOG
 
+### 1.6.7
+- Adding `Journal Title` as option in search dropdown
+
 ### 1.6.6
 - Updating @nypl/dgx-react-footer to 0.5.6.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nypl-discovery",
-  "version": "1.6.6",
+  "version": "1.6.7",
   "description": "Isomorphic React App for NYPL Research Catalog.",
   "main": "index.js",
   "scripts": {

--- a/src/app/components/Search/Search.jsx
+++ b/src/app/components/Search/Search.jsx
@@ -83,10 +83,21 @@ class Search extends React.Component {
       trackDiscovery('Search', `Field - ${this.state.field}`);
     }
 
+    // Set var for field querying so it can be overridden if necessary
+    let queryField = this.state.field;
+
+    // If user is making a search for periodicals switch from field to standard
+    // Title search with an issuance filter on the serial field
+    const additionalFilters = {};
+    if (this.state.field === 'journal title') {
+      additionalFilters.issuance = ['urn:biblevel:s'];
+      queryField = 'title';
+    }
+
     const searchKeywords = userSearchKeywords === '*' ? '' : userSearchKeywords;
     const apiQuery = this.props.createAPIQuery({
-      field: this.state.field,
-      selectedFilters: this.props.selectedFilters,
+      field: queryField,
+      selectedFilters: { ...this.props.selectedFilters, ...additionalFilters },
       searchKeywords,
       page: '1',
     });
@@ -118,6 +129,7 @@ class Search extends React.Component {
               >
                 <option value="all">All fields</option>
                 <option value="title">Title</option>
+                <option value="journal title">Journal Title</option>
                 <option value="contributor">Author/Contributor</option>
                 <option value="standard_number">Standard Numbers</option>
               </select>
@@ -133,7 +145,7 @@ class Search extends React.Component {
                 id="search-query"
                 aria-labelledby="search-input-label"
                 aria-controls="results-description"
-                placeholder="Keyword, title, or author/contributor"
+                placeholder="Keyword, title, journal title, or author/contributor"
                 onChange={this.inputChange}
                 value={this.state.searchKeywords}
                 name="q"

--- a/test/unit/Search.test.js
+++ b/test/unit/Search.test.js
@@ -148,13 +148,12 @@ describe('Search', () => {
     let triggerSubmitSpy;
     let submitSearchRequestSpy;
     let mock;
-    let contextRoutesPushed;
+    let contextRoutesPushed = [];
 
-    beforeEach(() => {
+    before(() => {
       createAPIQuery = basicQuery({});
       triggerSubmitSpy = sinon.spy(Search.prototype, 'triggerSubmit');
       submitSearchRequestSpy = sinon.spy(Search.prototype, 'submitSearchRequest');
-      contextRoutesPushed = [];
 
       component = mount(
         <Search createAPIQuery={createAPIQuery} />,
@@ -172,10 +171,15 @@ describe('Search', () => {
         .reply(500);
     });
 
-    afterEach(() => {
+    after(() => {
       mock.restore();
       triggerSubmitSpy.restore();
       submitSearchRequestSpy.restore();
+    });
+
+    afterEach(() => {
+      contextRoutesPushed = [];
+      submitSearchRequestSpy.reset();
     });
 
     it('should submit the input entered when clicking the submit button', (done) => {

--- a/test/unit/Search.test.js
+++ b/test/unit/Search.test.js
@@ -48,8 +48,8 @@ describe('Search', () => {
       expect(component.find('#search-by-field').length).to.equal(1);
     });
 
-    it('should render three option elements', () => {
-      expect(component.find('option').length).to.equal(4);
+    it('should render four option elements', () => {
+      expect(component.find('option').length).to.equal(5);
     });
 
     it('should have relevance as the default selected option', () => {
@@ -197,6 +197,19 @@ describe('Search', () => {
       component.find('input').at(0).simulate('change', { target: { value: 'Watts' } });
       component.find('button').at(0).simulate('click');
       expect(store.state.searchKeywords).not.to.equal('Watts');
+    });
+
+    it('should make a search request with issuance filter set for journal title searches', () => {
+      component.find('select').getDOMNode().value = 'journal title';
+      component.find('select').simulate('change');
+
+      mock = new MockAdapter(axios);
+      mock
+        .onGet(`${appConfig.baseUrl}/api?q=Dune&filters[issuance][0]]=urn:biblevel:s&search_scope=title`)
+        .reply(200, { searcResults: [] });
+
+      component.find('button').at(0).simulate('keyPress');
+      expect(triggerSubmitSpy.callCount).to.equal(2);
     });
   });
 });


### PR DESCRIPTION
**What's this do?**
This adds Journal Title as a search option in the main SCC search bar. This is done by adding in an additional filter on the `issuance` field when the option is selected. This restricts the results to `urn:biblvel:s` which corresponds to `serial` records. The main query is still executed on the `title` fields.

To achieve this, a small check is inserted for the search type and, if found, the `selectedFilters` field is extended with the serial value. This overrides any other values set on the `issuance` field, which I believe gives the intended functionality. (e.g. selecting Journal Title should override other format filters to avoid any unexpected results)

An additional test has been added to verify that the proper query URL is generated for the API when this option is selected.

**Why are we doing this? (w/ JIRA link if applicable)**
This is necessary to enable better serial discovery in scc [SCC-2228](https://jira.nypl.org/browse/SCC-2228)

**How should this be tested? / Do these changes have associated tests?**
Test suite should pass and new search function should be verified locally

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
Yes

**Did someone actually run this code to verify it works?**
Yes