### PR TITLE
Scc 2323

### DIFF
--- a/src/client/styles/components/BibPage.scss
+++ b/src/client/styles/components/BibPage.scss
@@ -185,3 +185,22 @@ div .tabbed {
     }
   }
 }
+
+@media (max-width: 490px) {
+  div .tabbed {
+    ul[role="tablist"] >  li, ul[role="tablist"] > li.activeTab {
+      border: 1px solid black;
+      border-bottom: none;
+      display: block;
+      width: 100%;
+    }
+
+    ul[role="tablist"] > li > a {
+      display: block;
+
+      &[aria-selected='true'] {
+        font-weight: 600;
+      }
+    }
+  }
+}

--- a/src/client/styles/components/BibPage.scss
+++ b/src/client/styles/components/BibPage.scss
@@ -32,8 +32,6 @@ div .tabbed {
   ul[role="tablist"] > li.activeTab {
     border: 1px solid black;
     border-bottom: none;
-    display: table-cell;
-    margin-bottom: 0;
   }
 
   ul[role="tablist"] > li > a {
@@ -42,7 +40,6 @@ div .tabbed {
     display: table-cell;
     font-weight: 500;
     text-decoration: none;
-    // border-bottom: 1px solid black;
   }
 
   ul[role="tablist"] > li:target > a {
@@ -50,12 +47,6 @@ div .tabbed {
   }
 
   ul[role="tablist"] > li > a[aria-selected='true'] {
-    padding: 5px 8px;
-    display: table-cell;
-    font-weight: 500;
-    text-decoration: none;
-    // border: 1px solid black;
-    // border-bottom: none;
     color: black;
   }
 


### PR DESCRIPTION
**What's this do?**
Here is a simpler implementation for the tab interface mobile view. This version keeps the tab component within the screen width. It basically makes the tabs a vertical list, rather than a horizontal one. Similar to the one here: https://codepen.io/heydon/pen/veeaEa (make the screen narrow to see mobile view)

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SCC-2323

**Did someone actually run this code to verify it works?**
I did