### PR TITLE
Add checkin card items to search results

### DIFF
--- a/src/app/components/Item/ItemsContainer.jsx
+++ b/src/app/components/Item/ItemsContainer.jsx
@@ -8,7 +8,7 @@ import ItemTable from './ItemTable';
 import ItemFilters from './ItemFilters';
 import appConfig from '../../data/appConfig';
 import { trackDiscovery, isOptionSelected } from '../../utils/utils';
-import { itemFilters, itemsListPageLimit } from '../../data/constants';
+import { itemFilters, bibPageItemsListLimit as itemsListPageLimit } from '../../data/constants';
 
 class ItemsContainer extends React.Component {
   constructor(props, context) {

--- a/src/app/components/ResultsList/ResultsList.jsx
+++ b/src/app/components/ResultsList/ResultsList.jsx
@@ -70,16 +70,7 @@ const ResultsList = ({
     const publicationStatement = result.publicationStatement && result.publicationStatement.length ?
       result.publicationStatement[0] : '';
     const items = (result.checkInItems || []).concat(LibraryItem.getItems(result));
-    const totalCheckInBoxes = result.holdings && result.holdings.length ?
-      result.holdings.reduce(
-        (acc, holding) =>
-          acc + (
-            holding.checkInBoxes && holding.checkInBoxes.length ?
-              holding.checkInBoxes.length : 0
-          ),
-        0)
-      : 0;
-    const totalItems = items.length + totalCheckInBoxes;
+    const totalItems = items.length;
     const hasRequestTable = items.length > 0;
     const { baseUrl } = appConfig;
     const bibUrl = `${baseUrl}/bib/${bibId}`;

--- a/src/app/components/ResultsList/ResultsList.jsx
+++ b/src/app/components/ResultsList/ResultsList.jsx
@@ -13,6 +13,7 @@ import {
 } from '../../utils/utils';
 import ItemTable from '../Item/ItemTable';
 import appConfig from '../../data/appConfig';
+import { searchResultItemsListLimit as itemTableLimit } from '../../data/constants';
 
 
 export const getBibTitle = (bib) => {
@@ -46,7 +47,6 @@ const ResultsList = ({
   subjectHeadingShow,
   searchKeywords,
 }) => {
-  const itemTableLimit = 3;
   const features = useSelector(state => state.features);
   const loading = useSelector(state => state.loading);
   const includeDrbb = features.includes('drb-integration');
@@ -69,7 +69,7 @@ const ResultsList = ({
     const yearPublished = getYearDisplay(result);
     const publicationStatement = result.publicationStatement && result.publicationStatement.length ?
       result.publicationStatement[0] : '';
-    const items = LibraryItem.getItems(result);
+    const items = (result.checkInItems || []).concat(LibraryItem.getItems(result));
     const totalCheckInBoxes = result.holdings && result.holdings.length ?
       result.holdings.reduce(
         (acc, holding) =>

--- a/src/app/data/constants.js
+++ b/src/app/data/constants.js
@@ -11,7 +11,7 @@ const breakpoints = [
   {
     maxValue: 870,
     media: 'tablet',
-  }
+  },
 ];
 
 const itemFilters = [
@@ -38,10 +38,13 @@ const itemFilters = [
   },
 ];
 
-const itemsListPageLimit = 20;
+const bibPageItemsListLimit = 20;
+const searchResultItemsListLimit = 3;
+
 
 export {
   breakpoints,
   itemFilters,
-  itemsListPageLimit,
+  bibPageItemsListLimit,
+  searchResultItemsListLimit,
 };

--- a/src/server/ApiRoutes/Bib.js
+++ b/src/server/ApiRoutes/Bib.js
@@ -21,7 +21,7 @@ const holdingsMappings = {
   Notes: 'notes',
 };
 
-const addHoldingDefinition = (holding) => {
+export const addHoldingDefinition = (holding) => {
   holding.holdingDefinition = Object.entries(holdingsMappings)
     .map(([key, value]) => ({ term: key, definition: holding[value] }))
     .filter(data => data.definition);
@@ -64,7 +64,7 @@ const checkInItemsForHolding = (holding) => {
   ));
 };
 
-const addCheckInItems = (bib) => {
+export const addCheckInItems = (bib) => {
   bib.checkInItems = bib
     .holdings
     .map(holding => checkInItemsForHolding(holding))
@@ -73,7 +73,7 @@ const addCheckInItems = (bib) => {
     .sort((box1, box2) => box2.position - box1.position);
 };
 
-const addLocationUrls = (bib) => {
+export const addLocationUrls = (bib) => {
   const holdingCodes = bib.holdings ?
     bib
       .holdings

--- a/src/server/ApiRoutes/Bib.js
+++ b/src/server/ApiRoutes/Bib.js
@@ -27,7 +27,7 @@ export const addHoldingDefinition = (holding) => {
     .filter(data => data.definition);
 };
 
-const findUrl = (location, urls) => {
+export const findUrl = (location, urls) => {
   const matches = urls[location.code] || [];
   const longestMatch = matches.reduce(
     (acc, el) => (el.code.length > acc.code.length ? el : acc), matches[0]);
@@ -73,7 +73,10 @@ export const addCheckInItems = (bib) => {
     .sort((box1, box2) => box2.position - box1.position);
 };
 
-export const addLocationUrls = (bib) => {
+export const fetchLocationUrls = codes => nyplApiClient()
+  .then(client => client.get(`/locations?location_codes=${codes}`));
+
+const addLocationUrls = (bib) => {
   const holdingCodes = bib.holdings ?
     bib
       .holdings
@@ -90,8 +93,7 @@ export const addLocationUrls = (bib) => {
   const codes = holdingCodes.concat(itemCodes).join(',');
 
   // get locations data by codes
-  return nyplApiClient()
-    .then(client => client.get(`/locations?location_codes=${codes}`))
+  return fetchLocationUrls(codes)
     .then((resp) => {
       // add location urls for holdings
       if (Array.isArray(bib.holdings)) {

--- a/src/server/ApiRoutes/Search.js
+++ b/src/server/ApiRoutes/Search.js
@@ -70,19 +70,15 @@ function fetchResults(searchKeywords = '', page, sortBy, order, field, filters, 
       const [results, aggregations, drbbResults] = response;
       return Promise.all(results.itemListElement.map((resultObj) => {
         const { result } = resultObj;
-        if (!result.holdings) return resultObj;
         return addLocationUrls(result).then((updatedResult) => {
           const { holdings } = updatedResult;
-          if (holdings) {
-            addCheckInItems(result);
-            holdings.slice(0, itemTableLimit).forEach(
-              holding => addHoldingDefinition(holding));
-          }
-          return { ...resultObj, result };
+          if (!holdings) return { ...resultObj, updatedResult };
+          addCheckInItems(updatedResult);
+          holdings.slice(0, itemTableLimit).forEach(
+            holding => addHoldingDefinition(holding));
+          return { ...resultObj, updatedResult };
         });
       })).then((processedItems) => {
-        console.log('processedItems', processedItems);
-        console.log('aggregations', aggregations);
         return ({
           aggregations,
           results: {
@@ -94,7 +90,6 @@ function fetchResults(searchKeywords = '', page, sortBy, order, field, filters, 
       });
     })
     .then((combinedResults) => {
-      console.log('combinedResults', combinedResults);
       const { aggregations, results, drbbResults } = combinedResults;
       cb(aggregations, results, page, drbbResults);
     })

--- a/src/server/ApiRoutes/Search.js
+++ b/src/server/ApiRoutes/Search.js
@@ -72,21 +72,17 @@ function fetchResults(searchKeywords = '', page, sortBy, order, field, filters, 
       const locationCodes = new Set();
       const { itemListElement } = results;
       itemListElement.forEach((resultObj) => {
-        let numItemsProcessed = 0;
         const { result } = resultObj;
         const { holdings } = resultObj.result;
         if (holdings) {
           addCheckInItems(result);
           holdings.slice(0, itemTableLimit).forEach((holding) => {
             addHoldingDefinition(holding);
-            if (numItemsProcessed < itemTableLimit && holding.location) {
-              locationCodes.add(holding.location[0].code);
-              numItemsProcessed += 1;
-            }
+            locationCodes.add(holding.location[0].code);
           });
         }
-        if (numItemsProcessed < itemTableLimit) {
-          result.items.slice(0, itemTableLimit - numItemsProcessed).forEach(
+        if (holdings.length < itemTableLimit) {
+          result.items.slice(0, itemTableLimit - holdings.length).forEach(
             item => locationCodes.add(item.holdingLocation[0]['@id']));
         }
       });

--- a/src/server/ApiRoutes/Search.js
+++ b/src/server/ApiRoutes/Search.js
@@ -79,7 +79,7 @@ function fetchResults(searchKeywords = '', page, sortBy, order, field, filters, 
           addCheckInItems(result);
           holdings.slice(0, itemTableLimit).forEach((holding) => {
             addHoldingDefinition(holding);
-            if (numItemsProcessed < 0 && holding.location) {
+            if (numItemsProcessed < itemTableLimit && holding.location) {
               locationCodes.add(holding.location[0].code);
               numItemsProcessed += 1;
             }

--- a/src/server/ApiRoutes/Search.js
+++ b/src/server/ApiRoutes/Search.js
@@ -123,18 +123,16 @@ function search(req, res, resolve) {
     order,
     apiQueryField,
     apiQueryFilters,
-    (apiFilters, searchResults, pageQuery, drbbResults) => {
-      resolve({
-        filters: apiFilters,
-        searchResults,
-        page: pageQuery,
-        drbbResults,
-        selectedFilters: createSelectedFiltersHash(filters, apiFilters),
-        searchKeywords: q,
-        sortBy,
-        field: fieldQuery,
-      });
-    },
+    (apiFilters, searchResults, pageQuery, drbbResults) => resolve({
+      filters: apiFilters,
+      searchResults,
+      page: pageQuery,
+      drbbResults,
+      selectedFilters: createSelectedFiltersHash(filters, apiFilters),
+      searchKeywords: q,
+      sortBy,
+      field: fieldQuery,
+    }),
     error => resolve(error),
     urlEnabledFeatures,
   );

--- a/src/server/ApiRoutes/Search.js
+++ b/src/server/ApiRoutes/Search.js
@@ -71,7 +71,7 @@ function fetchResults(searchKeywords = '', page, sortBy, order, field, filters, 
       const [results, aggregations, drbbResults] = response;
       const locationCodes = new Set();
       const { itemListElement } = results;
-      const processedItems = itemListElement.forEach((resultObj) => {
+      itemListElement.forEach((resultObj) => {
         let numItemsProcessed = 0;
         const { result } = resultObj;
         const { holdings } = resultObj.result;
@@ -97,7 +97,7 @@ function fetchResults(searchKeywords = '', page, sortBy, order, field, filters, 
           const items = (result.checkInItems || []).concat(result.items);
           items.slice(0, itemTableLimit).forEach((item) => {
             if (item.holdingLocation) item.holdingLocation[0].url = findUrl({ code: item.holdingLocation[0]['@id'] }, resp);
-            if (item.location) item.locationUrl = findUrl(item.location, resp);
+            if (item.location) item.locationUrl = findUrl({code: item.holdingLocationCode }, resp);
           });
         });
         return results;

--- a/test/unit/ItemsContainer.test.js
+++ b/test/unit/ItemsContainer.test.js
@@ -6,7 +6,7 @@ import { shallow, mount } from 'enzyme';
 
 import ItemsContainer from './../../src/app/components/Item/ItemsContainer';
 import LibraryItem from './../../src/app/utils/item';
-import { itemsListPageLimit } from './../../src/app/data/constants';
+import { bibPageItemsListLimit as itemsListPageLimit } from './../../src/app/data/constants';
 
 const items = [
   {


### PR DESCRIPTION
**What's this do?**
Adds the checkin card items to the search results and adds location urls. That second part may be a bit out of scope for this particular ticket, but if this approach seems ok it is a nice feature. I'm thinking maybe `addLocationUrls` should be reworked for this case to take a limit of how many items/holdings to get location urls for.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SCC-2369

**How should this be tested? / Do these changes have associated tests?**
... would be nice. Will give it a think and wait to see if anything major changes upon reviewal.

**Did someone actually run this code to verify it works?**
I tested with empty "Journal Title" search and empty general search