### PR TITLE
SCC-2141: Fix shep bib page pagination for last page

### DIFF
--- a/src/app/components/SubjectHeading/BibsList.jsx
+++ b/src/app/components/SubjectHeading/BibsList.jsx
@@ -21,7 +21,7 @@ class BibsList extends React.Component {
     };
     this.sort = context.router.location.query.sort || 'date';
     this.sortDirection = context.router.location.query.sort_direction || 'desc';
-    this.updateShepBibPage = this.updateShepBibPage.bind(this);
+    this.fetchBibsFromShep = this.fetchBibsFromShep.bind(this);
     this.updateBibPage = this.updateBibPage.bind(this);
     this.lastBib = this.lastBib.bind(this);
     this.firstBib = this.firstBib.bind(this);
@@ -94,13 +94,27 @@ class BibsList extends React.Component {
   }
 
   updateBibPage(newPage) {
-    if (this.state.bibsSource === 'shepApi') {
-      this.updateShepBibPage(newPage);
+    const {
+      bibsSource,
+      results,
+      totalResults,
+    } = this.state;
+    const { perPage } = this;
+    const fetchedBibsLength = results.length;
+    if (bibsSource === 'shepApi') {
+      if (
+        fetchedBibsLength < totalResults &&
+        newPage * perPage > fetchedBibsLength
+      ) this.fetchBibsFromShep(newPage);
+      else {
+        this.setState({
+          bibPage: newPage,
+        }, () => window.scrollTo(0, 300));
+      }
       return;
     }
 
     const stringifiedSortParams = `sort=${this.sort}&sort_direction=${this.sortDirection}&page=${newPage}&per_page=${this.perPage}&source=${this.state.bibsSource}`;
-
     this.setState({
       componentLoading: true,
     }, () => this.fetchBibs(
@@ -108,7 +122,7 @@ class BibsList extends React.Component {
       () => window.scrollTo(0, 300)));
   }
 
-  updateShepBibPage(newPage) {
+  fetchBibsFromShep(newPage) {
     const { nextUrl } = this.state;
 
     return axios(nextUrl)


### PR DESCRIPTION
**What's this do?**
So previously, we had been fetching the next page of bibs for both 'Next' and 'Previous'. There has been a bug for the pages that use SHEP API (remember some pages use Discovery API if there is a large bib count discrepancy). For those pages, the Previous button would not work for the last page, because nextUrl was undefined. Also, if you go forward and back, the nextUrl keeps changing until it is undefined and then you cannot make it to any further pages.
Example:
Go to 2nd page, go back to 1st page, go to 3rd page, try to go to 4th page or 2nd page
https://www.nypl.org/research/collections/shared-collection-catalog/subject_headings/40d0d45d-c772-4378-95ff-0d6640c5d44d?label=Jungius%2C%20Joachim%2C%201587-1657

There are a couple ways this could be fixed. This one only fetches more bibs when actually needed.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SCC-2141

**Did someone actually run this code to verify it works?**
PR author did.