### PR TITLE
SCC-2384: change feedback form to send LibAnswers email

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -3,15 +3,11 @@ export SET PLATFORM_API_CLIENT_ID=discovery_api
 export SET PLATFORM_API_CLIENT_SECRET=[secret]
 export SET PLATFORM_API_BASE_URL=https://[fqdn]/api/v0.1
 export SET SHEP_API=http://[fqdn shep api]/api/v0.1
-
 export SET HOLD_REQUEST_NOTIFICATION="notification"
 export SET CLOSED_LOCATIONS="all;Library for the Performing Arts"
 export SET SEARCH_RESULTS_NOTIFICATION="notification"
-
 export SET FEATURES="first-feature,second-feature,yet-another-feature"
-
-export SET INCLUDE_DRBB=true
-
 export SET GENERAL_RESEARCH_EMAIL=example@nypl.com
-export SET AIRTABLE_API_KEY=[secret]
-export SET FEEDBACK_FORM_URL=https://[fqdn airtable]/v0/[spreadsheet id]/Feedback
+export SET LIB_ANSWERS_EMAIL=example@nypl.com
+export SET SOURCE_EMAIL=example@nypl.com
+export SET LEGACY_CATALOG_BASE_URL=https://[fqdn]/

--- a/src/app/components/Application/Application.jsx
+++ b/src/app/components/Application/Application.jsx
@@ -28,7 +28,6 @@ export class Application extends React.Component {
     this.state = {
       media: 'desktop',
     };
-    this.submitFeedback = this.submitFeedback.bind(this);
 
     const urlEnabledFeatures = query.features ? query.features.split(',') : null;
     if (urlEnabledFeatures) {
@@ -72,14 +71,6 @@ export class Application extends React.Component {
     if (media !== newMedia) this.setState({ media: newMedia });
   }
 
-  submitFeedback(callback, e) {
-    e.preventDefault();
-    const { pathname, hash, search } = this.context.router.location;
-    const currentURL = `${pathname}${hash}${search}`;
-
-    callback(currentURL);
-  }
-
   render() {
     // dataLocation is passed as a key to DataLoader to ensure it reloads
     // whenever the location changes.
@@ -112,7 +103,7 @@ export class Application extends React.Component {
               {React.cloneElement(this.props.children)}
             </DataLoader>
             <Footer />
-            <Feedback submit={this.submitFeedback} />
+            <Feedback />
           </div>
         </DocumentTitle>
       </MediaContext.Provider>

--- a/src/app/components/Feedback/Feedback.jsx
+++ b/src/app/components/Feedback/Feedback.jsx
@@ -158,12 +158,13 @@ class Feedback extends React.Component {
                       value={fields.email}
                     />
                   </div>
-                  <Link
-                    href="https://www.nypl.org/help/about-nypl/legal-notices/privacy-policy"
-                    className="privacy-policy"
-                    target="_blank"
-                  >Privacy Policy
-                  </Link>
+                  <div className="privacy-policy">
+                    <Link
+                      href="https://www.nypl.org/help/about-nypl/legal-notices/privacy-policy"
+                      target="_blank"
+                    >Privacy Policy
+                    </Link>
+                  </div>
                   <Button
                     className={`cancel-button ${!showForm ? 'hidden' : ''}`}
                     onClick={e => this.deactivateForm(e)}

--- a/src/app/components/Feedback/Feedback.jsx
+++ b/src/app/components/Feedback/Feedback.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import FocusTrap from 'focus-trap-react';
 import axios from 'axios';
-import { Button, ButtonTypes } from '@nypl/design-system-react-components';
+import { Button, ButtonTypes, Input, Label, HelperErrorText } from '@nypl/design-system-react-components';
 
 import { trackDiscovery } from '../../utils/utils';
 import appConfig from '../../data/appConfig';
@@ -20,6 +20,7 @@ class Feedback extends React.Component {
       showForm: false,
       fields: initialFields(),
       success: false,
+      commentInputError: false,
     };
 
     this.commentText = React.createRef();
@@ -34,9 +35,7 @@ class Feedback extends React.Component {
   onSubmitForm(url) {
     const { fields } = this.state;
     if (!fields.feedback && !fields.feedback.length) {
-      this.commentText.current.focus();
-    } else if (!fields.email && !fields.email.length) {
-      this.emailInput.current.focus();
+      this.setState({ commentInputError: true })
     } else {
       this.postForm(url);
       trackDiscovery('Feedback', 'Submit');
@@ -85,6 +84,7 @@ class Feedback extends React.Component {
       showForm,
       fields,
       success,
+      commentInputError,
     } = this.state;
     const { submit } = this.props;
 
@@ -114,68 +114,73 @@ class Feedback extends React.Component {
             className={showForm ? 'active' : ''}
             id="feedback-menu"
           >
-            <h1>We are here to help!</h1>
             {!success && (
-              <form
-                target="hidden_feedback_iframe"
-                onSubmit={e => submit(this.onSubmitForm, e)}
-              >
-                <div>
-                  <label htmlFor="feedback-textarea-comment">
-                    Comments
-                    <span className="nypl-required-field">&nbsp;Required</span>
-                  </label>
-                  <textarea
-                    id="feedback-textarea-comment"
-                    name="feedback"
-                    value={fields.feedback}
-                    ref={this.commentText}
-                    rows="5"
-                    aria-required="true"
-                    tabIndex="0"
-                    onChange={this.handleInputChange}
-                  />
-                </div>
-                <div>
-                  <label htmlFor="feedback-input-email">
-                    Email Address
-                    <span className="nypl-required-field">&nbsp;Required</span>
-                  </label>
-                  <input
-                    name="email"
-                    id="feedback-input-email"
-                    type="email"
-                    value={fields.email}
-                    onChange={this.handleInputChange}
-                    ref={this.emailInput}
-                  />
-                </div>
-                <input name="fvv" value="1" type="hidden" />
-                <a
-                  href="https://www.nypl.org/help/about-nypl/legal-notices/privacy-policy"
-                  className="privacy-policy"
-                  target="_blank"
-                >Privacy Policy
-                </a>
-                <Button
-                  className={`cancel-button ${!showForm ? 'hidden' : ''}`}
-                  onClick={e => this.deactivateForm(e)}
-                  attributes={{
-                    'aria-expanded': !showForm,
-                    'aria-controls': 'feedback-menu',
-                  }}
-                  buttonType={ButtonTypes.Secondary}
+              <>
+                <h1>We are here to help!</h1>
+                <form
+                  target="hidden_feedback_iframe"
+                  onSubmit={e => submit(this.onSubmitForm, e)}
                 >
-                  Cancel
-                </Button>
+                  <div>
+                    <Label htmlFor="feedback-textarea-comment">
+                      Comments*
+                    </Label>
+                    <textarea
+                      id="feedback-textarea-comment"
+                      name="feedback"
+                      value={fields.feedback}
+                      ref={this.commentText}
+                      rows="4"
+                      aria-required="true"
+                      tabIndex="0"
+                      onChange={this.handleInputChange}
+                    />
+                    <HelperErrorText id="helperText" isError={commentInputError}>
+                      {commentInputError ? 'Please fill out this field' : ''}
+                    </HelperErrorText>
+                  </div>
+                  <div>
+                    <Label htmlFor="feedback-input-email">
+                      Email (If you need a response from us)
+                    </Label>
+                    <Input
+                      required
+                      attributes={{
+                        name: 'email',
+                        onChange: this.handleInputChange,
+                        ref: this.emailInput,
+                      }}
+                      id="feedback-input-email"
+                      type="email"
+                      value={fields.email}
+                    />
+                  </div>
+                  <a
+                    href="https://www.nypl.org/help/about-nypl/legal-notices/privacy-policy"
+                    className="privacy-policy"
+                    target="_blank"
+                  >Privacy Policy
+                  </a>
+                  <Button
+                    className={`cancel-button ${!showForm ? 'hidden' : ''}`}
+                    onClick={e => this.deactivateForm(e)}
+                    attributes={{
+                      'aria-expanded': !showForm,
+                      'aria-controls': 'feedback-menu',
+                    }}
+                    buttonType={ButtonTypes.Secondary}
+                  >
+                    Cancel
+                  </Button>
 
-                <Button
-                  type="submit"
-                  buttonType={ButtonTypes.Primary}
-                  className="submit-button"
-                >Submit
-                </Button>
-              </form>
+                  <Button
+                    type="submit"
+                    buttonType={ButtonTypes.Primary}
+                    className="submit-button"
+                  >Submit
+                  </Button>
+                </form>
+              </>
             )}
             {success && (
               <p>

--- a/src/app/components/Feedback/Feedback.jsx
+++ b/src/app/components/Feedback/Feedback.jsx
@@ -114,6 +114,7 @@ class Feedback extends React.Component {
             className={showForm ? 'active' : ''}
             id="feedback-menu"
           >
+            <h1>We are here to help!</h1>
             {!success && (
               <form
                 target="hidden_feedback_iframe"

--- a/src/app/components/Feedback/Feedback.jsx
+++ b/src/app/components/Feedback/Feedback.jsx
@@ -53,7 +53,6 @@ class Feedback extends React.Component {
       this.setState({
         fields: initialFields(),
         success: true,
-      // eslint-disable-next-line no-alert
       });
     }).catch(console.error);
   }

--- a/src/app/components/Feedback/Feedback.jsx
+++ b/src/app/components/Feedback/Feedback.jsx
@@ -54,7 +54,7 @@ class Feedback extends React.Component {
         showForm: false,
         fields: initialFields(),
       // eslint-disable-next-line no-alert
-      }, alert('Thank you, your feedback has been submitted.'));
+      });
     }).catch(console.error);
   }
 

--- a/src/app/components/Feedback/Feedback.jsx
+++ b/src/app/components/Feedback/Feedback.jsx
@@ -23,6 +23,7 @@ class Feedback extends React.Component {
     };
 
     this.commentText = React.createRef();
+    this.emailInput = React.createRef();
 
     this.onSubmitForm = this.onSubmitForm.bind(this);
     this.toggleForm = this.toggleForm.bind(this);
@@ -34,6 +35,8 @@ class Feedback extends React.Component {
     const { fields } = this.state;
     if (!fields.feedback && !fields.feedback.length) {
       this.commentText.current.focus();
+    } else if (!fields.email && !fields.email.length) {
+      this.emailInput.current.focus();
     } else {
       this.postForm(url);
       trackDiscovery('Feedback', 'Submit');
@@ -64,7 +67,7 @@ class Feedback extends React.Component {
 
   deactivateForm() {
     trackDiscovery('Feedback', 'Close');
-    this.setState({ showForm: false });
+    this.setState({ showForm: false, success: false });
   }
 
   handleInputChange(e) {
@@ -108,7 +111,7 @@ class Feedback extends React.Component {
         >
           <div
             role="menu"
-            className={showForm ? ' active' : ''}
+            className={showForm ? 'active' : ''}
             id="feedback-menu"
           >
             {!success && (
@@ -118,7 +121,7 @@ class Feedback extends React.Component {
               >
                 <div>
                   <label htmlFor="feedback-textarea-comment">
-                    Please provide your feedback about this page in the field below.
+                    Comments
                     <span className="nypl-required-field">&nbsp;Required</span>
                   </label>
                   <textarea
@@ -133,17 +136,26 @@ class Feedback extends React.Component {
                   />
                 </div>
                 <div>
-                  <label htmlFor="feedback-input-email">Email Address</label>
+                  <label htmlFor="feedback-input-email">
+                    Email Address
+                    <span className="nypl-required-field">&nbsp;Required</span>
+                  </label>
                   <input
                     name="email"
                     id="feedback-input-email"
                     type="email"
                     value={fields.email}
                     onChange={this.handleInputChange}
+                    ref={this.emailInput}
                   />
                 </div>
                 <input name="fvv" value="1" type="hidden" />
-
+                <a
+                  href="https://www.nypl.org/help/about-nypl/legal-notices/privacy-policy"
+                  className="privacy-policy"
+                  target="_blank"
+                >Privacy Policy
+                </a>
                 <Button
                   className={`cancel-button ${!showForm ? 'hidden' : ''}`}
                   onClick={e => this.deactivateForm(e)}
@@ -159,6 +171,7 @@ class Feedback extends React.Component {
                 <Button
                   type="submit"
                   buttonType={ButtonTypes.Primary}
+                  className="submit-button"
                 >Submit
                 </Button>
               </form>

--- a/src/app/components/Feedback/Feedback.jsx
+++ b/src/app/components/Feedback/Feedback.jsx
@@ -20,6 +20,7 @@ class Feedback extends React.Component {
     this.state = {
       showForm: false,
       fields: initialFields(),
+      success: false,
     };
 
     this.commentText = React.createRef();
@@ -51,8 +52,8 @@ class Feedback extends React.Component {
       },
     }).then(() => {
       this.setState({
-        showForm: false,
         fields: initialFields(),
+        success: true,
       // eslint-disable-next-line no-alert
       });
     }).catch(console.error);
@@ -82,6 +83,7 @@ class Feedback extends React.Component {
     const {
       showForm,
       fields,
+      success,
     } = this.state;
     const { submit } = this.props;
 
@@ -111,56 +113,63 @@ class Feedback extends React.Component {
             className={`feedback-form-container${showForm ? ' active' : ''}`}
             id="feedback-menu"
           >
-            <form
-              target="hidden_feedback_iframe"
-              onSubmit={e => submit(this.onSubmitForm, e)}
-            >
-              <div>
-                <label htmlFor="feedback-textarea-comment">
-                  Please provide your feedback about this page in the field below.
-                  <span className="nypl-required-field">&nbsp;Required</span>
-                </label>
-                <textarea
-                  id="feedback-textarea-comment"
-                  name="feedback"
-                  value={fields.feedback}
-                  ref={this.commentText}
-                  rows="5"
-                  aria-required="true"
-                  tabIndex="0"
-                  onChange={this.handleInputChange}
-                />
-              </div>
-              <div>
-                <label htmlFor="feedback-input-email">Email Address</label>
-                <input
-                  name="email"
-                  id="feedback-input-email"
-                  type="email"
-                  value={fields.email}
-                  onChange={this.handleInputChange}
-                />
-              </div>
-              <input name="fvv" value="1" type="hidden" />
-
-              <Button
-                className={`cancel-button ${!showForm ? 'hidden' : ''}`}
-                onClick={e => this.deactivateForm(e)}
-                attributes={{
-                  'aria-expanded': !showForm,
-                  'aria-controls': 'feedback-menu',
-                }}
-                buttonType={ButtonTypes.Secondary}
+            {!success && (
+              <form
+                target="hidden_feedback_iframe"
+                onSubmit={e => submit(this.onSubmitForm, e)}
               >
-                Cancel
-              </Button>
+                <div>
+                  <label htmlFor="feedback-textarea-comment">
+                    Please provide your feedback about this page in the field below.
+                    <span className="nypl-required-field">&nbsp;Required</span>
+                  </label>
+                  <textarea
+                    id="feedback-textarea-comment"
+                    name="feedback"
+                    value={fields.feedback}
+                    ref={this.commentText}
+                    rows="5"
+                    aria-required="true"
+                    tabIndex="0"
+                    onChange={this.handleInputChange}
+                  />
+                </div>
+                <div>
+                  <label htmlFor="feedback-input-email">Email Address</label>
+                  <input
+                    name="email"
+                    id="feedback-input-email"
+                    type="email"
+                    value={fields.email}
+                    onChange={this.handleInputChange}
+                  />
+                </div>
+                <input name="fvv" value="1" type="hidden" />
 
-              <Button
-                type="submit"
-                buttonType={ButtonTypes.Primary}
-              >Submit
-              </Button>
-            </form>
+                <Button
+                  className={`cancel-button ${!showForm ? 'hidden' : ''}`}
+                  onClick={e => this.deactivateForm(e)}
+                  attributes={{
+                    'aria-expanded': !showForm,
+                    'aria-controls': 'feedback-menu',
+                  }}
+                  buttonType={ButtonTypes.Secondary}
+                >
+                  Cancel
+                </Button>
+
+                <Button
+                  type="submit"
+                  buttonType={ButtonTypes.Primary}
+                >Submit
+                </Button>
+              </form>
+            )}
+            {success && (
+              <p>
+                Thank you for submitting your comments, if you requested a response, our service staff will get back to you as soon as possible.
+              </p>
+            )}
           </div>
         </FocusTrap>
       </div>

--- a/src/app/components/Feedback/Feedback.jsx
+++ b/src/app/components/Feedback/Feedback.jsx
@@ -1,9 +1,8 @@
-/* global alert */
 import React from 'react';
 import PropTypes from 'prop-types';
 import FocusTrap from 'focus-trap-react';
 import axios from 'axios';
-import { Button, Input, ButtonTypes } from '@nypl/design-system-react-components';
+import { Button, ButtonTypes } from '@nypl/design-system-react-components';
 
 import { trackDiscovery } from '../../utils/utils';
 import appConfig from '../../data/appConfig';
@@ -167,7 +166,9 @@ class Feedback extends React.Component {
             )}
             {success && (
               <p>
-                Thank you for submitting your comments, if you requested a response, our service staff will get back to you as soon as possible.
+                Thank you for submitting your comments,
+                if you requested a response, our service staff
+                will get back to you as soon as possible.
               </p>
             )}
           </div>

--- a/src/app/components/Feedback/Feedback.jsx
+++ b/src/app/components/Feedback/Feedback.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import FocusTrap from 'focus-trap-react';
 import axios from 'axios';
-import { Button, Input } from '@nypl/design-system-react-components';
+import { Button, Input, ButtonTypes } from '@nypl/design-system-react-components';
 
 import { trackDiscovery } from '../../utils/utils';
 import appConfig from '../../data/appConfig';
@@ -42,7 +42,7 @@ class Feedback extends React.Component {
 
   postForm(url) {
     const { fields } = this.state;
-    fields.URL = url;
+    fields.url = url;
     axios({
       method: 'POST',
       url: `${appConfig.baseUrl}/api/feedback`,
@@ -95,6 +95,7 @@ class Feedback extends React.Component {
             'aria-expanded': showForm,
             'aria-controls': 'feedback-menu',
           }}
+          buttonType={ButtonTypes.Secondary}
         >
           Help & Feedback
         </Button>
@@ -132,10 +133,8 @@ class Feedback extends React.Component {
               </div>
               <div>
                 <label htmlFor="feedback-input-email">Email Address</label>
-                <Input
-                  attributes={{
-                    name: 'email',
-                  }}
+                <input
+                  name="email"
                   id="feedback-input-email"
                   type="email"
                   value={fields.email}
@@ -144,16 +143,23 @@ class Feedback extends React.Component {
               </div>
               <input name="fvv" value="1" type="hidden" />
 
-              <button
+              <Button
                 className={`cancel-button ${!showForm ? 'hidden' : ''}`}
                 onClick={e => this.deactivateForm(e)}
-                aria-expanded={!showForm}
-                aria-controls="feedback-menu"
+                attributes={{
+                  'aria-expanded': !showForm,
+                  'aria-controls': 'feedback-menu',
+                }}
+                buttonType={ButtonTypes.Secondary}
               >
                 Cancel
-              </button>
+              </Button>
 
-              <button type="submit" className="large">Submit</button>
+              <Button
+                type="submit"
+                buttonType={ButtonTypes.Primary}
+              >Submit
+              </Button>
             </form>
           </div>
         </FocusTrap>

--- a/src/app/components/Feedback/Feedback.jsx
+++ b/src/app/components/Feedback/Feedback.jsx
@@ -108,7 +108,7 @@ class Feedback extends React.Component {
         >
           <div
             role="menu"
-            className={`feedback-form-container${showForm ? ' active' : ''}`}
+            className={showForm ? ' active' : ''}
             id="feedback-menu"
           >
             {!success && (

--- a/src/app/components/Feedback/Feedback.jsx
+++ b/src/app/components/Feedback/Feedback.jsx
@@ -3,13 +3,14 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import FocusTrap from 'focus-trap-react';
 import axios from 'axios';
+import { Button, Input } from '@nypl/design-system-react-components';
 
 import { trackDiscovery } from '../../utils/utils';
 import appConfig from '../../data/appConfig';
 
 const initialFields = () => ({
-  Email: '',
-  Feedback: '',
+  email: '',
+  feedback: '',
 });
 
 class Feedback extends React.Component {
@@ -31,7 +32,7 @@ class Feedback extends React.Component {
 
   onSubmitForm(url) {
     const { fields } = this.state;
-    if (!fields.Feedback && !fields.Feedback.length) {
+    if (!fields.feedback && !fields.feedback.length) {
       this.commentText.current.focus();
     } else {
       this.postForm(url);
@@ -85,16 +86,18 @@ class Feedback extends React.Component {
     const { submit } = this.props;
 
     return (
-      <div className="feedback">
-        <button
+      <div className="feedback nypl-ds">
+        <Button
           className="feedback-button"
           onClick={() => this.toggleForm()}
-          aria-haspopup="true"
-          aria-expanded={showForm}
-          aria-controls="feedback-menu"
+          attributes={{
+            'aria-haspopup': 'true',
+            'aria-expanded': showForm,
+            'aria-controls': 'feedback-menu',
+          }}
         >
-          Feedback
-        </button>
+          Help & Feedback
+        </Button>
         <FocusTrap
           focusTrapOptions={{
             onDeactivate: this.deactivateForm,
@@ -118,8 +121,8 @@ class Feedback extends React.Component {
                 </label>
                 <textarea
                   id="feedback-textarea-comment"
-                  name="Feedback"
-                  value={fields.Feedback}
+                  name="feedback"
+                  value={fields.feedback}
                   ref={this.commentText}
                   rows="5"
                   aria-required="true"
@@ -129,11 +132,13 @@ class Feedback extends React.Component {
               </div>
               <div>
                 <label htmlFor="feedback-input-email">Email Address</label>
-                <input
+                <Input
+                  attributes={{
+                    name: 'email',
+                  }}
                   id="feedback-input-email"
-                  name="Email"
                   type="email"
-                  value={fields.Email}
+                  value={fields.email}
                   onChange={this.handleInputChange}
                 />
               </div>

--- a/src/app/components/Feedback/Feedback.jsx
+++ b/src/app/components/Feedback/Feedback.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import FocusTrap from 'focus-trap-react';
 import axios from 'axios';
-import { Button, ButtonTypes, Input, Label, HelperErrorText } from '@nypl/design-system-react-components';
+import { Button, ButtonTypes, Input, Label, HelperErrorText, Link } from '@nypl/design-system-react-components';
 
 import { trackDiscovery } from '../../utils/utils';
 import appConfig from '../../data/appConfig';
@@ -35,7 +35,7 @@ class Feedback extends React.Component {
   onSubmitForm(url) {
     const { fields } = this.state;
     if (!fields.feedback && !fields.feedback.length) {
-      this.setState({ commentInputError: true })
+      this.setState({ commentInputError: true }, () => this.commentText.current.focus())
     } else {
       this.postForm(url);
       trackDiscovery('Feedback', 'Submit');
@@ -130,18 +130,21 @@ class Feedback extends React.Component {
                       name="feedback"
                       value={fields.feedback}
                       ref={this.commentText}
-                      rows="4"
+                      rows="8"
                       aria-required="true"
                       tabIndex="0"
                       onChange={this.handleInputChange}
                     />
-                    <HelperErrorText id="helperText" isError={commentInputError}>
+                    <HelperErrorText
+                      id="helper-text"
+                      isError={commentInputError}
+                    >
                       {commentInputError ? 'Please fill out this field' : ''}
                     </HelperErrorText>
                   </div>
                   <div>
                     <Label htmlFor="feedback-input-email">
-                      Email (If you need a response from us)
+                      Email <span>(If you need a response from us)</span>
                     </Label>
                     <Input
                       required
@@ -155,12 +158,12 @@ class Feedback extends React.Component {
                       value={fields.email}
                     />
                   </div>
-                  <a
+                  <Link
                     href="https://www.nypl.org/help/about-nypl/legal-notices/privacy-policy"
                     className="privacy-policy"
                     target="_blank"
                   >Privacy Policy
-                  </a>
+                  </Link>
                   <Button
                     className={`cancel-button ${!showForm ? 'hidden' : ''}`}
                     onClick={e => this.deactivateForm(e)}

--- a/src/app/components/Feedback/Feedback.jsx
+++ b/src/app/components/Feedback/Feedback.jsx
@@ -32,19 +32,19 @@ class Feedback extends React.Component {
     this.handleInputChange = this.handleInputChange.bind(this);
   }
 
-  onSubmitForm(url) {
+  onSubmitForm(e) {
+    e.preventDefault();
     const { fields } = this.state;
     if (!fields.feedback && !fields.feedback.length) {
       this.setState({ commentInputError: true }, () => this.commentText.current.focus())
     } else {
-      this.postForm(url);
+      this.postForm();
       trackDiscovery('Feedback', 'Submit');
     }
   }
 
-  postForm(url) {
+  postForm() {
     const { fields } = this.state;
-    fields.url = url;
     axios({
       method: 'POST',
       url: `${appConfig.baseUrl}/api/feedback`,
@@ -119,7 +119,7 @@ class Feedback extends React.Component {
                 <h1>We are here to help!</h1>
                 <form
                   target="hidden_feedback_iframe"
-                  onSubmit={e => submit(this.onSubmitForm, e)}
+                  onSubmit={this.onSubmitForm}
                 >
                   <div>
                     <Label htmlFor="feedback-textarea-comment">

--- a/src/app/data/appConfig.js
+++ b/src/app/data/appConfig.js
@@ -59,12 +59,12 @@ const appConfig = {
   },
   features: extractFeatures(process.env.FEATURES),
   generalResearchEmail: process.env.GENERAL_RESEARCH_EMAIL,
-  airtableApiKey: process.env.AIRTABLE_API_KEY,
-  feedbackFormUrl: process.env.FEEDBACK_FORM_URL,
   eddAboutUrl: {
     onSiteEdd: 'https://www.nypl.org/research/scan-and-deliver',
     default: 'https://www.nypl.org/help/request-research-materials#EDD',
   },
+  sourceEmail: process.env.SOURCE_EMAIL,
+  libAnswersEmail: process.env.LIB_ANSWERS_EMAIL,
 };
 
 export default appConfig;

--- a/src/app/utils/utils.js
+++ b/src/app/utils/utils.js
@@ -514,6 +514,16 @@ const hasValidFilters = (selectedFilters) => {
   return Object.values(selectedFilters || {}).some((v) => Array.isArray(v) ? v.length > 0 : v );
 };
 
+
+/**
+ * encodeHTML(str, maxLength)
+ * Return a version of the string sanitized to protect against XSS.
+ * @param {string} str - The string to be sanitized
+ */
+function encodeHTML(str) {
+  return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/"/g, '&quot;');
+}
+
 export {
   trackDiscovery,
   ajaxCall,
@@ -532,4 +542,5 @@ export {
   truncateStringOnWhitespace,
   isOptionSelected,
   hasValidFilters,
+  encodeHTML,
 };

--- a/src/client/styles/components/Feedback.scss
+++ b/src/client/styles/components/Feedback.scss
@@ -100,12 +100,15 @@
     border: 1px solid var(--ui-gray-medium);
   }
 
+  textarea {
+    height: 8em;
+  }
+
   input {
     padding: 0.3rem 0.4rem;
   }
 
   button {
-    margin-top: 21px;
     font-size: 1rem;
     display: inline;
     width: 164px;
@@ -120,12 +123,44 @@
   }
 }
 
-a.privacy-policy {
-  color: var(--ui-link-primary);
-  float: right;
-  font-size: .75rem;
+.privacy-policy {
+  display: flow-root;
+  a {
+    color: var(--ui-link-primary);
+    float: right;
+    font-size: .75rem;
+  }
 }
 
 .nypl-required-field {
   float: right;
+}
+
+@media (max-width: 768px) {
+  #feedback-menu {
+    height: 400px;
+    padding: 34px;
+
+    h1 {
+      font-size: 1rem;
+      margin-bottom: 7px;
+    }
+
+    label {
+      margin-bottom: 4px;
+    }
+
+    textarea {
+      height: 6em;
+    }
+
+    button {
+      margin-top: 13px;
+      width: 98px;
+      height: 25px;
+      font-size: .875rem;
+      padding: 0;
+    }
+  }
+
 }

--- a/src/client/styles/components/Feedback.scss
+++ b/src/client/styles/components/Feedback.scss
@@ -4,7 +4,7 @@
   right: 0;
   z-index: 100;
   text-align: right;
-  background: #54514A;
+  background: #FFF;
   color: #000;
 
   @include min-screen($tablet-portrait) {
@@ -15,21 +15,19 @@
 }
 
 .feedback-button {
-  background: #d0343a;
-  display: inline-block;
-  color: #FFF;
-  cursor: pointer;
+  background: $dsresearchprimary;
+  border: 1px solid $dsresearchprimary;
   box-sizing: border-box;
-  padding: 0.5rem 1rem;
-  border: 1px solid #d0343a;
-  text-align: center;
+  color: #FFF;
+  display: inline-block;
   font-size: 1rem;
+  padding: 0.5rem 1rem;
   position: relative;
+  text-align: center;
 
   &:hover {
     background: #FFF;
-    border: 0.04167rem solid #d0343a;
-    color: #d0343a;
+    color: $dsresearchprimary;
   }
 }
 
@@ -86,7 +84,6 @@
     display: block;
     width: 100%;
     background-color: $page-background-color;
-    border: 0;
     font-size: 1rem;
     line-height: 1.2;
     box-sizing: border-box;

--- a/src/client/styles/components/Feedback.scss
+++ b/src/client/styles/components/Feedback.scss
@@ -11,6 +11,7 @@
     position: fixed;
     background: inherit;
     max-width: 400px;
+    min-width: 400px;
   }
 }
 
@@ -32,7 +33,7 @@
 }
 
 .cancel-button {
-  border: 1px solid inherit;
+  border: 1px solid #E0E0E0;
   text-align: center;
   font-size: 1rem;
   margin-right: 15px;
@@ -96,4 +97,12 @@
   iframe {
     display: none;
   }
+}
+
+.privacy-policy {
+  float: right;
+}
+
+.nypl-required-field {
+  float: right;
 }

--- a/src/client/styles/components/Feedback.scss
+++ b/src/client/styles/components/Feedback.scss
@@ -32,15 +32,9 @@
 }
 
 .cancel-button {
-  background: #d0343a;
-  display: inline-block;
-  color: #FFF;
-  cursor: pointer;
-  box-sizing: border-box;
-  border: 1px solid #d0343a;
+  border: 1px solid inherit;
   text-align: center;
   font-size: 1rem;
-  position: relative;
   margin-right: 15px;
 }
 
@@ -87,6 +81,7 @@
     font-size: 1rem;
     line-height: 1.2;
     box-sizing: border-box;
+    border: 1px solid var(--ui-gray-medium);
   }
 
   input {
@@ -96,6 +91,7 @@
   button {
     font-size: 1rem;
     margin-top: 1rem;
+    display: inline;
   }
 
   iframe {

--- a/src/client/styles/components/Feedback.scss
+++ b/src/client/styles/components/Feedback.scss
@@ -39,7 +39,7 @@
 }
 
 
-.feedback-form-container {
+#feedback-menu {
   display: none;
   background: $page-color-light;
   border: 1px solid $border-color;

--- a/src/client/styles/components/Feedback.scss
+++ b/src/client/styles/components/Feedback.scss
@@ -46,15 +46,10 @@
   box-shadow: -1px 0 1px 0 rgba(0,0,0,0.3);
   padding: 0.35rem 0.5rem;
   text-align: left;
+  height: 300px;
 
   &.active {
     display: block;
-  }
-
-  p {
-    border-bottom: 1px solid $border-color;
-    margin-bottom: 0.35rem;
-    padding-bottom: 0.35rem;
   }
 
   form {

--- a/src/client/styles/components/Feedback.scss
+++ b/src/client/styles/components/Feedback.scss
@@ -45,9 +45,18 @@
   background: #FFF;
   border: 1px solid $border-color;
   box-shadow: -1px 0 1px 0 rgba(0,0,0,0.3);
-  padding: 0.35rem 0.5rem;
+  padding: 15px 25px;
   text-align: left;
   height: 300px;
+
+  h1 {
+    font-size: 1.125rem;
+    font-weight: 500;
+    line-height: 26px;
+    letter-spacing: 0px;
+    text-align: left;
+    margin: 0;
+  }
 
   &.active {
     display: block;
@@ -60,8 +69,8 @@
 
   label {
     display: block;
-    margin: 0.8rem 0 0.2rem;
-    font-size: 0.9rem;
+    font-size: 14px;
+    margin: var(--space-xs) 0;
 
     small {
       line-height: 1;

--- a/src/client/styles/components/Feedback.scss
+++ b/src/client/styles/components/Feedback.scss
@@ -42,7 +42,7 @@
 
 #feedback-menu {
   display: none;
-  background: $page-color-light;
+  background: #FFF;
   border: 1px solid $border-color;
   box-shadow: -1px 0 1px 0 rgba(0,0,0,0.3);
   padding: 0.35rem 0.5rem;

--- a/src/client/styles/components/Feedback.scss
+++ b/src/client/styles/components/Feedback.scss
@@ -67,6 +67,10 @@
     }
   }
 
+  p {
+    margin: 65px 40px;
+  }
+
   input,
   select,
   textarea {

--- a/src/client/styles/components/Feedback.scss
+++ b/src/client/styles/components/Feedback.scss
@@ -10,8 +10,8 @@
   @include min-screen($tablet-portrait) {
     position: fixed;
     background: inherit;
-    max-width: 400px;
-    min-width: 400px;
+    max-width: 571px;
+    min-width: 571px;
   }
 }
 
@@ -22,7 +22,7 @@
   color: #FFF;
   display: inline-block;
   font-size: 1rem;
-  padding: 0.5rem 1rem;
+  padding: .5rem 1rem;
   position: relative;
   text-align: center;
 
@@ -34,9 +34,9 @@
 
 .cancel-button {
   border: 1px solid #E0E0E0;
-  text-align: center;
   font-size: 1rem;
   margin-right: 15px;
+  text-align: center;
 }
 
 
@@ -45,17 +45,17 @@
   background: #FFF;
   border: 1px solid $border-color;
   box-shadow: -1px 0 1px 0 rgba(0,0,0,0.3);
-  padding: 15px 25px;
+  padding: 50px 42px;
   text-align: left;
-  height: 300px;
+  height: 472px;
 
   h1 {
-    font-size: 1.125rem;
+    font-size: 1.5rem;
     font-weight: 500;
     line-height: 26px;
     letter-spacing: 0px;
     text-align: left;
-    margin: 0;
+    margin: 0 0 14px 0;
   }
 
   &.active {
@@ -69,16 +69,23 @@
 
   label {
     display: block;
-    font-size: 14px;
-    margin: var(--space-xs) 0;
+    font-size: .875rem;
+    margin-bottom: 6px;
 
     small {
       line-height: 1;
     }
+
+    span {
+      font-size: .75rem;
+      font-weight: 300;
+    }
   }
 
   p {
-    margin: 65px 40px;
+    margin: 107px 40px;
+    font-size: 20px;
+    font-weight: 500;
   }
 
   input,
@@ -98,18 +105,25 @@
   }
 
   button {
+    margin-top: 21px;
     font-size: 1rem;
-    margin-top: 1rem;
     display: inline;
+    width: 164px;
   }
 
   iframe {
     display: none;
   }
+
+  .helper-text {
+    height: 21px;
+  }
 }
 
-.privacy-policy {
+a.privacy-policy {
+  color: var(--ui-link-primary);
   float: right;
+  font-size: .75rem;
 }
 
 .nypl-required-field {

--- a/src/client/styles/main.scss
+++ b/src/client/styles/main.scss
@@ -17,6 +17,7 @@ App-specific utilities and defaults
 // @import "utils/fonts.scss";
 @import "utils/variables.scss";
 @import "utils/base.scss";
+@import "utils/colors.scss";
 
 /*
 Import style rules from NYPL React module components

--- a/src/client/styles/utils/colors.scss
+++ b/src/client/styles/utils/colors.scss
@@ -1,3 +1,6 @@
+// Design System Research color
+$dsresearchprimary: #377f8b;
+
 // colors
 $nyplgray: #7B756F;
 $nypldarkgray: darken($nyplgray, 40%);

--- a/src/server/ApiRoutes/Feedback.js
+++ b/src/server/ApiRoutes/Feedback.js
@@ -16,8 +16,13 @@ export default {
     const emailText = `Question/Feedback from Research Catalog (SCC): ${submissionText}`;
 
     const emailHtml = `<div>
-    <h1>Question/Feedback from Research Catalog (SCC):</h1>
-    ${Object.entries(fields).map(([field, value]) => `<p>${field}: ${encodeHTML(value).replace(/\\n/g, '<br/>')}</p>`).join('')}
+      <h1>Question/Feedback from Research Catalog (SCC):</h1>
+      <dl>
+        ${Object.entries(fields).map(([field, value]) => `
+          <dt>${field}:</dt>
+          <dd>${encodeHTML(value).replace(/\\n/g, '<br/>')}</dd>
+        `).join('')}
+      </dl>
     </div>`;
 
     // Create sendEmail params

--- a/src/server/ApiRoutes/Feedback.js
+++ b/src/server/ApiRoutes/Feedback.js
@@ -1,6 +1,7 @@
 import aws from 'aws-sdk';
 
 import appConfig from '../../app/data/appConfig';
+import { encodeHTML } from '../../app/utils/utils';
 
 export default {
   post: (req, res) => {
@@ -11,12 +12,12 @@ export default {
 
     const { fields } = req.body;
 
-    const submissionText = Object.entries(fields).map(([field, value]) => `${field}: ${value}`).join(', ');
+    const submissionText = Object.entries(fields).map(([field, value]) => `${field}: ${encodeHTML(value)}`).join(', ');
     const emailText = `Question/Feedback from Research Catalog (SCC): ${submissionText}`;
 
     const emailHtml = `<div>
     <h1>Question/Feedback from Research Catalog (SCC):</h1>
-    ${Object.entries(fields).map(([field, value]) => `<p>${field}: ${value}</p>`).join('')}
+    ${Object.entries(fields).map(([field, value]) => `<p>${field}: ${encodeHTML(value).replace(/\\n/g, '<br/>')}</p>`).join('')}
     </div>`;
 
     // Create sendEmail params

--- a/src/server/ApiRoutes/Feedback.js
+++ b/src/server/ApiRoutes/Feedback.js
@@ -11,7 +11,7 @@ export default {
     aws.config.update({ region: 'us-east-1' });
 
     const { fields } = req.body;
-    const fullUrl = `${req.protocol}://${req.get('host')}${req.originalUrl}`;
+    const fullUrl = encodeHTML(req.headers.referer);
 
     const submissionText = ['Email', 'Feedback'].map(label => `${label}: ${encodeHTML(fields[label.toLowerCase()])}`).join(', ');
     const emailText = `Question/Feedback from Research Catalog (SCC): ${submissionText} URL: ${fullUrl}`;

--- a/src/server/ApiRoutes/Feedback.js
+++ b/src/server/ApiRoutes/Feedback.js
@@ -52,7 +52,7 @@ export default {
         },
       },
       Source: appConfig.sourceEmail, /* required */
-      ReplyToAddresses: [fields.email],
+      ReplyToAddresses: [fields.email || appConfig.sourceEmail],
     };
 
     // Create the promise and SES service object

--- a/src/server/ApiRoutes/Feedback.js
+++ b/src/server/ApiRoutes/Feedback.js
@@ -43,7 +43,7 @@ export default {
     const sendPromise = new aws.SES({ apiVersion: '2010-12-01' }).sendEmail(params).promise();
 
     return sendPromise
-      .then(data => console.log(data))
+      .then(data => res.json(data))
       .catch(err => console.error(err, err.stack));
   },
 };

--- a/src/server/ApiRoutes/Feedback.js
+++ b/src/server/ApiRoutes/Feedback.js
@@ -11,19 +11,24 @@ export default {
     aws.config.update({ region: 'us-east-1' });
 
     const { fields } = req.body;
+    const fullUrl = `${req.protocol}://${req.get('host')}${req.originalUrl}`;
 
-    const submissionText = ['email', 'feedback', 'url'].map(label => `${label}: ${encodeHTML(fields[label])}`).join(', ');
-    const emailText = `Question/Feedback from Research Catalog (SCC): ${submissionText}`;
+    const submissionText = ['Email', 'Feedback'].map(label => `${label}: ${encodeHTML(fields[label.toLowerCase()])}`).join(', ');
+    const emailText = `Question/Feedback from Research Catalog (SCC): ${submissionText} URL: ${fullUrl}`;
 
-    const emailHtml = `<div>
-      <h1>Question/Feedback from Research Catalog (SCC):</h1>
-      <dl>
-        ${Object.entries(fields).map(([field, value]) => `
-          <dt>${field}:</dt>
-          <dd>${encodeHTML(value).replace(/\\n/g, '<br/>')}</dd>
-        `).join('')}
-      </dl>
-    </div>`;
+    const emailHtml = `
+      <div>
+        <h1>Question/Feedback from Research Catalog (SCC):</h1>
+        <dl>
+          ${['Email', 'Feedback'].map(label => `
+            <dt>${label}:</dt>
+            <dd>${encodeHTML(fields[label.toLowerCase()]).replace(/\\n/g, '<br/>')}</dd>
+          `).join('')}
+          <dt>URL:</dt>
+          <dd>${fullUrl}</dd>
+        </dl>
+      </div>
+    `;
 
     // Create sendEmail params
     const params = {

--- a/src/server/ApiRoutes/Feedback.js
+++ b/src/server/ApiRoutes/Feedback.js
@@ -12,7 +12,7 @@ export default {
 
     const { fields } = req.body;
 
-    const submissionText = Object.entries(fields).map(([field, value]) => `${field}: ${encodeHTML(value)}`).join(', ');
+    const submissionText = ['email', 'feedback', 'url'].map(label => `${label}: ${encodeHTML(fields[label])}`).join(', ');
     const emailText = `Question/Feedback from Research Catalog (SCC): ${submissionText}`;
 
     const emailHtml = `<div>

--- a/src/server/ApiRoutes/Feedback.js
+++ b/src/server/ApiRoutes/Feedback.js
@@ -1,4 +1,3 @@
-import axios from 'axios';
 import aws from 'aws-sdk';
 
 import appConfig from '../../app/data/appConfig';
@@ -12,6 +11,9 @@ export default {
 
     aws.config.update({ region: 'us-east-1' });
 
+    const emailText = Object.entries(fields).map(([field, value]) => `${field}: ${value}`).join(', ');
+    const emailHtml = `<div>${Object.entries(fields).map(([field, value]) => `<p>${field}: ${value}</p>`).join('')}</div>`;
+
     // Create sendEmail params
     const params = {
       Destination: { /* required */
@@ -21,11 +23,11 @@ export default {
         Body: { /* required */
           Html: {
             Charset: 'UTF-8',
-            Data: 'HTML_FORMAT_BODY',
+            Data: emailHtml,
           },
           Text: {
             Charset: 'UTF-8',
-            Data: 'TEXT_FORMAT_BODY',
+            Data: emailText,
           },
         },
         Subject: {
@@ -40,22 +42,8 @@ export default {
     // Create the promise and SES service object
     const sendPromise = new aws.SES({ apiVersion: '2010-12-01' }).sendEmail(params).promise();
 
-    // Handle promise's fulfilled/rejected states
     return sendPromise
       .then(data => console.log(data))
       .catch(err => console.error(err, err.stack));
-    // return axios({
-    //   method: 'POST',
-    //   url: appConfig.feedbackFormUrl,
-    //   data: {
-    //     fields,
-    //   },
-    //   headers: {
-    //     Authorization: `Bearer ${appConfig.airtableApiKey}`,
-    //     'Content-Type': 'application/json',
-    //   },
-    // }).then((postResp) => {
-    //   return res.json(postResp.data);
-    // }).catch(error => res.status(500).json({ error }));
   },
 };

--- a/src/server/ApiRoutes/Feedback.js
+++ b/src/server/ApiRoutes/Feedback.js
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import aws from 'aws-sdk';
 
 import appConfig from '../../app/data/appConfig';
 
@@ -8,18 +9,53 @@ export default {
     if (!req.body.fields) return res.status(400).json({ error: 'Request body missing `field` key' });
 
     const { fields } = req.body;
-    return axios({
-      method: 'POST',
-      url: appConfig.feedbackFormUrl,
-      data: {
-        fields,
+
+    aws.config.update({ region: 'us-east-1' });
+
+    // Create sendEmail params
+    const params = {
+      Destination: { /* required */
+        ToAddresses: [appConfig.libAnswersEmail],
       },
-      headers: {
-        Authorization: `Bearer ${appConfig.airtableApiKey}`,
-        'Content-Type': 'application/json',
+      Message: { /* required */
+        Body: { /* required */
+          Html: {
+            Charset: 'UTF-8',
+            Data: 'HTML_FORMAT_BODY',
+          },
+          Text: {
+            Charset: 'UTF-8',
+            Data: 'TEXT_FORMAT_BODY',
+          },
+        },
+        Subject: {
+          Charset: 'UTF-8',
+          Data: 'Test email',
+        },
       },
-    }).then((postResp) => {
-      return res.json(postResp.data);
-    }).catch(error => res.status(500).json({ error }));
+      Source: appConfig.sourceEmail, /* required */
+      ReplyToAddresses: [fields.email],
+    };
+
+    // Create the promise and SES service object
+    const sendPromise = new aws.SES({ apiVersion: '2010-12-01' }).sendEmail(params).promise();
+
+    // Handle promise's fulfilled/rejected states
+    return sendPromise
+      .then(data => console.log(data))
+      .catch(err => console.error(err, err.stack));
+    // return axios({
+    //   method: 'POST',
+    //   url: appConfig.feedbackFormUrl,
+    //   data: {
+    //     fields,
+    //   },
+    //   headers: {
+    //     Authorization: `Bearer ${appConfig.airtableApiKey}`,
+    //     'Content-Type': 'application/json',
+    //   },
+    // }).then((postResp) => {
+    //   return res.json(postResp.data);
+    // }).catch(error => res.status(500).json({ error }));
   },
 };

--- a/src/server/ApiRoutes/Feedback.js
+++ b/src/server/ApiRoutes/Feedback.js
@@ -10,9 +10,13 @@ export default {
     const { fields } = req.body;
 
     aws.config.update({ region: 'us-east-1' });
+    const submissionText = Object.entries(fields).map(([field, value]) => `${field}: ${value}`).join(', ');
+    const emailText = `Question/Feedback from Research Catalog (SCC): ${submissionText}`;
 
-    const emailText = Object.entries(fields).map(([field, value]) => `${field}: ${value}`).join(', ');
-    const emailHtml = `<div>${Object.entries(fields).map(([field, value]) => `<p>${field}: ${value}</p>`).join('')}</div>`;
+    const emailHtml = `<div>
+    <h1>Question/Feedback from Research Catalog (SCC):</h1>
+    ${Object.entries(fields).map(([field, value]) => `<p>${field}: ${value}</p>`).join('')}
+    </div>`;
 
     // Create sendEmail params
     const params = {
@@ -32,7 +36,7 @@ export default {
         },
         Subject: {
           Charset: 'UTF-8',
-          Data: 'Test email',
+          Data: 'SCC Feedback',
         },
       },
       Source: appConfig.sourceEmail, /* required */

--- a/src/server/ApiRoutes/Feedback.js
+++ b/src/server/ApiRoutes/Feedback.js
@@ -7,9 +7,10 @@ export default {
     if (!req.body) return res.status(400).json({ error: 'Malformed request' });
     if (!req.body.fields) return res.status(400).json({ error: 'Request body missing `field` key' });
 
+    aws.config.update({ region: 'us-east-1' });
+
     const { fields } = req.body;
 
-    aws.config.update({ region: 'us-east-1' });
     const submissionText = Object.entries(fields).map(([field, value]) => `${field}: ${value}`).join(', ');
     const emailText = `Question/Feedback from Research Catalog (SCC): ${submissionText}`;
 

--- a/test/unit/Feedback.test.js
+++ b/test/unit/Feedback.test.js
@@ -1,0 +1,30 @@
+/* eslint-env mocha */
+/* eslint-disable react/jsx-filename-extension */
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+
+import Feedback from './../../src/app/components/Feedback/Feedback';
+
+describe('Feedback', () => {
+  let component;
+  before(() => {
+    component = shallow(<Feedback />);
+  });
+
+  it('should render a <div> with class .feedback', () => {
+    expect(component.find('.feedback')).to.have.length(1);
+  });
+
+  describe('success screen', () => {
+    before(() => {
+      component.setState({ success: true });
+    });
+
+    it('should render a <p>', () => {
+      const successP = component.find('p');
+      expect(successP).to.have.length(1);
+      expect(successP.text()).to.equal('Thank you for submitting your comments, if you requested a response, our service staff will get back to you as soon as possible.');
+    });
+  });
+});

--- a/test/unit/Feedback.test.js
+++ b/test/unit/Feedback.test.js
@@ -2,18 +2,38 @@
 /* eslint-disable react/jsx-filename-extension */
 import React from 'react';
 import { expect } from 'chai';
-import { shallow } from 'enzyme';
+import { mount } from 'enzyme';
 
 import Feedback from './../../src/app/components/Feedback/Feedback';
 
 describe('Feedback', () => {
   let component;
   before(() => {
-    component = shallow(<Feedback />);
+    component = mount(<Feedback />);
   });
 
   it('should render a <div> with class .feedback', () => {
     expect(component.find('.feedback')).to.have.length(1);
+  });
+
+  it('should have initial state', () => {
+    const initialState = component.state();
+    expect(initialState.showForm).to.equal(false);
+    expect(initialState.success).to.equal(false);
+  });
+
+  it('should render a ds <button> with text "Help & Feedback"', () => {
+    expect(component.find('Button').first().text()).to.equal('Help & Feedback');
+  });
+
+  it('closed state does not have .active on #feedback-menu', () => {
+    expect(component.find('#feedback-menu').hasClass('active')).to.equal(false);
+  });
+
+  it('should change showForm state on click and add .active class to #feedback-menu', () => {
+    component.find('Button').first().simulate('click');
+    expect(component.state().showForm).to.equal(true);
+    expect(component.find('#feedback-menu').hasClass('active')).to.equal(true);
   });
 
   describe('success screen', () => {


### PR DESCRIPTION
**What's this do?**
This PR changes the feedback form to send an email to LibAnswers (the address will be configured in the AWS console), instead of posting to a spreadsheet. There are also frontend changes based on the new designs and product requirements.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SCC-2384
[Figma](https://www.figma.com/file/hWsa3asvr3gD12NMIEHol8/SCC---Check-List?node-id=3316%3A35208) - in page context

**Do these changes have automated tests?**
Just added some tests for this component. Went from 0% coverage to 60% coverage

**How should this be QAed?**
Submit feedback, ask LibAnswers to check that it was received.

**Did someone actually run this code to verify it works?**
I did

**To come**
Will get product input about what to do if there is an error from Amazon SES.