### PR TITLE
Accounts - location change event listener

### DIFF
--- a/src/app/utils/accountPageUtils.js
+++ b/src/app/utils/accountPageUtils.js
@@ -82,13 +82,7 @@ const manipulateAccountPage = (
       if (locationSelect) {
         const locationChangeCb = (e) => {
           locationData[locationProp] = e.target.value.replace('+++', '');
-          makeRequest(
-            updateAccountHtml,
-            patron.id,
-            buildReqBody(contentType, {}, locationData),
-            contentType,
-            setIsLoading,
-          );
+          eventListenerCb(buildReqBody(contentType, {}, locationData));
         };
         locationSelect.addEventListener('change', locationChangeCb);
         eventListeners.push({ element: locationSelect, cb: locationChangeCb })

--- a/src/app/utils/accountPageUtils.js
+++ b/src/app/utils/accountPageUtils.js
@@ -32,7 +32,10 @@ const buildReqBody = (content, itemObj, locationData) => {
     case 'items':
       return { ...itemObj, renewsome: 'YES' };
     case 'holds':
-      return Object.assign(itemObj, { updateholdssome: 'YES' }, locationData);
+      return Object.assign(itemObj, {
+        updateholdssome: 'YES',
+        currentsortorder: 'current_pickup',
+      }, locationData);
     default:
       return itemObj;
   }
@@ -49,7 +52,7 @@ const manipulateAccountPage = (
     updateAccountHtml,
     patron.id,
     body,
-    content,
+    contentType,
     setIsLoading,
   );
 
@@ -87,14 +90,12 @@ const manipulateAccountPage = (
         if (option.selected) locationValue = `${option.value.trim()}+++`;
       });
       locationData[locationProp] = locationValue;
-      if (locationSelect) {
-        const locationChangeCb = (e) => {
-          locationData[locationProp] = e.target.value.replace('+++', '');
-          eventListenerCb(buildReqBody(contentType, {}, locationData));
-        };
-        locationSelect.addEventListener('change', locationChangeCb);
-        eventListeners.push({ element: locationSelect, cb: locationChangeCb })
-      }
+      const locationChangeCb = (e) => {
+        locationData[locationProp] = e.target.value.replace('+++', '');
+        eventListenerCb(buildReqBody(contentType, {}, locationData));
+      };
+      locationSelect.addEventListener('change', locationChangeCb);
+      eventListeners.push({ element: locationSelect, cb: locationChangeCb });
     }
     // get name and value from checkbox
     const inputs = el.querySelectorAll('input');
@@ -119,9 +120,9 @@ const manipulateAccountPage = (
       const eventCb = (e) => {
         e.preventDefault();
         eventListenerCb(buildReqBody(
-          content,
+          contentType,
           { [input.name]: input.value },
-          locationData
+          locationData,
         ));
       };
       button.addEventListener('click', eventCb);

--- a/src/app/utils/accountPageUtils.js
+++ b/src/app/utils/accountPageUtils.js
@@ -80,7 +80,7 @@ const manipulateAccountPage = (
       });
       locationData[locationProp] = locationValue;
       if (locationSelect) {
-        locationSelect.addEventListener('change', (e) => {
+        const locationChangeCb = (e) => {
           locationData[locationProp] = e.target.value.replace('+++', '');
           makeRequest(
             updateAccountHtml,
@@ -89,7 +89,9 @@ const manipulateAccountPage = (
             contentType,
             setIsLoading,
           );
-        });
+        };
+        locationSelect.addEventListener('change', locationChangeCb);
+        eventListeners.push({ element: locationSelect, cb: locationChangeCb })
       }
     }
     // get name and value from checkbox

--- a/src/server/ApiRoutes/Account.js
+++ b/src/server/ApiRoutes/Account.js
@@ -46,7 +46,7 @@ function postToAccountPage(req, res) {
   const reqBodyString = Object.keys(req.body).map(key => `${key}=${req.body[key]}`).join('&');
   axios.post(
     `${appConfig.legacyCatalog}/dp/patroninfo*eng~Sdefault/${patronId}/${content}`,
-    `currentsortorder=current_pickup&${reqBodyString}`, {
+    reqBodyString, {
       headers: {
         Cookie: req.headers.cookie,
       },


### PR DESCRIPTION
**What's this do?**
Adds the pickup location change functionality to the account page. This submits the location change on the `<select>` change.

**Did someone actually run this code to verify it works?**
I did