### PR TITLE
SCC-2489: set `type` of "Cancel" button to "reset"

### DIFF
--- a/src/app/components/Feedback/Feedback.jsx
+++ b/src/app/components/Feedback/Feedback.jsx
@@ -170,6 +170,7 @@ class Feedback extends React.Component {
                     </Link>
                   </div>
                   <Button
+                    type="reset"
                     className={`cancel-button ${!showForm ? 'hidden' : ''}`}
                     onClick={e => this.deactivateForm(e)}
                     attributes={{

--- a/test/unit/Feedback.test.js
+++ b/test/unit/Feedback.test.js
@@ -26,7 +26,7 @@ describe('Feedback', () => {
     expect(component.find('Button').first().text()).to.equal('Help & Feedback');
   });
 
-  it('closed state does not have .active on #feedback-menu', () => {
+  it('in closed state does not have .active on #feedback-menu', () => {
     expect(component.find('#feedback-menu').hasClass('active')).to.equal(false);
   });
 
@@ -34,6 +34,18 @@ describe('Feedback', () => {
     component.find('Button').first().simulate('click');
     expect(component.state().showForm).to.equal(true);
     expect(component.find('#feedback-menu').hasClass('active')).to.equal(true);
+  });
+
+  it('should have a "Cancel" button', () => {
+    const cancelButton = component.find('Button').at(1);
+    expect(cancelButton.text()).to.equal('Cancel');
+    expect(cancelButton.props().type).to.equal('reset');
+  });
+
+  it('should have a "Submit" button', () => {
+    const submitButton = component.find('Button').at(2);
+    expect(submitButton.text()).to.equal('Submit');
+    expect(submitButton.props().type).to.equal('submit');
   });
 
   describe('success screen', () => {

--- a/test/unit/Feedback.test.js
+++ b/test/unit/Feedback.test.js
@@ -9,9 +9,12 @@ import Feedback from './../../src/app/components/Feedback/Feedback';
 
 describe('Feedback', () => {
   let component;
-  let onSubmitFormSpy = spy(Feedback.prototype, 'onSubmitForm');
+  const onSubmitFormSpy = spy(Feedback.prototype, 'onSubmitForm');
   before(() => {
     component = mount(<Feedback />);
+  });
+  after(() => {
+    onSubmitFormSpy.restore();
   });
 
   it('should render a <div> with class .feedback', () => {
@@ -44,7 +47,7 @@ describe('Feedback', () => {
     expect(cancelButton.props().type).to.equal('reset');
   });
 
-  it('should have a "Cancel" button', () => {
+  it('should deactivate form when "Cancel" button is clicked', () => {
     const cancelButton = component.find('Button').at(1).find('button').first();
     cancelButton.simulate('click');
     expect(onSubmitFormSpy.notCalled).to.equal(true);
@@ -56,7 +59,7 @@ describe('Feedback', () => {
     expect(submitButton.props().type).to.equal('submit');
   });
 
-  it('should have a "Submit" button', () => {
+  it('should call `onSubmitForm` when form is submitted', () => {
     const submitButton = component.find('Button').at(2).find('button');
     submitButton.simulate('submit');
     expect(onSubmitFormSpy.calledOnce).to.equal(true);

--- a/test/unit/Feedback.test.js
+++ b/test/unit/Feedback.test.js
@@ -3,11 +3,13 @@
 import React from 'react';
 import { expect } from 'chai';
 import { mount } from 'enzyme';
+import { spy } from 'sinon';
 
 import Feedback from './../../src/app/components/Feedback/Feedback';
 
 describe('Feedback', () => {
   let component;
+  let onSubmitFormSpy = spy(Feedback.prototype, 'onSubmitForm');
   before(() => {
     component = mount(<Feedback />);
   });
@@ -42,10 +44,22 @@ describe('Feedback', () => {
     expect(cancelButton.props().type).to.equal('reset');
   });
 
+  it('should have a "Cancel" button', () => {
+    const cancelButton = component.find('Button').at(1).find('button').first();
+    cancelButton.simulate('click');
+    expect(onSubmitFormSpy.notCalled).to.equal(true);
+  });
+
   it('should have a "Submit" button', () => {
     const submitButton = component.find('Button').at(2);
     expect(submitButton.text()).to.equal('Submit');
     expect(submitButton.props().type).to.equal('submit');
+  });
+
+  it('should have a "Submit" button', () => {
+    const submitButton = component.find('Button').at(2).find('button');
+    submitButton.simulate('submit');
+    expect(onSubmitFormSpy.calledOnce).to.equal(true);
   });
 
   describe('success screen', () => {


### PR DESCRIPTION
**What's this do?**
Previously, the "Cancel" button was attempting to submit the feedback form. Adding a `type` attribute of "reset" prevents this from happening.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SCC-2489

**Do these changes have automated tests?**
I added tests to check for the existence, text content, and `type` property of the "Cancel" and "Submit" buttons. 

I attempted to use a sinon spy and Enzyme simulate to check that `onSubmitForm` gets called with the right button. Enzyme simulate is a little funky for a form submission. Based on logging from inside the different event functions: 
- For the 'Cancel' button, 'click' event simulation works as expected, calling `deactivateForm`. 
- For the 'Submit' button (`type="submit"`), 'click' event does not do anything.
- For both buttons, 'submit' event acts as a form submission, instead of an action on the button.

Best I could do for right now is test the 'Cancel' click and the form submission with the `onSubmitForm` spy.

**How should this be QAed?**
When 'Cancel' button is clicked and form is reopened, neither the success page nor the "Please fill out this field" text is displayed.

**Did someone actually run this code to verify it works?**
I did