### PR TITLE
Fix logic for search page item counts

### DIFF
--- a/src/app/components/ResultsList/ResultsList.jsx
+++ b/src/app/components/ResultsList/ResultsList.jsx
@@ -70,16 +70,7 @@ const ResultsList = ({
     const publicationStatement = result.publicationStatement && result.publicationStatement.length ?
       result.publicationStatement[0] : '';
     const items = (result.checkInItems || []).concat(LibraryItem.getItems(result));
-    const totalCheckInBoxes = result.holdings && result.holdings.length ?
-      result.holdings.reduce(
-        (acc, holding) =>
-          acc + (
-            holding.checkInBoxes && holding.checkInBoxes.length ?
-              holding.checkInBoxes.length : 0
-          ),
-        0)
-      : 0;
-    const totalItems = items.length + totalCheckInBoxes;
+    const totalItems = items.length;
     const hasRequestTable = items.length > 0;
     const { baseUrl } = appConfig;
     const bibUrl = `${baseUrl}/bib/${bibId}`;


### PR DESCRIPTION
**What's this do?**
- Change the way we calculate the number of items on search results pages
- Take advantages of scc-2369 changes to simplify item counts and make more consistent 
- should be pretty disjoint from remaining work on this branch

**Why are we doing this? (w/ JIRA link if applicable)**
Now that we have checkin items on search results, the most straightforward way to get this number is just to count how many items there are. This also fixes some mismatches between search results pages and bib pages in the current way of calculating.

**How should this be tested? / Do these changes have associated tests?**

**Dependencies for merging? Releasing to production?**

**Has the application documentation been updated for these changes?**

**Did someone actually run this code to verify it works?**

PR author tested locally.
