### PR TITLE
Catch errors in data loader, api routes, search api

### DIFF
--- a/src/app/utils/dataLoaderUtil.js
+++ b/src/app/utils/dataLoaderUtil.js
@@ -1,3 +1,4 @@
+/* global window */
 import { ajaxCall } from '@utils';
 import {
   updateBibPage,
@@ -40,10 +41,12 @@ const routes = {
 const successCb = (pathType, dispatch) => (response) => {
   const { data } = response;
   if (data && data.redirect) {
-    const fullUrl = encodeURIComponent(window.location.href);
-    window.location.replace(`${appConfig.loginUrl}?redirect_uri=${fullUrl}`);
-    return { redirect: true }
-  };
+    if (window) {
+      const fullUrl = encodeURIComponent(window.location.href);
+      window.location.replace(`${appConfig.loginUrl}?redirect_uri=${fullUrl}`);
+    }
+    return { redirect: true };
+  }
   dispatch(routes[pathType].action(data));
   return data;
 };
@@ -86,9 +89,12 @@ function loadDataForRoutes(location, dispatch) {
     successCb(pathType, dispatch),
     errorCb,
   ).then((resp) => {
-    if (!resp.redirect) dispatch(updateLastLoaded(path));
+    if (resp && !resp.redirect) dispatch(updateLastLoaded(path));
     dispatch(updateLoadingStatus(false));
     return resp;
+  }).catch((error) => {
+    console.error(error);
+    dispatch(updateLoadingStatus(false));
   });
 }
 

--- a/src/server/ApiRoutes/ApiRoutes.js
+++ b/src/server/ApiRoutes/ApiRoutes.js
@@ -46,10 +46,12 @@ Object.keys(routes).forEach((routeName) => {
     router
       .route(`${appConfig.baseUrl}${pathType}${path}${params}`)
       .get((req, res, next) => new Promise(
-        resolve => routeMethods[routeName](req, res, resolve),
+        resolve => routeMethods[routeName](req, res, resolve)
       )
-        .then(data => (api ? res.json(data) : successCb(routeName, global.store.dispatch)({ data })))
-        .then(() => (api ? null : next())),
+        .then(data => (
+          api ? res.json(data) : successCb(routeName, global.store.dispatch)({ data })))
+        .then(() => (api ? null : next()))
+        .catch(console.error)
       );
   });
 });

--- a/src/server/ApiRoutes/Search.js
+++ b/src/server/ApiRoutes/Search.js
@@ -71,6 +71,13 @@ function fetchResults(searchKeywords = '', page, sortBy, order, field, filters, 
       const [results, aggregations, drbbResults] = response;
       const locationCodes = new Set();
       const { itemListElement } = results;
+      if (!itemListElement) {
+        return cb(
+          aggregations,
+          results,
+          page,
+          drbbResults);
+      }
       itemListElement.forEach((resultObj) => {
         const { result } = resultObj;
         const { holdings } = resultObj.result;
@@ -114,7 +121,8 @@ function fetchResults(searchKeywords = '', page, sortBy, order, field, filters, 
           logger.error('Error making server search call in search function', error);
           errorcb(error);
         });
-    });
+    })
+    .catch(console.error);
 }
 
 function search(req, res, resolve) {


### PR DESCRIPTION
**What's this do?**
Catches and prevents error that comes up related to the search api request timing out. There will still be no discovery search results sadly, but the loading layer will stop and the DRB results may be helpful!

**How should this be tested? / Do these changes have associated tests?**
Locally, try searching for "new york times" and compare to production. On prod, the loading layer will continue and this error appears in the console:
```
Uncaught (in promise) TypeError: Cannot read property 'redirect' of undefined
    at dataLoaderUtil.js:89
```

**Did someone actually run this code to verify it works?**
I did