### PR TITLE
SCC-2445: Mobile Item Filters buttons bugs

### DIFF
--- a/src/app/components/Item/ItemFilter.jsx
+++ b/src/app/components/Item/ItemFilter.jsx
@@ -26,9 +26,9 @@ const ItemFilter = ({
   submitFilterSelections,
   setSelectedFilters,
   isOpen,
-}, { router }) => {
-  const { location } = router;
-  const { query } = location;
+  initialFilters,
+}) => {
+  if (!options) return null;
   const [selectionMade, setSelectionMade] = useState(false);
 
   const selectFilter = (value) => {
@@ -65,15 +65,14 @@ const ItemFilter = ({
   };
 
   const isSelected = (option) => {
-    if (!query) return false;
+    if (!initialFilters) return false;
     const result = isOptionSelected(selectedFilters[filter], option.id);
 
     return result;
   };
 
   const distinctOptions = parseDistinctOptions(options);
-  const initialFilters = location.query ? location.query : {};
-  const thisFilterSelections = initialFilters[filter];
+  const thisFilterSelections = initialFilters ? initialFilters[filter] : null;
   const determineNumOfSelections = () => {
     if (!thisFilterSelections) return null;
     return typeof thisFilterSelections === 'string' ? 1 : thisFilterSelections.length;
@@ -159,6 +158,7 @@ ItemFilter.propTypes = {
   selectedFilters: PropTypes.object,
   submitFilterSelections: PropTypes.func,
   setSelectedFilters: PropTypes.func,
+  initialFilters: PropTypes.object,
 };
 
 ItemFilter.contextTypes = {

--- a/src/app/components/Item/ItemFilters.jsx
+++ b/src/app/components/Item/ItemFilters.jsx
@@ -86,11 +86,11 @@ const ItemFilters = ({ items, hasFilterApplied, numOfFilteredItems }, { router }
   };
 
   const itemFilterComponentProps = {
-    openFilter,
     selectedFilters,
     manageFilterDisplay,
     setSelectedFilters,
     submitFilterSelections,
+    initialFilters,
   };
 
   return (
@@ -104,7 +104,6 @@ const ItemFilters = ({ items, hasFilterApplied, numOfFilteredItems }, { router }
               ['mobile', 'tabletPortrait'].includes(media) ?
               (<ItemFiltersMobile
                 options={options}
-                initialFilters={initialFilters}
                 {...itemFilterComponentProps}
               />) :
               (

--- a/src/app/components/Item/ItemFilters.jsx
+++ b/src/app/components/Item/ItemFilters.jsx
@@ -13,12 +13,18 @@ import { MediaContext } from '../Application/Application';
 const ItemFilters = ({ items, hasFilterApplied, numOfFilteredItems }, { router }) => {
   if (!items || !items.length) return null;
   const [openFilter, changeOpenFilter] = useState('none');
-  const { location, createHref } = router;
-  const initialFilters = location.query ? Object.assign({}, location.query) : {};
+  const { createHref } = router;
+  const { query } = router.location;
+  const initialFilters = query ? {
+    location: query.location || [],
+    format: query.format || [],
+    status: query.status || [],
+  } : {};
+
   const [selectedFilters, setSelectedFilters] = useState(initialFilters);
 
   const manageFilterDisplay = (filterType) => {
-    setSelectedFilters(location.query);
+    setSelectedFilters(query);
     if (filterType === openFilter) {
       trackDiscovery('Search Filters', `Close Filter - ${filterType}`);
       changeOpenFilter('none');
@@ -45,9 +51,9 @@ const ItemFilters = ({ items, hasFilterApplied, numOfFilteredItems }, { router }
   // join filter selections and add single quotes
   const parsedFilterSelections = () => itemFilters
     .map((filter) => {
-      if (location.query[filter.type]) {
+      if (query[filter.type]) {
         let filtersString;
-        const filters = location.query[filter.type];
+        const filters = query[filter.type];
         if (Array.isArray(filters)) {
           filtersString = filters.join("', '");
         } else {
@@ -68,7 +74,7 @@ const ItemFilters = ({ items, hasFilterApplied, numOfFilteredItems }, { router }
 
   const submitFilterSelections = (filters) => {
     const href = createHref({
-      ...location,
+      ...router.location,
       ...{
         query: filters,
         hash: '#item-filters',
@@ -98,6 +104,7 @@ const ItemFilters = ({ items, hasFilterApplied, numOfFilteredItems }, { router }
               ['mobile', 'tabletPortrait'].includes(media) ?
               (<ItemFiltersMobile
                 options={options}
+                initialFilters={initialFilters}
                 {...itemFilterComponentProps}
               />) :
               (

--- a/src/app/components/Item/ItemFilters.jsx
+++ b/src/app/components/Item/ItemFilters.jsx
@@ -14,12 +14,12 @@ const ItemFilters = ({ items, hasFilterApplied, numOfFilteredItems }, { router }
   if (!items || !items.length) return null;
   const [openFilter, changeOpenFilter] = useState('none');
   const { createHref } = router;
-  const { query } = router.location;
-  const initialFilters = query ? {
+  const query = router.location.query || {};
+  const initialFilters = {
     location: query.location || [],
     format: query.format || [],
     status: query.status || [],
-  } : {};
+  };
 
   const [selectedFilters, setSelectedFilters] = useState(initialFilters);
 

--- a/src/app/components/Item/ItemFilters.jsx
+++ b/src/app/components/Item/ItemFilters.jsx
@@ -12,7 +12,7 @@ import { MediaContext } from '../Application/Application';
 
 const ItemFilters = ({ items, hasFilterApplied, numOfFilteredItems }, { router }) => {
   if (!items || !items.length) return null;
-  const [openFilter, changeOpenFilter] = useState('none');
+  const [openFilter, setOpenFilter] = useState('none');
   const { createHref } = router;
   const query = router.location.query || {};
   const initialFilters = {
@@ -24,16 +24,17 @@ const ItemFilters = ({ items, hasFilterApplied, numOfFilteredItems }, { router }
   const [selectedFilters, setSelectedFilters] = useState(initialFilters);
 
   const manageFilterDisplay = (filterType) => {
-    setSelectedFilters(query);
+    // reset `selectFilters` to `initialFilters` any time `openFilter` changes
+    setSelectedFilters(initialFilters);
     if (filterType === openFilter) {
       trackDiscovery('Search Filters', `Close Filter - ${filterType}`);
-      changeOpenFilter('none');
+      setOpenFilter('none');
     } else {
       if (filterType === 'none') trackDiscovery('Search Filters', `Close Filter - ${openFilter}`);
       else {
         trackDiscovery('Search Filters', `Open Filter - ${openFilter}`);
       }
-      changeOpenFilter(filterType);
+      setOpenFilter(filterType);
     }
   };
 
@@ -51,9 +52,9 @@ const ItemFilters = ({ items, hasFilterApplied, numOfFilteredItems }, { router }
   // join filter selections and add single quotes
   const parsedFilterSelections = () => itemFilters
     .map((filter) => {
-      if (query[filter.type]) {
+      const filters = initialFilters[filter.type];
+      if (filters.length) {
         let filtersString;
-        const filters = query[filter.type];
         if (Array.isArray(filters)) {
           filtersString = filters.join("', '");
         } else {

--- a/src/app/components/Item/ItemFiltersMobile.jsx
+++ b/src/app/components/Item/ItemFiltersMobile.jsx
@@ -14,6 +14,7 @@ const ItemFiltersMobile = ({
   selectedFilters,
   setSelectedFilters,
   submitFilterSelections,
+  initialFilters,
 }) => {
   const [displayFilters, toggleFilterDisplay] = useState(false);
 
@@ -28,22 +29,31 @@ const ItemFiltersMobile = ({
     );
   }
 
+  const showResultsAction = () => {
+    toggleFilterDisplay(false);
+    submitFilterSelections(selectedFilters);
+  };
+
+  const goBackAction = () => {
+    toggleFilterDisplay(false);
+    setSelectedFilters(initialFilters);
+  };
+
   return (
     <Modal
-      onClick={() => toggleFilters(true)}
       buttonType="outline"
       className="scc-item-filters nypl-ds"
     >
       <Button
         buttonType="link"
-        onClick={() => toggleFilterDisplay(false)}
+        onClick={goBackAction}
         className="go-back-button"
       >
         <Icon name="arrow" iconRotation="rotate-90" />Go back
       </Button>
       <Button
         className="show-results-button"
-        onClick={() => submitFilterSelections(selectedFilters)}
+        onClick={showResultsAction}
       >
         Show Results
       </Button>
@@ -76,6 +86,7 @@ ItemFiltersMobile.propTypes = {
   selectedFilters: PropTypes.object,
   setSelectedFilters: PropTypes.func,
   submitFilterSelections: PropTypes.func,
+  initialFilters: PropTypes.object,
 };
 
 ItemFiltersMobile.contextTypes = {

--- a/src/app/components/Item/ItemFiltersMobile.jsx
+++ b/src/app/components/Item/ItemFiltersMobile.jsx
@@ -9,13 +9,13 @@ import { itemFilters } from '../../data/constants';
 
 const ItemFiltersMobile = ({
   options,
-  openFilter,
   manageFilterDisplay,
   selectedFilters,
   setSelectedFilters,
   submitFilterSelections,
   initialFilters,
 }) => {
+  if (!options) return null;
   const [displayFilters, toggleFilterDisplay] = useState(false);
 
   if (!displayFilters) {
@@ -48,6 +48,7 @@ const ItemFiltersMobile = ({
         buttonType="link"
         onClick={goBackAction}
         className="go-back-button"
+        type="reset"
       >
         <Icon name="arrow" iconRotation="rotate-90" />Go back
       </Button>
@@ -64,13 +65,13 @@ const ItemFiltersMobile = ({
             <ItemFilter
               filter={filter.type}
               options={options[filter.type]}
-              openFilter={openFilter}
               manageFilterDisplay={manageFilterDisplay}
               key={filter.type}
               mobile
               selectedFilters={selectedFilters}
               setSelectedFilters={setSelectedFilters}
               submitFilterSelections={submitFilterSelections}
+              initialFilters={initialFilters}
             />
           ))
         }
@@ -81,7 +82,6 @@ const ItemFiltersMobile = ({
 
 ItemFiltersMobile.propTypes = {
   options: PropTypes.object,
-  openFilter: PropTypes.string,
   manageFilterDisplay: PropTypes.func,
   selectedFilters: PropTypes.object,
   setSelectedFilters: PropTypes.func,

--- a/src/app/components/Item/ItemFiltersMobile.jsx
+++ b/src/app/components/Item/ItemFiltersMobile.jsx
@@ -50,7 +50,7 @@ const ItemFiltersMobile = ({
         className="go-back-button"
         type="reset"
       >
-        <Icon name="arrow" iconRotation="rotate-90" />Go back
+        <Icon name="arrow" iconRotation="rotate-90" />Go Back
       </Button>
       <Button
         className="show-results-button"

--- a/test/unit/ItemFiltersMobile.test.js
+++ b/test/unit/ItemFiltersMobile.test.js
@@ -1,0 +1,63 @@
+/* eslint-disable react/jsx-filename-extension */
+/* eslint-env mocha */
+import React from 'react';
+import { expect } from 'chai';
+import { shallow, mount } from 'enzyme';
+
+import ItemFiltersMobile from './../../src/app/components/Item/ItemFiltersMobile';
+
+const context = {
+  router: {
+    location: {
+      query: {},
+    },
+  },
+};
+
+const formatOptions = {
+  format: [
+    {
+      id: 'PRINT',
+      label: 'PRINT',
+    },
+    {
+      id: 'Text',
+      label: 'Text',
+    },
+  ],
+};
+
+describe('ItemFiltersMobile', () => {
+  describe('default rendering', () => {
+    it('should not render without props', () => {
+      const component = shallow(<ItemFiltersMobile />, { context });
+      expect(component.type()).to.equal(null);
+    });
+  });
+  describe('with options', () => {
+    let component;
+    before(() => {
+      component = mount(
+        <ItemFiltersMobile
+          options={formatOptions}
+        />,
+      );
+    });
+
+    describe('closed state', () => {
+      it('should render "Filters" button for closed state', () => {
+        const closedStateButton = component.find('button');
+        expect(closedStateButton.length).to.equal(1);
+        expect(closedStateButton.find('button').text()).to.equal('Filters');
+      });
+      it('should open on click of closed state button', () => {
+        const closedStateButton = component.find('button');
+        closedStateButton.simulate('click');
+      });
+    });
+
+    describe('open state', () => {
+      
+    });
+  });
+});

--- a/test/unit/ItemFiltersMobile.test.js
+++ b/test/unit/ItemFiltersMobile.test.js
@@ -37,11 +37,18 @@ describe('ItemFiltersMobile', () => {
   describe('with props', () => {
     let component;
     before(() => {
+      const initialFilters = {
+        format: [],
+        status: [],
+        location: [],
+      };
       component = mount(
         <ItemFiltersMobile
           options={formatOptions}
           setSelectedFilters={() => {}}
           submitFilterSelections={() => {}}
+          initialFilters={initialFilters}
+          selectedFilters={initialFilters}
         />,
       );
     });
@@ -65,31 +72,39 @@ describe('ItemFiltersMobile', () => {
       it('should render a `Modal` from Design System', () => {
         expect(component.find('Modal').length).to.equal(1);
       });
-      it('should render a "Go Back" button', () => {
-        goBackButton = component.find('button').at(0);
-        expect(goBackButton.text()).to.equal('Go Back');
-      });
+
       it('should render `ItemFilter` for option types passed', () => {
-        expect(component.find('ItemFilter').length).to.be.at.least(1);
+        expect(component.find('.item-filter').length).to.equal(1);
       });
-      it('should close when "Go Back" is clicked', () => {
-        goBackButton.simulate('click');
-        closedStateButton = component.find('button');
-        expect(component.find('Modal').length).to.equal(0);
-        expect(closedStateButton.length).to.equal(1);
-        expect(closedStateButton.find('button').text()).to.equal('Filters');
+
+      describe('"Go Back" button', () => {
+        it('should render a "Go Back" button', () => {
+          goBackButton = component.find('button').at(0);
+          expect(goBackButton.text()).to.equal('Go Back');
+        });
+        it('should close when "Go Back" is clicked', () => {
+          goBackButton.simulate('click');
+          closedStateButton = component.find('button');
+          expect(component.find('Modal').length).to.equal(0);
+          expect(closedStateButton.length).to.equal(1);
+          expect(closedStateButton.find('button').text()).to.equal('Filters');
+        });
       });
-      it('should render a "Show Results" button', () => {
-        // re-open modal
-        closedStateButton.simulate('click');
-        showResultsButton = component.find('button').at(1);
-        expect(showResultsButton.text()).to.equal('Show Results');
-      });
-      it('should close when "Show Results" is clicked', () => {
-        showResultsButton.simulate('click');
-        expect(closedStateButton.length).to.equal(1);
-        expect(component.find('Modal').length).to.equal(0);
-        expect(closedStateButton.find('button').text()).to.equal('Filters');
+
+      describe('"Show Results" button', () => {
+        it('should render a "Show Results" button', () => {
+          // re-open modal
+          closedStateButton = component.find('button');
+          closedStateButton.simulate('click');
+          showResultsButton = component.find('button').at(1);
+          expect(showResultsButton.text()).to.equal('Show Results');
+        });
+        it('should close when "Show Results" is clicked', () => {
+          showResultsButton.simulate('click');
+          expect(closedStateButton.length).to.equal(1);
+          expect(component.find('Modal').length).to.equal(0);
+          expect(closedStateButton.find('button').text()).to.equal('Filters');
+        });
       });
     });
   });

--- a/test/unit/ItemFiltersMobile.test.js
+++ b/test/unit/ItemFiltersMobile.test.js
@@ -34,12 +34,14 @@ describe('ItemFiltersMobile', () => {
       expect(component.type()).to.equal(null);
     });
   });
-  describe('with options', () => {
+  describe('with props', () => {
     let component;
     before(() => {
       component = mount(
         <ItemFiltersMobile
           options={formatOptions}
+          setSelectedFilters={() => {}}
+          submitFilterSelections={() => {}}
         />,
       );
     });
@@ -57,7 +59,38 @@ describe('ItemFiltersMobile', () => {
     });
 
     describe('open state', () => {
-      
+      let goBackButton;
+      let closedStateButton;
+      let showResultsButton;
+      it('should render a `Modal` from Design System', () => {
+        expect(component.find('Modal').length).to.equal(1);
+      });
+      it('should render a "Go Back" button', () => {
+        goBackButton = component.find('button').at(0);
+        expect(goBackButton.text()).to.equal('Go Back');
+      });
+      it('should render `ItemFilter` for option types passed', () => {
+        expect(component.find('ItemFilter').length).to.be.at.least(1);
+      });
+      it('should close when "Go Back" is clicked', () => {
+        goBackButton.simulate('click');
+        closedStateButton = component.find('button');
+        expect(component.find('Modal').length).to.equal(0);
+        expect(closedStateButton.length).to.equal(1);
+        expect(closedStateButton.find('button').text()).to.equal('Filters');
+      });
+      it('should render a "Show Results" button', () => {
+        // re-open modal
+        closedStateButton.simulate('click');
+        showResultsButton = component.find('button').at(1);
+        expect(showResultsButton.text()).to.equal('Show Results');
+      });
+      it('should close when "Show Results" is clicked', () => {
+        showResultsButton.simulate('click');
+        expect(closedStateButton.length).to.equal(1);
+        expect(component.find('Modal').length).to.equal(0);
+        expect(closedStateButton.find('button').text()).to.equal('Filters');
+      });
     });
   });
 });


### PR DESCRIPTION
**What's this do?**
In recent QA, Chris found that "Show Results" was not closing the Modal if no change to the filter selections had been made. This PR fixes that. I also found that the "Go Back" button was not clearing new selections. There is some refactoring and simplifying that came of out test driven development for `ItemFiltersMobile`.

This PR also:
- Makes a proper `initialFilters` variable/prop for all 3 components involved, instead of relying on `router.location.query`. `initialFilters` is set in `ItemFilters` and checks for each filter type ('location', 'status', 'format'). If there are selections for a type, it will be set accordingly, otherwise it will be set to an empty array.
- This also assists in removing `context` from `ItemFilter`, which makes testing easier.
- Code cleanup removing destructuring of  `router.location` into `location`, because in this context 'location' has a different meaning.
- Remove `openFilter` prop from children components, since this is not relevant for mobile and `ItemFilter` ended up with a boolean `isOpen` based off parent's `openFilter` state.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SCC-2445

**Do these changes have automated tests?**
Yes. Improved testing at least. Had trouble with testing the "Go Back" reseting, since the selected filter state is in the parent component. Also, had trouble with testing `ItemFiltersMobile` inside the `ItemFilters` test, because the Enzyme context API is so finicky. I think there is preference coming from Design System/design technologist to use CSS instead of React to hide device specific components. So, maybe when we adopted the soon-to-be-released design system "Dropdown" we can also refactor away the media context here.

**How should this be QAed?**
Check "Show Results" with no change made. Check "Go Back" with change made. Also, a little regression check QA.

**Has the application documentation been updated for these changes?**

**Did someone actually run this code to verify it works?**
I did