### PR TITLE
Move "Availability"/items below tabbed portion

### DIFF
--- a/src/app/components/BibPage/BibPage.jsx
+++ b/src/app/components/BibPage/BibPage.jsx
@@ -55,7 +55,7 @@ const BibPage = (props) => {
     { label: 'Supplementary Content', value: 'supplementaryContent', selfLinkable: true },
   ];
 
-  const bottomFields = [
+  const tabFields = [
     { label: 'Additional Authors', value: 'contributorLiteral', linkable: true },
     { label: 'Found In', value: 'partOf' },
     { label: 'Publication Date', value: 'serialPublicationDates' },
@@ -83,7 +83,7 @@ const BibPage = (props) => {
   // we will use the subjectLiteral property from the
   // Discovery API response instead
   if (!bib.subjectHeadingData) {
-    bottomFields.push({
+    tabFields.push({
       label: 'Subject', value: 'subjectLiteral', linkable: true,
     });
   }
@@ -100,10 +100,10 @@ const BibPage = (props) => {
   // Related to removing MarcRecord because the webpack MarcRecord is not working. Sep/28/2017
   // const marcRecord = isNYPLReCAP ? <MarcRecord bNumber={bNumber[0]} /> : null;
 
-  const bottomDetails = (
+  const tabDetails = (
     <BibDetails
       bib={bib}
-      fields={bottomFields}
+      fields={tabFields}
       electronicResources={aggregatedElectronicResources}
     />
   );
@@ -113,13 +113,9 @@ const BibPage = (props) => {
 
   const otherLibraries = ['Princeton University Library', 'Columbia University Libraries'];
   const tabs = [
-    itemHoldings ? {
-      title: 'Availability',
-      content: itemHoldings,
-    } : null,
     {
       title: 'Details',
-      content: bottomDetails,
+      content: tabDetails,
     },
     !otherLibraries.includes(getOwner(bib)) ? {
       title: 'Full Description',
@@ -160,22 +156,19 @@ const BibPage = (props) => {
 
         <div className="nypl-full-width-wrapper">
           <div className="nypl-row">
-            <div
-              className="nypl-column-three-quarters"
-              role="region"
-            >
-              <div className="nypl-item-details">
-                <BibDetails
-                  bib={bib}
-                  fields={topFields}
-                  logging
-                  electronicResources={aggregatedElectronicResources}
-                />
-                <Tabbed
-                  tabs={tabs}
-                  hash={location.hash}
-                />
-              </div>
+            <div className="nypl-item-details">
+              <BibDetails
+                bib={bib}
+                fields={topFields}
+                logging
+                electronicResources={aggregatedElectronicResources}
+              />
+              <Tabbed
+                tabs={tabs}
+                hash={location.hash}
+              />
+              <h2>Availability</h2>
+              {itemHoldings}
             </div>
           </div>
         </div>

--- a/src/app/components/BibPage/BibPage.jsx
+++ b/src/app/components/BibPage/BibPage.jsx
@@ -167,7 +167,6 @@ const BibPage = (props) => {
                 tabs={tabs}
                 hash={location.hash}
               />
-              <h2>Availability</h2>
               {itemHoldings}
             </div>
           </div>

--- a/src/app/components/Item/ItemHoldings.jsx
+++ b/src/app/components/Item/ItemHoldings.jsx
@@ -133,6 +133,7 @@ class ItemHoldings extends React.Component {
 
     return (
       <div className="nypl-results-item">
+        <h2>Availability</h2>
         {itemTable}
         {
           !!(shortenItems && items.length >= 20 && !this.state.showAll) &&

--- a/src/client/styles/components/BibPage.scss
+++ b/src/client/styles/components/BibPage.scss
@@ -38,9 +38,7 @@ div .tabbed {
 
   ul[role="tablist"] > li > a {
     color: $nypl-gray-brown;
-    padding: 20px;
-    padding-left: 30px;
-    padding-right: 30px;
+    padding: 5px 8px;
     display: table-cell;
     font-weight: 500;
     text-decoration: none;
@@ -52,9 +50,7 @@ div .tabbed {
   }
 
   ul[role="tablist"] > li > a[aria-selected='true'] {
-    padding: 20px;
-    padding-left: 30px;
-    padding-right: 30px;
+    padding: 5px 8px;
     display: table-cell;
     font-weight: 500;
     text-decoration: none;
@@ -65,10 +61,9 @@ div .tabbed {
 
   .blank {
     border-bottom: 1px solid black;
-     color: white;
-     //padding: 10px;
-     content: "";
-     width: 50%;
+    color: white;
+    content: '';
+    width: 100%;
   }
 
   ul[role="tablist"] {

--- a/src/client/styles/style-v2.scss
+++ b/src/client/styles/style-v2.scss
@@ -1,6 +1,10 @@
 // discovery-item.v2.html
 // item info / the full item record
 .nypl-item-details {
+  dl:first-of-type {
+    padding-bottom: 7px;
+  }
+
   dl {
     border-left: 0;
     font-size: 0.95rem;

--- a/test/unit/BibPage.test.js
+++ b/test/unit/BibPage.test.js
@@ -19,7 +19,7 @@ describe('BibPage', () => {
     const tabs = tabbed.props().tabs;
     const titles = tabs.map(tab => tab.title);
     expect(tabbed.length).to.equal(1);
-    expect(tabs.length).to.equal(3);
-    expect(titles).to.deep.equal(['Availability', 'Details', 'Full Description']);
+    expect(tabs.length).to.equal(2);
+    expect(titles).to.deep.equal(['Details', 'Full Description']);
   });
 });


### PR DESCRIPTION
**What's this do?**
Move the item table below the tabbed information.

For some reason, this throws off the position that the `focus()` function scrolls to. I am going to keep playing around with this, but would like to get it onto dev.

**Dependencies for merging? Releasing to production?**
For some reason, this throws off the position that the `focus()` function scrolls to. I am going to keep playing around with this, but would like to get it onto dev.

**Did someone actually run this code to verify it works?**
I did