### PR TITLE
SCC-2383: Remove extra loading layer text

### DIFF
--- a/src/app/components/Application/Application.jsx
+++ b/src/app/components/Application/Application.jsx
@@ -103,7 +103,6 @@ export class Application extends React.Component {
               skipNav={{ target: 'mainContent' }}
             />
             <LoadingLayer
-              title="Loading"
               loading={this.props.loading}
             />
             <DataLoader

--- a/src/app/components/HoldRequest/HoldRequest.jsx
+++ b/src/app/components/HoldRequest/HoldRequest.jsx
@@ -360,10 +360,7 @@ export class HoldRequest extends React.Component {
       <DocumentTitle title="Item Request | Shared Collection Catalog | NYPL">
         <div>
           {
-            !userLoggedIn || loading ? <LoadingLayer
-              title="Loading"
-              loading
-            /> : null
+            !userLoggedIn || loading ? <LoadingLayer loading /> : null
           }
           <div className="nypl-request-page-header">
             <div className="nypl-full-width-wrapper">

--- a/src/app/components/LoadingLayer/LoadingLayer.jsx
+++ b/src/app/components/LoadingLayer/LoadingLayer.jsx
@@ -29,9 +29,6 @@ const LoadingLayer = ({ loading, title, focus }) => {
           <span id="loading-animation" className="loadingLayer-texts-loadingWord">
             Loading...
           </span>
-          <span id="loading-description" className="loadingLayer-texts-title">
-            {title}
-          </span>
           <div className="loadingDots">
             <span />
             <span />

--- a/src/app/components/ShepContainer/ShepContainer.jsx
+++ b/src/app/components/ShepContainer/ShepContainer.jsx
@@ -44,7 +44,6 @@ ShepContainer.propTypes = {
   extraBannerElement: PropTypes.element,
   secondaryExtraBannerElement: PropTypes.element,
   extraRow: PropTypes.element,
-  loadingLayerText: PropTypes.string,
   breadcrumbProps: PropTypes.object,
   bannerOptions: PropTypes.object,
 };
@@ -52,7 +51,6 @@ ShepContainer.propTypes = {
 ShepContainer.defaultProps = {
   mainContent: null,
   extraBannerElement: null,
-  loadingLayerText: "Loading",
   breadcrumbProps: {
     type: '',
     breadcrumbUrls: {},

--- a/src/app/pages/SearchResults.jsx
+++ b/src/app/pages/SearchResults.jsx
@@ -154,7 +154,6 @@ const SearchResults = (props, context) => {
             </div>
           </div>
         }
-        loadingLayerText="Searching"
         breadcrumbsType="search"
       />
     </DocumentTitle>

--- a/src/app/pages/SubjectHeadingShowPage.jsx
+++ b/src/app/pages/SubjectHeadingShowPage.jsx
@@ -35,7 +35,6 @@ const SubjectHeadingShowPage = (props) => {
         }
       }
       extraBannerElement={<SubjectHeadingSearch />}
-      loadingLayerText="Subject Heading"
       breadcrumbProps={{
         type: 'subjectHeading',
         urls: breadcrumbUrls,

--- a/src/app/pages/SubjectHeadingsIndexPage.jsx
+++ b/src/app/pages/SubjectHeadingsIndexPage.jsx
@@ -34,7 +34,6 @@ const SubjectHeadingsIndexPage = (props) => {
         }
       }
       extraBannerElement={<SubjectHeadingSearch />}
-      loadingLayerText="Subject Headings"
       breadcrumbProps={{
         type: 'subjectHeadings',
         urls: breadcrumbUrls,


### PR DESCRIPTION
**What's this do?**
When we moved the `LoadingLayer` from each individual page to `Application` for various reasons, we did not implement a way to modify the secondary text as needed. For now, we are removing the secondary text. Maybe in the future we will re-implement it.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SCC-2383

**Did someone actually run this code to verify it works?**
I did