### PR TITLE
SCC-2253: detect `reachedHoldLimit` block from `patron-eligibility-service`

### DIFF
--- a/src/app/components/HoldConfirmation/HoldConfirmation.jsx
+++ b/src/app/components/HoldConfirmation/HoldConfirmation.jsx
@@ -40,6 +40,10 @@ export class HoldConfirmation extends React.Component {
     return (<li className="errorItem">Your card does not permit placing holds on ReCAP materials.</li>);
   }
 
+  reachedHoldLimit() {
+    return (<li className="errorItem">You have reached the allowed number of holds.</li>);
+  }
+
   /**
    * eligibilityErrorText supplies the appropriate text when a patron is ineligible to place holds.
    * @return {HTML Element}
@@ -51,7 +55,8 @@ export class HoldConfirmation extends React.Component {
       const blocked = errors.blocked ? this.blockedMessage() : null;
       const moneyOwed = errors.moneyOwed ? this.moneyOwedMessage() : null;
       const ptypeDisallowsHolds = errors.ptypeDisallowsHolds ? this.ptypeDisallowsHolds() : null;
-      const defaultText = expired || blocked || moneyOwed || ptypeDisallowsHolds ? null : 'There is a problem with your library account.';
+      const reachedHoldLimit = errors.reachedHoldLimit ? this.reachedHoldLimit() : null;
+      const defaultText = expired || blocked || moneyOwed || ptypeDisallowsHolds || reachedHoldLimit ? null : 'There is a problem with your library account.';
       return (
         <p> This is because:
           <ul>
@@ -60,6 +65,7 @@ export class HoldConfirmation extends React.Component {
             {blocked}
             {ptypeDisallowsHolds}
             {defaultText}
+            {reachedHoldLimit}
           </ul>
           Please see a librarian or contact 917-ASK-NYPL (<a href="tel:19172756975">917-275-6975</a>) if you require assistance.
         </p>);

--- a/src/app/components/HoldConfirmation/HoldConfirmation.jsx
+++ b/src/app/components/HoldConfirmation/HoldConfirmation.jsx
@@ -64,8 +64,8 @@ export class HoldConfirmation extends React.Component {
             {expired}
             {blocked}
             {ptypeDisallowsHolds}
-            {defaultText}
             {reachedHoldLimit}
+            {defaultText}
           </ul>
           Please see a librarian or contact 917-ASK-NYPL (<a href="tel:19172756975">917-275-6975</a>) if you require assistance.
         </p>);


### PR DESCRIPTION
**What's this do?**
Corresponding frontend changes for https://github.com/NYPL-discovery/patron-eligibility-service/pull/9

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SCC-2153

**Did someone actually run this code to verify it works?**
PR author did