### PR TITLE
NO-REF: General changes to bib page and search results for serials launch

### DIFF
--- a/src/app/components/BibPage/BibPage.jsx
+++ b/src/app/components/BibPage/BibPage.jsx
@@ -141,31 +141,29 @@ export const BibPage = (props) => {
     <DocumentTitle title="Item Details | Shared Collection Catalog | NYPL">
       <main className="main-page">
         <div className="nypl-page-header">
-          <div className="nypl-full-width-wrapper">
+          <div className="nypl-full-width-wrapper drbb-integration">
             <div className="nypl-row">
-              <div className="nypl-column-three-quarters">
-                <Breadcrumbs type="bib" searchUrl={searchUrl} />
-                <h1 id="mainContent">{title}</h1>
-                {
-                  searchKeywords && (
-                    <div className="nypl-row search-control">
-                      <LeftWedgeIcon
-                        preserveAspectRatio="xMidYMid meet"
-                        title="Back to Results"
-                      />
-                      <BackLink
-                        searchUrl={searchUrl}
-                        searchKeywords={searchKeywords}
-                      />
-                    </div>
-                  )
-                }
-              </div>
+              <Breadcrumbs type="bib" searchUrl={searchUrl} />
+              <h1 id="mainContent">{title}</h1>
+              {
+                searchKeywords && (
+                  <div className="nypl-row search-control">
+                    <LeftWedgeIcon
+                      preserveAspectRatio="xMidYMid meet"
+                      title="Back to Results"
+                    />
+                    <BackLink
+                      searchUrl={searchUrl}
+                      searchKeywords={searchKeywords}
+                    />
+                  </div>
+                )
+              }
             </div>
           </div>
         </div>
 
-        <div className="nypl-full-width-wrapper">
+        <div className="nypl-full-width-wrapper drbb-integration">
           <div className="nypl-row">
             <div className="nypl-item-details">
               <BibDetails

--- a/src/app/components/Item/ItemTableRow.jsx
+++ b/src/app/components/Item/ItemTableRow.jsx
@@ -90,12 +90,29 @@ class ItemTableRow extends React.Component {
 
     return (
       <tr className={item.availability}>
-        {includeVolColumn ? <td className='vol-date-col'><span className="mobile">Vol/Date</span> {item.volume || ''}</td> : null}
-        {page !== 'SearchResults' ? <td><span className="mobile">Format</span>{item.format || ' '}</td> : null}
-        <td><span className="mobile">Message</span>{this.message()}</td>
-        <td><span className="mobile">Status</span>{this.requestButton()}</td>
-        <td><span className="mobile">Call Number</span>{itemCallNumber}</td>
-        <td><span className="mobile">Location</span>{item.location || ' '}</td>
+        {includeVolColumn ? (
+          <td className='vol-date-col'>
+            <span aria-hidden="true" className="mobile">Vol/Date</span>
+            {item.volume || ''}
+          </td>
+        ) : null}
+        {page !== 'SearchResults' ? (
+          <td>
+            <span className="mobile">Format</span>{item.format || ' '}
+          </td>
+        ) : null}
+        <td>
+          <span aria-hidden="true" className="mobile">Message</span>{this.message()}
+        </td>
+        <td>
+          <span aria-hidden="true" className="mobile">Status</span>{this.requestButton()}
+        </td>
+        <td>
+          <span aria-hidden="true" className="mobile">Call Number</span>{itemCallNumber}
+        </td>
+        <td>
+          <span aria-hidden="true" className="mobile">Location</span>{item.location || ' '}
+        </td>
       </tr>
     );
   }

--- a/src/app/components/Item/ItemTableRow.jsx
+++ b/src/app/components/Item/ItemTableRow.jsx
@@ -90,29 +90,12 @@ class ItemTableRow extends React.Component {
 
     return (
       <tr className={item.availability}>
-        {includeVolColumn ? (
-          <td className='vol-date-col'>
-            <span aria-hidden="true" className="mobile">Vol/Date</span>
-            {item.volume || ''}
-          </td>
-        ) : null}
-        {page !== 'SearchResults' ? (
-          <td>
-            <span className="mobile">Format</span>{item.format || ' '}
-          </td>
-        ) : null}
-        <td>
-          <span aria-hidden="true" className="mobile">Message</span>{this.message()}
-        </td>
-        <td>
-          <span aria-hidden="true" className="mobile">Status</span>{this.requestButton()}
-        </td>
-        <td>
-          <span aria-hidden="true" className="mobile">Call Number</span>{itemCallNumber}
-        </td>
-        <td>
-          <span aria-hidden="true" className="mobile">Location</span>{item.location || ' '}
-        </td>
+        {includeVolColumn ? <td className='vol-date-col'><span className="mobile">Vol/Date</span> {item.volume || ''}</td> : null}
+        {page !== 'SearchResults' ? <td><span className="mobile">Format</span>{item.format || ' '}</td> : null}
+        <td><span className="mobile">Message</span>{this.message()}</td>
+        <td><span className="mobile">Status</span>{this.requestButton()}</td>
+        <td><span className="mobile">Call Number</span>{itemCallNumber}</td>
+        <td><span className="mobile">Location</span>{item.location || ' '}</td>
       </tr>
     );
   }

--- a/src/app/components/Item/ItemTableRow.jsx
+++ b/src/app/components/Item/ItemTableRow.jsx
@@ -90,12 +90,12 @@ class ItemTableRow extends React.Component {
 
     return (
       <tr className={item.availability}>
-        {includeVolColumn ? <td>{item.volume || ''}</td> : null}
-        {page !== 'SearchResults' ? <td>{item.format || ' '}</td> : null}
-        <td>{this.message()}</td>
-        <td>{this.requestButton()}</td>
-        <td>{itemCallNumber}</td>
-        <td>{item.location || ' '}</td>
+        {includeVolColumn ? <td className='vol-date-col'><span className="mobile">Vol/Date</span> {item.volume || ''}</td> : null}
+        {page !== 'SearchResults' ? <td><span className="mobile">Format</span>{item.format || ' '}</td> : null}
+        <td><span className="mobile">Message</span>{this.message()}</td>
+        <td><span className="mobile">Status</span>{this.requestButton()}</td>
+        <td><span className="mobile">Call Number</span>{itemCallNumber}</td>
+        <td><span className="mobile">Location</span>{item.location || ' '}</td>
       </tr>
     );
   }

--- a/src/app/components/Item/ItemTableRow.jsx
+++ b/src/app/components/Item/ItemTableRow.jsx
@@ -90,12 +90,20 @@ class ItemTableRow extends React.Component {
 
     return (
       <tr className={item.availability}>
-        {includeVolColumn ? <td className='vol-date-col'><span className="mobile">Vol/Date</span> {item.volume || ''}</td> : null}
-        {page !== 'SearchResults' ? <td><span className="mobile">Format</span>{item.format || ' '}</td> : null}
-        <td><span className="mobile">Message</span>{this.message()}</td>
-        <td><span className="mobile">Status</span>{this.requestButton()}</td>
-        <td><span className="mobile">Call Number</span>{itemCallNumber}</td>
-        <td><span className="mobile">Location</span>{item.location || ' '}</td>
+        {includeVolColumn ? (
+          <td className='vol-date-col' data-th="Vol/Date">
+            {item.volume || ''}
+          </td>
+        ) : null}
+        {page !== 'SearchResults' ? (
+          <td data-th="Format">
+            {item.format || ' '}
+          </td>
+        ) : null}
+        <td data-th="Message">{this.message()}</td>
+        <td data-th="Status">{this.requestButton()}</td>
+        <td data-th="Call Number">{itemCallNumber}</td>
+        <td data-th="Location">{item.location || ' '}</td>
       </tr>
     );
   }

--- a/src/client/styles/components/ItemTable.scss
+++ b/src/client/styles/components/ItemTable.scss
@@ -72,3 +72,43 @@ dl dd.multi-item-list .nypl-basic-table a,
     }
   }
 }
