### PR TITLE
Fix items list pagination bug

### DIFF
--- a/src/app/components/Item/ItemsContainer.jsx
+++ b/src/app/components/Item/ItemsContainer.jsx
@@ -118,7 +118,13 @@ class ItemsContainer extends React.Component {
   updatePage(page, type) {
     this.setState({ page });
     trackDiscovery('Pagination', `${type} - page ${page}`);
-    this.context.router.push(`${appConfig.baseUrl}/bib/${this.props.bibId}?itemPage=${page}`);
+    this.context.router.push({
+      pathname: `${appConfig.baseUrl}/bib/${this.props.bibId}`,
+      query: {
+        ...this.query,
+        itemPage: page,
+      },
+    });
   }
 
   /*


### PR DESCRIPTION
**What's this do?**
Persists the item filters when paginating through items

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SCC-2377

**Did someone actually run this code to verify it works?**
I did