### PR TITLE
Scc 2439 batches

### DIFF
--- a/server.js
+++ b/server.js
@@ -87,7 +87,8 @@ app.get('/*', (req, res) => {
     } else if (redirectLocation) {
       res.redirect(302, redirectLocation.pathname + redirectLocation.search);
     } else if (renderProps) {
-      store.dispatch(updateLoadingStatus(false));
+      console.log('store loading: ', store.getState());
+      if (!store.managesLoading) store.dispatch(updateLoadingStatus(false));
       application = ReactDOMServer.renderToString(
         <Provider store={store}>
           <RouterContext {...renderProps} />

--- a/server.js
+++ b/server.js
@@ -87,7 +87,6 @@ app.get('/*', (req, res) => {
     } else if (redirectLocation) {
       res.redirect(302, redirectLocation.pathname + redirectLocation.search);
     } else if (renderProps) {
-      console.log('store loading: ', store.getState());
       if (!store.managesLoading) store.dispatch(updateLoadingStatus(false));
       application = ReactDOMServer.renderToString(
         <Provider store={store}>

--- a/src/app/actions/Actions.js
+++ b/src/app/actions/Actions.js
@@ -137,7 +137,11 @@ export const updateSearchResultsPage = data => dispatch => new Promise(() => {
   return data;
 });
 
-export const updateBibPage = ({ bib }) => dispatch => new Promise(() => dispatch(updateBib(bib)));
+export const updateBibPage = ({ bib }) => dispatch => new Promise(() => {
+  dispatch(updateBib(bib));
+  dispatch(updateLoadingStatus(true));
+  return { bib };
+});
 
 export const updateHoldRequestPage = data => dispatch => new Promise(() => {
   const { bib, deliveryLocations, isEddRequestable, searchKeywords } = data;

--- a/src/app/actions/Actions.js
+++ b/src/app/actions/Actions.js
@@ -138,7 +138,6 @@ export const updateSearchResultsPage = data => dispatch => new Promise(() => {
 });
 
 export const updateBibPage = ({ bib }) => dispatch => new Promise(() => {
-  console.log('updating Bib page');
   dispatch(updateBib(bib));
   dispatch(updateLoadingStatus(true));
   return { bib };

--- a/src/app/actions/Actions.js
+++ b/src/app/actions/Actions.js
@@ -138,6 +138,7 @@ export const updateSearchResultsPage = data => dispatch => new Promise(() => {
 });
 
 export const updateBibPage = ({ bib }) => dispatch => new Promise(() => {
+  console.log('updating Bib page');
   dispatch(updateBib(bib));
   dispatch(updateLoadingStatus(true));
   return { bib };

--- a/src/app/components/BibPage/BibPage.jsx
+++ b/src/app/components/BibPage/BibPage.jsx
@@ -28,18 +28,14 @@ import {
 } from '../../utils/utils';
 
 const checkForMoreItems = (bib, dispatch, itemFrom = itemBatchSize, items = []) => {
-  console.log('bib items: ', bib.items && bib.items.length);
   const baseUrl = appConfig.baseUrl;
   const bibApi = `${window.location.pathname.replace(baseUrl, `${baseUrl}/api`)}?itemFrom=${itemFrom}`;
-  console.log('bibApi: ', bibApi);
   return ajaxCall(
     bibApi,
     (resp) => {
-      console.log('bib response: ', resp);
       const bibResp = resp.data.bib;
       if (!(bibResp && bibResp.items && bibResp.items.length) || bibResp.items.length < itemBatchSize) {
         // done
-        console.log('finsihed bibResp: ', bibResp);
         dispatch(updateBibPage({
           bib:
           Object.assign(
@@ -52,7 +48,6 @@ const checkForMoreItems = (bib, dispatch, itemFrom = itemBatchSize, items = []) 
         dispatch(updateLoadingStatus(false));
       } else {
         // need to continue loading
-        console.log('checking for more items');
         checkForMoreItems(bib, dispatch, itemFrom + itemBatchSize, items.concat(bibResp.items));
       }
     },
@@ -75,7 +70,6 @@ export const BibPage = (props) => {
     dispatch,
   } = props;
 
-  console.log('rendering BibPage', props.bib && props.bib.items && props.bib.items.length);
   const bib = props.bib ? props.bib : {};
   if (typeof window !== 'undefined' && bib && bib.items && !(bib.items.length < itemBatchSize) && !bib.done) {
     checkForMoreItems(bib, dispatch);

--- a/src/app/components/DataLoader/DataLoader.jsx
+++ b/src/app/components/DataLoader/DataLoader.jsx
@@ -16,7 +16,10 @@ export class DataLoader extends React.Component {
       pathname,
     } = location;
     const nextPage = `${pathname}${search}`;
-    const isItemFiltering = pathname === lastLoaded.split('?')[0] && pathname.includes('/bib/');
+
+    const isItemFiltering = pathname === lastLoaded.split('?')[0]
+      && pathname.includes('/bib/')
+      && (new URLSearchParams(search).get('itemPage') === new URLSearchParams(lastLoaded.split('?')[1]).get('itemPage'));
     if (lastLoaded === nextPage || isItemFiltering) {
       dispatch(updateLoadingStatus(false));
       return;

--- a/src/app/components/DataLoader/DataLoader.jsx
+++ b/src/app/components/DataLoader/DataLoader.jsx
@@ -17,9 +17,7 @@ export class DataLoader extends React.Component {
     } = location;
     const nextPage = `${pathname}${search}`;
 
-    const isItemFiltering = pathname === lastLoaded.split('?')[0]
-      && pathname.includes('/bib/')
-      && (new URLSearchParams(search).get('itemPage') === new URLSearchParams(lastLoaded.split('?')[1]).get('itemPage'));
+    const isItemFiltering = pathname === lastLoaded.split('?')[0] && pathname.includes('/bib/');
     if (lastLoaded === nextPage || isItemFiltering) {
       dispatch(updateLoadingStatus(false));
       return;

--- a/src/app/components/DataLoader/DataLoader.jsx
+++ b/src/app/components/DataLoader/DataLoader.jsx
@@ -19,7 +19,6 @@ export class DataLoader extends React.Component {
 
     const isItemFiltering = pathname === lastLoaded.split('?')[0] && pathname.includes('/bib/');
     if (lastLoaded === nextPage || isItemFiltering) {
-      // dispatch(updateLoadingStatus(false));
       return;
     }
 

--- a/src/app/components/DataLoader/DataLoader.jsx
+++ b/src/app/components/DataLoader/DataLoader.jsx
@@ -19,7 +19,7 @@ export class DataLoader extends React.Component {
 
     const isItemFiltering = pathname === lastLoaded.split('?')[0] && pathname.includes('/bib/');
     if (lastLoaded === nextPage || isItemFiltering) {
-      dispatch(updateLoadingStatus(false));
+      // dispatch(updateLoadingStatus(false));
       return;
     }
 

--- a/src/app/components/Item/ItemFilters.jsx
+++ b/src/app/components/Item/ItemFilters.jsx
@@ -11,6 +11,7 @@ import { MediaContext } from '../Application/Application';
 
 
 const ItemFilters = ({ items, hasFilterApplied, numOfFilteredItems }, { router }) => {
+  console.log('rendering itemfilters: ', numOfFilteredItems);
   if (!items || !items.length) return null;
   const [openFilter, changeOpenFilter] = useState('none');
   const { location, createHref } = router;

--- a/src/app/components/Item/ItemFilters.jsx
+++ b/src/app/components/Item/ItemFilters.jsx
@@ -11,7 +11,6 @@ import { MediaContext } from '../Application/Application';
 
 
 const ItemFilters = ({ items, hasFilterApplied, numOfFilteredItems }, { router }) => {
-  console.log('rendering itemfilters: ', numOfFilteredItems);
   if (!items || !items.length) return null;
   const [openFilter, changeOpenFilter] = useState('none');
   const { location, createHref } = router;

--- a/src/app/components/Item/ItemsContainer.jsx
+++ b/src/app/components/Item/ItemsContainer.jsx
@@ -33,7 +33,6 @@ class ItemsContainer extends React.Component {
   }
 
   componentDidMount() {
-    console.log('Mounting ItemsContainer')
     // Mostly things we want to do on the client-side only:
     this.filteredItems = this.filterItems(this.props.items) || [];
     const items = this.filteredItems;

--- a/src/app/components/Item/ItemsContainer.jsx
+++ b/src/app/components/Item/ItemsContainer.jsx
@@ -33,7 +33,9 @@ class ItemsContainer extends React.Component {
   }
 
   componentDidMount() {
+    console.log('Mounting ItemsContainer')
     // Mostly things we want to do on the client-side only:
+    this.filteredItems = this.filterItems(this.props.items) || [];
     const items = this.filteredItems;
     let chunkedItems = [];
     let noItemPage = false;
@@ -156,7 +158,9 @@ class ItemsContainer extends React.Component {
     const shortenItems = !this.props.shortenItems;
     let pagination = null;
 
-    let itemsToDisplay = this.filteredItems;
+    // let itemsToDisplay = this.filteredItems;
+    let allItemsToDisplay = this.filterItems(this.props.items) || [];
+    let itemsToDisplay = allItemsToDisplay;
     if (this.state.js && itemsToDisplay && itemsToDisplay.length > itemsListPageLimit && !this.state.showAll) {
       pagination = (
         <Pagination
@@ -181,11 +185,11 @@ class ItemsContainer extends React.Component {
           items={items}
           hasFilterApplied={this.hasFilter}
           query={this.query}
-          numOfFilteredItems={this.filteredItems.length}
+          numOfFilteredItems={allItemsToDisplay.length}
         />
         {itemTable}
         {
-          !!(shortenItems && this.filteredItems.length > itemsListPageLimit && !this.state.showAll) &&
+          !!(shortenItems && allItemsToDisplay.length > itemsListPageLimit && !this.state.showAll) &&
             (
               <div className="view-all-items-container">
                 {

--- a/src/app/data/constants.js
+++ b/src/app/data/constants.js
@@ -40,7 +40,7 @@ const itemFilters = [
 
 const bibPageItemsListLimit = 20;
 const searchResultItemsListLimit = 3;
-const itemBatchSize = 3000;
+const itemBatchSize = 1000;
 
 
 export {

--- a/src/app/data/constants.js
+++ b/src/app/data/constants.js
@@ -40,8 +40,7 @@ const itemFilters = [
 
 const bibPageItemsListLimit = 20;
 const searchResultItemsListLimit = 3;
-const itemBatchSize = 2;
-// const itemBatchSize = 1000;
+const itemBatchSize = 1000;
 
 
 export {

--- a/src/app/data/constants.js
+++ b/src/app/data/constants.js
@@ -40,6 +40,7 @@ const itemFilters = [
 
 const bibPageItemsListLimit = 20;
 const searchResultItemsListLimit = 3;
+const itemBatchSize = 3000;
 
 
 export {
@@ -47,4 +48,5 @@ export {
   itemFilters,
   bibPageItemsListLimit,
   searchResultItemsListLimit,
+  itemBatchSize,
 };

--- a/src/app/data/constants.js
+++ b/src/app/data/constants.js
@@ -40,7 +40,8 @@ const itemFilters = [
 
 const bibPageItemsListLimit = 20;
 const searchResultItemsListLimit = 3;
-const itemBatchSize = 1000;
+const itemBatchSize = 2;
+// const itemBatchSize = 1000;
 
 
 export {

--- a/src/app/utils/dataLoaderUtil.js
+++ b/src/app/utils/dataLoaderUtil.js
@@ -23,6 +23,7 @@ const routes = {
     action: updateBibPage,
     path: 'bib',
     params: '/:bibId',
+    managesLoading: true,
   },
   search: {
     action: updateSearchResultsPage,
@@ -40,6 +41,7 @@ const routes = {
 // out separately is because it is used front-end and back-end
 const successCb = (pathType, dispatch) => (response) => {
   const { data } = response;
+  console.log('data: ', data);
   if (data && data.redirect) {
     if (window) {
       const fullUrl = encodeURIComponent(window.location.href);
@@ -90,7 +92,7 @@ function loadDataForRoutes(location, dispatch) {
     errorCb,
   ).then((resp) => {
     if (resp && !resp.redirect) dispatch(updateLastLoaded(path));
-    dispatch(updateLoadingStatus(false));
+    if (!routes[pathType].managesLoading) dispatch(updateLoadingStatus(false));
     return resp;
   }).catch((error) => {
     console.error(error);

--- a/src/app/utils/dataLoaderUtil.js
+++ b/src/app/utils/dataLoaderUtil.js
@@ -41,7 +41,6 @@ const routes = {
 // out separately is because it is used front-end and back-end
 const successCb = (pathType, dispatch) => (response) => {
   const { data } = response;
-  console.log('data: ', data);
   if (data && data.redirect) {
     if (window) {
       const fullUrl = encodeURIComponent(window.location.href);

--- a/src/server/ApiRoutes/ApiRoutes.js
+++ b/src/server/ApiRoutes/ApiRoutes.js
@@ -46,12 +46,13 @@ Object.keys(routes).forEach((routeName) => {
     router
       .route(`${appConfig.baseUrl}${pathType}${path}${params}`)
       .get((req, res, next) => new Promise(
-        resolve => routeMethods[routeName](req, res, resolve)
+        resolve => routeMethods[routeName](req, res, resolve),
       )
         .then(data => (
           api ? res.json(data) : successCb(routeName, global.store.dispatch)({ data })))
+        .then(() => { global.store.managesLoading = routes[routeName].managesLoading; })
         .then(() => (api ? null : next()))
-        .catch(console.error)
+        .catch(console.error),
       );
   });
 });

--- a/src/server/ApiRoutes/Bib.js
+++ b/src/server/ApiRoutes/Bib.js
@@ -8,7 +8,8 @@ import { itemBatchSize } from '../../app/data/constants';
 
 const nyplApiClientCall = (query, urlEnabledFeatures, itemFrom) => {
   // If on-site-edd feature enabled in front-end, enable it in discovery-api:
-  const queryItemPage = itemFrom ? `?items_size=${itemBatchSize}&items_from=${itemFrom}` : '';
+  const queryItemPage = typeof itemFrom !== 'undefined' ? `?items_size=${itemBatchSize}&items_from=${itemFrom}` : '';
+  console.log('calling: ', `/discovery/resources/${query}${queryItemPage}`);
   const requestOptions = appConfig.features.includes('on-site-edd') || urlEnabledFeatures.includes('on-site-edd') ? { headers: { 'X-Features': 'on-site-edd' } } : {};
   return nyplApiClient().then(client => client.get(`/discovery/resources/${query}${queryItemPage}`, requestOptions));
 };
@@ -128,11 +129,12 @@ function fetchBib(bibId, cb, errorcb, reqOptions) {
     features: [],
   }, reqOptions);
   return Promise.all([
-    nyplApiClientCall(bibId, options.features, reqOptions.itemFrom),
+    nyplApiClientCall(bibId, options.features, reqOptions.itemFrom || 0),
     nyplApiClientCall(`${bibId}.annotated-marc`, options.features),
   ])
     .then((response) => {
       // First response is jsonld formatting:
+      console.log('response: ', !!response);
       const data = response[0];
       // Assign second response (annotated-marc formatting) as property of bib:
       data.annotatedMarc = response[1];

--- a/src/server/ApiRoutes/Bib.js
+++ b/src/server/ApiRoutes/Bib.js
@@ -9,7 +9,6 @@ import { itemBatchSize } from '../../app/data/constants';
 const nyplApiClientCall = (query, urlEnabledFeatures, itemFrom) => {
   // If on-site-edd feature enabled in front-end, enable it in discovery-api:
   const queryItemPage = typeof itemFrom !== 'undefined' ? `?items_size=${itemBatchSize}&items_from=${itemFrom}` : '';
-  console.log('calling: ', `/discovery/resources/${query}${queryItemPage}`);
   const requestOptions = appConfig.features.includes('on-site-edd') || urlEnabledFeatures.includes('on-site-edd') ? { headers: { 'X-Features': 'on-site-edd' } } : {};
   return nyplApiClient().then(client => client.get(`/discovery/resources/${query}${queryItemPage}`, requestOptions));
 };
@@ -134,7 +133,6 @@ function fetchBib(bibId, cb, errorcb, reqOptions) {
   ])
     .then((response) => {
       // First response is jsonld formatting:
-      console.log('response: ', !!response);
       const data = response[0];
       // Assign second response (annotated-marc formatting) as property of bib:
       data.annotatedMarc = response[1];

--- a/test/unit/BibPage.test.js
+++ b/test/unit/BibPage.test.js
@@ -47,6 +47,7 @@ describe('BibPage', () => {
       component = mount(<BibPage
         location={{ search: 'search', pathname: '' }}
         bib={bib}
+        dispatch={() => {}}
       />, {
         context: {
           router: { location: { query: {} }, createHref: () => {} },

--- a/test/unit/BibPage.test.js
+++ b/test/unit/BibPage.test.js
@@ -23,6 +23,7 @@ describe('BibPage', () => {
       component = shallow(<BibPage
         location={{ search: 'search', pathname: '' }}
         bib={bib}
+        dispatch={() => {}}
       />, { context: {
         router: { location: {} } } });
     });

--- a/test/unit/dataLoaderUtil.test.js
+++ b/test/unit/dataLoaderUtil.test.js
@@ -141,8 +141,8 @@ describe('dataLoaderUtil', () => {
         expect(axiosSpy.firstCall.args[0]).to.equal(`${appConfig.baseUrl}/api/bib/1`);
       });
       it('should call dispatch with the search action and the response', () => {
-        // 4 calls: loading true, search action, updateLastLoaded, loading false
-        expect(mockDispatch.getCalls()).to.have.lengthOf(4);
+        // 3 calls: loading true, search action, updateLastLoaded
+        expect(mockDispatch.getCalls()).to.have.lengthOf(3);
         expect(mockDispatch.secondCall.args).to.have.lengthOf(1);
         expect(mockDispatch.secondCall.args[0]).to.equal('mockBibAction response');
         expect(mockBibArgs).to.have.lengthOf(1);


### PR DESCRIPTION
**What's this do?**
Changes the way we load items on the Bib Page. Instead of loading them all at once, they are loaded in batches. In order to prevent the loading layer from firing multiple times as each batch is loaded, this also requires some changes to the way the loading status is handled. Below is a more detailed breakdown of the changes:

- Changes directly related to loading the batches of items:
  - In the `BibPage` component, added `checkForMoreItems`. This function is invoked if the number of items hits the batch limit, and recursively hits the api for the next batch until it receives a batch with fewer than the max number of items (signaling that we have reached the end). It then loads the new items into the bib and marks the bib as `done`
  - In the `Bib` api, a new size limit and `itemFrom` parameter in the query to support getting items in batches
  - A new constant in `constants` to set the number of items per batch
  - `ItemsContainer` needs to recalculate the filtered items when the component remounts, otherwise it will display only the number of items in the first batch

- Changes related to loading (NB: this may have to change, will discuss in planning today): The approach here is to let the `BibPage` handle its own loading behavior, by adding a parameter to the data loading flow that signals this page will handle its own loading. This is written in a way that will allow other pages to handle their own loading if we ever want to do that. This requires changes in the following files:
  - `server.js` adds a line to not set loading to false if it receives a message that the page handles its own loading (`managesLoading`)
  - `Actions`: when `updateBibPage` is called we set loading to true, so that the `BibPage` can decide when loading is done
  - `BibPage`: when `window` is defined (signalling this is happening on the front end), if we don't need to check for more items, we set loading to false. Otherwise `checkForMoreItems` sets loading to false when it is done
  - the `DataLoader` component no longer sets loading to false for the `BibPage`
  - the `dataLoaderUtil` has a new field, `managesLoading`. This is `true` for the `bib` route, and the `dataLoaderUtil` doesn't set loading to false in this case
  - `ApiRoutes` passes the `managesLoading` message to `server`

- Some minor changes to tests. `BibPage` now needs a `dispatch` prop, also we don't expect `loading` to be set in the `dataLoaderUtil` tests for the `bib` path.

**Why are we doing this? (w/ JIRA link if applicable)**
This is to prevent timeouts for bibs with large numbers of items. This requirement is ticketed in scc-2439

**Do these changes have automated tests?**
Minor changes to the existing tests to capture the changed loading behavior, as described above.

**How should this be QAed?**
Bibs with large numbers of items should not timeout, and should display the correct number of items.

**Dependencies for merging? Releasing to production?**
No

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
I tested locally.
