### PR TITLE
Fix DrbbContainer disappearing at certain widths

### DIFF
--- a/src/app/components/SearchResults/SearchResultsContainer.jsx
+++ b/src/app/components/SearchResults/SearchResultsContainer.jsx
@@ -59,7 +59,7 @@ const SearchResultsContainer = (props) => {
                   /> :
                   noResultElementForDrbbIntegration
               }
-              { includeDrbb && media === 'desktop' ? <DrbbContainer /> : null}
+              {includeDrbb && media === 'desktop' ? <DrbbContainer /> : null}
               {
                 hasResults ?
                   <Pagination
@@ -71,7 +71,7 @@ const SearchResultsContainer = (props) => {
                     updatePage={updatePage}
                   /> : null
               }
-              { includeDrbb && ['tablet', 'mobile'].includes(media) ? <DrbbContainer /> : null}
+              {includeDrbb && media !== 'desktop' ? <DrbbContainer /> : null}
             </div>
           </div>
         </React.Fragment>


### PR DESCRIPTION
**What's this do?**
At some point, another media type was added (`tabletPortrait`). Now, we will just check that the media type is not `desktop` to put the `DrbbContainer` in the correct position.

**Why are we doing this? (w/ JIRA link if applicable)**
Small bug I just found

**Do these changes have automated tests?**
[Brief description of new automated tests]

**How should this be QAed?**
[Description of any tests that need to be performed once merged]

**Dependencies for merging? Releasing to production?**
[Description of any watchouts, dependencies, or issues we should be aware of]

**Has the application documentation been updated for these changes?**

**Did someone actually run this code to verify it works?**
I did