### PR TITLE
Add link to classic catalog

### DIFF
--- a/src/app/components/BibPage/BibPage.jsx
+++ b/src/app/components/BibPage/BibPage.jsx
@@ -199,6 +199,11 @@ BibPage.propTypes = {
   searchKeywords: PropTypes.string,
   location: PropTypes.object,
   bib: PropTypes.object,
+  features: PropTypes.object,
+};
+
+BibPage.defaultProps = {
+  features: [],
 };
 
 const mapStateToProps = ({

--- a/src/app/components/BibPage/BibPage.jsx
+++ b/src/app/components/BibPage/BibPage.jsx
@@ -137,7 +137,7 @@ export const BibPage = (props) => {
 
   const classicLink = (
     bibId.startsWith('b') && features.includes('catalog-link') ?
-      <a href={`https://catalog.nypl.org/record=${bibId}~S1`}>View in Classic</a>
+      <a href={`https://catalog.nypl.org/record=${bibId}~S1`}>View in Catalog</a>
       :
       null
   );

--- a/src/app/components/BibPage/BibPage.jsx
+++ b/src/app/components/BibPage/BibPage.jsx
@@ -27,6 +27,7 @@ export const BibPage = (props) => {
   const {
     location,
     searchKeywords,
+    features,
   } = props;
 
   const bib = props.bib ? props.bib : {};
@@ -134,6 +135,13 @@ export const BibPage = (props) => {
     } : null,
   ].filter(tab => tab);
 
+  const classicLink = (
+    bibId.startsWith('b') && features.includes('catalog-link') ?
+      <a href={`https://catalog.nypl.org/record=${bibId}~S1`}>View in Classic</a>
+      :
+      null
+  );
+
   const createAPIQuery = basicQuery(props);
   const searchUrl = createAPIQuery({});
 
@@ -178,6 +186,7 @@ export const BibPage = (props) => {
                 tabs={tabs}
                 hash={location.hash}
               />
+              { classicLink }
             </div>
           </div>
         </div>
@@ -195,9 +204,11 @@ BibPage.propTypes = {
 const mapStateToProps = ({
   bib,
   searchKeywords,
+  features,
 }) => ({
   bib,
   searchKeywords,
+  features,
 });
 
 export default withRouter(connect(mapStateToProps)(BibPage));

--- a/src/app/components/BibPage/BibPage.jsx
+++ b/src/app/components/BibPage/BibPage.jsx
@@ -15,6 +15,7 @@ import AdditionalDetailsViewer from './AdditionalDetailsViewer';
 import Tabbed from './Tabbed';
 import LibraryHoldings from './LibraryHoldings';
 import getOwner from '../../utils/getOwner';
+import appConfig from '../../data/appConfig';
 // Removed MarcRecord because the webpack MarcRecord is not working. Sep/28/2017
 // import MarcRecord from './MarcRecord';
 
@@ -137,7 +138,7 @@ export const BibPage = (props) => {
 
   const classicLink = (
     bibId.startsWith('b') && features.includes('catalog-link') ?
-      <a href={`https://catalog.nypl.org/record=${bibId}~S1`}>View in Catalog</a>
+      <a href={`${appConfig.classicCatalog}/record=${bibId}~S1`}>View in Catalog</a>
       :
       null
   );

--- a/src/app/data/appConfig.js
+++ b/src/app/data/appConfig.js
@@ -19,6 +19,7 @@ const appConfig = {
       production: 'https://digital-research-books-api.nypl.org/v3/sfr/search',
     },
   },
+  classicCatalog: process.env.CLASSIC_CATALOG,
   shepApi: process.env.SHEP_API,
   loginUrl: process.env.LOGIN_URL || 'https://login.nypl.org/auth/login',
   tokenUrl: 'https://isso.nypl.org/',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -50,6 +50,7 @@ const commonSettings = {
       'process.env': {
         SHEP_API: JSON.stringify(process.env.SHEP_API),
         LOGIN_URL: JSON.stringify(process.env.LOGIN_URL),
+        CLASSIC_CATALOG: JSON.stringify(process.env.CLASSIC_CATALOG),
       },
     }),
     // new BundleAnalyzerPlugin({
@@ -218,6 +219,7 @@ if (ENV === 'production') {
           GA_ENV: JSON.stringify(process.env.GA_ENV),
           SHEP_API: process.env.SHEP_API,
           LOGIN_URL: process.env.LOGIN_URL,
+          CLASSIC_CATALOG: process.env.CLASSIC_CATALOG,
         },
       }),
     ],


### PR DESCRIPTION
**What's this do?**
Adds a link to the classic catalog on nypl bib pages, behind a feature flag.

**Why are we doing this? (w/ JIRA link if applicable)**
This is scc-2303, we are doing this to prepare for switching over the default catalog to scc

**How should this be tested? / Do these changes have associated tests?**
Including
```
export SET CLASSIC_CATALOG=http://catalog.nypl.org
export SET FEATURES='catalog-link'
```
in your env file, you should see links to the catalog on nypl-bib pages, as in the design.

without these variables, you should not see a link

**Dependencies for merging? Releasing to production?**

**Has the application documentation been updated for these changes?**

**Did someone actually run this code to verify it works?**
PR author tested locally.
