### PR TITLE
SCC-2369: bug fix - Add more checks for properties

### DIFF
--- a/src/server/ApiRoutes/Search.js
+++ b/src/server/ApiRoutes/Search.js
@@ -82,8 +82,9 @@ function fetchResults(searchKeywords = '', page, sortBy, order, field, filters, 
             locationCodes.add(holding.location[0].code);
           });
           if (holdings.length < itemTableLimit) {
-            result.items.slice(0, itemTableLimit - holdings.length).forEach(
-              item => locationCodes.add(item.holdingLocation[0]['@id']));
+            result.items.slice(0, itemTableLimit - holdings.length).forEach((item) => {
+              if (item.holdingLocation) locationCodes.add(item.holdingLocation[0]['@id']);
+            });
           }
         } else if (result.items) {
           result.items.slice(0, itemTableLimit).forEach((item) => {

--- a/src/server/ApiRoutes/Search.js
+++ b/src/server/ApiRoutes/Search.js
@@ -74,16 +74,21 @@ function fetchResults(searchKeywords = '', page, sortBy, order, field, filters, 
       itemListElement.forEach((resultObj) => {
         const { result } = resultObj;
         const { holdings } = resultObj.result;
+        if (!result.items || !result.holdings) return;
         if (holdings) {
           addCheckInItems(result);
           holdings.slice(0, itemTableLimit).forEach((holding) => {
             addHoldingDefinition(holding);
             locationCodes.add(holding.location[0].code);
           });
-        }
-        if (holdings.length < itemTableLimit) {
-          result.items.slice(0, itemTableLimit - holdings.length).forEach(
-            item => locationCodes.add(item.holdingLocation[0]['@id']));
+          if (holdings.length < itemTableLimit) {
+            result.items.slice(0, itemTableLimit - holdings.length).forEach(
+              item => locationCodes.add(item.holdingLocation[0]['@id']));
+          }
+        } else if (result.items) {
+          result.items.slice(0, itemTableLimit).forEach((item) => {
+            if (item.holdingLocation) locationCodes.add(item.holdingLocation[0]['@id']);
+          });
         }
       });
       const codes = Array.from(locationCodes).join(',');
@@ -92,6 +97,7 @@ function fetchResults(searchKeywords = '', page, sortBy, order, field, filters, 
           const { result } = resultObj;
           const items = (result.checkInItems || []).concat(result.items);
           items.slice(0, itemTableLimit).forEach((item) => {
+            if (!item) return;
             if (item.holdingLocation) item.holdingLocation[0].url = findUrl({ code: item.holdingLocation[0]['@id'] }, resp);
             if (item.location) item.locationUrl = findUrl({code: item.holdingLocationCode }, resp);
           });


### PR DESCRIPTION
**What's this do?**
Checks for the existence of `holdings`, `items`, or `holdingLocation` as needed

**Why are we doing this? (w/ JIRA link if applicable)**
Bug fix

**Did someone actually run this code to verify it works?**
I did. Checked keyword search, empty search, search with gibberish