### PR TITLE
SCC-2477: Get notice preference info into account page

### DIFF
--- a/src/app/components/AccountPage/AccountSettings.jsx
+++ b/src/app/components/AccountPage/AccountSettings.jsx
@@ -26,6 +26,8 @@ const AccountSettings = ({ patron, legacyCatalog }) => (
       <dd>{patron.emails ? patron.emails[0] : 'None'}</dd>
       <dt>Preferred Pick Up Location</dt>
       <dd>{patron.homeLibraryCode || 'None'}</dd>
+      <dt>Preferred Contact Method</dt>
+      <dd>{patron.noticePreference}</dd>
     </dl>
     <hr />
     <div className="pin">

--- a/src/app/data/constants.js
+++ b/src/app/data/constants.js
@@ -41,10 +41,17 @@ const itemFilters = [
 const bibPageItemsListLimit = 20;
 const searchResultItemsListLimit = 3;
 
+const noticePreferenceMapping = {
+  'z': 'Email',
+  'p': 'Telephone',
+  '-': 'None',
+};
+
 
 export {
   breakpoints,
   itemFilters,
   bibPageItemsListLimit,
   searchResultItemsListLimit,
+  noticePreferenceMapping,
 };

--- a/src/app/utils/utils.js
+++ b/src/app/utils/utils.js
@@ -18,6 +18,7 @@ import {
 } from 'underscore';
 
 import appConfig from '../data/appConfig';
+import { noticePreferenceMapping } from '../data/constants';
 
 /**
  * ajaxCall
@@ -524,6 +525,13 @@ function encodeHTML(str) {
   return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/"/g, '&quot;');
 }
 
+function extractNoticePreference(fixedFields) {
+  if (!fixedFields) return 'None';
+  const noticePreferenceField = fixedFields['268'];
+  if (!noticePreferenceField || !noticePreferenceField.value) return 'None';
+  return noticePreferenceMapping[noticePreferenceField.value];
+}
+
 export {
   trackDiscovery,
   ajaxCall,
@@ -543,4 +551,5 @@ export {
   isOptionSelected,
   hasValidFilters,
   encodeHTML,
+  extractNoticePreference,
 };

--- a/src/app/utils/utils.js
+++ b/src/app/utils/utils.js
@@ -534,7 +534,7 @@ function extractNoticePreference(fixedFields) {
   if (!fixedFields) return 'None';
   const noticePreferenceField = fixedFields['268'];
   if (!noticePreferenceField || !noticePreferenceField.value) return 'None';
-  return noticePreferenceMapping[noticePreferenceField.value];
+  return noticePreferenceMapping[noticePreferenceField.value] || 'None';
 }
 
 export {

--- a/src/app/utils/utils.js
+++ b/src/app/utils/utils.js
@@ -525,6 +525,11 @@ function encodeHTML(str) {
   return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/"/g, '&quot;');
 }
 
+/**
+ * extractNoticePreference(fixedFields)
+ * Returns 'None', 'Email', or 'Telephone'.
+ * @param {string} fixedFields - Object coming from patron object `fixedFields` property
+ */
 function extractNoticePreference(fixedFields) {
   if (!fixedFields) return 'None';
   const noticePreferenceField = fixedFields['268'];

--- a/src/server/routes/api/index.js
+++ b/src/server/routes/api/index.js
@@ -5,6 +5,7 @@ import nyplApiClient from '../nyplApiClient';
 import logger from '../../../../logger';
 
 import { updatePatronData } from '../../../app/actions/Actions';
+import { extractNoticePreference } from '../../../app/utils/utils';
 
 
 export function getPatronData(req, res, next) {
@@ -42,6 +43,7 @@ export function getPatronData(req, res, next) {
                 phones,
               } = response.data;
               const barcodes = response.data.barCodes;
+              const noticePreference = extractNoticePreference(response.data.fixedFields);
               // Data exists for the Patron
               const patron = {
                 id,
@@ -54,6 +56,7 @@ export function getPatronData(req, res, next) {
                 patronType,
                 expirationDate,
                 phones,
+                noticePreference,
               };
 
               dispatch(updatePatronData(patron));

--- a/test/unit/utils.test.js
+++ b/test/unit/utils.test.js
@@ -18,6 +18,7 @@ import {
   getAggregatedElectronicResources,
   truncateStringOnWhitespace,
   hasValidFilters,
+  extractNoticePreference,
 } from '../../src/app/utils/utils';
 
 /**
@@ -772,3 +773,21 @@ describe('hasValidFilters', () => {
     expect(hasValidFilters(filters)).to.equal(true);
   });
 });
+
+describe('extractNoticePreference', () => {
+  it('should return "None" if fixedFields is empty', () => {
+    expect(extractNoticePreference()).to.equal('None');
+  });
+  it('should return "None" if fixedFields does not have a "268" field', () => {
+    expect(extractNoticePreference({ '123': 'nonsense' })).to.equal('None');
+  });
+  it('should return "Email" if "268" field value is "z"', () => {
+    expect(extractNoticePreference({ '268': {'value': 'z'} })).to.equal('Email');
+  });
+  it('should return "Telephone" if "268" field value is "p"', () => {
+    expect(extractNoticePreference({ '268': {'value': 'p'} })).to.equal('Telephone');
+  });
+  it('should return "None" if "268" field value is "-"', () => {
+    expect(extractNoticePreference({ '268': {'value': '-'} })).to.equal('None');
+  });
+})


### PR DESCRIPTION
**What's this do?**
Adds the "Notice Preference" field from the Sierra patron object to the Account Settings tab as "Preferred Contact Method". 

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SCC-2477

**Do these changes have automated tests?**
Yes :)

**How should this be QAed?**
Check for patrons with each of the three possible values - 'p' (phone), 'z' (email), '-' (none)

**Did someone actually run this code to verify it works?**
I did