### PR TITLE
SCC-2386: Fix pagination when total is multiple of page length

### DIFF
--- a/src/app/components/Pagination/Pagination.jsx
+++ b/src/app/components/Pagination/Pagination.jsx
@@ -83,8 +83,8 @@ class Pagination extends React.Component {
     if (!subjectHeadingPage) {
       if (!total) return null;
       pageFactor = parseInt(page, 10) * perPage;
-      nextPage = (total < perPage || pageFactor > total) ? null : this.getPage(page, 'Next');
-      totalPages = Math.floor(total / perPage) + 1;
+      nextPage = (pageFactor >= total) ? null : this.getPage(page, 'Next');
+      totalPages = Math.ceil(total / perPage);
     } else {
       if (total && perPage) totalPages = Math.ceil(total / perPage);
       nextPage = this.getPage(page, 'Next');

--- a/test/unit/Pagination.test.js
+++ b/test/unit/Pagination.test.js
@@ -70,12 +70,12 @@ describe('Pagination', () => {
     });
 
     it('should display what page you are on', () => {
-      expect(component.find('span').text()).to.equal('Page 1 of 9');
+      expect(component.find('span').text()).to.equal('Page 1 of 8');
     });
 
     it('should have a descriptive aria-label', () => {
       expect(component.find('span').prop('aria-label'))
-        .to.equal('Displaying page 1 out of 9 total pages.');
+        .to.equal('Displaying page 1 out of 8 total pages.');
     });
   });
 
@@ -97,12 +97,12 @@ describe('Pagination', () => {
     });
 
     it('should display what page you are on', () => {
-      expect(component.find('span').text()).to.equal('Page 2 of 9');
+      expect(component.find('span').text()).to.equal('Page 2 of 8');
     });
 
     it('should have a description aria-label', () => {
       expect(component.find('span').prop('aria-label'))
-        .to.equal('Displaying page 2 out of 9 total pages.');
+        .to.equal('Displaying page 2 out of 8 total pages.');
     });
   });
 
@@ -120,12 +120,12 @@ describe('Pagination', () => {
     });
 
     it('should display what page you are on', () => {
-      expect(component.find('span').text()).to.equal('Page 3 of 81');
+      expect(component.find('span').text()).to.equal('Page 3 of 80');
     });
 
     it('should have a description aria-label', () => {
       expect(component.find('span').prop('aria-label'))
-        .to.equal('Displaying page 3 out of 81 total pages.');
+        .to.equal('Displaying page 3 out of 80 total pages.');
     });
   });
 


### PR DESCRIPTION
**What's this do?**
Fix some long standing bugs in pagination:
* Fix calculation of `totalPages`
* Do not render "Next" button when total is multiple of page length
* Fix total page values in tests

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SCC-2386

**How should this be tested? / Do these changes have associated tests?**
Tests were misleading! 400 / 50 = 8; 4000 / 50 = 80

**Did someone actually run this code to verify it works?**
I did