### PR TITLE
Add link styling in Notification

### DIFF
--- a/src/client/styles/components/Notification.scss
+++ b/src/client/styles/components/Notification.scss
@@ -1,0 +1,5 @@
+.nypl-banner-alert {
+  a {
+    display: inline;
+  }
+}


### PR DESCRIPTION
Note: we'll have to merge this feature to `qa` and `production` separately

**What's this do?**
Changes links in the `Notification` to `display: inline`

**Why are we doing this? (w/ JIRA link if applicable)**
This fixes an unwanted line brek.

**How should this be tested? / Do these changes have associated tests?**
Changes are visible on landing page, hold request page, and search results page, with this `.env` setup:

```
export SET HOLD_REQUEST_NOTIFICATION="Search this catalog to place requests for <a href='https://www.nypl.org/research/scan-and-deliver'>Scan and Deliver</a> service of select items. The Research Libraries are now offering limited onsite access to Library collections by appointment only. <a href='https://www.nypl.org/research/appointments'>Schedule a virtual one-on-one consultation now</a> to discuss your visit."
export SET SEARCH_RESULTS_NOTIFICATION="Search this catalog to place requests for <a href='https://www.nypl.org/research/scan-and-deliver'>Scan and Deliver</a> service of select items. The Research Libraries are now offering limited onsite access to Library collections by appointment only. <a href='https://www.nypl.org/research/appointments'>Schedule a virtual one-on-one consultation now</a> to discuss your visit."

```

**Dependencies for merging? Releasing to production?**
[Description of any watchouts, dependencies, or issues we should be aware of goes here]

**Has the application documentation been updated for these changes?**

**Did someone actually run this code to verify it works?**

PR author tested locally.