+
+.nypl-basic-table td span.mobile {
+  display: none;
+}
+
+@media (max-width: 490px) {
+  thead {
+    display: none;
+  }
+
+  tr, .nypl-results-item .nypl-basic-table tbody tr:last-child {
+    border: 1px solid var(--ui-gray-light);
+  }
+
+  .nypl-basic-table, .nypl-results-item .nypl-basic-table {
+    display: revert;
+
+    td {
+      display: block;
+      text-align: right;
+
+      &.vol-date-col {
+        background-color: var(--ui-gray-light);
+      }
+    }
+  }
+
+  .nypl-basic-table td span.mobile {
+    display: inline-block;
+    width: 22%;
+    float: left;
+    text-align: left;
+    font-weight: 500;
+  }
+
+  .nypl-results-list .nypl-results-item.has-request {
+    border-bottom: none;
+    margin-bottom: 0;
+  }
+}

--- a/src/client/styles/components/ItemTable.scss
+++ b/src/client/styles/components/ItemTable.scss
@@ -73,10 +73,6 @@ dl dd.multi-item-list .nypl-basic-table a,
   }
 }
 
-.nypl-basic-table td span.mobile {
-  display: none;
-}
-
 @media (max-width: 490px) {
   thead {
     display: none;
@@ -98,17 +94,17 @@ dl dd.multi-item-list .nypl-basic-table a,
       }
     }
   }
