### PR TITLE
SCC-2360: Add "Notes" field to "Library Holdings" tab

### DIFF
--- a/src/server/ApiRoutes/Bib.js
+++ b/src/server/ApiRoutes/Bib.js
@@ -18,7 +18,7 @@ const holdingsMappings = {
   Format: 'format',
   'Call Number': 'shelfMark',
   'Library Has': 'holdingStatement',
-  Note: 'note',
+  Notes: 'notes',
 };
 
 const addHoldingDefinition = (holding) => {

--- a/test/fixtures/mockBibWithHolding.json
+++ b/test/fixtures/mockBibWithHolding.json
@@ -3114,6 +3114,9 @@
           "code": "loc:rc2ma"
         }
       ],
+      "notes": [
+        "FAKE NOTE"
+      ],
       "checkInBoxes": [
         {
           "@type": "nypl:CheckInBox",

--- a/test/unit/BibPage.test.js
+++ b/test/unit/BibPage.test.js
@@ -38,6 +38,7 @@ describe('BibPage', () => {
 
   describe('Serial', () => {
     let itemTable;
+    let holdingsTab;
     before(() => {
       mockBibWithHolding.holdings.forEach(holding => Bib.addHoldingDefinition(holding));
       Bib.addCheckInItems(mockBibWithHolding);
@@ -63,15 +64,16 @@ describe('BibPage', () => {
       expect(tabTitles).to.deep.equal(['Availability', 'Details', 'Full Description', 'Library Holdings']);
     });
 
-    // not implemented yet
     it('has item table with volume column', () => {
       expect(itemTable.find('th').at(0).text()).to.equal('Vol/Date');
     });
 
-    // not implemented yet
     it('gets the format from holdings statement', () => {
-      // console.log('itemTable find: ', itemTable.html());
       expect(itemTable.find('td').at(1).text()).to.equal('PRINT');
+    });
+
+    it('displays any notes in the "Library Holdings" tab', () => {
+      expect(component.find('dt').findWhere(n => n.type() === 'dt' && n.text() === 'Notes').length).to.equal(1);
     });
   });
 });

--- a/test/unit/Tabbed.test.js
+++ b/test/unit/Tabbed.test.js
@@ -147,7 +147,7 @@ describe('Tabbed', () => {
 
   let component = mount(
     <Tabbed tabs={[
-      {title: 'Availability', content: mockItemsContainer},
+      { title: 'Availability', content: mockItemsContainer },
       { title: 'Details', content: bibDetails },
       { title: 'Full Description', content: additionalDetails }]}
     />


### PR DESCRIPTION
**What's this do?**
Changes "note" to "notes" to match the property on the holdings object.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SCC-2360

**How should this be tested? / Do these changes have associated tests?**
Added a test to check for the existence of "Notes" definition.

**Did someone actually run this code to verify it works?**
I did