### PR TITLE
SCC-2485: Login redirect bug iframe

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -11,3 +11,4 @@ export SET GENERAL_RESEARCH_EMAIL=example@nypl.com
 export SET LIB_ANSWERS_EMAIL=example@nypl.com
 export SET SOURCE_EMAIL=example@nypl.com
 export SET LEGACY_CATALOG_BASE_URL=https://[fqdn]/
+export SET LOGOUT_URL=https://[fqdn]/logout

--- a/src/app/components/Logout/Logout.jsx
+++ b/src/app/components/Logout/Logout.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import appConfig from '../../data/appConfig';
+
+const Logout = (props) => (
+  <iframe src={appConfig.logoutUrl} />
+);
+
+export default Logout;

--- a/src/app/data/appConfig.js
+++ b/src/app/data/appConfig.js
@@ -24,7 +24,7 @@ const appConfig = {
   shepApi: process.env.SHEP_API,
   legacyCatalog: process.env.LEGACY_CATALOG_BASE_URL,
   loginUrl: process.env.LOGIN_URL || 'https://login.nypl.org/auth/login',
-  logoutUrl: process.env.LOGOUT_URL,
+  logoutUrl: process.env.LOGOUT_URL || 'https://login.nypl.org/auth/logout',
   tokenUrl: 'https://isso.nypl.org/',
   publicKey:
     '-----BEGIN PUBLIC KEY-----\n' +

--- a/src/app/data/appConfig.js
+++ b/src/app/data/appConfig.js
@@ -24,6 +24,7 @@ const appConfig = {
   shepApi: process.env.SHEP_API,
   legacyCatalog: process.env.LEGACY_CATALOG_BASE_URL,
   loginUrl: process.env.LOGIN_URL || 'https://login.nypl.org/auth/login',
+  logoutUrl: process.env.LOGOUT_URL,
   tokenUrl: 'https://isso.nypl.org/',
   publicKey:
     '-----BEGIN PUBLIC KEY-----\n' +

--- a/src/app/routes/routes.jsx
+++ b/src/app/routes/routes.jsx
@@ -20,6 +20,7 @@ import HoldRequest from '../components/HoldRequest/HoldRequest';
 import HoldConfirmation from '../components/HoldConfirmation/HoldConfirmation';
 import ElectronicDelivery from '../components/ElectronicDelivery/ElectronicDelivery';
 import NotFound404 from '../components/NotFound404/NotFound404';
+import Logout from '../components/Logout/Logout';
 import appConfig from '../data/appConfig';
 
 const { baseUrl } = appConfig;
@@ -38,6 +39,7 @@ const routes = {
       <Route path="/subject_headings" component={SubjectHeadingsIndexPage} />
       <Route path="/account(/:content)" component={AccountPage} />
       <Route path="/404" component={NotFound404} />
+      <Route path="/logout" component={Logout} />
       <Redirect from="*" to="/404" />
     </Route>
   ),
@@ -55,6 +57,7 @@ const routes = {
       <Route path={`${baseUrl}/subject_headings`} component={SubjectHeadingsIndexPage} />
       <Route path={`${baseUrl}/account(/:content)`} component={AccountPage} />
       <Route path={`${baseUrl}/404`} component={NotFound404} />
+      <Route path={`${baseUrl}/logout`} component={Logout} />
       <Redirect from="*" to={`${baseUrl}/404`} />
     </Route>
   ),

--- a/src/server/ApiRoutes/Account.js
+++ b/src/server/ApiRoutes/Account.js
@@ -26,12 +26,17 @@ function fetchAccountPage(req, res, resolve) {
       // If Header thinks patron is logged in,
       // but patron is not actually logged in, the case below is hit
       if (resp.request.path.includes('/login?')) {
+        console.warn('Hit login mismatch. Logging user out.');
         // This will hit the login redirect infinite loop. Let's log the user out properly.
-        console.warn('Hit infinite login redirect. Logging user out');
-        if (!fullUrl.includes('%2Fapi%2F')) {
-          res.redirect(`${appConfig.logoutUrl}?redirect_uri=${fullUrl}`);
-          return;
-        }
+        axios.get(`${appConfig.logoutUrl}`, {
+          headers: {
+            Cookie: req.headers.cookie,
+          },
+        })
+          .then(resp => {
+            res.redirect('https://www.nypl.org/research/collections/shared-collection-catalog/');
+          });
+        return;
       }
       resolve(resp.data);
     })

--- a/src/server/ApiRoutes/Account.js
+++ b/src/server/ApiRoutes/Account.js
@@ -24,12 +24,12 @@ function fetchAccountPage(req, res, resolve) {
       // If Header thinks patron is logged in,
       // but patron is not actually logged in, the case below is hit
       if (resp.request.path.includes('/login?')) {
-        // need to implement
-        console.log('need to redirect, might be buggy?');
-        // redirect to login
-        const fullUrl = encodeURIComponent(`${req.protocol}://${req.get('host')}${req.originalUrl}`);
+        // This will hit the login redirect infinite loop. Let's log the user out properly.
         if (!fullUrl.includes('%2Fapi%2F')) {
-          res.redirect(`${appConfig.loginUrl}?redirect_uri=${fullUrl}`);
+          console.warn('Hit infinite login redirect. Logging user out');
+          const fullUrl = encodeURIComponent(`${req.protocol}://${req.get('host')}${req.originalUrl}`);
+          res.redirect(`${appConfig.logoutUrl}?redirect_uri=${fullUrl}`);
+          return;
         }
       }
       resolve(resp.data);

--- a/src/server/ApiRoutes/Account.js
+++ b/src/server/ApiRoutes/Account.js
@@ -34,7 +34,7 @@ function fetchAccountPage(req, res, resolve) {
           },
         })
           .then(resp => {
-            res.redirect('https://www.nypl.org/research/collections/shared-collection-catalog/');
+            res.redirect(`${appConfig.baseUrl}/logout`);
           });
         return;
       }

--- a/test/unit/Application.test.js
+++ b/test/unit/Application.test.js
@@ -39,8 +39,8 @@ describe('Application', () => {
     expect(component.find('.app-wrapper')).to.have.length(1);
   });
 
-  it('should render a <Header /> components', () => {
-    expect(component.find('Header')).to.have.length(1);
+  it('should render the NYPL header', () => {
+    expect(component.find('#nyplHeader')).to.have.length(1);
   });
 
   it('should have the skip navigation link enabled,', () => {


### PR DESCRIPTION
**What's this do?**
This is the barebones work to add a logout page to SCC with an iframe of the actual log out page.

If interested: some commits show other attempts at tackling this bug.

**Why are we doing this? (w/ JIRA link if applicable)**
Sometimes the login indicators and logic gets out of sync between SCC, Header and Encore (this is the general hypothesis). We would like a safety net for the case, which is to log the user out. It appears we need to do this with an iframe.
https://jira.nypl.org/browse/SCC-2485

**Did someone actually run this code to verify it works?**
I did