+  .nypl-results-list .nypl-results-item.has-request {
+    border-bottom: none;
+    margin-bottom: 0;
+  }
 
-  .nypl-basic-table td span.mobile {
+  td[data-th]:before  {
+    content: attr(data-th);
     display: inline-block;
     width: 22%;
     float: left;
     text-align: left;
     font-weight: 500;
-  }
-
-  .nypl-results-list .nypl-results-item.has-request {
-    border-bottom: none;
-    margin-bottom: 0;
   }
 }

--- a/src/client/styles/components/ItemsContainer.scss
+++ b/src/client/styles/components/ItemsContainer.scss
@@ -65,35 +65,13 @@
     display: inline-block;
     padding-right: 10px;
     margin-bottom: 20px;
+    font-size: 1rem;
+    font-weight: 600;
   }
 
   button {
     color: rgb(195, 76, 61);
     display: inline-block;
-  }
-}
-
-// this is the minimum width at which the `Status` options will not go beyond the screenwidth
-@media (max-width: 750px) {
-  .item-filter {
-    display: block;
-    width: 100%;
-    margin: 10px 0;
-  }
-
-  .item-filter-button {
-    width: 100%;
-  }
-
-  .item-filter-content {
-    position: unset;
-    width: 100%;
-    float: left;
-    margin-bottom: 10px;
-  }
-
-  .item-filter-button {
-    border-bottom: none;
   }
 }
 
@@ -122,4 +100,42 @@
 .show-results-button {
   float: right;
   padding-right: 10px;
+}
+
+.nypl-results-item .nypl-basic-table#bib-item-table {
+  thead > tr {
+    border-bottom: 1px solid var(--ui-gray-light);
+
+    th {
+      width: auto;
+    }
+  }
+
+  tbody tr, tbody tr:last-child {
+    border-bottom: 1px solid var(--ui-gray-light);
+  }
+}
+
+// this is the minimum width at which the `Status` options will not go beyond the screenwidth
+@media (max-width: 750px) {
+  .item-filter {
+    display: block;
+    width: 100%;
+    margin: 10px 0;
+  }
+
+  .item-filter-button {
+    width: 100%;
+  }
+
+  .item-filter-content {
+    position: unset;
+    width: 100%;
+    float: left;
+    margin-bottom: 10px;
+  }
+
+  .item-filter-button {
+    border-bottom: none;
+  }
 }

