### PR TITLE
Scc 2311

### DIFF
--- a/src/app/components/BibPage/BibPage.jsx
+++ b/src/app/components/BibPage/BibPage.jsx
@@ -36,7 +36,6 @@ export const BibPage = (props) => {
   } = props;
 
   const bib = props.bib ? props.bib : {};
-  console.log('bib: ', bib);
   const bibId = bib && bib['@id'] ? bib['@id'].substring(4) : '';
   const title = bib.title && bib.title.length ? bib.title[0] : '';
   const items = (bib.checkInItems || []).concat(LibraryItem.getItems(bib));

--- a/src/app/components/BibPage/BibPage.jsx
+++ b/src/app/components/BibPage/BibPage.jsx
@@ -36,6 +36,7 @@ export const BibPage = (props) => {
   } = props;
 
   const bib = props.bib ? props.bib : {};
+  console.log('bib: ', bib);
   const bibId = bib && bib['@id'] ? bib['@id'].substring(4) : '';
   const title = bib.title && bib.title.length ? bib.title[0] : '';
   const items = (bib.checkInItems || []).concat(LibraryItem.getItems(bib));

--- a/src/app/components/Item/ItemTableRow.jsx
+++ b/src/app/components/Item/ItemTableRow.jsx
@@ -88,6 +88,20 @@ class ItemTableRow extends React.Component {
       itemCallNumber = item.callNumber;
     }
 
