### PR TITLE
SCC-2401: DS breadcrumb bug

### DIFF
--- a/src/app/components/AccountPage/AccountPage.jsx
+++ b/src/app/components/AccountPage/AccountPage.jsx
@@ -78,6 +78,12 @@ const AccountPage = (props) => {
 
   return (
     <div className="nypl-patron-page nypl-ds nypl--research">
+      <Breadcrumb
+        breadcrumbs={[{
+          url: '#',
+          text: 'Home',
+        }]}
+      />
       <Hero
         heading={
           <Heading level={1} text="Research Catalog" />

--- a/src/app/components/AccountPage/AccountPage.jsx
+++ b/src/app/components/AccountPage/AccountPage.jsx
@@ -2,7 +2,8 @@
 import React, { useEffect, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import PropTypes from 'prop-types';
-import { Link } from 'react-router';
+
+import { Hero, Heading, Breadcrumb, Link } from '@nypl/design-system-react-components';
 
 import appConfig from '../../data/appConfig';
 import { addEventListenersToAccountLinks } from '../../utils/accountPageUtils';
@@ -76,18 +77,24 @@ const AccountPage = (props) => {
   const { baseUrl } = appConfig;
 
   return (
-    <div className="nypl-full-width-wrapper nypl-patron-page">
+    <div className="nypl-patron-page nypl-ds nypl--research">
+      <Hero
+        heading={
+          <Heading level={1} text="Research Catalog" />
+        }
+        heroType="SECONDARY"
+      />
       <div className="nypl-patron-details">
         {patron.names ? `Name: ${patron.names[0]}` : null}
         <br />
         {patron.emails ? `Email: ${patron.emails[0]}` : null}
       </div>
       <ul>
-        <li><Link to={`${baseUrl}/account/items`}>Checkouts</Link></li>
-        <li><Link to={`${baseUrl}/account/holds`}>Holds</Link></li>
-        <li><Link to={`${baseUrl}/account/mylists`}>My Lists</Link></li>
-        <li><Link to={`${baseUrl}/account/overdues`}>Fines{`${patron.moneyOwed ? ` ($${patron.moneyOwed.toFixed(2)})` : ''}`}</Link></li>
-        <li><Link to={`${baseUrl}/account/msg`}>Messages</Link></li>
+        <li><Link href={`${baseUrl}/account/items`}>Checkouts</Link></li>
+        <li><Link href={`${baseUrl}/account/holds`}>Holds</Link></li>
+        <li><Link href={`${baseUrl}/account/mylists`}>My Lists</Link></li>
+        <li><Link href={`${baseUrl}/account/overdues`}>Fines{`${patron.moneyOwed ? ` ($${patron.moneyOwed.toFixed(2)})` : ''}`}</Link></li>
+        <li><Link href={`${baseUrl}/account/msg`}>Messages</Link></li>
       </ul>
       <a
         href={`https://ilsstaff.nypl.org:443/patroninfo*eng~Sdefault/${patron.id}/modpinfo`}

--- a/src/app/components/AccountPage/AccountPage.jsx
+++ b/src/app/components/AccountPage/AccountPage.jsx
@@ -3,7 +3,7 @@ import React, { useEffect, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import PropTypes from 'prop-types';
 
-import { Hero, Heading, Breadcrumb, Link } from '@nypl/design-system-react-components';
+import { Hero, Heading, Breadcrumbs, Link } from '@nypl/design-system-react-components';
 
 import appConfig from '../../data/appConfig';
 import { addEventListenersToAccountLinks } from '../../utils/accountPageUtils';
@@ -78,9 +78,9 @@ const AccountPage = (props) => {
 
   return (
     <div className="nypl-patron-page nypl-ds nypl--research">
-      <Breadcrumb
+      <Breadcrumbs
         breadcrumbs={[{
-          url: '#',
+          url: appConfig.baseUrl,
           text: 'Home',
         }]}
       />


### PR DESCRIPTION
**What's this do?**
Add hero and breadcrumb to Account Page.

The DS `Breadcrumb` is causing the page to break with this error:
`Warning: React.createElement: type is invalid -- expected a string (for built-in components) or a class/function (for composite components) but got: undefined.`

**Why are we doing this? (w/ JIRA link if applicable)**
This will soon be the design for all Research Catalog pages. We are trying it out here first.