### PR TITLE
Scc 2439 no loading

### DIFF
--- a/src/app/components/BibPage/BibPage.jsx
+++ b/src/app/components/BibPage/BibPage.jsx
@@ -7,7 +7,7 @@ import { connect } from 'react-redux';
 import { withRouter } from 'react-router';
 
 import Breadcrumbs from '../Breadcrumbs/Breadcrumbs';
-import ItemsContainer from '../Item/ItemsContainer';
+import itemsContainer from '../Item/ItemsContainer';
 import BibDetails from './BibDetails';
 import LibraryItem from '../../utils/item';
 import BackLink from './BackLink';
@@ -26,6 +26,8 @@ import {
   basicQuery,
   getAggregatedElectronicResources,
 } from '../../utils/utils';
+
+const ItemsContainer = itemsContainer.ItemsContainer;
 
 const checkForMoreItems = (bib, dispatch) => {
   console.log('bib: ', bib);

--- a/src/app/components/BibPage/BibPage.jsx
+++ b/src/app/components/BibPage/BibPage.jsx
@@ -57,8 +57,6 @@ const checkForMoreItems = (bib, dispatch) => {
               },
             ),
         }));
-        // keep fetching if not done
-        // if (!done) checkForMoreItems(bib, dispatch);
       },
       (error) => { console.error(error); },
     );
@@ -78,6 +76,9 @@ export const BibPage = (props) => {
   } = props;
 
   const bib = props.bib ? props.bib : {};
+  // check whether this is a server side or client side render
+  // by whether 'window' is defined. After the first render on the client side
+  // check for more items
   if (typeof window !== 'undefined') {
     checkForMoreItems(bib, dispatch);
   }

--- a/src/app/components/BibPage/BibPage.jsx
+++ b/src/app/components/BibPage/BibPage.jsx
@@ -7,7 +7,7 @@ import { connect } from 'react-redux';
 import { withRouter } from 'react-router';
 
 import Breadcrumbs from '../Breadcrumbs/Breadcrumbs';
-import itemsContainer from '../Item/ItemsContainer';
+import itemsContainerModule from '../Item/ItemsContainer';
 import BibDetails from './BibDetails';
 import LibraryItem from '../../utils/item';
 import BackLink from './BackLink';
@@ -27,20 +27,16 @@ import {
   getAggregatedElectronicResources,
 } from '../../utils/utils';
 
-const ItemsContainer = itemsContainer.ItemsContainer;
+const ItemsContainer = itemsContainerModule.ItemsContainer;
 
 const checkForMoreItems = (bib, dispatch) => {
-  console.log('bib: ', bib);
   if (!bib || !bib.items || !bib.items.length || (bib && bib.done)) {
     // nothing to do
-    console.log('nothing to do');
   } else if (bib && bib.items.length < itemBatchSize) {
     // done
-    console.log('done');
     dispatch(updateBibPage({ bib: Object.assign({}, bib, { done: true }) }));
   } else {
     // need to fetch more items
-    console.log('need to fetch more items');
     const baseUrl = appConfig.baseUrl;
     const itemFrom = bib.itemFrom || itemBatchSize;
     const bibApi = `${window.location.pathname.replace(baseUrl, `${baseUrl}/api`)}?itemFrom=${itemFrom}`;
@@ -144,7 +140,6 @@ export const BibPage = (props) => {
     });
   }
 