--- a/src/client/styles/main.scss
+++ b/src/client/styles/main.scss
@@ -161,7 +161,6 @@ select {
 .nypl-basic-table {
   td span {
     color: #000;
-    background: #fff;
   }
 }
 

--- a/src/client/styles/style-v2.scss
+++ b/src/client/styles/style-v2.scss
@@ -3,6 +3,7 @@
 .nypl-item-details {
 
   h2 {
+    padding-top: 10px;
     margin-top: 0;
   }
 

--- a/test/unit/BibPage.test.js
+++ b/test/unit/BibPage.test.js
@@ -63,15 +63,12 @@ describe('BibPage', () => {
       expect(tabTitles).to.deep.equal(['Availability', 'Details', 'Full Description', 'Library Holdings']);
     });
 
-    // not implemented yet
     it('has item table with volume column', () => {
       expect(itemTable.find('th').at(0).text()).to.equal('Vol/Date');
     });
 
-    // not implemented yet
     it('gets the format from holdings statement', () => {
-      // console.log('itemTable find: ', itemTable.html());
-      expect(itemTable.find('td').at(1).text()).to.equal('PRINT');
+      expect(itemTable.find('td').at(1).childAt(1).text()).to.equal('PRINT');
     });
   });
 });

--- a/test/unit/ItemTableRow.test.js
+++ b/test/unit/ItemTableRow.test.js
@@ -50,23 +50,23 @@ describe('ItemTableRow', () => {
       });
 
       it('should not have a format as the first <td> column data', () => {
-        expect(component.find('td').at(0).text()).to.equal(' ');
+        expect(component.find('td').at(0).childAt(1).text()).to.equal(' ');
       });
 
       it('should not have an access message as the second <td> column data', () => {
-        expect(component.find('td').at(1).text()).to.equal(' ');
+        expect(component.find('td').at(1).childAt(1).text()).to.equal(' ');
       });
 
       it('should not have a status as the third <td> column data', () => {
-        expect(component.find('td').at(2).text()).to.equal(' ');
+        expect(component.find('td').at(2).childAt(1).text()).to.equal(' ');
       });
 
       it('should not have a call number as the fourth <td> column data', () => {
-        expect(component.find('td').at(3).text()).to.equal(' ');
+        expect(component.find('td').at(3).childAt(1).text()).to.equal(' ');
       });
 
       it('should not have a location as the fifth <td> column data', () => {
-        expect(component.find('td').at(4).text()).to.equal(' ');
+        expect(component.find('td').at(4).childAt(1).text()).to.equal(' ');
       });
     });
 
@@ -88,23 +88,23 @@ describe('ItemTableRow', () => {
       });
 
       it('should have a format as the first <td> column data', () => {
-        expect(component.find('td').at(0).text()).to.equal('Text');
+        expect(component.find('td').at(0).childAt(1).text()).to.equal('Text');
       });
 
       it('should have an access message as the second <td> column data', () => {
-        expect(component.find('td').at(1).text()).to.equal('USE IN LIBRARY');
+        expect(component.find('td').at(1).childAt(1).text()).to.equal('USE IN LIBRARY');
       });
 
       it('should have a status as the third <td> column data', () => {
-        expect(component.find('td').at(2).text()).to.equal('Available');
+        expect(component.find('td').at(2).childAt(1).text()).to.equal('Available');
       });
 
       it('should have a call number as the fourth <td> column data', () => {
-        expect(component.find('td').at(3).text()).to.equal('JFE 07-5007 ---');
+        expect(component.find('td').at(3).childAt(1).text()).to.equal('JFE 07-5007 ---');
       });
 
       it('should have a location as the fifth <td> column data', () => {
-        expect(component.find('td').at(4).text()).to.equal('SASB M1 - General Research - Room 315');
+        expect(component.find('td').at(4).childAt(1).text()).to.equal('SASB M1 - General Research - Room 315');
       });
     });
 
