### PR TITLE
Persist features in `resetState`

### DIFF
--- a/src/app/stores/Reducers.js
+++ b/src/app/stores/Reducers.js
@@ -5,8 +5,14 @@ import appConfig from '../data/appConfig';
 function appReducer(state = initialState, action) {
   switch (action.type) {
     case Actions.RESET_STATE:
-      // Reset state except appConfig and patron
-      return { ...initialState, appConfig: state.appConfig, patron: state.patron, loading: false };
+      // Reset state except appConfig, patron, features
+      return {
+        ...initialState,
+        appConfig: state.appConfig,
+        patron: state.patron,
+        loading: false,
+        features: state.features,
+      };
     case Actions.UPDATE_LOADING_STATUS:
       return { ...state, loading: action.payload };
     case Actions.UPDATE_SEARCH_RESULTS:


### PR DESCRIPTION
**What's this do?**
Persist features in "RESET_STATE" reducer to account for url enabled features

**Why are we doing this? (w/ JIRA link if applicable)**
Bug Daniel found: [JIRA comment](https://jira.nypl.org/browse/SCC-2339?focusedCommentId=48189&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-48189)

**How should this be tested? / Do these changes have associated tests?**
Locally, try http://local.nypl.org:3001/research/collections/shared-collection-catalog/search?features=drb-integration&q=cats
Go to landing page from "Shared Collection Catalog" breadcrumb
Do another search. Drb results should still display

**Dependencies for merging? Releasing to production?**
This needs to be merged to the `serials` branch as well to be on the `edd-training` server.

**Did someone actually run this code to verify it works?**
I did