### PR TITLE
Scc 2438

### DIFF
--- a/src/app/components/ResultsList/ResultsList.jsx
+++ b/src/app/components/ResultsList/ResultsList.jsx
@@ -70,7 +70,7 @@ const ResultsList = ({
     const yearPublished = getYearDisplay(result);
     const publicationStatement = result.publicationStatement && result.publicationStatement.length ?
       result.publicationStatement[0] : '';
-    const items = (result.checkInItems || []).concat(LibraryItem.getItems(result));
+    const items = (result.checkInItems || []).concat(ItemSorter.sortItems(LibraryItem.getItems(result)));
     const totalItems = (result.checkInItems || []).length + result.numItems;
     const hasRequestTable = items.length > 0;
     const { baseUrl } = appConfig;
@@ -104,7 +104,7 @@ const ResultsList = ({
         {
           hasRequestTable &&
           <ItemTable
-            items={ItemSorter.sortItems(items.slice(0, itemTableLimit))}
+            items={items.slice(0, itemTableLimit)}
             bibId={bibId}
             id={null}
             searchKeywords={searchKeywords}

--- a/src/app/components/ResultsList/ResultsList.jsx
+++ b/src/app/components/ResultsList/ResultsList.jsx
@@ -70,9 +70,8 @@ const ResultsList = ({
     const yearPublished = getYearDisplay(result);
     const publicationStatement = result.publicationStatement && result.publicationStatement.length ?
       result.publicationStatement[0] : '';
-    console.log('result: ', result);
     const items = (result.checkInItems || []).concat(LibraryItem.getItems(result));
-    const totalItems = (result.checkInItems || []).length + result.numItems; // should this be numAvailable ?
+    const totalItems = (result.checkInItems || []).length + result.numItems;
     const hasRequestTable = items.length > 0;
     const { baseUrl } = appConfig;
     const bibUrl = `${baseUrl}/bib/${bibId}`;

--- a/src/app/components/ResultsList/ResultsList.jsx
+++ b/src/app/components/ResultsList/ResultsList.jsx
@@ -14,6 +14,7 @@ import {
 import ItemTable from '../Item/ItemTable';
 import appConfig from '../../data/appConfig';
 import { searchResultItemsListLimit as itemTableLimit } from '../../data/constants';
+import ItemSorter from '../../utils/itemSorter';
 
 
 export const getBibTitle = (bib) => {
@@ -69,8 +70,9 @@ const ResultsList = ({
     const yearPublished = getYearDisplay(result);
     const publicationStatement = result.publicationStatement && result.publicationStatement.length ?
       result.publicationStatement[0] : '';
+    console.log('result: ', result);
     const items = (result.checkInItems || []).concat(LibraryItem.getItems(result));
-    const totalItems = items.length;
+    const totalItems = (result.checkInItems || []).length + result.numItems; // should this be numAvailable ?
     const hasRequestTable = items.length > 0;
     const { baseUrl } = appConfig;
     const bibUrl = `${baseUrl}/bib/${bibId}`;
@@ -103,7 +105,7 @@ const ResultsList = ({
         {
           hasRequestTable &&
           <ItemTable
-            items={items.slice(0, itemTableLimit)}
+            items={ItemSorter.sortItems(items.slice(0, itemTableLimit))}
             bibId={bibId}
             id={null}
             searchKeywords={searchKeywords}

--- a/src/app/utils/itemSorter.js
+++ b/src/app/utils/itemSorter.js
@@ -1,0 +1,74 @@
+const ItemSorter = {};
+
+/**
+ * Get a sortable shelfmark value by collapsing whitespace and zero-padding
+ * anything that looks like a box, volume, or tube number, identified as:
+ *  - any number terminating the string, or
+ *  - any number following known prefixes (e.g. box, tube, v., etc).
+ *
+ * If number is identified by prefix (e.g. box, tube), prefix will be made
+ * lowercase.
+ *
+ * @return {string} A sortable version of the given shelfmark
+ *
+ * e.g.:
+ *  "*T-Mss 1991-010   Box 27" ==> "*T-Mss 1991-010 box 000027"
+ *  "*T-Mss 1991-010   Tube 70" ==> "*T-Mss 1991-010 tube 000070"
+ *  "Map Div. 98­914    Box 25, Wi­Z')" ==> "Map Div. 98­914 box 000025, Wi­Z')"
+ *
+ * In addition to padding terminating numbers, any number following one of
+ * these sequences anywhere in the string, case-insensitive, is padded:
+ *  - box
+ *  - tube
+ *  - v.
+ *  - no.
+ *  - r.
+ */
+ItemSorter.sortableShelfMark = (shelfMark) => {
+  // NodeJS doesn't have lookbehinds, so fake it with replace callback:
+  const reg = /(\d+$|((^|\s)(box|v\.|no\.|r\.|box|tube) )(\d+))/i;
+  // This callback will receive all matches:
+  const replace = (m0, fullMatch, label, labelWhitespace, labelText, number) => (
+    // If we matched a label, build string from label and then pad number
+    label ? `${label.toLowerCase()}${ItemSorter.zeroPadString(number)}`
+    // Otherwise just pad whole match (presumably it's a line terminating num):
+      : ItemSorter.zeroPadString(fullMatch)
+  );
+  return shelfMark
+    .replace(reg, replace)
+    // Collapse redundant whitespace:
+    .replace(/\s{2,}/g, ' ');
+};
+
+/**
+ * Returns a '0' left-padded string to default length of 6
+ */
+ItemSorter.zeroPadString = (s, padLen = 6) => (new Array(Math.max(0, (padLen - s.length) + 1))).join('0') + s;
+
+/**
+ * Add sortableShelfMark
+ */
+ItemSorter.itemWithSortableShelfMark = (item) => {
+  let shelfMarkSort;
+  // Order by id if we have no call numbers, but make sure these items
+  // go after items with call numbers
+  if (!item.shelfMark || item.shelfMark.length === 0) {
+    if (item.uri) {
+      shelfMarkSort = `b${item.uri}`;
+    } else {
+      shelfMarkSort = 'c';
+    }
+  } else {
+    // order by call number, put these items first
+    shelfMarkSort = `a${ItemSorter.sortableShelfMark(item.shelfMark[0])}`;
+  }
+
+  return { item, shelfMarkSort };
+};
+
+ItemSorter.sortItems = items => items
+  .map(ItemSorter.itemWithSortableShelfMark)
+  .sort((i1, i2) => (i1.shelfMarkSort > i2.shelfMarkSort ? 1 : -1))
+  .map(i => i.item);
+
+export default ItemSorter;

--- a/test/unit/ResultsList.test.js
+++ b/test/unit/ResultsList.test.js
@@ -169,7 +169,7 @@ describe('ResultsList', () => {
     it('should have a total items description', () => {
       const yearPublished = component.find('.nypl-results-info');
       expect(yearPublished.length).to.equal(1);
-      expect(yearPublished.text()).to.equal('4 items');
+      expect(yearPublished.text()).to.equal(`${bib.result.numItems} items`);
     });
 
     it('should have a table', () => {
@@ -183,6 +183,7 @@ describe('ResultsList', () => {
 
   describe('Rendering with one bib and one item', () => {
     const bib = resultsBibs[1];
+
     let component;
 
     before(() => {
@@ -192,7 +193,7 @@ describe('ResultsList', () => {
     it('should have a total items description', () => {
       const yearPublished = component.find('.nypl-results-info');
       expect(yearPublished.length).to.equal(1);
-      expect(yearPublished.text()).to.equal('1 item');
+      expect(yearPublished.text()).to.equal(`${bib.result.numItems} items`);
     });
 
     it('should have one table', () => {


### PR DESCRIPTION
**What's this do?**
Adds sorting items and adjusting item counts for bib results on the search page. NB we may need to watch the counts for:

1. Whether there are significant discrepancies with what is seen on the Bib page. This is possible now since the Bib page uses a true count of filtered items and the search page just uses the `numItems` property (since the filtered items are not all available in the search page). If the discrepancies are bad we may need to revisit this.
2. Whether we want to just display the number of available items. This is possible too, it is just a decision we need to make.

**Why are we doing this? (w/ JIRA link if applicable)**
Now that we are limiting the results from the api, we can't count on the item count to be correct. Also, we need to sort the items since it is possible some bibs with small numbers of items will not have been re-indexed on the backend

**Do these changes have automated tests?**
No. The only complex code is the item sorting, and this is copied directly from the `discovery-api`, where the code is being tested.

**How should this be QAed?**
Item counts should look correct on search result pages (in particular there should be some results with > 3 items)

**Dependencies for merging? Releasing to production?**
Not for merging. There will have to be a reindex of bibs with >3 items before this goes to production.

**Has the application documentation been updated for these changes?**
No.

**Did someone actually run this code to verify it works?**
I checked locally.