@@ -117,20 +117,20 @@ describe('ItemTableRow', () => {
       });
 
       it('should have an access message as the second <td> column data', () => {
-        expect(component.find('td').at(1).text()).to.equal('USE IN LIBRARY');
+        expect(component.find('td').at(1).childAt(1).text()).to.equal('USE IN LIBRARY');
       });
 
       it('should have a status as the third <td> column data and not a button', () => {
-        expect(component.find('td').at(2).render().text()).to.equal('Request');
+        expect(component.find('td').at(2).childAt(1).render().text()).to.equal('Request');
         expect(component.find('td').find('Link').length).to.equal(1);
       });
 
       it('should have a call number as the fourth <td> column data', () => {
-        expect(component.find('td').at(3).text()).to.equal('JFE 07-5007 ---');
+        expect(component.find('td').at(3).childAt(1).text()).to.equal('JFE 07-5007 ---');
       });
 
       it('should have a location as the fifth <td> column data', () => {
-        expect(component.find('td').at(4).text()).to.equal('SASB M1 - General Research - Room 315');
+        expect(component.find('td').at(4).childAt(1).text()).to.equal('SASB M1 - General Research - Room 315');
       });
     });
 
@@ -143,20 +143,20 @@ describe('ItemTableRow', () => {
       });
 
       it('should have an access message as the second <td> column data', () => {
-        expect(component.find('td').at(1).text()).to.equal('USE IN LIBRARY');
+        expect(component.find('td').at(1).childAt(1).text()).to.equal('USE IN LIBRARY');
       });
 
       it('should have a call number as the fourth <td> column data', () => {
-        expect(component.find('td').at(3).text()).to.equal('JFE 07-5007 ---');
+        expect(component.find('td').at(3).childAt(1).text()).to.equal('JFE 07-5007 ---');
       });
 
       it('should have a status as the third <td> column data and not a button', () => {
-        expect(component.find('td').at(2).text()).to.equal('Available');
+        expect(component.find('td').at(2).childAt(1).text()).to.equal('Available');
         expect(component.find('td').at(2).render().find('Link').length).to.equal(0);
       });
 
       it('should have a location as the fifth <td> column data', () => {
-        expect(component.find('td').at(4).text()).to.equal('SASB M1 - General Research - Room 315');
+        expect(component.find('td').at(4).childAt(1).text()).to.equal('SASB M1 - General Research - Room 315');
       });
     });
 
@@ -172,7 +172,7 @@ describe('ItemTableRow', () => {
       });
 
       it('should render the Request button in the third <td> column', () => {
-        expect(component.find('td').at(2).render().text()).to.equal('Request');
+        expect(component.find('td').at(2).childAt(1).render().text()).to.equal('Request');
         expect(component.find('td').find('Link').length).to.equal(1);
       });
 
@@ -196,7 +196,7 @@ describe('ItemTableRow', () => {
       });
 
       it('should render "In Use" as the request label', () => {
-        expect(component.find('td').at(2).text()).to.equal('In Use');
+        expect(component.find('td').at(2).childAt(1).text()).to.equal('In Use');
       });
     });
 


### PR DESCRIPTION
**What's this do?**
This PR:
- Makes the bib page wider*
- Changes the mobile styling for the items in the table based on Ellen's design
- There are borders between the items on the Bib page

*right now, the easiest way to do this is to apply the `.drbb-integration` class. I would like to change this eventually, but it is used in a lot of places and with conditional rendering. So, I would like a little more time to make sure the outcome is correct.

**Why are we doing this? (w/ JIRA link if applicable)**
Figma: https://www.figma.com/file/CCCdFt8H7pMqHjkRQlivSw/IA---Templates-%2B-Components?node-id=40154%3A93230

**Dependencies for merging? Releasing to production?**
With this change, in the mobile view, the `thead` is set to `display: none`. Each `td` is set to `display: block` and appears as a row. I did check-in with Helen about this component. Design System will soon have a sort of Definition List, which should replace this. But for now, this is a definite improvement over the current mobile view.

**Did someone actually run this code to verify it works?**
I did