### PR TITLE
"Cancel" bug: put `currentsortorder: 'current_pickup'` first in request body

### DIFF
--- a/src/app/utils/accountPageUtils.js
+++ b/src/app/utils/accountPageUtils.js
@@ -32,10 +32,12 @@ const buildReqBody = (content, itemObj, locationData) => {
     case 'items':
       return { ...itemObj, renewsome: 'YES' };
     case 'holds':
-      return Object.assign(itemObj, {
-        updateholdssome: 'YES',
+      return {
         currentsortorder: 'current_pickup',
-      }, locationData);
+        updateholdssome: 'YES',
+        ...itemObj,
+        ...locationData,
+      };
     default:
       return itemObj;
   }

--- a/src/server/ApiRoutes/Account.js
+++ b/src/server/ApiRoutes/Account.js
@@ -43,9 +43,11 @@ function postToAccountPage(req, res) {
   const patronId = req.patronTokenResponse.decodedPatron.sub;
   const content = req.params.content || 'items';
   const reqBodyString = Object.keys(req.body).map(key => `${key}=${req.body[key]}`).join('&');
+
   axios.post(
     `${appConfig.legacyCatalog}/dp/patroninfo*eng~Sdefault/${patronId}/${content}`,
-    reqBodyString, {
+    reqBodyString,
+    {
       headers: {
         Cookie: req.headers.cookie,
       },


### PR DESCRIPTION
**What's this do?**
For some reason, this property needs to be first to make cancel work. 

**Did someone actually run this code to verify it works?**
I did