### PR TITLE
Fix bugs for updating searchKeywords and "Journal Title" field

### DIFF
--- a/src/app/components/Search/Search.jsx
+++ b/src/app/components/Search/Search.jsx
@@ -7,10 +7,6 @@ import {
   trackDiscovery,
 } from '../../utils/utils';
 import appConfig from '../../data/appConfig';
-import {
-  updateField,
-  updateSearchKeywords,
-} from '../../actions/Actions';
 
 /**
  * The main container for the top Search section.
@@ -161,8 +157,6 @@ Search.propTypes = {
   searchKeywords: PropTypes.string,
   createAPIQuery: PropTypes.func,
   selectedFilters: PropTypes.object,
-  updateField: PropTypes.func,
-  updateSearchKeywords: PropTypes.func,
   router: PropTypes.object,
 };
 
@@ -178,10 +172,4 @@ const mapStateToProps = ({
   selectedFilters,
 }) => ({ searchKeywords, field, selectedFilters });
 
-
-const mapDispatchToProps = dispatch => ({
-  updateField: field => dispatch(updateField(field)),
-  updateSearchKeywords: searchKeywords => dispatch(updateSearchKeywords(searchKeywords)),
-});
-
-export default connect(mapStateToProps, mapDispatchToProps)(Search);
+export default connect(mapStateToProps)(Search);

--- a/src/app/components/Search/Search.jsx
+++ b/src/app/components/Search/Search.jsx
@@ -46,7 +46,7 @@ class Search extends React.Component {
    */
   onFieldChange() {
     const newFieldVal = this.searchByFieldRef.value;
-    this.setState({ field: newFieldVal }, () => this.props.updateField(newFieldVal));
+    this.setState({ field: newFieldVal });
   }
 
   /**
@@ -71,7 +71,7 @@ class Search extends React.Component {
    * as FireFox doesn't accept event as a global variable.
    */
   inputChange(event) {
-    this.props.updateSearchKeywords(event.target.value);
+    this.setState({ searchKeywords: event.target.value });
   }
 
   /**
@@ -88,21 +88,10 @@ class Search extends React.Component {
       trackDiscovery('Search', `Field - ${this.state.field}`);
     }
 
-    // Set var for field querying so it can be overridden if necessary
-    let queryField = this.state.field;
-
-    // If user is making a search for periodicals switch from field to standard
-    // Title search with an issuance filter on the serial field
-    const additionalFilters = {};
-    if (this.state.field === 'journal_title') {
-      additionalFilters.issuance = ['urn:biblevel:s'];
-      queryField = 'journal_title';
-    }
-
     const searchKeywords = userSearchKeywords === '*' ? '' : userSearchKeywords;
     const apiQuery = this.props.createAPIQuery({
-      field: queryField,
-      selectedFilters: { ...this.props.selectedFilters, ...additionalFilters },
+      field: this.state.field,
+      selectedFilters: this.props.selectedFilters,
       searchKeywords,
       page: '1',
     });

--- a/src/app/components/Search/Search.jsx
+++ b/src/app/components/Search/Search.jsx
@@ -7,7 +7,10 @@ import {
   trackDiscovery,
 } from '../../utils/utils';
 import appConfig from '../../data/appConfig';
-import { updateField } from '../../actions/Actions';
+import {
+  updateField,
+  updateSearchKeywords,
+} from '../../actions/Actions';
 
 /**
  * The main container for the top Search section.
@@ -68,7 +71,7 @@ class Search extends React.Component {
    * as FireFox doesn't accept event as a global variable.
    */
   inputChange(event) {
-    this.setState({ searchKeywords: event.target.value });
+    this.props.updateSearchKeywords(event.target.value);
   }
 
   /**
@@ -91,9 +94,9 @@ class Search extends React.Component {
     // If user is making a search for periodicals switch from field to standard
     // Title search with an issuance filter on the serial field
     const additionalFilters = {};
-    if (this.state.field === 'journal title') {
+    if (this.state.field === 'journal_title') {
       additionalFilters.issuance = ['urn:biblevel:s'];
-      queryField = 'title';
+      queryField = 'journal_title';
     }
 
     const searchKeywords = userSearchKeywords === '*' ? '' : userSearchKeywords;
@@ -131,7 +134,7 @@ class Search extends React.Component {
               >
                 <option value="all">All fields</option>
                 <option value="title">Title</option>
-                <option value="journal title">Journal Title</option>
+                <option value="journal_title">Journal Title</option>
                 <option value="contributor">Author/Contributor</option>
                 <option value="standard_number">Standard Numbers</option>
               </select>
@@ -170,6 +173,7 @@ Search.propTypes = {
   createAPIQuery: PropTypes.func,
   selectedFilters: PropTypes.object,
   updateField: PropTypes.func,
+  updateSearchKeywords: PropTypes.func,
   router: PropTypes.object,
 };
 
@@ -186,6 +190,9 @@ const mapStateToProps = ({
 }) => ({ searchKeywords, field, selectedFilters });
 
 
-const mapDispatchToProps = dispatch => ({ updateField: field => dispatch(updateField(field)) });
+const mapDispatchToProps = dispatch => ({
+  updateField: field => dispatch(updateField(field)),
+  updateSearchKeywords: searchKeywords => dispatch(updateSearchKeywords(searchKeywords)),
+});
 
 export default connect(mapStateToProps, mapDispatchToProps)(Search);

--- a/src/app/utils/utils.js
+++ b/src/app/utils/utils.js
@@ -381,6 +381,7 @@ function displayContext({ searchKeywords, selectedFilters, field, count }) {
     contributor: 'author/contributor',
     title: 'title',
     standard_number: 'standard number',
+    journal_title: 'journal title'
   };
 
   // Build up an array of human-readable "clauses" representing the query:

--- a/src/app/utils/utils.js
+++ b/src/app/utils/utils.js
@@ -381,7 +381,7 @@ function displayContext({ searchKeywords, selectedFilters, field, count }) {
     contributor: 'author/contributor',
     title: 'title',
     standard_number: 'standard number',
-    journal_title: 'journal title'
+    journal_title: 'journal title',
   };
 
   // Build up an array of human-readable "clauses" representing the query:

--- a/src/server/ApiRoutes/Search.js
+++ b/src/server/ApiRoutes/Search.js
@@ -31,11 +31,12 @@ const nyplApiClientCall = (query) => {
 };
 
 function fetchResults(searchKeywords = '', page, sortBy, order, field, filters, cb, errorcb) {
+  const apiQueryField = field === 'journal_title' ? 'title' : field;
   const encodedResultsQueryString = createAPIQuery({
     searchKeywords,
     sortBy: sortBy ? `${sortBy}_${order}` : '',
     selectedFilters: filters,
-    field,
+    field: apiQueryField,
     page,
   });
   const encodedAggregationsQueryString = createAPIQuery({

--- a/test/helpers/store.js
+++ b/test/helpers/store.js
@@ -32,6 +32,5 @@ export const mountTestRender = (ui, { store, ...otherOpts }) => testRender(
 export function makeTestStore(opts = initialState) {
   const mockStore = configureStore([thunk]);
   const store = mockStore({ ...initialState, ...opts });
-  store.dispatch = stub(store, 'dispatch');
   return store;
 }

--- a/test/unit/Search.test.js
+++ b/test/unit/Search.test.js
@@ -146,6 +146,7 @@ describe('Search', () => {
       component.find('input').at(0).simulate('change', { target: { value: 'Dune' } });
 
       expect(inputChangeSpy.callCount).to.equal(1);
+      expect(component.state('searchKeywords')).to.equal('Dune');
     });
   });
 
@@ -194,13 +195,17 @@ describe('Search', () => {
       component.find('button').at(0).simulate('click');
       setTimeout(() => {
         expect(submitSearchRequestSpy.callCount).to.equal(1);
+        expect(component.state('searchKeywords')).to.equal('Dune');
         done();
       }, 1000);
     });
 
     it('should submit the input entered when pressing enter', () => {
       component.find('input').at(0).simulate('change', { target: { value: 'Dune' } });
+      expect(component.state('searchKeywords')).to.equal('Dune');
+      component.find('input').at(0).simulate('change', { target: { value: 'Harry Potter' } });
       component.find('button').at(0).simulate('keyPress');
+      expect(component.state('searchKeywords')).to.equal('Harry Potter');
       expect(triggerSubmitSpy.callCount).to.equal(1);
     });
 
@@ -208,19 +213,6 @@ describe('Search', () => {
       component.find('input').at(0).simulate('change', { target: { value: 'Watts' } });
       component.find('button').at(0).simulate('click');
       expect(mockStore.getState().searchKeywords).not.to.equal('Watts');
-    });
-
-    it('should make a search request with issuance filter set for journal title searches', (done) => {
-      component.find('select').getDOMNode().value = 'journal_title';
-      component.find('select').simulate('change');
-
-      component.find('input').at(0).simulate('change', { target: { value: 'Time' } });
-      component.find('button').at(0).simulate('click');
-
-      setTimeout(() => {
-        expect(submitSearchRequestSpy.callCount).to.equal(1);
-        done();
-      }, 1000);
     });
   });
 });

--- a/test/unit/Search.test.js
+++ b/test/unit/Search.test.js
@@ -146,7 +146,6 @@ describe('Search', () => {
       component.find('input').at(0).simulate('change', { target: { value: 'Dune' } });
 
       expect(inputChangeSpy.callCount).to.equal(1);
-      expect(component.state('searchKeywords')).to.equal('Dune');
     });
   });
 
@@ -194,7 +193,6 @@ describe('Search', () => {
       component.find('input').at(0).simulate('change', { target: { value: 'Dune' } });
       component.find('button').at(0).simulate('click');
       setTimeout(() => {
-        expect(component.state('searchKeywords')).to.equal('Dune');
         expect(submitSearchRequestSpy.callCount).to.equal(1);
         done();
       }, 1000);
@@ -202,11 +200,7 @@ describe('Search', () => {
 
     it('should submit the input entered when pressing enter', () => {
       component.find('input').at(0).simulate('change', { target: { value: 'Dune' } });
-      expect(component.state('searchKeywords')).to.equal('Dune');
-      component.find('input').at(0).simulate('change', { target: { value: 'Harry Potter' } });
       component.find('button').at(0).simulate('keyPress');
-
-      expect(component.state('searchKeywords')).to.equal('Harry Potter');
       expect(triggerSubmitSpy.callCount).to.equal(1);
     });
 
@@ -217,7 +211,7 @@ describe('Search', () => {
     });
 
     it('should make a search request with issuance filter set for journal title searches', (done) => {
-      component.find('select').getDOMNode().value = 'journal title';
+      component.find('select').getDOMNode().value = 'journal_title';
       component.find('select').simulate('change');
 
       component.find('input').at(0).simulate('change', { target: { value: 'Time' } });
@@ -225,8 +219,6 @@ describe('Search', () => {
 
       setTimeout(() => {
         expect(submitSearchRequestSpy.callCount).to.equal(1);
-        expect(contextRoutesPushed[0])
-          .to.equal('/research/collections/shared-collection-catalog/search?q=Time&filters[issuance][0]=urn%3Abiblevel%3As&search_scope=title');
         done();
       }, 1000);
     });


### PR DESCRIPTION
**What's this do?**
This fixes some small bugs with the Search Keyword state and the new "Journal Title" field.
Bugs can be seen on this environment: http://discoveryui-edd-training.nypl.org/research/collections/shared-collection-catalog/
For the search keyword bug: type in a search term, change the field, see that that search term disappears. Or submit a search, change the term, change the field, the term reverts to the first term.
"Journal Title" bug: submit a search with "Journal Title" selected, the field is displayed as "Title"

**How should this be tested? / Do these changes have associated tests?**
~~Some tests broke from the search keyword bug fix. I'm not sure how to fix them :(~~
Not a problem with commit def9506

**Did someone actually run this code to verify it works?**
PR author did