### PR TITLE
Fix styling for Bib page item table mobile view

### DIFF
--- a/src/client/styles/components/BibPage.scss
+++ b/src/client/styles/components/BibPage.scss
@@ -98,13 +98,6 @@ div .tabbed {
   display: inline-block;
 }
 
-.tabbed span {
-  display: inline-block;
-  padding-left: 5px;
-  padding-right: 5px;
-  max-width: 75%;
-}
-
 // If there is a single hierarchical string of subjects,
 // they will appear as a's under a dd. If the dd is hovered, we make the
 // a's light blue

--- a/src/client/styles/components/ItemTable.scss
+++ b/src/client/styles/components/ItemTable.scss
@@ -93,6 +93,13 @@ dl dd.multi-item-list .nypl-basic-table a,
           background-color: var(--ui-gray-light);
         }
       }
+
+      span {
+        display: inline-block;
+        padding-left: 5px;
+        min-width: 50%;
+        max-width: 67%;
+      }
     }
     .nypl-results-list .nypl-results-item.has-request {
       border-bottom: none;
@@ -102,10 +109,9 @@ dl dd.multi-item-list .nypl-basic-table a,
     td[data-th]:before  {
       content: attr(data-th);
       display: inline-block;
-      width: 22%;
-      float: left;
-      text-align: left;
       font-weight: 500;
+      min-width: 27%;
+      max-width: 30%;
     }
   }
 }


### PR DESCRIPTION
**What's this do?**
Some styling intended for the mobile view ended up being applied to too many components and not just on the mobile view. This PR fixes that and tweaks the width ratios a bit.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SCC-2370

**How should this be tested? / Do these changes have associated tests?**
Example: http://local.nypl.org:3001/research/collections/shared-collection-catalog/bib/cb621946
In details tab, details should not have a min-width. In availability tab table, on narrow screen, label and value components should not overlap and value should not go below label.

**Did someone actually run this code to verify it works?**
I did