### PR TITLE
Make loginUrl configurable (for scc-2250)

### DIFF
--- a/src/app/data/appConfig.js
+++ b/src/app/data/appConfig.js
@@ -26,7 +26,7 @@ const appConfig = {
     },
   },
   shepApi: process.env.SHEP_API,
-  loginUrl: 'https://login.nypl.org/auth/login',
+  loginUrl: process.env.LOGIN_URL,
   tokenUrl: 'https://isso.nypl.org/',
   publicKey:
     '-----BEGIN PUBLIC KEY-----\n' +

--- a/src/app/data/appConfig.js
+++ b/src/app/data/appConfig.js
@@ -26,7 +26,7 @@ const appConfig = {
     },
   },
   shepApi: process.env.SHEP_API,
-  loginUrl: process.env.LOGIN_URL,
+  loginUrl: process.env.LOGIN_URL || 'https://login.nypl.org/auth/login',
   tokenUrl: 'https://isso.nypl.org/',
   publicKey:
     '-----BEGIN PUBLIC KEY-----\n' +

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -49,6 +49,7 @@ const commonSettings = {
       appEnv: JSON.stringify(appEnv),
       'process.env': {
         SHEP_API: JSON.stringify(process.env.SHEP_API),
+        LOGIN_URL: JSON.stringify(process.env.LOGIN_URL),
       },
     }),
     // new BundleAnalyzerPlugin({
@@ -216,6 +217,7 @@ if (ENV === 'production') {
           NODE_ENV: JSON.stringify('production'),
           GA_ENV: JSON.stringify(process.env.GA_ENV),
           SHEP_API: process.env.SHEP_API,
+          LOGIN_URL: process.env.LOGIN_URL,
         },
       }),
     ],


### PR DESCRIPTION
**What's this do?**
Makes the `loginUrl` parameter configurable in the env variables.

**Why are we doing this? (w/ JIRA link if applicable)**
For scc-2250, we want to be able to test out the development/qa deployments of discovery-front-end against the development/qa deployments of the oauth app/server. This will be easier if the `loginUrl` parameter can be easily changed in the env variables instead of requiring a code change.

**How should this be tested? / Do these changes have associated tests?**
[Description of any tests that need to be performed once merged goes here]

**Dependencies for merging? Releasing to production?**
[Description of any watchouts, dependencies, or issues we should be aware of goes here]

**Has the application documentation been updated for these changes?**

**Did someone actually run this code to verify it works?**
PR author tested locally.