### PR TITLE
Get bibId from params for eligibility redirect

### DIFF
--- a/src/app/components/HoldRequest/HoldRequest.jsx
+++ b/src/app/components/HoldRequest/HoldRequest.jsx
@@ -180,13 +180,15 @@ class HoldRequest extends React.Component {
   // checking for manual blocks, expired cards, and excessive fines.
 
   conditionallyRedirect() {
+    const { params } = this.props;
     return this.checkEligibility().then((eligibility) => {
       if (!eligibility.eligibility) {
         const bib = (this.props.bib && !_isEmpty(this.props.bib)) ?
           this.props.bib : null;
-        const bibId = (bib && bib['@id'] && typeof bib['@id'] === 'string') ?
+        let bibId = (bib && bib['@id'] && typeof bib['@id'] === 'string') ?
           bib['@id'].substring(4) : '';
-        const itemId = (this.props.params && this.props.params.itemId) ? this.props.params.itemId : '';
+        if (!bibId) bibId = (params && params.bibId) ? params.bibId : '';
+        const itemId = (params && params.itemId) ? params.itemId : '';
         const path = `${appConfig.baseUrl}/hold/confirmation/${bibId}-${itemId}`;
         return this.redirectWithErrors(path, 'eligibility', JSON.stringify(eligibility));
       }


### PR DESCRIPTION
**What's this do?**
The redirect url for ineligible users has a bug. It appears that at the point of the redirect, the bib is not set in props. But we can get the bibId from the params. The fix is the same between the current live version and the Redux version.