### PR TITLE
Add Hero and Breadcrumb to My Account

### DIFF
--- a/src/app/components/AccountPage/AccountPage.jsx
+++ b/src/app/components/AccountPage/AccountPage.jsx
@@ -100,7 +100,7 @@ const AccountPage = (props) => {
             breadcrumbs={[
               { url: "htttps://www.nypl.org", text: "Home" },
               { url: "https://www.nypl.org/research", text: "Research" },
-              { url: appConfig.baseUrl, text: "Research Catalog" },
+              { url: baseUrl, text: "Research Catalog" },
             ]}
             className="breadcrumbs"
           />
@@ -117,9 +117,23 @@ const AccountPage = (props) => {
                   className="sub-nav apply-brand-styles"
                   aria-label="sub-nav"
                 >
-                  <Link href="#">Search</Link> |&nbsp;
-                  <Link href="#">Subject Heading Explorer</Link> |&nbsp;
-                  <Link href="#">My Account</Link>
+                  <Link
+                    className="sub-nav__link"
+                    href={baseUrl}
+                  >
+                    Search
+                  </Link> |&nbsp;
+                  <Link
+                    className="sub-nav__link"
+                    href={`${baseUrl}/subject_headings`}
+                  >
+                    Subject Heading Explorer
+                  </Link> |&nbsp;
+                  <span
+                    className="sub-nav__active-section"
+                  >
+                    My Account
+                  </span>
                 </nav>
               </>
             )}

--- a/src/app/components/AccountPage/AccountPage.jsx
+++ b/src/app/components/AccountPage/AccountPage.jsx
@@ -3,7 +3,16 @@ import React, { useEffect, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import PropTypes from 'prop-types';
 
-import { SkeletonLoader, Heading, Button, ButtonTypes } from '@nypl/design-system-react-components';
+import {
+  SkeletonLoader,
+  Heading,
+  Button,
+  ButtonTypes,
+  Breadcrumbs,
+  Hero,
+  HeroTypes,
+  Link,
+} from '@nypl/design-system-react-components';
 
 import LinkTabSet from './LinkTabSet';
 import AccountSettings from './AccountSettings';
@@ -84,74 +93,113 @@ const AccountPage = (props) => {
   };
 
   return (
-    <div className="nypl-full-width-wrapper drbb-integration nypl-patron-page nypl-ds">
-      <Heading level={2} text="My Account" />
-      <div className="nypl-patron-details">
-        <div className="name">{patron.names ? patron.names[0] : null}</div>
-        <div>{patron.barcodes ? patron.barcodes[0] : null}</div>
-        <div>Expiration Date: {patron.expirationDate}</div>
-      </div>
-      {itemToCancel ? (
-        <div className="scc-modal">
-          <div>
-            <p>You requested <span>canceling</span> of following item:</p>
-            <p>{itemToCancel.title}</p>
-            <Button
-              buttonType={ButtonTypes.Secondary}
-              onClick={() => setItemToCancel(null)}
-            >Back
-            </Button>
-            <Button
-              buttonType={ButtonTypes.Primary}
-              onClick={cancelItem}
-            >Confirm
-            </Button>
-          </div>
+    <div className="nypl-ds nypl--research layout-container">
+      <main className="main" id="mainContent">
+        <div className="content-header">
+          <Breadcrumbs
+            breadcrumbs={[
+              { url: "htttps://www.nypl.org", text: "Home" },
+              { url: "https://www.nypl.org/research", text: "Research" },
+              { url: appConfig.baseUrl, text: "Research Catalog" },
+            ]}
+            className="breadcrumbs"
+          />
+          <Hero
+            heroType={HeroTypes.Secondary}
+            heading={(
+              <>
+                <Heading
+                  level={1}
+                  id={"1"}
+                  text="Research Catalog"
+                />
+                <nav
+                  className="sub-nav apply-brand-styles"
+                  aria-label="sub-nav"
+                >
+                  <Link href="#">Search</Link> |&nbsp;
+                  <Link href="#">Subject Heading Explorer</Link> |&nbsp;
+                  <Link href="#">My Account</Link>
+                </nav>
+              </>
+            )}
+            className="apply-brand-styles hero"
+          />
         </div>
-      ) : null}
-      <LinkTabSet
-        activeTab={content}
-        tabs={[
-          {
-            label: 'Checkouts',
-            link: `${baseUrl}/account/items`,
-            content: 'items'
-          },
-          {
-            label: 'Holds',
-            link: `${baseUrl}/account/holds`,
-            content: 'holds',
-          },
-          {
-            label: `Fines${patron.moneyOwed ? ` ($${patron.moneyOwed.toFixed(2)})` : ''}`,
-            link: `${baseUrl}/account/overdues`,
-            content: 'overdues',
-          },
-          {
-            label: 'Account Settings',
-            link: `${baseUrl}/account/settings`,
-            content: 'settings',
-          },
-        ]}
-      />
-      {isLoading && content !== 'settings' ? <SkeletonLoader /> : ''}
-      {
-        typeof accountHtml === 'string' && content !== 'settings' ? (
-          <div
-            dangerouslySetInnerHTML={{ __html: accountHtml }}
-            id="account-page-content"
-            className={`${content} ${isLoading ? 'loading' : ''}`}
+        <div className="content-primary page-content nypl-patron-page">
+          <Heading
+            level={2}
+            id="2"
+            text="My Account"
           />
-        ) : ''
-      }
-      {
-        content === 'settings' ? (
-          <AccountSettings
-            patron={patron}
-            legacyCatalog={appConfig.legacyCatalog}
+          <div className="nypl-patron-details">
+            <div className="name">{patron.names ? patron.names[0] : null}</div>
+            <div>{patron.barcodes ? patron.barcodes[0] : null}</div>
+            <div>Expiration Date: {patron.expirationDate}</div>
+          </div>
+          {itemToCancel ? (
+            <div className="scc-modal">
+              <div>
+                <p>You requested <span>canceling</span> of following item:</p>
+                <p>{itemToCancel.title}</p>
+                <Button
+                  buttonType={ButtonTypes.Secondary}
+                  onClick={() => setItemToCancel(null)}
+                >Back
+                </Button>
+                <Button
+                  buttonType={ButtonTypes.Primary}
+                  onClick={cancelItem}
+                >Confirm
+                </Button>
+              </div>
+            </div>
+          ) : null}
+          <LinkTabSet
+            activeTab={content}
+            tabs={[
+              {
+                label: 'Checkouts',
+                link: `${baseUrl}/account/items`,
+                content: 'items'
+              },
+              {
+                label: 'Holds',
+                link: `${baseUrl}/account/holds`,
+                content: 'holds',
+              },
+              {
+                label: `Fines${patron.moneyOwed ? ` ($${patron.moneyOwed.toFixed(2)})` : ''}`,
+                link: `${baseUrl}/account/overdues`,
+                content: 'overdues',
+              },
+              {
+                label: 'Account Settings',
+                link: `${baseUrl}/account/settings`,
+                content: 'settings',
+              },
+            ]}
           />
-        ) : null
-      }
+          {isLoading && content !== 'settings' ? <SkeletonLoader /> : ''}
+          {
+            typeof accountHtml === 'string' && content !== 'settings' ? (
+              <div
+                dangerouslySetInnerHTML={{ __html: accountHtml }}
+                id="account-page-content"
+                className={`${content} ${isLoading ? 'loading' : ''}`}
+              />
+            ) : ''
+          }
+          {
+            content === 'settings' ? (
+              <AccountSettings
+                patron={patron}
+                legacyCatalog={appConfig.legacyCatalog}
+              />
+            ) : null
+          }
+        </div>
+      </main>
     </div>
   );
 };

