### PR TITLE
Fix tab section padding

### DIFF
--- a/src/client/styles/components/BibPage.scss
+++ b/src/client/styles/components/BibPage.scss
@@ -75,6 +75,7 @@ div .tabbed {
 
 .default {
   display: block;
+  padding-top: 15px;
 }
 
 .non-default {
@@ -84,7 +85,7 @@ div .tabbed {
 @for $i from 1 through 4 {
   #tab#{$i}:target ~ #section#{$i} {
     display: block;
-    padding: 15px 1% 0;
+    padding: 15px 0;
   }
 }
 


### PR DESCRIPTION
**What's this do?**
Small change that was made to the `default` tab section, but not to the others. Remove left padding. Also, Make top padding consistent between "default" and `#tab1`

**Why are we doing this? (w/ JIRA link if applicable)**
Feedback from Ellen