### PR TITLE
SCC-2358: Retain all parts of search query in "Back to Results" link

### DIFF
--- a/src/app/components/BibPage/BibPage.jsx
+++ b/src/app/components/BibPage/BibPage.jsx
@@ -29,6 +29,10 @@ export const BibPage = (props) => {
     location,
     searchKeywords,
     features,
+    field,
+    selectedFilters,
+    page,
+    sortBy,
   } = props;
 
   const bib = props.bib ? props.bib : {};
@@ -143,7 +147,13 @@ export const BibPage = (props) => {
       null
   );
 
-  const createAPIQuery = basicQuery(props);
+  const createAPIQuery = basicQuery({
+    searchKeywords,
+    field,
+    selectedFilters,
+    page,
+    sortBy,
+  });
   const searchUrl = createAPIQuery({});
 
   return (
@@ -199,6 +209,10 @@ BibPage.propTypes = {
   location: PropTypes.object,
   bib: PropTypes.object,
   features: PropTypes.array,
+  field: PropTypes.string,
+  selectedFilters: PropTypes.object,
+  page: PropTypes.string,
+  sortBy: PropTypes.string,
 };
 
 BibPage.defaultProps = {
@@ -209,10 +223,18 @@ const mapStateToProps = ({
   bib,
   searchKeywords,
   features,
+  field,
+  selectedFilters,
+  page,
+  sortBy,
 }) => ({
   bib,
   searchKeywords,
   features,
+  field,
+  selectedFilters,
+  page,
+  sortBy,
 });
 
 export default withRouter(connect(mapStateToProps)(BibPage));


### PR DESCRIPTION
**What's this do?**
Previously, only the `searchKeywords` were being included in the "Back to Results" link from the bib page. This PR adds the other components of the search query: field, sorting, page, selected filters.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SCC-2358

**Did someone actually run this code to verify it works?**
I did