### PR TITLE
Move check for search results page to includeVolColumn

### DIFF
--- a/src/app/components/Item/ItemTable.jsx
+++ b/src/app/components/Item/ItemTable.jsx
@@ -14,7 +14,7 @@ const ItemTable = ({ items, holdings, bibId, id, searchKeywords, page }) => {
   }
 
   const includeVolColumn = (
-    items.some(item => item.volume && item.volume.length)
+    items.some(item => item.volume && item.volume.length) && page !== 'SearchResults'
   );
 
   return (

--- a/src/app/components/Item/ItemTableRow.jsx
+++ b/src/app/components/Item/ItemTableRow.jsx
@@ -90,7 +90,7 @@ class ItemTableRow extends React.Component {
 
     return (
       <tr className={item.availability}>
-        {(includeVolColumn && page !== 'SearchResults') ? (
+        { includeVolColumn ? (
           <td className='vol-date-col' data-th="Vol/Date">
             <span>{item.volume || ''}</span>
           </td>


### PR DESCRIPTION
**What's this do?**
Fixes a bug where the header for the volume column still displayed on the search results page, by moving the check for the page type into `includeVolColumn`

**Why are we doing this? (w/ JIRA link if applicable)**
The previous approach causes a bug where the vol/date information is removed by the column heading is not, causing the access message to be incorrectly displayed under the volume column header

**How should this be tested? / Do these changes have associated tests?**
[Description of any tests that need to be performed once merged goes here]

**Dependencies for merging? Releasing to production?**
[Description of any watchouts, dependencies, or issues we should be aware of goes here]

**Has the application documentation been updated for these changes?**

**Did someone actually run this code to verify it works?**

PR author tested locally.
