### PR TITLE
SCC-2397: Add tabs to accounts

### DIFF
--- a/src/app/components/AccountPage/AccountPage.jsx
+++ b/src/app/components/AccountPage/AccountPage.jsx
@@ -6,6 +6,8 @@ import { Link } from 'react-router';
 
 import { SkeletonLoader } from '@nypl/design-system-react-components';
 
+import LinkTabSet from './LinkTabSet';
+
 import appConfig from '../../data/appConfig';
 import manipulateAccountPage from '../../utils/accountPageUtils';
 
@@ -63,12 +65,26 @@ const AccountPage = (props) => {
         <br />
         {patron.emails ? `Email: ${patron.emails[0]}` : null}
       </div>
-      <ul>
-        <li><Link to={`${baseUrl}/account/items`}>Checkouts</Link></li>
-        <li><Link to={`${baseUrl}/account/holds`}>Holds</Link></li>
-        <li><Link to={`${baseUrl}/account/overdues`}>Fines{`${patron.moneyOwed ? ` ($${patron.moneyOwed.toFixed(2)})` : ''}`}</Link></li>
-        <li><Link to={`${baseUrl}/account/msg`}>Messages</Link></li>
-      </ul>
+      <LinkTabSet
+        tabs={[
+          {
+            label: 'Checkouts',
+            link: `${baseUrl}/account/items`,
+          },
+          {
+            label: 'Holds',
+            link: `${baseUrl}/account/holds`,
+          },
+          {
+            label: `Fines${patron.moneyOwed ? ` ($${patron.moneyOwed.toFixed(2)})` : ''}`,
+            link: `${baseUrl}/account/overdues`,
+          },
+          {
+            label: 'Messages',
+            link: `${baseUrl}/account/msg`,
+          },
+        ]}
+      />
       <a
         href={`https://ilsstaff.nypl.org:443/patroninfo*eng~Sdefault/${patron.id}/modpinfo`}
         target="_blank"

--- a/src/app/components/AccountPage/AccountPage.jsx
+++ b/src/app/components/AccountPage/AccountPage.jsx
@@ -2,7 +2,6 @@
 import React, { useEffect, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import PropTypes from 'prop-types';
-import { Link } from 'react-router';
 
 import { SkeletonLoader } from '@nypl/design-system-react-components';
 
@@ -19,6 +18,7 @@ const AccountPage = (props) => {
   }));
 
   const content = props.params.content || 'items';
