### PR TITLE
Check for `holding.location`

### DIFF
--- a/src/server/ApiRoutes/Bib.js
+++ b/src/server/ApiRoutes/Bib.js
@@ -39,7 +39,7 @@ const checkInItemsForHolding = (holding) => {
   let location = '';
   let holdingLocationCode = '';
   let locationUrl;
-  if (holding.location.length) {
+  if (holding.location && holding.location.length) {
     holdingLocationCode = holding.location[0].code;
     location = holding.location[0].label;
     locationUrl = holding.location[0].url;

--- a/src/server/ApiRoutes/Search.js
+++ b/src/server/ApiRoutes/Search.js
@@ -86,11 +86,13 @@ function fetchResults(searchKeywords = '', page, sortBy, order, field, filters, 
           addCheckInItems(result);
           holdings.slice(0, itemTableLimit).forEach((holding) => {
             addHoldingDefinition(holding);
-            locationCodes.add(holding.location[0].code);
+            if (holding.location) locationCodes.add(holding.location[0].code);
           });
           if (holdings.length < itemTableLimit) {
             result.items.slice(0, itemTableLimit - holdings.length).forEach((item) => {
-              if (item.holdingLocation) locationCodes.add(item.holdingLocation[0]['@id']);
+              if (item.holdingLocation) item.holdingLocation.forEach((holdingLocation) => {
+                locationCodes.add(holdingLocation['@id']);
+              });
             });
           }
         } else if (result.items) {


### PR DESCRIPTION
**What's this do?**
I found a bug from searching for "Moon" on prod. Looks like a bib (b12347398) has a holding without a `location` property. Is this a valid `holdings` property in the API response?
```
holdings:
   [ { holdingStatement: [Array],
       identifier: [Array],
       notes: [Array],
       physicalLocation: [Array],
       uri: 'h1027389',
       shelfMark: [Array],
       holdingDefinition: [Array] } ]
```

**Why are we doing this? (w/ JIRA link if applicable)**
Found bug on prod.

**How should this be tested? / Do these changes have associated tests?**
Thoughts on trying implementing separate tests for the server side code? Right now, we have some mocks in the component tests. But it would be nice to separate concerns.

**Did someone actually run this code to verify it works?**
I did. I checked the same search using prod API. 