### PR TITLE
SCC-2390: Remove item count for bib with no items

### DIFF
--- a/src/app/components/ResultsList/ResultsList.jsx
+++ b/src/app/components/ResultsList/ResultsList.jsx
@@ -91,9 +91,13 @@ const ResultsList = ({
             <li className="nypl-results-media">{materialType}</li>
             <li className="nypl-results-publication">{publicationStatement}</li>
             {yearPublished}
-            <li className="nypl-results-info">
-              {totalItems} item{totalItems !== 1 ? 's' : ''}
-            </li>
+            {
+              totalItems > 0 ?
+                <li className="nypl-results-info">
+                  {totalItems} item{totalItems !== 1 ? 's' : ''}
+                </li>
+                : ''
+            }
           </ul>
         </div>
         {


### PR DESCRIPTION
**What's this do?**
Remove "0 items" from search results that have no items. I am pretty sure these are all e-resources.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SCC-2390

**Did someone actually run this code to verify it works?**
I did. On "qa-discovery", "Climate change" search returns a result a little down the list that has "0 items". This is gone with this change.