-  console.log('items: ', items);
   const itemsContainer = items.length && !isElectronicResources ? (
     <ItemsContainer
       key={bibId}

--- a/src/app/components/BibPage/BibPage.jsx
+++ b/src/app/components/BibPage/BibPage.jsx
@@ -27,15 +27,20 @@ import {
   getAggregatedElectronicResources,
 } from '../../utils/utils';
 
-const checkForMoreItems = (bib, dispatch, itemFrom = itemBatchSize) => {
+const checkForMoreItems = (bib, dispatch) => {
+  console.log('bib: ', bib);
   if (!bib || !bib.items || !bib.items.length || (bib && bib.done)) {
     // nothing to do
+    console.log('nothing to do');
   } else if (bib && bib.items.length < itemBatchSize) {
     // done
+    console.log('done');
     dispatch(updateBibPage({ bib: Object.assign({}, bib, { done: true }) }));
   } else {
     // need to fetch more items
+    console.log('need to fetch more items');
     const baseUrl = appConfig.baseUrl;
+    const itemFrom = bib.itemFrom || itemBatchSize;
     const bibApi = `${window.location.pathname.replace(baseUrl, `${baseUrl}/api`)}?itemFrom=${itemFrom}`;
     ajaxCall(
       bibApi,
@@ -48,12 +53,14 @@ const checkForMoreItems = (bib, dispatch, itemFrom = itemBatchSize) => {
             Object.assign(
               {},
               bib,
-              { items: bib.items.concat((bibResp && bibResp.items) || []) },
-              { done },
+              { items: bib.items.concat((bibResp && bibResp.items) || []),
+                done,
+                itemFrom: itemFrom + itemBatchSize,
+              },
             ),
         }));
         // keep fetching if not done
-        if (!done) checkForMoreItems(bib, dispatch, itemFrom + itemBatchSize);
+        // if (!done) checkForMoreItems(bib, dispatch);
       },
       (error) => { console.error(error); },
     );
@@ -135,6 +142,7 @@ export const BibPage = (props) => {
     });
   }
 