+
   const dispatch = useDispatch();
   const updateAccountHtml = newContent => dispatch({
     type: 'UPDATE_ACCOUNT_HTML',
@@ -35,6 +35,10 @@ const AccountPage = (props) => {
   }, [patron]);
 
   useEffect(() => {
+    if (content === 'settings') {
+      setIsLoading(false);
+      return;
+    };
     const accountPageContent = document.getElementById('account-page-content');
 
     if (accountPageContent) {
@@ -60,42 +64,40 @@ const AccountPage = (props) => {
 
   return (
     <div className="nypl-full-width-wrapper drbb-integration nypl-patron-page">
+      <h2>My Account</h2>
       <div className="nypl-patron-details">
-        {patron.names ? `Name: ${patron.names[0]}` : null}
-        <br />
-        {patron.emails ? `Email: ${patron.emails[0]}` : null}
+        {patron.names ? patron.names[0] : null}
       </div>
       <LinkTabSet
+        activeTab={content}
         tabs={[
           {
             label: 'Checkouts',
             link: `${baseUrl}/account/items`,
+            content: 'items'
           },
           {
             label: 'Holds',
             link: `${baseUrl}/account/holds`,
+            content: 'holds',
           },
           {
             label: `Fines${patron.moneyOwed ? ` ($${patron.moneyOwed.toFixed(2)})` : ''}`,
             link: `${baseUrl}/account/overdues`,
+            content: 'overdues',
           },
           {
             label: 'Messages',
             link: `${baseUrl}/account/msg`,
+            content: 'msg',
+          },
+          {
+            label: 'Account Settings',
+            link: `${baseUrl}/account/settings`,
+            content: 'settings',
           },
         ]}
       />
-      <a
-        href={`https://ilsstaff.nypl.org:443/patroninfo*eng~Sdefault/${patron.id}/modpinfo`}
-        target="_blank"
-      >My Settings
-      </a>
-      <a
-        href={`https://ilsstaff.nypl.org:443/patroninfo*eng~Sdefault/${patron.id}/newpin`}
-        target="_blank"
-      >Change Pin
-      </a>
-      <hr />
       {isLoading ? <SkeletonLoader /> : ''}
       {
         typeof accountHtml === 'string' ? (
@@ -105,6 +107,22 @@ const AccountPage = (props) => {
             className={`${content} ${isLoading ? 'loading' : ''}`}
           />
         ) : ''
+      }
+      {
+        content === 'settings' ? (
+          <>
+            <a
+              href={`https://ilsstaff.nypl.org:443/patroninfo*eng~Sdefault/${patron.id}/modpinfo`}
+              target="_blank"
+            >My Settings
+            </a>
+            <a
+              href={`https://ilsstaff.nypl.org:443/patroninfo*eng~Sdefault/${patron.id}/newpin`}
+              target="_blank"
+            >Change Pin
+            </a>
+          </>
+        ) : null
       }
     </div>
   );

--- a/src/app/components/AccountPage/LinkTabSet.jsx
+++ b/src/app/components/AccountPage/LinkTabSet.jsx
@@ -6,7 +6,7 @@ const LinkTabSet = ({ tabs, activeTab }) => {
     <div className="tabbed">
       <ul role="tablist">
         { tabs.map((tab) => {
-          const isActiveTab = tab.label === activeTab;
+          const isActiveTab = tab.content === activeTab;
           return (
             <li id={`tab-${tab.label}`} key={`tab-${tab.label}`} className={isActiveTab ? 'activeTab' : null} role="presentation">
               <a

--- a/src/app/components/AccountPage/LinkTabSet.jsx
+++ b/src/app/components/AccountPage/LinkTabSet.jsx
@@ -1,29 +1,31 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const LinkTabSet = ({ tabs, activeTab }) => {
-  return (
-    <div className="tabbed">
-      <ul role="tablist">
-        { tabs.map((tab) => {
-          const isActiveTab = tab.content === activeTab;
-          return (
-            <li id={`tab-${tab.label}`} key={`tab-${tab.label}`} className={isActiveTab ? 'activeTab' : null} role="presentation">
-              <a
-                href={tab.link}
-                id={`link-${tab.label}`}
-                tabIndex="-1"
-                aria-selected={isActiveTab}
-                role="tab"
-              >{tab.label}
-              </a>
-            </li>
-          );
-        })}
-      </ul>
-    </div>
-  );
-};
+const LinkTabSet = ({ tabs, activeTab }) => (
+  <div className="tabbed">
+    <ul role="tablist">
+      { tabs.map((tab) => {
+        const isActiveTab = tab.content === activeTab;
+        return (
+          <li
+            id={`tab-${tab.label}`}
+            key={`tab-${tab.label}`}
+            className={isActiveTab ? 'activeTab' : null}
+            role="presentation"
+          >
+            <a
+              href={tab.link}
+              id={`link-${tab.label}`}
+              aria-selected={isActiveTab}
+              role="tab"
+            >{tab.label}
+            </a>
+          </li>
+        );
+      })}
+    </ul>
+  </div>
+);
 
 LinkTabSet.propTypes = {
   tabs: PropTypes.array,

--- a/src/app/components/AccountPage/LinkTabSet.jsx
+++ b/src/app/components/AccountPage/LinkTabSet.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const LinkTabSet = ({ tabs, activeTab }) => {
+  return (
+    <div className="tabbed">
+      <ul role="tablist">
+        { tabs.map((tab) => {
+          const isActiveTab = tab.label === activeTab;
+          return (
+            <li id={`tab-${tab.label}`} key={`tab-${tab.label}`} className={isActiveTab ? 'activeTab' : null} role="presentation">
+              <a
+                href={tab.link}
+                id={`link-${tab.label}`}
+                tabIndex="-1"
+                aria-selected={isActiveTab}
+                role="tab"
+              >{tab.label}
+              </a>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+};
+
+LinkTabSet.propTypes = {
+  tabs: PropTypes.array,
+  activeTab: PropTypes.string,
+};
+
+export default LinkTabSet;

--- a/src/client/styles/components/AccountPage.scss
+++ b/src/client/styles/components/AccountPage.scss
@@ -22,6 +22,27 @@
       width: 20%;
     }
   }
+
+  .tabbed {
+    a {
+      width: 165px;
+      text-align: center;
+    }
+  }
+
+  .tabbed ul[role="tablist"] {
+    &> li {
+      border-color: #0576D3;
+    }
+
+    &> li > a[aria-selected='true'] {
+      color: #0576D3;
+    }
+
+    &> li.activeTab {
+      border-color: #0576D3;
+    }
+  }
 }
 
 .loading#account-page-content {

--- a/src/client/styles/components/AccountPage.scss
+++ b/src/client/styles/components/AccountPage.scss
@@ -75,7 +75,6 @@
       border-color: #0576D3;
     }
   }
-}
 
   button {
     display: inline-block;
@@ -87,4 +86,8 @@
     background-color: #F5F5F5;
     width: 100%;
   }
+}
+
+.loading#account-page-content {
+  display: none;
 }

--- a/src/client/styles/components/BibPage.scss
+++ b/src/client/styles/components/BibPage.scss
@@ -38,7 +38,7 @@ div .tabbed {
     color: $nypl-gray-brown;
     padding: 5px 8px;
     display: table-cell;
-    font-weight: 500;
+    font-weight: 300;
     text-decoration: none;
   }
 
@@ -48,6 +48,7 @@ div .tabbed {
 
   ul[role="tablist"] > li > a[aria-selected='true'] {
     color: black;
+    font-weight: 500;
   }
 
   .blank {

--- a/test/unit/AccountPage.test.js
+++ b/test/unit/AccountPage.test.js
@@ -1,0 +1,30 @@
+/* eslint-env mocha */
+/* eslint-disable react/jsx-filename-extension */
+import React from 'react';
+import { expect } from 'chai';
+import { mount } from 'enzyme';
+
+import AccountPage from './../../src/app/components/AccountPage/AccountPage';
+
+import { mountTestRender, makeTestStore } from '../helpers/store';
+
+describe('AccountPage', () => {
+  let mockStore;
+  let component;
+  before(() => {
+    mockStore = makeTestStore({});
+    component = mountTestRender(<AccountPage params={{}} />, { store: mockStore });
+  });
+
+  it('should render a <div> with class .nypl-patron-page', () => {
+    expect(component.find('.nypl-patron-page')).to.have.length(1);
+  });
+
+  it('should render an <h2> with text "My Account"', () => {
+    expect(component.find('h2').first().text()).to.equal('My Account');
+  });
+
+  it('should render an `LinkTabSet`', () => {
+    expect(component.find('LinkTabSet')).to.have.length(1);
+  });
+});


### PR DESCRIPTION
**What's this do?**
Adds a version of the tab set SCC already has onto the account page. I made a new, simplified component, because these tabs are really links and the content is not already there. The original `Tabbed` component takes HTML as the content. While the tab set design wise is up in the air and we want to get moving on demoing and QAing accounts, I think having two separate components is fine for now, instead of trying to massage the two cases into one.

**Why are we doing this? (w/ JIRA link if applicable)**
[SCC-2397](https://jira.nypl.org/browse/SCC-2397)

**Do these changes have automated tests?**
Just added the initial tests of this component. The tabs, unlike the main content of this page, will be easier to test.

**How should this be QAed?**
This is a feature of the page. It will be part of a larger QA.

**Did someone actually run this code to verify it works?**
I did