### PR TITLE
NO-REF: Derive patron id from cookie instead of URL

### DIFF
--- a/src/app/components/AccountPage/AccountPage.jsx
+++ b/src/app/components/AccountPage/AccountPage.jsx
@@ -27,11 +27,11 @@ const AccountPage = (props, { router }) => {
           Email: {patron.emails[0]}
       </div>
       <ul>
-        <li><Link to={`${baseUrl}/account/${patron.id}/items`}>Checkouts</Link></li>
-        <li><Link to={`${baseUrl}/account/${patron.id}/holds`}>Holds</Link></li>
-        <li><Link to={`${baseUrl}/account/${patron.id}/mylists`}>My Lists</Link></li>
-        <li><Link to={`${baseUrl}/account/${patron.id}/overdues`}>Fines{`${patron.moneyOwed ? ` ($${patron.moneyOwed.toFixed(2)})` : null}`}</Link></li>
-        <li><Link to={`${baseUrl}/account/${patron.id}/msg`}>Messages</Link></li>
+        <li><Link to={`${baseUrl}/account/items`}>Checkouts</Link></li>
+        <li><Link to={`${baseUrl}/account/holds`}>Holds</Link></li>
+        <li><Link to={`${baseUrl}/account/mylists`}>My Lists</Link></li>
+        <li><Link to={`${baseUrl}/account/overdues`}>Fines{`${patron.moneyOwed ? ` ($${patron.moneyOwed.toFixed(2)})` : null}`}</Link></li>
+        <li><Link to={`${baseUrl}/account/msg`}>Messages</Link></li>
       </ul>
       <a
         href={`https://ilsstaff.nypl.org:443/patroninfo*eng~Sdefault/${patron.id}/modpinfo`}

--- a/src/app/routes/routes.jsx
+++ b/src/app/routes/routes.jsx
@@ -36,7 +36,7 @@ const routes = {
       <Route path="/hold/confirmation/:bibId-:itemId" component={HoldConfirmation} />
       <Route path="/subject_headings/:subjectHeadingUuid" component={SubjectHeadingShowPage} />
       <Route path="/subject_headings" component={SubjectHeadingsIndexPage} />
-      <Route path="/account/:patronId(/:content)" component={AccountPage} />
+      <Route path="/account(/:content)" component={AccountPage} />
       <Route path="/404" component={NotFound404} />
       <Redirect from="*" to="/404" />
     </Route>
@@ -53,7 +53,7 @@ const routes = {
       <Route path={`${baseUrl}/hold/confirmation/:bibId-:itemId`} component={HoldConfirmation} />
       <Route path={`${baseUrl}/subject_headings/:subjectHeadingUuid`} component={SubjectHeadingShowPage} />
       <Route path={`${baseUrl}/subject_headings`} component={SubjectHeadingsIndexPage} />
-      <Route path={`${baseUrl}/account/:patronId(/:content)`} component={AccountPage} />
+      <Route path={`${baseUrl}/account(/:content)`} component={AccountPage} />
       <Route path={`${baseUrl}/404`} component={NotFound404} />
       <Redirect from="*" to={`${baseUrl}/404`} />
     </Route>

--- a/src/app/utils/dataLoaderUtil.js
+++ b/src/app/utils/dataLoaderUtil.js
@@ -37,7 +37,7 @@ const routes = {
   account: {
     action: updateAccountHtml,
     path: 'account',
-    params: '/:patronId/:content?',
+    params: '/:content?',
   }
 };
 

--- a/src/server/ApiRoutes/Account.js
+++ b/src/server/ApiRoutes/Account.js
@@ -1,25 +1,21 @@
 import axios from 'axios';
 
 import User from './User';
-import { updateAccountHtml } from '../../app/actions/Actions';
 
 function fetchAccountPage(req, res, resolve) {
   const requireUser = User.requireUser(req, res);
   const { redirect } = requireUser;
   if (redirect) resolve({ redirect });
 
-  const { patronId } = req.params;
+  const patronId = req.patronTokenResponse.decodedPatron.sub;
   const content = req.params.content || 'items';
-  const { dispatch } = global.store;
 
-  axios.get(`https://ilsstaff.nypl.org:443/dp/patroninfo*eng~Sdefault/${patronId}/${content}`, {
+  axios.get(`https://ilsstaff.nypl.org/dp/patroninfo*eng~Sdefault/${patronId}/${content}`, {
     headers: {
       Cookie: req.headers.cookie,
     },
   })
-    .then(resp => {
-      resolve(resp.data);
-    })
+    .then(resp => resolve(resp.data))
     .catch(console.log);
 }
 


### PR DESCRIPTION
**What's this do?**
Small change to account work that I would like to get onto the "edd-training" server. This will make it easier to share the URL and creates less risk of discrepancy between what is in URL and what is on the page. Encore does not include the patron ID in the url.

**Did someone actually run this code to verify it works?**
I did. This works for my account. Will test with more accounts. I think this is a step in the right direction for reliability.