### PR TITLE
SCC-2296: Fix bug calculating availability of Use In Library

### DIFF
--- a/src/app/utils/item.js
+++ b/src/app/utils/item.js
@@ -194,7 +194,7 @@ function LibraryItem() {
     const status = item.status && item.status.length ? item.status[0] : {};
     const availability = !_isEmpty(status) && status.prefLabel ?
       status.prefLabel.replace(/\W/g, '').toLowerCase() : '';
-    const available = availability === 'available';
+    const available = ['available', 'useinlibrary'].includes(availability);
     // non-NYPL ReCAP
     const nonNyplRecap = itemSource.indexOf('Recap') !== -1;
     const holdingLocation = this.getHoldingLocation(item, nonNyplRecap);

--- a/test/unit/utils-item.test.js
+++ b/test/unit/utils-item.test.js
@@ -1,0 +1,40 @@
+import LibraryItem from './../../src/app/utils/item';
+import { expect } from 'chai';
+import items from '../fixtures/mocked-item';
+
+describe('utils/item', () => {
+  describe('LibraryItem', () => {
+    describe('mapItem', () => {
+      it('interprets status "Available" as available', () => {
+        const libraryItem = LibraryItem.mapItem(items[0])
+        expect(libraryItem.available).to.eq(true);
+      });
+
+      it('interprets status "Loaned" as not available', () => {
+        const unavailableItem = Object.assign({}, items[0], {
+          status: [
+            {
+              '@id': 'status:co',
+              prefLabel: 'Loaned',
+            },
+          ]
+        });
+        const libraryItem = LibraryItem.mapItem(unavailableItem)
+        expect(libraryItem.available).to.eq(false);
+      });
+
+      it('interprets status "Use in Library" as available', () => {
+        const unavailableItem = Object.assign({}, items[0], {
+          status: [
+            {
+              '@id': 'status:o',
+              prefLabel: 'Use in Library',
+            },
+          ]
+        });
+        const libraryItem = LibraryItem.mapItem(unavailableItem)
+        expect(libraryItem.available).to.eq(true);
+      });
+    });
+  });
+});


### PR DESCRIPTION
**What's this do?**
Fixes bug handling items with status "Use In Library", which is
currently rendered as "In Use" because "Use In Library" is not an
acknowledged "available" status. This bug prevented 'Request' buttons
from appearing next to on-site materials that should have been available
for EDD.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SCC-2296

**How should this be tested? / Do these changes have associated tests?**
Added new test file for testing LibraryItem object, which was not previously tested.

**Dependencies for merging? Releasing to production?**
n/a

**Has the application documentation been updated for these changes?**

**Did someone actually run this code to verify it works?**
I did locally.