### PR TITLE
SCC-2523: Prevent "bad" urls and small optimization

### DIFF
--- a/src/server/ApiRoutes/Account.js
+++ b/src/server/ApiRoutes/Account.js
@@ -20,6 +20,7 @@ function fetchAccountPage(req, res, resolve) {
 
   if (!['items', 'holds', 'overdues'].includes(content)) {
     res.redirect(`${appConfig.baseUrl}/account`);
+    return;
   }
 
   axios.get(`${appConfig.legacyCatalog}/dp/patroninfo*eng~Sdefault/${patronId}/${content}`, {

--- a/src/server/ApiRoutes/Account.js
+++ b/src/server/ApiRoutes/Account.js
@@ -15,6 +15,13 @@ function fetchAccountPage(req, res, resolve) {
   const patronId = req.patronTokenResponse.decodedPatron.sub;
   const content = req.params.content || 'items';
 
+  // no need to fetch from Webpac for this tab
+  if (content === 'settings') return resolve('');
+
+  if (!['items', 'holds', 'overdues'].includes(content)) {
+    res.redirect(`${appConfig.baseUrl}/account`);
+  }
+
   axios.get(`${appConfig.legacyCatalog}/dp/patroninfo*eng~Sdefault/${patronId}/${content}`, {
     headers: {
       Cookie: req.headers.cookie,

--- a/test/unit/Account.test.js
+++ b/test/unit/Account.test.js
@@ -1,0 +1,100 @@
+/* eslint-env mocha */
+import sinon from 'sinon';
+import { expect } from 'chai';
+import axios from 'axios';
+// import MockAdapter from 'axios-mock-adapter';
+
+import Account from './../../src/server/ApiRoutes/Account';
+import User from './../../src/server/ApiRoutes/User';
+import appConfig from './../../src/app/data/appConfig';
+
+let mockPatronTokenResponse = {
+  isTokenValid: true,
+  decodedPatron: {
+    iss: 'https://www.nypl.org',
+    sub: '6677666',
+    aud: 'app_myaccount',
+    iat: 1498162833,
+    exp: 1498166433,
+    auth_time: 1498162833,
+    scope: 'openid offline_access patron:read',
+  },
+  errorCode: null,
+};
+const renderMockReq = content => ({
+  params: { content },
+  get: n => n,
+  patronTokenResponse: mockPatronTokenResponse,
+  headers: {
+    cookie: '',
+  },
+});
+let urlToTest = '';
+const mockRes = {
+  redirect: (url) => {
+    urlToTest = url;
+  },
+  json: (resp) => {resp},
+};
+const mockResolve = resp => resp;
+
+describe('`fetchAccountPage`', () => {
+  let fetchAccountPage;
+  let requireUser;
+  let axiosGet;
+
+  before(() => {
+    fetchAccountPage = sinon.spy(Account, 'fetchAccountPage');
+    requireUser = sinon.stub(User, 'requireUser').callsFake(() => ({ redirect: false }));
+    axiosGet = sinon.spy(axios, 'get');
+  });
+
+  after(() => {
+    fetchAccountPage.restore();
+    requireUser.restore();
+    axiosGet.restore();
+  });
+
+  beforeEach(() => {
+    axiosGet.reset();
+  })
+
+  describe('does not receive valid value from "req.params.content"', () => {
+    it('should redirect', () => {
+      fetchAccountPage(renderMockReq('blahblah'), mockRes, mockResolve);
+
+      expect(urlToTest).to.equal('/research/collections/shared-collection-catalog/account');
+    });
+
+    it('should not make axios request', () => {
+      expect(axiosGet.notCalled).to.equal(true);
+    });
+  });
+
+  describe('"settings" content', () => {
+    it('should not make axios request', () => {
+      fetchAccountPage(renderMockReq('settings'), mockRes, mockResolve);
+
+      expect(axiosGet.notCalled).to.equal(true);
+    });
+  });
+
+  describe('content to get from Webpac', () => {
+    it('should make axios request', () => {
+      fetchAccountPage(renderMockReq('holds'), mockRes, mockResolve);
+      console.log('axiosGet', axiosGet.calledOnce);
+
+      expect(axiosGet.calledOnce).to.equal(true);
+      expect(axiosGet.firstCall.args[0]).to.equal(`${appConfig.legacyCatalog}/dp/patroninfo*eng~Sdefault/6677666/holds`);
+    });
+  });
+
+  describe('"/account", with no `content` param', () => {
+    it('should fetch the "items" page', () => {
+      fetchAccountPage(renderMockReq(), mockRes, mockResolve);
+
+      expect(axiosGet.calledOnce).to.equal(true);
+      expect(axiosGet.firstCall.args[0]).to.equal(`${appConfig.legacyCatalog}/dp/patroninfo*eng~Sdefault/6677666/items`);
+    });
+  })
+});

--- a/test/unit/Account.test.js
+++ b/test/unit/Account.test.js
@@ -93,7 +93,6 @@ describe('`fetchAccountPage`', () => {
   describe('content to get from Webpac', () => {
     it('should make axios request', () => {
       fetchAccountPage(renderMockReq('holds'), mockRes, mockResolve);
-      console.log('axiosGet', axiosGet.calledOnce);
 
       expect(axiosGet.calledOnce).to.equal(true);
       expect(axiosGet.firstCall.args[0]).to.equal(`${appConfig.legacyCatalog}/dp/patroninfo*eng~Sdefault/6677666/holds`);

--- a/test/unit/Account.test.js
+++ b/test/unit/Account.test.js
@@ -2,7 +2,6 @@
 import sinon from 'sinon';
 import { expect } from 'chai';
 import axios from 'axios';
-// import MockAdapter from 'axios-mock-adapter';
 
 import Account from './../../src/server/ApiRoutes/Account';
 import User from './../../src/server/ApiRoutes/User';


### PR DESCRIPTION
**What's this do?**
- Redirects any url in the form of "account/[*]" to "/account", unless the part after the second `/` is 'items', 'holds', 'settings', or 'overdues'. 
  * Does this seem like a good approach?
- 'settings' does not need to fetch the Webpac HTML. So, that extra call is prevented now

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SCC-2523

**Do these changes have automated tests?**
Yes

**How should this be QAed?**
Make sure the tabs and urls still work. Make sure "/account/some-unsupported-url" redirects to "/account"

**Dependencies for merging? Releasing to production?**
[Description of any watchouts, dependencies, or issues we should be aware of]

**Has the application documentation been updated for these changes?**

**Did someone actually run this code to verify it works?**
I did