### PR TITLE
Fix checkbox sizing for Safari

### DIFF
--- a/src/client/styles/components/BibPage.scss
+++ b/src/client/styles/components/BibPage.scss
@@ -67,6 +67,10 @@ div .tabbed {
       border-bottom: 0;
     }
   }
+
+  .checkbox {
+    display: -webkit-box;
+  }
 }
 
 .default {


### PR DESCRIPTION
**What's this do?**
Short code change. For some reason, on Safari the checkboxes are irregular sizes based on the width of the label. Example here: http://qa-discovery.nypl.org/research/collections/shared-collection-catalog/bib/b11483389

**How should this be QAed?**
Cross browser QA

**Did someone actually run this code to verify it works?**
I did