--- a/src/client/styles/Layout.scss
+++ b/src/client/styles/Layout.scss
@@ -27,4 +27,10 @@ Build out global styles for Research Catalog
 
 .sub-nav {
   width: 100%;
+  &__link {
+    font-weight: 400;
+  }
+  &__active-section {
+    font-weight: 600;
+  }
 }

--- a/src/client/styles/Layout.scss
+++ b/src/client/styles/Layout.scss
@@ -1,0 +1,30 @@
+/*
+Build out global styles for Research Catalog
+*/
+
+.apply-brand-styles {
+  background: var(--section-research-primary);
+
+  .heading {
+    color: var(--ui-white);
+  }
+
+  .sub-nav {
+    color: var(--ui-white);
+    padding-bottom: var(--space-xs);
+
+    .link:not(:hover) {
+      color: var(--ui-white);
+      text-decoration: none;
+    }
+  }
+}
+
+.page-content {
+  padding-bottom: var(--space-l);
+  padding-top: var(--space-l);
+}
+
+.sub-nav {
+  width: 100%;
+}

--- a/src/client/styles/main.scss
+++ b/src/client/styles/main.scss
@@ -28,6 +28,7 @@ Import style rules from NYPL React module components
 @import "components/**/*.scss";
 
 @import "style-v2.scss";
+@import "Layout.scss";
 
 html {
   @include font-settings;


### PR DESCRIPTION
**What's this do?**
Adds the NYPL Hero and Breadcrumb to My Account page. This is the last bit we need for this to be ready for QA and then launch.

**Why are we doing this? (w/ JIRA link if applicable)**
Add this global component to this new page first. Most of the other pages are currently built this way with the entire HTML from the Breadcrumb down. Hopefully at some point soon, the SCC template and applied across the board.

**Did someone actually run this code to verify it works?**
I did