### PR TITLE
SCC-2278: Make tab padding smaller for mobile view

### DIFF
--- a/src/app/components/BibPage/BibPage.jsx
+++ b/src/app/components/BibPage/BibPage.jsx
@@ -160,22 +160,17 @@ const BibPage = (props) => {
 
         <div className="nypl-full-width-wrapper">
           <div className="nypl-row">
-            <div
-              className="nypl-column-three-quarters"
-              role="region"
-            >
-              <div className="nypl-item-details">
-                <BibDetails
-                  bib={bib}
-                  fields={topFields}
-                  logging
-                  electronicResources={aggregatedElectronicResources}
-                />
-                <Tabbed
-                  tabs={tabs}
-                  hash={location.hash}
-                />
-              </div>
+            <div className="nypl-item-details">
+              <BibDetails
+                bib={bib}
+                fields={topFields}
+                logging
+                electronicResources={aggregatedElectronicResources}
+              />
+              <Tabbed
+                tabs={tabs}
+                hash={location.hash}
+              />
             </div>
           </div>
         </div>

--- a/src/app/utils/dataLoaderUtil.js
+++ b/src/app/utils/dataLoaderUtil.js
@@ -43,7 +43,7 @@ const successCb = (pathType, dispatch) => (response) => {
     const fullUrl = encodeURIComponent(window.location.href);
     window.location.replace(`${appConfig.loginUrl}?redirect_uri=${fullUrl}`);
     return { redirect: true }
-  };
+  }
   dispatch(routes[pathType].action(data));
   return data;
 };

--- a/src/client/styles/components/BibPage.scss
+++ b/src/client/styles/components/BibPage.scss
@@ -189,7 +189,7 @@ div .tabbed {
   }
 }
 
-@media (min-width: $mobile-breakpoint) {
+@media (min-width: $xtrasmall-breakpoint) {
   ul[role="tablist"] > li > a {
     padding: 20px 30px;
   }
@@ -199,7 +199,7 @@ div .tabbed {
   }
 }
 
-@media (max-width: $mobile-breakpoint) {
+@media (max-width: $xtrasmall-breakpoint) {
   ul[role="tablist"] > li > a {
     padding: 5px 10px;
   }

--- a/src/client/styles/components/BibPage.scss
+++ b/src/client/styles/components/BibPage.scss
@@ -38,13 +38,9 @@ div .tabbed {
 
   ul[role="tablist"] > li > a {
     color: $nypl-gray-brown;
-    padding: 20px;
-    padding-left: 30px;
-    padding-right: 30px;
     display: table-cell;
-    font-weight: 500;
+    font-weight: 400;
     text-decoration: none;
-    // border-bottom: 1px solid black;
   }
 
   ul[role="tablist"] > li:target > a {
@@ -52,23 +48,17 @@ div .tabbed {
   }
 
   ul[role="tablist"] > li > a[aria-selected='true'] {
-    padding: 20px;
-    padding-left: 30px;
-    padding-right: 30px;
     display: table-cell;
     font-weight: 500;
     text-decoration: none;
-    // border: 1px solid black;
-    // border-bottom: none;
     color: black;
   }
 
   .blank {
     border-bottom: 1px solid black;
-     color: white;
-     //padding: 10px;
-     content: "";
-     width: 50%;
+    color: white;
+    content: '';
+    width: 100%;
   }
 
   ul[role="tablist"] {
@@ -191,62 +181,30 @@ div .tabbed {
   }
 }
 
-// end styles for hierarchical subjects
-
-// #tab0:target ~ #section0 {
-//   display: block;
-// }
-//
-// #tab1:target ~ #section1 {
-//   display: block;
-// }
-// .non-default {
-//   display: none;
-// }
-//
-// .default {
-//   display: block;
-// }
-//
-// .non-default:target {
-//   display: block;
-// }
-//
-// .non-default:target ~ .default {
-//   display: none
-// }
-//
-// section {
-//   display: none;
-// }
-// .default {
-//   display: block;
-// }
-// .untargeted:target ~ #section0 {
-//   display: none;
-// }
-//
-// @for $i from 0 through 1 {
-//   #ind#{$i}:target ~ #section#{$i} {
-//     display: block;
-//   }
-//   #ind#{$i}:target ~ #section#{$i} {
-//     display: block;
-//   }
-// }
-//
-// .activeTab {
-//   display: block;
-// }
-//
-// .inactiveTab {
-//   display: none;
-// }
-
 @media (max-width: 1120px) {
   .additionalDetails {
-  dt {
-    float: none;
+    dt {
+      float: none;
+    }
   }
 }
+
+@media (min-width: $mobile-breakpoint) {
+  ul[role="tablist"] > li > a {
+    padding: 20px 30px;
+  }
+
+  ul[role="tablist"] > li > a[aria-selected='true'] {
+    padding: 20px 30px;
+  }
+}
+
+@media (max-width: $mobile-breakpoint) {
+  ul[role="tablist"] > li > a {
+    padding: 5px 10px;
+  }
+
+  ul[role="tablist"] > li > a[aria-selected='true'] {
+    padding: 5px 10px;
+  }
 }

--- a/src/client/styles/main.scss
+++ b/src/client/styles/main.scss
@@ -186,3 +186,9 @@ div {
     outline-offset: 0;
   }
 }
+
+@media (max-width: $mobile-breakpoint) {
+  .nypl-full-width-wrapper {
+    padding-left: 1rem;
+  }
+}


### PR DESCRIPTION
**What's this do?**
With a third tab, the current padding is too big for mobile view. This PR trims down the padding for screen-widths smaller than 483px.

**Why are we doing this? (w/ JIRA link if applicable)**
Newest designs have a dropdown for mobile view. This might be needed once the "Library Holdings" tab is implemented. But for now, these changes are sufficient and a little more inline with designs.

**Did someone actually run this code to verify it works?**
PR author did