### PR TITLE
SCC-2230: Create placeholder for "Library Holdings" tab

### DIFF
--- a/src/app/components/BibPage/BibPage.jsx
+++ b/src/app/components/BibPage/BibPage.jsx
@@ -13,6 +13,7 @@ import LibraryItem from '../../utils/item';
 import BackLink from './BackLink';
 import AdditionalDetailsViewer from './AdditionalDetailsViewer';
 import Tabbed from './Tabbed';
+import LibraryHoldings from './LibraryHoldings';
 import getOwner from '../../utils/getOwner';
 // Removed MarcRecord because the webpack MarcRecord is not working. Sep/28/2017
 // import MarcRecord from './MarcRecord';
@@ -110,16 +111,20 @@ const BibPage = (props) => {
 
   const additionalDetails = (<AdditionalDetailsViewer bib={bib} />);
 
-
   const otherLibraries = ['Princeton University Library', 'Columbia University Libraries'];
+
   const tabs = [
     {
       title: 'Details',
       content: tabDetails,
     },
-    !otherLibraries.includes(getOwner(bib)) ? {
+    !otherLibraries.includes(getOwner(bib)) && bib.annotatedMarc ? {
       title: 'Full Description',
       content: additionalDetails,
+    } : null,
+    bib.holdings ? {
+      title: 'Library Holdings',
+      content: <LibraryHoldings />,
     } : null,
   ].filter(tab => tab);
 

--- a/src/app/components/BibPage/LibraryHoldings.jsx
+++ b/src/app/components/BibPage/LibraryHoldings.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const LibraryHoldings = ({ holdings }) => {
+  if (!holdings) {
+    return null;
+  }
+
+  return (
+    <div>
+      Holdings data here
+    </div>
+  );
+};
+
+LibraryHoldings.propTypes = {
+  holdings: PropTypes.object,
+};
+
+export default LibraryHoldings;

--- a/test/unit/BibPage.test.js
+++ b/test/unit/BibPage.test.js
@@ -19,9 +19,26 @@ describe('BibPage', () => {
   it('has Tabbed component with three tabs', () => {
     const tabbed = component.find('Tabbed');
     const tabs = tabbed.props().tabs;
-    const titles = tabs.map(tab => tab.title);
+    const tabTitles = tabs.map(tab => tab.title);
     expect(tabbed.length).to.equal(1);
     expect(tabs.length).to.equal(2);
-    expect(titles).to.deep.equal(['Details', 'Full Description']);
+    expect(tabTitles).to.deep.equal(['Details', 'Full Description']);
+  });
+
+  describe('serial', () => {
+    before(() => {
+      const bib = { ...bibs[0], ...annotatedMarc, holdings: { holding_string: 'holdings data' } };
+      const mockStore = makeTestStore({ bib });
+      component = mountTestRender(<BibPage location={{ search: 'search', pathname: '' }} />, { store: mockStore });
+    });
+
+    it('has Tabbed component with four tabs', () => {
+      const tabbed = component.find('Tabbed');
+      const tabs = tabbed.props().tabs;
+      const tabTitles = tabs.map(tab => tab.title);
+      expect(tabbed.length).to.equal(1);
+      expect(tabs.length).to.equal(3);
+      expect(tabTitles).to.deep.equal(['Details', 'Full Description', 'Library Holdings']);
+    });
   });
 });


### PR DESCRIPTION
**What's this do?**
Fixes the merge issues from PR #1485. Add placeholder for "Library Holdings" data.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SCC-2230