### PR TITLE
Fix bug causing url-enabled feature to persist between sessions

### DIFF
--- a/src/app/actions/Actions.js
+++ b/src/app/actions/Actions.js
@@ -17,7 +17,7 @@ export const Actions = {
   UPDATE_SUBJECT_HEADING: 'UPDATE_SUBJECT_HEADING',
   UPDATE_DRBB_RESULTS: 'UPDATE_DRBB_RESULTS',
   UPDATE_PATRON_DATA: 'UPDATE_PATRON_DATA',
-  ADD_FEATURES: 'ADD_FEATURES',
+  UPDATE_FEATURES: 'UPDATE_FEATURES',
 };
 
 export const resetState = () => ({
@@ -100,8 +100,8 @@ export const updateLoadingStatus = loading => ({
   payload: loading,
 });
 
-export const addFeatures = features => ({
-  type: Actions.ADD_FEATURES,
+export const updateFeatures = features => ({
+  type: Actions.UPDATE_FEATURES,
   payload: features,
 });
 

--- a/src/app/components/Application/Application.jsx
+++ b/src/app/components/Application/Application.jsx
@@ -12,7 +12,7 @@ import LoadingLayer from '../LoadingLayer/LoadingLayer';
 import DataLoader from '../DataLoader/DataLoader';
 import appConfig from '../../data/appConfig';
 
-import { addFeatures } from '../../actions/Actions';
+import { updateFeatures } from '../../actions/Actions';
 
 import { breakpoints } from '../../data/constants';
 
@@ -35,7 +35,10 @@ export class Application extends React.Component {
         urlFeat => !appConfig.features.includes(urlFeat));
       const urlFeaturesString = urlFeatures.join(',');
       if (urlFeaturesString) this.state.urlEnabledFeatures = urlFeaturesString;
-      if (urlFeatures) this.props.addFeatures(urlFeatures);
+      if (urlFeatures.some(urlFeat => !this.props.features.includes(urlFeat))) {
+        const allFeatures = Array.from(new Set(...this.props.features, ...urlFeatures));
+        this.props.updateFeatures(allFeatures);
+      };
     }
   }
 
@@ -43,7 +46,6 @@ export class Application extends React.Component {
     window.addEventListener('resize', this.onWindowResize.bind(this));
     this.onWindowResize();
     const { router } = this.context;
-    console.log('this.state.urlEnabledFeatures', this.state.urlEnabledFeatures);
     if (this.state.urlEnabledFeatures) {
       router.listen(() => {
         const {
@@ -86,7 +88,6 @@ export class Application extends React.Component {
   }
 
   render() {
-    console.log('from Application, appConfig.features', appConfig.features);
     // dataLocation is passed as a key to DataLoader to ensure it reloads
     // whenever the location changes.
     const dataLocation = Object.assign(
@@ -144,7 +145,7 @@ Application.contextTypes = {
 const mapStateToProps = ({ patron, loading, features }) => ({ patron, loading, features });
 
 const mapDispatchToProps = dispatch => ({
-  addFeatures: features => dispatch(addFeatures(features)),
+  updateFeatures: features => dispatch(updateFeatures(features)),
 });
 
 export default withRouter(connect(mapStateToProps, mapDispatchToProps)(Application));

--- a/src/app/components/Application/Application.jsx
+++ b/src/app/components/Application/Application.jsx
@@ -132,6 +132,7 @@ Application.propTypes = {
   children: PropTypes.object,
   patron: PropTypes.object,
   loading: PropTypes.bool,
+  features: PropTypes.array,
 };
 
 Application.defaultProps = {

--- a/src/app/components/ElectronicDelivery/ElectronicDelivery.jsx
+++ b/src/app/components/ElectronicDelivery/ElectronicDelivery.jsx
@@ -223,8 +223,6 @@ class ElectronicDelivery extends React.Component {
 
     const searchUrl = basicQuery(this.props)({});
 
-    console.log('this.props.features', this.props.features);
-
     return (
       <DocumentTitle title="Electronic Delivery Request | Shared Collection Catalog | NYPL">
         <div id="mainContent">

--- a/src/app/stores/Reducers.js
+++ b/src/app/stores/Reducers.js
@@ -35,12 +35,8 @@ function appReducer(state = initialState, action) {
       return { ...state, patron: action.payload };
     case Actions.UPDATE_DELIVERY_LOCATIONS:
       return { ...state, deliveryLocations: action.payload };
-    case Actions.ADD_FEATURES:
-      const allFeatures = state.features;
-      action.payload.forEach(incomingFeat => {
-        if (!allFeatures.includes(incomingFeat)) allFeatures.push(incomingFeat);
-      });
-      return { ...state, features: allFeatures };
+    case Actions.UPDATE_FEATURES:
+      return { ...state, features: action.payload };
     case Actions.SET_APP_CONFIG:
       return { ...state, appConfig };
     default:

--- a/src/server/ApiRoutes/Search.js
+++ b/src/server/ApiRoutes/Search.js
@@ -22,8 +22,6 @@ const createAPIQuery = basicQuery({
 });
 
 const nyplApiClientCall = (query, urlEnabledFeatures = []) => {
-  console.log('Search API call urlEnabledFeatures', urlEnabledFeatures);
-  console.log('appConfig.features', appConfig.features);
   const requestOptions = appConfig.features.includes('on-site-edd') || urlEnabledFeatures.includes('on-site-edd') ? { headers: { 'X-Features': 'on-site-edd' } } : {};
 
   return nyplApiClient()

--- a/test/unit/Application.test.js
+++ b/test/unit/Application.test.js
@@ -93,7 +93,8 @@ describe('Application', () => {
         <Application
           children={{}}
           router={context.router}
-          addFeatures={() => {}}
+          updateFeatures={() => {}}
+          features={[]}
         >
           <a href='/subject_headings'>link</a>
         </Application>, { context });


### PR DESCRIPTION
**What's this do?**
The last change to this functionality from PR #1507 introduced a bug which caused the url-enabled feature to persist between sessions, whether or not the feature flag was in the URL. I could see this locally as well. I guess the action/reducer for a slice of state needs to allow for a complete over ride. The previous one was only adding new features to the feature state. I thought the setting of `initialState` would override this.

**Did someone actually run this code to verify it works?**
I did