### PR TITLE
Fix some breaking bugs related to item table

### DIFF
--- a/src/app/components/BibPage/LibraryHoldings.jsx
+++ b/src/app/components/BibPage/LibraryHoldings.jsx
@@ -7,6 +7,16 @@ const LibraryHoldings = ({ holdings }) => {
     return null;
   }
 
+  const liForEl = (el) => {
+    if (typeof el === 'string') return el;
+    if (!el.url) return el.label;
+    return (
+      <a href={el.url}>
+        { el.label }
+      </a>
+    );
+  };
+
   const htmlDefinitions = holding => holding
     .holdingDefinition
     .map(definition => (
@@ -15,21 +25,7 @@ const LibraryHoldings = ({ holdings }) => {
         definition: (
           <ul>
             {
-              definition.definition.map(el =>
-                (
-                  <li key={el}>
-                    {
-                      typeof el === 'string'
-                      ?
-                      el
-                      :
-                      <a href={el.url}>
-                        { el.label }
-                      </a>
-                    }
-                  </li>
-                ),
-              )
+              definition.definition.map(el => liForEl(el))
             }
           </ul>
         ),

--- a/src/app/components/BibPage/LibraryHoldings.jsx
+++ b/src/app/components/BibPage/LibraryHoldings.jsx
@@ -8,12 +8,14 @@ const LibraryHoldings = ({ holdings }) => {
   }
 
   const liForEl = (el) => {
-    if (typeof el === 'string') return el;
-    if (!el.url) return el.label;
+    if (typeof el === 'string') return <li>{el}</li>;
+    if (!el.url) return <li>{el.label}</li>;
     return (
-      <a href={el.url}>
-        { el.label }
-      </a>
+      <li>
+        <a href={el.url}>
+          { el.label }
+        </a>
+      </li>
     );
   };
 
@@ -25,7 +27,7 @@ const LibraryHoldings = ({ holdings }) => {
         definition: (
           <ul>
             {
-              definition.definition.map(el => <li>{liForEl(el)}</li>)
+              definition.definition.map(el => liForEl(el))
             }
           </ul>
         ),

--- a/src/app/components/BibPage/LibraryHoldings.jsx
+++ b/src/app/components/BibPage/LibraryHoldings.jsx
@@ -25,7 +25,7 @@ const LibraryHoldings = ({ holdings }) => {
         definition: (
           <ul>
             {
-              definition.definition.map(el => liForEl(el))
+              definition.definition.map(el => <li>{liForEl(el)}</li>)
             }
           </ul>
         ),

--- a/src/app/components/Item/ItemsContainer.jsx
+++ b/src/app/components/Item/ItemsContainer.jsx
@@ -99,7 +99,7 @@ class ItemsContainer extends React.Component {
           const isOffsite = filterType === 'location' && selection === 'offsite';
           if (isOffsite) return item.isOffsite;
           const itemProperty = filter.extractItemProperty(item);
-          return isOptionSelected(selection, itemProperty);
+          return isOptionSelected(selection, itemProperty, true);
         });
       });
       return showItem;

--- a/src/app/data/constants.js
+++ b/src/app/data/constants.js
@@ -16,9 +16,9 @@ const itemFilters = [
     type: 'format',
     options: items => items.map(item => ({
       label: item.format || '',
-      id: item.materialType ? item.materialType['@id'] : '',
+      id: item.format || '',
     })),
-    extractItemProperty: item => item.materialType['@id'],
+    extractItemProperty: item => item.format,
   },
   {
     type: 'status',

--- a/src/app/utils/utils.js
+++ b/src/app/utils/utils.js
@@ -461,8 +461,9 @@ const truncateStringOnWhitespace = (str, maxLength) => {
   @param {string} itemValue
   @return {boolean}
 */
-const isOptionSelected = (filterValue, itemValue) => {
-  if (typeof filterValue === 'string') return filterValue === itemValue;
+const isOptionSelected = (filterValue, itemValue, allowMany = false) => {
+  console.log('checking isOptionSelected: ', filterValue, itemValue);
+  if (typeof filterValue === 'string') return filterValue === itemValue || (allowMany && itemValue.includes && itemValue.includes(filterValue));
   if (Array.isArray(filterValue)) {
     return filterValue.includes(itemValue);
   }

--- a/src/app/utils/utils.js
+++ b/src/app/utils/utils.js
@@ -462,7 +462,6 @@ const truncateStringOnWhitespace = (str, maxLength) => {
   @return {boolean}
 */
 const isOptionSelected = (filterValue, itemValue, allowMany = false) => {
-  console.log('checking isOptionSelected: ', filterValue, itemValue);
   if (typeof filterValue === 'string') return filterValue === itemValue || (allowMany && itemValue.includes && itemValue.includes(filterValue));
   if (Array.isArray(filterValue)) {
     return filterValue.includes(itemValue);

--- a/src/server/ApiRoutes/Bib.js
+++ b/src/server/ApiRoutes/Bib.js
@@ -31,6 +31,7 @@ const findUrl = (location, urls) => {
   const matches = urls[location.code];
   const longestMatch = matches.reduce(
     (acc, el) => (el.code.length > acc.code.length ? el : acc), matches[0]);
+  if (!longestMatch || !longestMatch.url) return undefined;
   return longestMatch.url;
 };
 
@@ -42,6 +43,7 @@ const checkInItemsForHolding = (holding) => {
     location = holding.location[0].label;
   }
   const format = holding.format || '';
+  if (!holding.checkInBoxes) return [];
   return holding.checkInBoxes.map(box => (
     {
       location,


### PR DESCRIPTION
**What's this do?**
Fixes some bugs related to the item table that were causing crashes. Most of these were fixed by checking for item properties, with one exception: I have changed the `format` filter to use the `format` property instead of `materialType`, because `checkInCard` items don't have `materialType`.

There are still some bugs (which I have reported in further tickets), but this at least seems to stop the app from crashing.

**Why are we doing this? (w/ JIRA link if applicable)**
scc-2322

**How should this be tested? / Do these changes have associated tests?**

navigate to a serials page, try applying format filters, the app should not break.

also should not break when navigating to bib page for a serials bib with no checkin card items (e.g. `Journal of African Cultural Studies`)

**Dependencies for merging? Releasing to production?**
[Description of any watchouts, dependencies, or issues we should be aware of goes here]

**Has the application documentation been updated for these changes?**

**Did someone actually run this code to verify it works?**
PR author tested locally.