+    let itemLocation;
+
+    if (item.location && item.locationUrl) {
+      itemLocation = (
+        <a href={item.locationUrl} className="itemLocationLink">{item.location}</a>
+      );
+    } else if (item.location) {
+      itemLocation = item.location;
+    } else {
+      itemLocation = ' ';
+    }
+
+    console.log('location url: ', item.locationUrl, item);
+
     return (
       <tr className={item.availability}>
         {includeVolColumn ? (
@@ -103,7 +117,7 @@ class ItemTableRow extends React.Component {
         <td data-th="Message"><span>{this.message()}</span></td>
         <td data-th="Status"><span>{this.requestButton()}</span></td>
         <td data-th="Call Number"><span>{itemCallNumber}</span></td>
-        <td data-th="Location"><span>{item.location || ' '}</span></td>
+        <td data-th="Location"><span>{itemLocation}</span></td>
       </tr>
     );
   }

--- a/src/app/components/Item/ItemTableRow.jsx
+++ b/src/app/components/Item/ItemTableRow.jsx
@@ -100,8 +100,6 @@ class ItemTableRow extends React.Component {
       itemLocation = ' ';
     }
 
-    console.log('location url: ', item.locationUrl, item);
-
     return (
       <tr className={item.availability}>
         {includeVolColumn ? (

--- a/src/app/utils/item.js
+++ b/src/app/utils/item.js
@@ -223,8 +223,6 @@ function LibraryItem() {
       url = this.getLocationHoldUrl(holdingLocation);
     }
 
-    console.log('mapping item: ', item);
-
     return {
       id,
       status,

--- a/src/app/utils/item.js
+++ b/src/app/utils/item.js
@@ -223,6 +223,8 @@ function LibraryItem() {
       url = this.getLocationHoldUrl(holdingLocation);
     }
 
+    console.log('mapping item: ', item);
+
     return {
       id,
       status,
@@ -232,6 +234,7 @@ function LibraryItem() {
       isElectronicResource,
       electronicResources,
       location: holdingLocation.prefLabel,
+      locationUrl: holdingLocation.url,
       holdingLocationCode: holdingLocation['@id'] || '',
       callNumber,
       url,

--- a/src/client/styles/components/ItemTable.scss
+++ b/src/client/styles/components/ItemTable.scss
@@ -1,5 +1,5 @@
 dl dd.multi-item-list .nypl-basic-table a,
-.nypl-results-item .nypl-basic-table a {
+.nypl-results-item .nypl-basic-table a:not(.itemLocationLink) {
   background-color: $results-list-item-button;
   border: 0.08333rem solid $results-list-item-button;
   border-radius: 0.13333rem;

--- a/src/server/ApiRoutes/Bib.js
+++ b/src/server/ApiRoutes/Bib.js
@@ -28,7 +28,7 @@ const addHoldingDefinition = (holding) => {
 };
 
 const findUrl = (location, urls) => {
-  const matches = urls[location.code];
+  const matches = urls[location.code] || [];
   const longestMatch = matches.reduce(
     (acc, el) => (el.code.length > acc.code.length ? el : acc), matches[0]);
   if (!longestMatch || !longestMatch.url) return undefined;
@@ -38,15 +38,18 @@ const findUrl = (location, urls) => {
 const checkInItemsForHolding = (holding) => {
   let location = '';
   let holdingLocationCode = '';
+  let locationUrl;
   if (holding.location.length) {
     holdingLocationCode = holding.location[0].code;
     location = holding.location[0].label;
+    locationUrl = holding.location[0].url;
   }
   const format = holding.format || '';
   if (!holding.checkInBoxes) return [];
   return holding.checkInBoxes.map(box => (
     {
       location,
+      locationUrl,
       holdingLocationCode,
       format,
       position: box.position || 0,
@@ -71,10 +74,13 @@ const addCheckInItems = (bib) => {
 };
 
 const addLocationUrls = (bib) => {
-  const holdingCodes = bib
-    .holdings
-    .map(holding => holding.location.reduce((acc, el) => acc.concat([el.code]), []))
-    .reduce((acc, el) => acc.concat(el), []);
+  console.log('adding location urls');
+  const holdingCodes = bib.holdings ?
+    bib
+      .holdings
+      .map(holding => holding.location.reduce((acc, el) => acc.concat([el.code]), []))
+      .reduce((acc, el) => acc.concat(el), [])
+    : [];
 
   const itemCodes = bib.items.map(item =>
     item.holdingLocation.map(location => location['@id'])
@@ -82,21 +88,36 @@ const addLocationUrls = (bib) => {
 
   const codes = holdingCodes.concat(itemCodes).join(',');
 
+  console.log('codes: ', codes);
+
   // get locations data by codes
   return nyplApiClient()
     .then(client => client.get(`/locations?location_codes=${codes}`))
     .then((resp) => {
       // add location urls for holdings
-      bib.holdings.forEach((holding) => {
-        holding.location.forEach((location) => {
-          location.url = findUrl(location, resp);
+      if (bib.holdings) {
+        bib.holdings.forEach((holding) => {
+          holding.location.forEach((location) => {
+            location.url = findUrl(location, resp);
+          });
         });
-      });
-      // add checkin location urls
+      }
       // add item location urls;
+      bib.items.forEach((item) => {
+        if (item.holdingLocation) {
+          item.holdingLocation.forEach((holdingLocation) => {
+            console.log('finding for holding location: ', holdingLocation);
+            if (holdingLocation['@id']) {
+              console.log('found: ', holdingLocation['@id'], findUrl({ code: holdingLocation['@id'] }, resp));
+              holdingLocation.url = findUrl({ code: holdingLocation['@id'] }, resp);
+            }
+          });
+        }
+      });
+      console.log('addLocationUrls bib: ', JSON.stringify(bib, null, 2));
       return bib;
-    });
-
+    })
+    .catch((err) => { console.log('catching nypl client ', err)});
 };
 
 function fetchBib(bibId, cb, errorcb, reqOptions) {
@@ -118,30 +139,34 @@ function fetchBib(bibId, cb, errorcb, reqOptions) {
 
       return data;
     })
+    .then(bib => addLocationUrls(bib))
     .then((bib) => {
       if (bib.holdings) {
         addCheckInItems(bib);
-        const codes = bib
-          .holdings
-          .map(holding => holding.location.reduce((acc, el) => acc.concat([el.code]), []))
-          .reduce((acc, el) => acc.concat(el), [])
-          .join(',');
-
-        return nyplApiClient()
-          .then(client => client.get(`/locations?location_codes=${codes}`))
-          .then((resp) => {
-            bib.holdings.forEach((holding) => {
-              holding.location.forEach((location) => {
-                location.url = findUrl(location, resp);
-              });
-            });
-            return bib;
-          });
+        // addLocationUrls(bib);
+        console.log('bib: ', JSON.stringify(bib, null, 2));
+        // const codes = bib
+        //   .holdings
+        //   .map(holding => holding.location.reduce((acc, el) => acc.concat([el.code]), []))
+        //   .reduce((acc, el) => acc.concat(el), [])
+        //   .join(',');
+        //
+        // return nyplApiClient()
+        //   .then(client => client.get(`/locations?location_codes=${codes}`))
+        //   .then((resp) => {
+        //     bib.holdings.forEach((holding) => {
+        //       holding.location.forEach((location) => {
+        //         location.url = findUrl(location, resp);
+        //         console.log('holdings: ', JSON.stringify(bib.holdings, null, 2), 'items: ', JSON.stringify(bib.items, null, 2), 'resp: ', resp);
+        //       });
+        //     });
+        //     return bib;
+        //   });
       }
       return bib;
     })
     .then((bib) => {
-      console.log('bib: ', JSON.stringify(bib, null, 2));
+      // console.log('bib: ', JSON.stringify(bib, null, 2));
       if (bib.holdings) {
         bib.holdings.forEach(holding => addHoldingDefinition(holding));
       }

--- a/src/server/ApiRoutes/Bib.js
+++ b/src/server/ApiRoutes/Bib.js
@@ -74,7 +74,6 @@ const addCheckInItems = (bib) => {
 };
 
 const addLocationUrls = (bib) => {
-  console.log('adding location urls');
   const holdingCodes = bib.holdings ?
     bib
       .holdings
@@ -87,8 +86,6 @@ const addLocationUrls = (bib) => {
   ).reduce((acc, el) => acc.concat(el), []);
 
   const codes = holdingCodes.concat(itemCodes).join(',');
-
-  console.log('codes: ', codes);
 
   // get locations data by codes
   return nyplApiClient()
@@ -106,18 +103,15 @@ const addLocationUrls = (bib) => {
       bib.items.forEach((item) => {
         if (item.holdingLocation) {
           item.holdingLocation.forEach((holdingLocation) => {
-            console.log('finding for holding location: ', holdingLocation);
             if (holdingLocation['@id']) {
-              console.log('found: ', holdingLocation['@id'], findUrl({ code: holdingLocation['@id'] }, resp));
               holdingLocation.url = findUrl({ code: holdingLocation['@id'] }, resp);
             }
           });
         }
       });
-      console.log('addLocationUrls bib: ', JSON.stringify(bib, null, 2));
       return bib;
     })
-    .catch((err) => { console.log('catching nypl client ', err)});
+    .catch((err) => { console.log('catching nypl client ', err); });
 };
 
 function fetchBib(bibId, cb, errorcb, reqOptions) {
@@ -143,30 +137,10 @@ function fetchBib(bibId, cb, errorcb, reqOptions) {
     .then((bib) => {
       if (bib.holdings) {
         addCheckInItems(bib);
-        // addLocationUrls(bib);
-        console.log('bib: ', JSON.stringify(bib, null, 2));
-        // const codes = bib
-        //   .holdings
-        //   .map(holding => holding.location.reduce((acc, el) => acc.concat([el.code]), []))
-        //   .reduce((acc, el) => acc.concat(el), [])
-        //   .join(',');
-        //
-        // return nyplApiClient()
-        //   .then(client => client.get(`/locations?location_codes=${codes}`))
-        //   .then((resp) => {
-        //     bib.holdings.forEach((holding) => {
-        //       holding.location.forEach((location) => {
-        //         location.url = findUrl(location, resp);
-        //         console.log('holdings: ', JSON.stringify(bib.holdings, null, 2), 'items: ', JSON.stringify(bib.items, null, 2), 'resp: ', resp);
-        //       });
-        //     });
-        //     return bib;
-        //   });
       }
       return bib;
     })
     .then((bib) => {
-      // console.log('bib: ', JSON.stringify(bib, null, 2));
       if (bib.holdings) {
         bib.holdings.forEach(holding => addHoldingDefinition(holding));
       }

--- a/test/unit/Bib.test.js
+++ b/test/unit/Bib.test.js
@@ -65,6 +65,7 @@ describe('addCheckInItems', () => {
         holdingLocationCode: 'fake:fake',
         isSerial: true,
         location: 'fake',
+        locationUrl: undefined,
         position: 3,
         requestable: false,
         status: {
@@ -82,6 +83,7 @@ describe('addCheckInItems', () => {
         format: 'AV',
         isSerial: true,
         location: 'mock',
+        locationUrl: undefined,
         holdingLocationCode: 'mock:mock',
         position: 2,
         requestable: false,
@@ -101,6 +103,7 @@ describe('addCheckInItems', () => {
         holdingLocationCode: 'fake:fake',
         isSerial: true,
         location: 'fake',
+        locationUrl: undefined,
         position: 1,
         requestable: false,
         status: {


### PR DESCRIPTION
**What's this do?**
- Replace item location text with a link if url is available
- Revert styling for this link to default link styling
- Refactor code for adding locations data into a separate function
- Add logic to fetch locations for regular items as well as check in items, and to add these urls to the item

**Why are we doing this? (w/ JIRA link if applicable)**
For scc-2311, we want to make locations in the item table into links if possible

**How should this be tested? / Do these changes have associated tests?**
Should be visible on any nypl bib page with items, e.g. `The Intercollegiate review [microform]` bib page. Should not change any non-nypl items.

**Dependencies for merging? Releasing to production?**

**Has the application documentation been updated for these changes?**

**Did someone actually run this code to verify it works?**
PR author tested locally.
