### PR TITLE
NO-REF: volume column bug

### DIFF
--- a/src/app/components/Item/ItemTable.jsx
+++ b/src/app/components/Item/ItemTable.jsx
@@ -15,7 +15,7 @@ const ItemTable = ({ items, holdings, bibId, id, searchKeywords, page }) => {
 
   const includeVolColumn = (
     items.some(item => item.isSerial)
-    && holdings && holdings.some(holding => holding.checkInBoxes.some(checkInBox => checkInBox.coverage))
+    && holdings && holdings.some(holding => holding.checkInBoxes && holding.checkInBoxes.some(checkInBox => checkInBox.coverage))
   );
 
   return (


### PR DESCRIPTION
**What's this do?**
Fixes small bug found on this page: http://discoveryui-edd-training.nypl.org/research/collections/shared-collection-catalog/bib/b10011034

Not all holdings have `checkInBoxes` property