### PR TITLE
Scc 2215: add features to store

### DIFF
--- a/src/app/actions/Actions.js
+++ b/src/app/actions/Actions.js
@@ -17,6 +17,7 @@ export const Actions = {
   UPDATE_SUBJECT_HEADING: 'UPDATE_SUBJECT_HEADING',
   UPDATE_DRBB_RESULTS: 'UPDATE_DRBB_RESULTS',
   UPDATE_PATRON_DATA: 'UPDATE_PATRON_DATA',
+  ADD_FEATURES: 'ADD_FEATURES',
 };
 
 export const resetState = () => ({
@@ -97,6 +98,11 @@ export const updatePatronData = patronData => ({
 export const updateLoadingStatus = loading => ({
   type: Actions.UPDATE_LOADING_STATUS,
   payload: loading,
+});
+
+export const addFeatures = features => ({
+  type: Actions.ADD_FEATURES,
+  payload: features,
 });
 
 /* `updateSearchResultsPage` performs:

--- a/src/app/components/Application/Application.jsx
+++ b/src/app/components/Application/Application.jsx
@@ -12,6 +12,8 @@ import LoadingLayer from '../LoadingLayer/LoadingLayer';
 import DataLoader from '../DataLoader/DataLoader';
 import appConfig from '../../data/appConfig';
 
+import { addFeatures } from '../../actions/Actions';
+
 import { breakpoints } from '../../data/constants';
 
 export const MediaContext = React.createContext('desktop');
@@ -29,10 +31,11 @@ export class Application extends React.Component {
 
     const urlEnabledFeatures = query.features ? query.features.split(',') : null;
     if (urlEnabledFeatures) {
-      const urlFeaturesString = urlEnabledFeatures.filter(
-        urlFeat => !appConfig.features.includes(urlFeat))
-        .join(',');
+      const urlFeatures = urlEnabledFeatures.filter(
+        urlFeat => !appConfig.features.includes(urlFeat));
+      const urlFeaturesString = urlFeatures.join(',');
       if (urlFeaturesString) this.state.urlEnabledFeatures = urlFeaturesString;
+      if (urlFeatures) this.props.addFeatures(urlFeatures);
     }
   }
 
@@ -136,4 +139,10 @@ Application.contextTypes = {
   router: PropTypes.object,
 };
 
-export default withRouter(connect(({ patron, loading }) => ({ patron, loading }))(Application));
+const mapStateToProps = ({ patron, loading, features }) => ({ patron, loading, features });
+
+const mapDispatchToProps = dispatch => ({
+  addFeatures: features => dispatch(addFeatures(features)),
+});
+
+export default withRouter(connect(mapStateToProps, mapDispatchToProps)(Application));

--- a/src/app/components/ElectronicDelivery/ElectronicDelivery.jsx
+++ b/src/app/components/ElectronicDelivery/ElectronicDelivery.jsx
@@ -330,7 +330,7 @@ const mapStateToProps = state => ({
   patron: state.patron,
   bib: state.bib,
   searchKeywords: state.searchKeywords,
-  features: state.appConfig.features,
+  features: state.features,
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/src/app/components/FilterPopup/FilterPopup.jsx
+++ b/src/app/components/FilterPopup/FilterPopup.jsx
@@ -618,9 +618,7 @@ FilterPopup.contextTypes = {
 const mapStateToProps = (state) => {
   const {
     filters,
-    appConfig: {
-      features,
-    },
+    features,
     searchResults,
     searchKeywords,
     selectedFilters,

--- a/src/app/components/ResultsCount/ResultsCount.jsx
+++ b/src/app/components/ResultsCount/ResultsCount.jsx
@@ -96,8 +96,8 @@ ResultsCount.defaultProps = {
   features: [],
 };
 
-const mapStateToProps = ({ appConfig, searchKeywords, page }) => ({
-  features: appConfig.features,
+const mapStateToProps = ({ searchKeywords, page, features }) => ({
+  features,
   searchKeywords,
   page,
 });

--- a/src/app/components/ResultsList/ResultsList.jsx
+++ b/src/app/components/ResultsList/ResultsList.jsx
@@ -47,7 +47,7 @@ const ResultsList = ({
   searchKeywords,
 }) => {
   const itemTableLimit = 3;
-  const features = useSelector(state => state.appConfig.features);
+  const features = useSelector(state => state.features);
   const loading = useSelector(state => state.loading);
   const includeDrbb = features.includes('drb-integration');
 

--- a/src/app/components/SccContainer/SccContainer.jsx
+++ b/src/app/components/SccContainer/SccContainer.jsx
@@ -54,4 +54,4 @@ SccContainer.contextTypes = {
   router: PropTypes.object,
 };
 
-export default connect(({ appConfig }) => ({ features: appConfig.features }))(SccContainer);
+export default connect(({ features }) => ({ features }))(SccContainer);

--- a/src/app/components/SearchResults/SearchResultsContainer.jsx
+++ b/src/app/components/SearchResults/SearchResultsContainer.jsx
@@ -15,7 +15,7 @@ import { MediaContext } from '../Application/Application';
 // Renders ResultsList and Pagination components
 const SearchResultsContainer = (props) => {
   const searchResults = useSelector(state => state.searchResults);
-  const features = useSelector(state => state.appConfig.features);
+  const features = useSelector(state => state.features);
   const searchKeywords = useSelector(state => state.searchKeywords);
   const page = useSelector(state => state.page);
   const { createAPIQuery } = props;

--- a/src/app/pages/SearchResults.jsx
+++ b/src/app/pages/SearchResults.jsx
@@ -22,25 +22,21 @@ import {
 const SearchResults = (props, context) => {
   const {
     searchResults,
-    appConfig,
     searchKeywords,
     sortBy,
     field,
     page,
     selectedFilters,
+    features,
   } = useSelector(state => ({
     searchResults: state.searchResults,
-    appConfig: state.appConfig,
+    features: state.features,
     searchKeywords: state.searchKeywords,
     sortBy: state.sortBy,
     field: state.field,
     page: state.page,
     selectedFilters: state.selectedFilters,
   }));
-
-  const {
-    features,
-  } = appConfig;
 
   const {
     router,

--- a/src/app/stores/InitialState.js
+++ b/src/app/stores/InitialState.js
@@ -30,6 +30,7 @@ const initialState = {
   },
   appConfig,
   lastLoaded: appConfig.baseUrl,
+  features: appConfig.features || [],
 };
 
 export default initialState;

--- a/src/app/stores/Reducers.js
+++ b/src/app/stores/Reducers.js
@@ -35,6 +35,12 @@ function appReducer(state = initialState, action) {
       return { ...state, patron: action.payload };
     case Actions.UPDATE_DELIVERY_LOCATIONS:
       return { ...state, deliveryLocations: action.payload };
+    case Actions.ADD_FEATURES:
+      const allFeatures = state.features;
+      action.payload.forEach(incomingFeat => {
+        if (!allFeatures.includes(incomingFeat)) allFeatures.push(incomingFeat);
+      });
+      return { ...state, features: allFeatures };
     case Actions.SET_APP_CONFIG:
       return { ...state, appConfig };
     default:

--- a/test/helpers/store.js
+++ b/test/helpers/store.js
@@ -33,6 +33,6 @@ export const mountTestRender = (ui, { store, ...otherOpts }) => testRender(
 
 export function makeTestStore(opts = initialState) {
   const mockStore = configureStore([thunk]);
-  const store = mockStore({ ...initialState, ...opts });
+  const store = mockStore({ ...initialState, ...opts, features: (opts.appConfig ? opts.appConfig.features : []) });
   return store;
 }

--- a/test/unit/Application.test.js
+++ b/test/unit/Application.test.js
@@ -28,6 +28,7 @@ describe('Application', () => {
         route={{
           history: { listen: stub() },
         }}
+        addFeatures={() => {}}
       />, { context });
 
     component.setState({ patron: {} });
@@ -92,6 +93,7 @@ describe('Application', () => {
         <Application
           children={{}}
           router={context.router}
+          addFeatures={() => {}}
         >
           <a href='/subject_headings'>link</a>
         </Application>, { context });


### PR DESCRIPTION
**What's this do?**
This makes `features` a separate property in the store. The feature flags coming from the URL get added to that. I realized there was an oversight in the previous work done, which is to actually apply the feature flags. Without these changes, only the bit of server side code for retrieving results was getting the `on-site-edd` enabling.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SCC-2215

**Has the application documentation been updated for these changes?**
Will do that soon.

**Did someone actually run this code to verify it works?**
PR author did