+  console.log('items: ', items);
   const itemsContainer = items.length && !isElectronicResources ? (
     <ItemsContainer
       key={bibId}

--- a/src/app/components/Item/ItemsContainer.jsx
+++ b/src/app/components/Item/ItemsContainer.jsx
@@ -159,7 +159,6 @@ class ItemsContainer extends React.Component {
       : (this.props.items || []);
     const bibId = this.props.bibId;
     const bibDone = this.props.bib && this.props.bib.done;
-    // const bibDone = false;
     const { items } = this.props;
     if (!items) return null;
     const shortenItems = !this.props.shortenItems;

--- a/src/app/components/Item/ItemsContainer.jsx
+++ b/src/app/components/Item/ItemsContainer.jsx
@@ -264,4 +264,9 @@ const mapStateToProps = state => ({
   bib: state.bib,
 });
 
-export default connect(mapStateToProps)(ItemsContainer);
+export default {
+  ItemsContainer: connect(mapStateToProps)(ItemsContainer),
+  unwrappedItemsContainer: ItemsContainer,
+};
+
+// export default connect(mapStateToProps)(ItemsContainer);

--- a/src/app/components/Item/ItemsContainer.jsx
+++ b/src/app/components/Item/ItemsContainer.jsx
@@ -37,7 +37,6 @@ class ItemsContainer extends React.Component {
   }
 
   componentDidMount() {
-    console.log('component did mount itemsContainer');
     // Mostly things we want to do on the client-side only:
     const items = this.filteredItems;
     let chunkedItems = [];
@@ -162,7 +161,6 @@ class ItemsContainer extends React.Component {
     const bibDone = this.props.bib && this.props.bib.done;
     // const bibDone = false;
     const { items } = this.props;
-    console.log('items container items: ', items);
     if (!items) return null;
     const shortenItems = !this.props.shortenItems;
     let pagination = null;

--- a/src/app/components/Item/ItemsContainer.jsx
+++ b/src/app/components/Item/ItemsContainer.jsx
@@ -37,9 +37,7 @@ class ItemsContainer extends React.Component {
   }
 
   componentDidMount() {
-    this.filteredItems = this.props.bib && this.props.bib.done ?
-      (this.filterItems(this.props.items) || [])
-      : (this.props.items || []);
+    console.log('component did mount itemsContainer');
     // Mostly things we want to do on the client-side only:
     const items = this.filteredItems;
     let chunkedItems = [];
@@ -157,10 +155,14 @@ class ItemsContainer extends React.Component {
   }
 
   render() {
+    this.filteredItems = this.props.bib && this.props.bib.done ?
+      (this.filterItems(this.props.items) || [])
+      : (this.props.items || []);
     const bibId = this.props.bibId;
     const bibDone = this.props.bib && this.props.bib.done;
     // const bibDone = false;
     const { items } = this.props;
+    console.log('items container items: ', items);
     if (!items) return null;
     const shortenItems = !this.props.shortenItems;
     let pagination = null;

--- a/src/app/components/Item/ItemsContainer.jsx
+++ b/src/app/components/Item/ItemsContainer.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router';
 import { isArray as _isArray } from 'underscore';
+import { connect } from 'react-redux';
 
 import Pagination from '../Pagination/Pagination';
 import ItemTable from './ItemTable';
@@ -24,7 +25,10 @@ class ItemsContainer extends React.Component {
     this.query = context.router.location.query;
     this.hasFilter = Object.keys(this.query).some(param => (
       itemFilters.map(filter => filter.type).includes(param)));
-    this.filteredItems = this.filterItems(this.props.items) || [];
+
+    this.filteredItems = this.props.bib && this.props.bib.done ?
+      (this.filterItems(this.props.items) || [])
+      : (this.props.items || []);
 
     this.updatePage = this.updatePage.bind(this);
     this.chunk = this.chunk.bind(this);
@@ -33,6 +37,9 @@ class ItemsContainer extends React.Component {
   }
 
   componentDidMount() {
+    this.filteredItems = this.props.bib && this.props.bib.done ?
+      (this.filterItems(this.props.items) || [])
+      : (this.props.items || []);
     // Mostly things we want to do on the client-side only:
     const items = this.filteredItems;
     let chunkedItems = [];
@@ -151,6 +158,8 @@ class ItemsContainer extends React.Component {
 
   render() {
     const bibId = this.props.bibId;
+    const bibDone = this.props.bib && this.props.bib.done;
+    // const bibDone = false;
     const { items } = this.props;
     if (!items) return null;
     const shortenItems = !this.props.shortenItems;
@@ -173,16 +182,36 @@ class ItemsContainer extends React.Component {
     }
 
     const itemTable = this.getTable(itemsToDisplay, shortenItems, this.state.showAll);
+    const numItemsEstimate = this.props.bib.numItems + (this.props.bib.checkInItems || []).length;
+    const itemLoadingMessage = (
+      <div className="item-filter-info">
+        <h3>
+          <br />
+          About {`${numItemsEstimate}`} Item{numItemsEstimate !== 1 ? 's. ' : '. ' }
+          <div className="items-loading">
+            Still Loading More items
+            <span className="dot1">.</span>
+            <span className="dot2">.</span>
+            <span className="dot3">.</span>
+          </div>
+        </h3>
+      </div>
+    );
 
     return (
       <div className="nypl-results-item">
         <h2>Items in the Library & Offsite</h2>
-        <ItemFilters
-          items={items}
-          hasFilterApplied={this.hasFilter}
-          query={this.query}
-          numOfFilteredItems={this.filteredItems.length}
-        />
+        {
+          bibDone ?
+            <ItemFilters
+              items={items}
+              hasFilterApplied={this.hasFilter}
+              query={this.query}
+              numOfFilteredItems={this.filteredItems.length}
+            />
+            :
+            itemLoadingMessage
+        }
         {itemTable}
         {
           !!(shortenItems && this.filteredItems.length > itemsListPageLimit && !this.state.showAll) &&
@@ -229,4 +258,8 @@ ItemsContainer.contextTypes = {
   router: PropTypes.object,
 };
 
-export default ItemsContainer;
+const mapStateToProps = state => ({
+  bib: state.bib,
+});
+
+export default connect(mapStateToProps)(ItemsContainer);

--- a/src/app/data/constants.js
+++ b/src/app/data/constants.js
@@ -40,6 +40,7 @@ const itemFilters = [
 
 const bibPageItemsListLimit = 20;
 const searchResultItemsListLimit = 3;
+const itemBatchSize = 1000;
 
 
 export {
@@ -47,4 +48,5 @@ export {
   itemFilters,
   bibPageItemsListLimit,
   searchResultItemsListLimit,
+  itemBatchSize,
 };

--- a/src/client/styles/components/ItemsContainer.scss
+++ b/src/client/styles/components/ItemsContainer.scss
@@ -163,3 +163,76 @@ button.item-table-filters {
     border-bottom: none;
   }
 }
+
+.items-loading {
+  display: inline-flex;
+
+  .dot1 {
+   animation: visibility 3s linear infinite;
+  }
+
+  @keyframes visibility {
+   0% {
+   opacity: 1;
+   }
+   65% {
+   opacity: 1;
+   }
+   66% {
+   opacity: 0;
+   }
+   100% {
+   opacity: 0;
+   }
+  }
+
+  .dot2 {
+   animation: visibility2 3s linear infinite;
+  }
+
+  @keyframes visibility2 {
+   0% {
+    opacity: 0;
+   }
+   21% {
+    opacity: 0;
+   }
+   22% {
+    opacity: 1;
+   }
+   65% {
+    opacity: 1;
+   }
+   66% {
+    opacity: 0;
+   }
+   100% {
+    opacity: 0;
+   }
+  }
+
+  .dot3 {
+   animation: visibility3 3s linear infinite;
+  }
+
+  @keyframes visibility3 {
+   0% {
+    opacity: 0;
+   }
+   43% {
+    opacity: 0;
+   }
+   44% {
+    opacity: 1;
+   }
+   65% {
+    opacity: 1;
+   }
+   66% {
+    opacity: 0;
+   }
+   100% {
+    opacity: 0;
+   }
+  }
+}

--- a/src/server/ApiRoutes/Bib.js
+++ b/src/server/ApiRoutes/Bib.js
@@ -4,11 +4,13 @@ import nyplApiClient from '../routes/nyplApiClient';
 import logger from '../../../logger';
 import appConfig from '../../app/data/appConfig';
 import extractFeatures from '../../app/utils/extractFeatures';
+import { itemBatchSize } from '../../app/data/constants';
 
-const nyplApiClientCall = (query, urlEnabledFeatures) => {
+const nyplApiClientCall = (query, urlEnabledFeatures, itemFrom) => {
   // If on-site-edd feature enabled in front-end, enable it in discovery-api:
+  const queryItemPage = typeof itemFrom !== 'undefined' ? `?items_size=${itemBatchSize}&items_from=${itemFrom}` : '';
   const requestOptions = appConfig.features.includes('on-site-edd') || urlEnabledFeatures.includes('on-site-edd') ? { headers: { 'X-Features': 'on-site-edd' } } : {};
-  return nyplApiClient().then(client => client.get(`/discovery/resources/${query}`, requestOptions));
+  return nyplApiClient().then(client => client.get(`/discovery/resources/${query}${queryItemPage}`, requestOptions));
 };
 
 const shepApiCall = bibId => axios(`${appConfig.shepApi}/bibs/${bibId}/subject_headings`);
@@ -126,7 +128,7 @@ function fetchBib(bibId, cb, errorcb, reqOptions) {
     features: [],
   }, reqOptions);
   return Promise.all([
-    nyplApiClientCall(bibId, options.features),
+    nyplApiClientCall(bibId, options.features, reqOptions.itemFrom || 0),
     nyplApiClientCall(`${bibId}.annotated-marc`, options.features),
   ])
     .then((response) => {
@@ -173,7 +175,7 @@ function fetchBib(bibId, cb, errorcb, reqOptions) {
 
 function bibSearch(req, res, resolve) {
   const bibId = req.params.bibId;
-  const { features } = req.query;
+  const { features, itemFrom } = req.query;
   const urlEnabledFeatures = extractFeatures(features);
 
   fetchBib(
@@ -183,6 +185,7 @@ function bibSearch(req, res, resolve) {
     {
       features: urlEnabledFeatures,
       fetchSubjectHeadingData: true,
+      itemFrom,
     },
   );
 }

--- a/src/server/ApiRoutes/Bib.js
+++ b/src/server/ApiRoutes/Bib.js
@@ -8,9 +8,9 @@ import { itemBatchSize } from '../../app/data/constants';
 
 const nyplApiClientCall = (query, urlEnabledFeatures, itemFrom) => {
   // If on-site-edd feature enabled in front-end, enable it in discovery-api:
-  const queryItemPage = typeof itemFrom !== 'undefined' ? `?items_size=${itemBatchSize}&items_from=${itemFrom}` : '';
+  const queryForItemPage = typeof itemFrom !== 'undefined' ? `?items_size=${itemBatchSize}&items_from=${itemFrom}` : '';
   const requestOptions = appConfig.features.includes('on-site-edd') || urlEnabledFeatures.includes('on-site-edd') ? { headers: { 'X-Features': 'on-site-edd' } } : {};
-  return nyplApiClient().then(client => client.get(`/discovery/resources/${query}${queryItemPage}`, requestOptions));
+  return nyplApiClient().then(client => client.get(`/discovery/resources/${query}${queryForItemPage}`, requestOptions));
 };
 
 const shepApiCall = bibId => axios(`${appConfig.shepApi}/bibs/${bibId}/subject_headings`);

--- a/test/unit/BibPage.test.js
+++ b/test/unit/BibPage.test.js
@@ -4,6 +4,7 @@ import React from 'react';
 import { expect } from 'chai';
 import { shallow, mount } from 'enzyme';
 import PropTypes from 'prop-types';
+import { Provider } from 'react-redux';
 
 // Import Bib for pre-processing
 
@@ -23,6 +24,7 @@ describe('BibPage', () => {
       component = shallow(<BibPage
         location={{ search: 'search', pathname: '' }}
         bib={bib}
+        dispatch={() => {}}
       />, { context: {
         router: { location: {} } } });
     });
@@ -43,15 +45,29 @@ describe('BibPage', () => {
       mockBibWithHolding.holdings.forEach(holding => Bib.addHoldingDefinition(holding));
       Bib.addCheckInItems(mockBibWithHolding);
       const bib = { ...mockBibWithHolding, ...annotatedMarc };
-      component = mount(<BibPage
-        location={{ search: 'search', pathname: '' }}
-        bib={bib}
-      />, {
-        context: {
-          router: { location: { query: {} }, createHref: () => {} },
+      const testStore = {
+        bib: {
+          done: true,
+          numItems: 0,
         },
-        childContextTypes: { router: PropTypes.object },
-      });
+        getState: () => testStore,
+        subscribe: () => {},
+      };
+
+      component = mount(
+        <Provider store={testStore}>
+          <BibPage
+            location={{ search: 'search', pathname: '' }}
+            bib={bib}
+            dispatch={() => {}}
+          />
+        </Provider>
+        , {
+          context: {
+            router: { location: { query: {} }, createHref: () => {} },
+          },
+          childContextTypes: { router: PropTypes.object },
+        });
       itemTable = component.find('ItemTable');
     });
 

--- a/test/unit/ItemsContainer.test.js
+++ b/test/unit/ItemsContainer.test.js
@@ -4,11 +4,11 @@ import React from 'react';
 import { expect } from 'chai';
 import { shallow, mount } from 'enzyme';
 
-import itemContainerExport from './../../src/app/components/Item/ItemsContainer';
+import itemsContainerModule from './../../src/app/components/Item/ItemsContainer';
 import LibraryItem from './../../src/app/utils/item';
 import { bibPageItemsListLimit as itemsListPageLimit } from './../../src/app/data/constants';
 
-const ItemsContainer = itemContainerExport.unwrappedItemsContainer;
+const ItemsContainer = itemsContainerModule.unwrappedItemsContainer;
 const items = [
   {
     accessMessage: {
@@ -94,7 +94,6 @@ const testBib = {
 };
 
 describe('ItemsContainer', () => {
-  // console.log('ItemsContainer: ', ItemsContainer);
   describe('Default rendering', () => {
     it('should return null with no props passed', () => {
       const component = shallow(<ItemsContainer bib={testBib} />, {

--- a/test/unit/ItemsContainer.test.js
+++ b/test/unit/ItemsContainer.test.js
@@ -4,10 +4,11 @@ import React from 'react';
 import { expect } from 'chai';
 import { shallow, mount } from 'enzyme';
 
-import ItemsContainer from './../../src/app/components/Item/ItemsContainer';
+import itemContainerExport from './../../src/app/components/Item/ItemsContainer';
 import LibraryItem from './../../src/app/utils/item';
 import { bibPageItemsListLimit as itemsListPageLimit } from './../../src/app/data/constants';
 
+const ItemsContainer = itemContainerExport.unwrappedItemsContainer;
 const items = [
   {
     accessMessage: {
@@ -87,10 +88,16 @@ const context = {
   },
 };
 
+const testBib = {
+  done: true,
+  numItems: 0,
+};
+
 describe('ItemsContainer', () => {
+  // console.log('ItemsContainer: ', ItemsContainer);
   describe('Default rendering', () => {
     it('should return null with no props passed', () => {
-      const component = shallow(<ItemsContainer />, {
+      const component = shallow(<ItemsContainer bib={testBib} />, {
         disableLifecycleMethods: true,
         context,
       });
@@ -102,7 +109,7 @@ describe('ItemsContainer', () => {
     let component;
 
     before(() => {
-      component = shallow(<ItemsContainer items={items} />, {
+      component = shallow(<ItemsContainer items={items} bib={testBib} />, {
         disableLifecycleMethods: true,
         context,
       });
@@ -138,7 +145,7 @@ describe('ItemsContainer', () => {
     let component;
 
     before(() => {
-      component = mount(<ItemsContainer items={longListItems} />, { context });
+      component = mount(<ItemsContainer items={longListItems} bib={testBib} />, { context });
     });
 
     it('should have an ItemTable component, which renders a table', () => {
@@ -162,7 +169,7 @@ describe('ItemsContainer', () => {
     let component;
 
     before(() => {
-      component = mount(<ItemsContainer items={longListItems} shortenItems={false} />, { context });
+      component = mount(<ItemsContainer items={longListItems} shortenItems={false} bib={testBib} />, { context });
     });
 
     it('should render a "View All Items" link', () => {
@@ -190,7 +197,7 @@ describe('ItemsContainer', () => {
 
     before(() => {
       component = mount(
-        <ItemsContainer items={longListItems} shortenItems={false} />,
+        <ItemsContainer items={longListItems} shortenItems={false} bib={testBib} />,
         { context },
       );
     });
@@ -236,7 +243,7 @@ describe('ItemsContainer', () => {
 
     before(() => {
       component = mount(
-        <ItemsContainer items={longListItems} shortenItems={false} page="4" />,
+        <ItemsContainer items={longListItems} shortenItems={false} page="4" bib={testBib} />,
         { context },
       );
     });
@@ -252,7 +259,7 @@ describe('ItemsContainer', () => {
     // gets done in componentDidMount which is called when the component actually mounts.
     it('should have an empty chunkedItems state', () => {
       const component = shallow(
-        <ItemsContainer items={longListItems} />, {
+        <ItemsContainer items={longListItems} bib={testBib} />, {
           disableLifecycleMethods: true,
           context,
         });
@@ -263,7 +270,7 @@ describe('ItemsContainer', () => {
     // gets done in componentDidMount which is called when the component actually mounts.
     it('should have two arrays of in the chunkedItems state,' +
       'the first array with 20 items and the second with 4', () => {
-      const component = mount(<ItemsContainer items={longListItems} />, { context });
+      const component = mount(<ItemsContainer items={longListItems} bib={testBib} />, { context });
       expect(component.state('chunkedItems')).to.eql(
         [
           [
@@ -306,7 +313,7 @@ describe('ItemsContainer', () => {
     let component;
     before(() => {
       component = mount(
-        <ItemsContainer items={twentyItems} shortenItems={false} page="4" />,
+        <ItemsContainer items={twentyItems} shortenItems={false} page="4" bib={testBib} />,
         { context },
       );
     });


### PR DESCRIPTION
**What's this do?**
- Updates Bib page and API to load items in batches in the background.
- Also disables filters until items are finished loading. This requires filtered items to be re-calculated on rendering.
- Some minor changes to tests

**Why are we doing this? (w/ JIRA link if applicable)**
This is scc-2439. We're having trouble with timeouts on bibs with very large numbers of items.

**Do these changes have automated tests?**
Some minor changes to existing tests.

**How should this be QAed?**
Should no longer see timeouts on bib pages with large numbers of items

**Dependencies for merging? Releasing to production?**
NA

**Has the application documentation been updated for these changes?**
NA

**Did someone actually run this code to verify it works?**
I tested locally.
