### PR TITLE
SCC-2478 partial: Search Results

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -889,9 +889,9 @@
       }
     },
     "@nypl/design-system-react-components": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@nypl/design-system-react-components/-/design-system-react-components-0.19.1.tgz",
-      "integrity": "sha512-SWwG5l+IVsrG4tqSRgW4UsPbL/b+5pqMrMCpXZi4OxHjTNgu7LTTTHxYt0rPAB4wOoxGh7WhlLcdjKU2SZEBIw==",
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/@nypl/design-system-react-components/-/design-system-react-components-0.20.1.tgz",
+      "integrity": "sha512-N887SUnzAwd7ksqPfHNOg1MU9EsjpiVkfmhY6vLbdO8LlUahGQJJmvcTKR2mKQviuyAF6N+nlXwrgTD0ogcIbw==",
       "requires": {
         "he": "^1.2.0",
         "react": "^16.13.1",
@@ -9787,9 +9787,9 @@
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.12.5",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
-          "integrity": "sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==",
+          "version": "7.12.13",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.13.tgz",
+          "integrity": "sha512-8+3UMPBrjFa/6TtKi/7sehPKqfAm4g6K+YQjyyFOLUTxzOngcRZTlAVY8sc2CORJYqdHQY8gRPHmn+qo15rCBw==",
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
@@ -16553,9 +16553,9 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "typescript": {
-      "version": "3.9.7",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
-      "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw=="
+      "version": "3.9.9",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.9.tgz",
+      "integrity": "sha512-kdMjTiekY+z/ubJCATUPlRDl39vXYiMV9iyeMuEuXZh2we6zz80uovNN2WlAxmmdE/Z/YQe+EbOEXB5RHEED3w=="
     },
     "ua-parser-js": {
       "version": "0.7.21",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "@babel/preset-env": "^7.7.7",
     "@babel/preset-react": "^7.7.4",
     "@babel/register": "^7.7.7",
-    "@nypl/design-system-react-components": "^0.19.1",
+    "@nypl/design-system-react-components": "^0.20.1",
     "@nypl/design-toolkit": "^0.1.38",
     "@nypl/dgx-header-component": "git+https://git@github.com/NYPL/dgx-header-component#reactupdate",
     "@nypl/dgx-react-footer": "0.5.6",

--- a/src/app/components/Application/Application.jsx
+++ b/src/app/components/Application/Application.jsx
@@ -93,9 +93,9 @@ export class Application extends React.Component {
               patron={this.props.patron}
               skipNav={{ target: 'mainContent' }}
             />
-            <LoadingLayer
+          {/*<LoadingLayer
               loading={this.props.loading}
-            />
+            />*/}
             <DataLoader
               location={this.context.router.location}
               key={JSON.stringify(dataLocation)}

--- a/src/app/components/Application/Application.jsx
+++ b/src/app/components/Application/Application.jsx
@@ -93,9 +93,9 @@ export class Application extends React.Component {
               patron={this.props.patron}
               skipNav={{ target: 'mainContent' }}
             />
-          {/*<LoadingLayer
+            <LoadingLayer
               loading={this.props.loading}
-            />*/}
+            />
             <DataLoader
               location={this.context.router.location}
               key={JSON.stringify(dataLocation)}

--- a/src/app/components/FilterPopup/FilterPopup.jsx
+++ b/src/app/components/FilterPopup/FilterPopup.jsx
@@ -471,16 +471,12 @@ export class FilterPopup extends React.Component {
 
     return (
       <div className="filter-container">
-        <div className={`nypl-full-width-wrapper${includeDrbb ? ' drbb-integration' : ''}`}>
-          <div className="nypl-row">
-            <div className="nypl-column-full">
-              <div className="filter-text">
-                <h2 id="filter-title" ref={this.filterTitle} tabIndex="0">Refine your search</h2>
-                <p>Toggle filters to narrow and define your search</p>
-              </div>
-              {(!showForm && !!(totalResults && totalResults !== 0)) && openPopupButton}
-            </div>
+        <div className="nypl-column-full">
+          <div className="filter-text">
+            <h2 id="filter-title" ref={this.filterTitle}>Refine your search</h2>
+            <p>Toggle filters to narrow and define your search</p>
           </div>
+          {(!showForm && !!(totalResults && totalResults !== 0)) && openPopupButton}
         </div>
         {
           showForm && (
@@ -503,7 +499,9 @@ export class FilterPopup extends React.Component {
                 }
               >
                 {
-                  this.state.raisedErrors && !_isEmpty(this.state.raisedErrors) && (errorMessageBlock)
+                  this.state.raisedErrors
+                  && !_isEmpty(this.state.raisedErrors)
+                  && (errorMessageBlock)
                 }
                 <form
                   action={`${appConfig.baseUrl}/search?q=${searchKeywords}`}
@@ -511,74 +509,62 @@ export class FilterPopup extends React.Component {
                   onSubmit={() => this.submitForm('Form submission')}
                 >
                   <div className="form-full-width">
-                    <div className={`nypl-full-width-wrapper${includeDrbb ? ' drbb-integration' : ''}`}>
-                      <div className="nypl-row">
-                        <div className="nypl-column-full">
-                          <ul
-                            className="filter-action-buttons"
-                            aria-label="Refine Search Options"
-                          >
-                            <li>{resetButton({ ref: this.filterResetBtn, position: 'top row' })}</li>
-                            <li>{cancelButton('top row')}</li>
-                            <li>{applyButton('top row')}</li>
-                          </ul>
-                        </div>
-                      </div>
+                    <div className="nypl-column-full">
+                      <ul
+                        className="filter-action-buttons"
+                        aria-label="Refine Search Options"
+                      >
+                        <li>{resetButton({ ref: this.filterResetBtn, position: 'top row' })}</li>
+                        <li>{cancelButton('top row')}</li>
+                        <li>{applyButton('top row')}</li>
+                      </ul>
                     </div>
                   </div>
 
                   <fieldset className="nypl-fieldset">
-                    <div className={`nypl-full-width-wrapper${includeDrbb ? ' drbb-integration' : ''}`}>
-                      <div className="nypl-row">
-                        <div className="nypl-column-full">
-                          <FieldsetList
-                            legend="Format"
-                            filterId="materialType"
-                            filter={materialTypeFilters}
-                            selectedFilters={filtersToShow.materialType}
-                            onFilterClick={this.onFilterClick}
-                          />
+                    <div className="nypl-column-full">
+                      <FieldsetList
+                        legend="Format"
+                        filterId="materialType"
+                        filter={materialTypeFilters}
+                        selectedFilters={filtersToShow.materialType}
+                        onFilterClick={this.onFilterClick}
+                      />
 
-                          <FieldsetDate
-                            legend="Date"
-                            selectedFilters={dateSelectedFilters}
-                            onDateFilterChange={this.onDateFilterChange}
-                            submitError={isDateInputError}
-                          />
+                      <FieldsetDate
+                        legend="Date"
+                        selectedFilters={dateSelectedFilters}
+                        onDateFilterChange={this.onDateFilterChange}
+                        submitError={isDateInputError}
+                      />
 
-                          <FieldsetList
-                            legend="Language"
-                            filterId="language"
-                            filter={languageFilters}
-                            selectedFilters={filtersToShow.language}
-                            onFilterClick={this.onFilterClick}
-                          />
+                      <FieldsetList
+                        legend="Language"
+                        filterId="language"
+                        filter={languageFilters}
+                        selectedFilters={filtersToShow.language}
+                        onFilterClick={this.onFilterClick}
+                      />
 
-                          <FieldsetList
-                            legend="Subject"
-                            filterId="subjectLiteral"
-                            filter={subjectLiteralFilters}
-                            selectedFilters={filtersToShow.subjectLiteral}
-                            onFilterClick={this.onFilterClick}
-                          />
-                        </div>
-                      </div>
+                      <FieldsetList
+                        legend="Subject"
+                        filterId="subjectLiteral"
+                        filter={subjectLiteralFilters}
+                        selectedFilters={filtersToShow.subjectLiteral}
+                        onFilterClick={this.onFilterClick}
+                      />
                     </div>
 
                     <div className="bottom-action-row form-full-width">
-                      <div className={`nypl-full-width-wrapper${includeDrbb ? ' drbb-integration' : ''}`}>
-                        <div className="nypl-row">
-                          <div className="nypl-column-full">
-                            <ul
-                              className="filter-action-buttons"
-                              aria-label="Refine Search Options"
-                            >
-                              <li>{resetButton({ ref: this.nullRef, position: 'bottom row' })}</li>
-                              <li>{cancelButton('bottom row')}</li>
-                              <li>{applyButton('bottom row')}</li>
-                            </ul>
-                          </div>
-                        </div>
+                      <div className="nypl-column-full">
+                        <ul
+                          className="filter-action-buttons"
+                          aria-label="Refine Search Options"
+                        >
+                          <li>{resetButton({ ref: this.nullRef, position: 'bottom row' })}</li>
+                          <li>{cancelButton('bottom row')}</li>
+                          <li>{applyButton('bottom row')}</li>
+                        </ul>
                       </div>
                     </div>
                   </fieldset>

--- a/src/app/components/SccContainer/SccContainer.jsx
+++ b/src/app/components/SccContainer/SccContainer.jsx
@@ -2,52 +2,94 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
-import Breadcrumbs from '../Breadcrumbs/Breadcrumbs';
+import {
+  Heading,
+  Breadcrumbs,
+  Hero,
+  HeroTypes,
+  Link,
+} from '@nypl/design-system-react-components';
+
 import Notification from '../Notification/Notification';
+import LoadingLayer from '../LoadingLayer/LoadingLayer';
+import appConfig from '../../data/appConfig';
 
 const SccContainer = (props) => {
-  const { features } = props;
+  const { features, useLoadingLayer, children } = props;
+  console.log('children', children);
+  const { baseUrl } = appConfig;
   const includeDrbb = features.includes('drb-integration');
   return (
-    <main className="main-page">
-      <div className="nypl-page-header">
-        <div className={`nypl-full-width-wrapper filter-page${includeDrbb ? ' drbb-integration' : ''}`}>
-          <div className="nypl-row">
-            <div className="nypl-column-full">
-              <Breadcrumbs type={props.breadcrumbsType} />
-              <Notification notificationType="searchResultsNotification" />
-              <h1
-                aria-label={props.bannerOptions.ariaLabel || props.bannerOptions.text}
-              >
-                { props.bannerOptions.text }
-              </h1>
-              { props.extraBannerElement }
-            </div>
-          </div>
+    <div className="nypl-ds nypl--research layout-container">
+      {
+        useLoadingLayer ? (
+          <LoadingLayer
+            loading={props.loading}
+          />
+        ) : null
+      }
+      <main className="main">
+        <div className="content-header">
+          <Breadcrumbs
+            breadcrumbs={[
+              { url: "htttps://www.nypl.org", text: "Home" },
+              { url: "https://www.nypl.org/research", text: "Research" },
+              { url: appConfig.baseUrl, text: "Research Catalog" },
+            ]}
+            className="breadcrumbs"
+          />
+          <Hero
+            heroType={HeroTypes.Secondary}
+            heading={(
+              <>
+                <Heading
+                  level={1}
+                  id={"1"}
+                  text="Research Catalog"
+                />
+                <nav
+                  className="sub-nav apply-brand-styles"
+                  aria-label="sub-nav"
+                >
+                  <Link
+                    className="sub-nav__link"
+                    href={appConfig.baseUrl}
+                  >
+                    Search
+                  </Link> |&nbsp;
+                  <Link
+                    className="sub-nav__link"
+                    href={`${baseUrl}/subject_headings`}
+                  >
+                    Subject Heading Explorer
+                  </Link> |&nbsp;
+                  <span
+                    className="sub-nav__active-section"
+                  >
+                    My Account
+                  </span>
+                </nav>
+              </>
+            )}
+            className="apply-brand-styles hero"
+          />
         </div>
-        { props.secondaryExtraBannerElement }
-      </div>
-      { props.extraRow }
-      <div className={`nypl-full-width-wrapper${includeDrbb ? ' drbb-integration' : ''}`}>
-        { props.mainContent }
-      </div>
-    </main>
+        <div className="content-primary">
+          {children}
+        </div>
+      </main>
+    </div>
   );
 };
 
 SccContainer.propTypes = {
-  mainContent: PropTypes.element,
-  extraBannerElement: PropTypes.element,
-  secondaryExtraBannerElement: PropTypes.element,
-  extraRow: PropTypes.element,
-  breadcrumbsType: PropTypes.string,
-  bannerOptions: PropTypes.object,
+  children: PropTypes.object,
+  useLoadingLayer: PropTypes.bool,
   features: PropTypes.array,
 };
 
 SccContainer.defaultProps = {
-  mainContent: null,
-  extraBannerElement: null,
+  useLoadingLayer: true,
 };
 
 SccContainer.contextTypes = {

--- a/src/app/components/SccContainer/SccContainer.jsx
+++ b/src/app/components/SccContainer/SccContainer.jsx
@@ -12,11 +12,12 @@ import {
 
 import Notification from '../Notification/Notification';
 import LoadingLayer from '../LoadingLayer/LoadingLayer';
+import SubNav from '../SubNav/SubNav';
 import appConfig from '../../data/appConfig';
 
 const SccContainer = (props) => {
   const { features, useLoadingLayer, children } = props;
-  console.log('children', children);
+
   const { baseUrl } = appConfig;
   const includeDrbb = features.includes('drb-integration');
   return (
@@ -41,38 +42,17 @@ const SccContainer = (props) => {
           <Hero
             heroType={HeroTypes.Secondary}
             heading={(
-              <>
-                <Heading
-                  level={1}
-                  id={"1"}
-                  text="Research Catalog"
-                />
-                <nav
-                  className="sub-nav apply-brand-styles"
-                  aria-label="sub-nav"
-                >
-                  <Link
-                    className="sub-nav__link"
-                    href={appConfig.baseUrl}
-                  >
-                    Search
-                  </Link> |&nbsp;
-                  <Link
-                    className="sub-nav__link"
-                    href={`${baseUrl}/subject_headings`}
-                  >
-                    Subject Heading Explorer
-                  </Link> |&nbsp;
-                  <span
-                    className="sub-nav__active-section"
-                  >
-                    My Account
-                  </span>
-                </nav>
-              </>
+              <Heading
+                level={1}
+                id={"1"}
+                blockName={"hero"}
+              >
+                Research Catalog
+              </Heading>
             )}
             className="apply-brand-styles hero"
           />
+          <SubNav activeSection="search" />
         </div>
         <div className="content-primary">
           {children}

--- a/src/app/components/SccContainer/SccContainer.jsx
+++ b/src/app/components/SccContainer/SccContainer.jsx
@@ -13,7 +13,7 @@ import SubNav from '../SubNav/SubNav';
 import appConfig from '../../data/appConfig';
 
 const SccContainer = (props) => {
-  const { useLoadingLayer, children } = props;
+  const { useLoadingLayer, children, activeSection } = props;
 
   return (
     <div className="nypl-ds nypl--research layout-container">
@@ -42,12 +42,12 @@ const SccContainer = (props) => {
                 id="1"
                 blockName="hero"
               >
-                Shared Collection Catalog
+                {appConfig.displayTitle}
               </Heading>
             )}
             className="apply-brand-styles hero"
           />
-          <SubNav activeSection="search" />
+          <SubNav activeSection={activeSection} />
         </div>
         <div className="content-primary">
           {children}
@@ -60,6 +60,7 @@ const SccContainer = (props) => {
 SccContainer.propTypes = {
   children: PropTypes.array,
   useLoadingLayer: PropTypes.bool,
+  activeSection: PropTypes.string,
 };
 
 SccContainer.defaultProps = {

--- a/src/app/components/SccContainer/SccContainer.jsx
+++ b/src/app/components/SccContainer/SccContainer.jsx
@@ -1,25 +1,20 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
 
 import {
   Heading,
   Breadcrumbs,
   Hero,
   HeroTypes,
-  Link,
 } from '@nypl/design-system-react-components';
 
-import Notification from '../Notification/Notification';
 import LoadingLayer from '../LoadingLayer/LoadingLayer';
 import SubNav from '../SubNav/SubNav';
 import appConfig from '../../data/appConfig';
 
 const SccContainer = (props) => {
-  const { features, useLoadingLayer, children } = props;
+  const { useLoadingLayer, children } = props;
 
-  const { baseUrl } = appConfig;
-  const includeDrbb = features.includes('drb-integration');
   return (
     <div className="nypl-ds nypl--research layout-container">
       {
@@ -29,13 +24,13 @@ const SccContainer = (props) => {
           />
         ) : null
       }
-      <main className="main">
+      <main className="main main-page">
         <div className="content-header">
           <Breadcrumbs
             breadcrumbs={[
-              { url: "htttps://www.nypl.org", text: "Home" },
-              { url: "https://www.nypl.org/research", text: "Research" },
-              { url: appConfig.baseUrl, text: "Research Catalog" },
+              { url: 'htttps://www.nypl.org', text: 'Home' },
+              { url: 'https://www.nypl.org/research', text: 'Research' },
+              { url: appConfig.baseUrl, text: 'Research Catalog' },
             ]}
             className="breadcrumbs"
           />
@@ -44,10 +39,10 @@ const SccContainer = (props) => {
             heading={(
               <Heading
                 level={1}
-                id={"1"}
-                blockName={"hero"}
+                id="1"
+                blockName="hero"
               >
-                Research Catalog
+                Shared Collection Catalog
               </Heading>
             )}
             className="apply-brand-styles hero"
@@ -63,9 +58,8 @@ const SccContainer = (props) => {
 };
 
 SccContainer.propTypes = {
-  children: PropTypes.object,
+  children: PropTypes.array,
   useLoadingLayer: PropTypes.bool,
-  features: PropTypes.array,
 };
 
 SccContainer.defaultProps = {
@@ -76,4 +70,4 @@ SccContainer.contextTypes = {
   router: PropTypes.object,
 };
 
-export default connect(({ features }) => ({ features }))(SccContainer);
+export default SccContainer;

--- a/src/app/components/SearchResults/SearchResultsContainer.jsx
+++ b/src/app/components/SearchResults/SearchResultsContainer.jsx
@@ -45,34 +45,32 @@ const SearchResultsContainer = (props) => {
     <MediaContext.Consumer>
       { media => (
         <React.Fragment>
-          <div className="nypl-row">
-            <div
-              className="nypl-column-full"
-              role="region"
-              aria-describedby="results-description"
-            >
-              {
-                hasResults ?
-                  <ResultsList
-                    results={results}
-                    searchKeywords={searchKeywords}
-                  /> :
-                  noResultElementForDrbbIntegration
-              }
-              {includeDrbb && media === 'desktop' ? <DrbbContainer /> : null}
-              {
-                hasResults ?
-                  <Pagination
-                    ariaControls="nypl-results-list"
-                    total={totalResults}
-                    perPage={50}
-                    page={parseInt(page, 10)}
-                    createAPIQuery={createAPIQuery}
-                    updatePage={updatePage}
-                  /> : null
-              }
-              {includeDrbb && media !== 'desktop' ? <DrbbContainer /> : null}
-            </div>
+          <div
+            className="nypl-column-full"
+            role="region"
+            aria-describedby="results-description"
+          >
+            {
+              hasResults ?
+                <ResultsList
+                  results={results}
+                  searchKeywords={searchKeywords}
+                /> :
+                noResultElementForDrbbIntegration
+            }
+            {includeDrbb && media === 'desktop' ? <DrbbContainer /> : null}
+            {
+              hasResults ?
+                <Pagination
+                  ariaControls="nypl-results-list"
+                  total={totalResults}
+                  perPage={50}
+                  page={parseInt(page, 10)}
+                  createAPIQuery={createAPIQuery}
+                  updatePage={updatePage}
+                /> : null
+            }
+            {includeDrbb && media !== 'desktop' ? <DrbbContainer /> : null}
           </div>
         </React.Fragment>
       )}

--- a/src/app/components/SubNav/SubNav.jsx
+++ b/src/app/components/SubNav/SubNav.jsx
@@ -1,17 +1,20 @@
 import React from 'react';
 import { Link } from 'react-router';
-import { Link as DSLink} from '@nypl/design-system-react-components';
+import { Link as DSLink } from '@nypl/design-system-react-components';
+import PropTypes from 'prop-types';
 
 import appConfig from '../../data/appConfig';
 
 const SubNavLink = ({ type, activeSection, href, children }) => {
-  if (type === activeSection) return (
-    <span
-      className="sub-nav__link__active-section"
-    >
-      {children}
-    </span>
-  )
+  if (type === activeSection) {
+    return (
+      <span
+        className="sub-nav__link__active-section"
+      >
+        {children}
+      </span>
+    );
+  }
 
   return (
     <DSLink
@@ -19,12 +22,19 @@ const SubNavLink = ({ type, activeSection, href, children }) => {
     >
       <Link to={href}>{children}</Link>
     </DSLink>
-  )
-}
+  );
+};
 
-const SubNav = props => {
+SubNavLink.propTypes = {
+  type: PropTypes.string,
+  activeSection: PropTypes.string,
+  href: PropTypes.string,
+  children: PropTypes.string,
+};
+
+const SubNav = (props) => {
   const { baseUrl } = appConfig;
-  return(
+  return (
     <nav
       className="sub-nav apply-brand-styles"
       aria-label="sub-nav"
@@ -33,27 +43,27 @@ const SubNav = props => {
         <SubNavLink
           type="search"
           href={appConfig.baseUrl}
-          { ...props }
-          >
+          {...props}
+        >
           Search
         </SubNavLink> |&nbsp;
         <SubNavLink
           type="shep"
           href={`${baseUrl}/subject_headings`}
-          { ...props }
-          >
+          {...props}
+        >
           Subject Heading Explorer
         </SubNavLink> |&nbsp;
         <SubNavLink
           type="account"
           href={`${baseUrl}/account`}
-          { ...props }
-          >
+          {...props}
+        >
           My Account
         </SubNavLink>
       </ul>
     </nav>
-  )
-}
+  );
+};
 
 export default SubNav;

--- a/src/app/components/SubNav/SubNav.jsx
+++ b/src/app/components/SubNav/SubNav.jsx
@@ -9,7 +9,7 @@ const SubNavLink = ({ type, activeSection, href, children }) => {
   if (type === activeSection) {
     return (
       <span
-        className="sub-nav__link__active-section"
+        className="sub-nav__active-section"
       >
         {children}
       </span>

--- a/src/app/components/SubNav/SubNav.jsx
+++ b/src/app/components/SubNav/SubNav.jsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { Link } from 'react-router';
+import { Link as DSLink} from '@nypl/design-system-react-components';
+
+import appConfig from '../../data/appConfig';
+
+const SubNavLink = ({ type, activeSection, href, children }) => {
+  if (type === activeSection) return (
+    <span
+      className="sub-nav__link__active-section"
+    >
+      {children}
+    </span>
+  )
+
+  return (
+    <DSLink
+      className="sub-nav__link"
+    >
+      <Link to={href}>{children}</Link>
+    </DSLink>
+  )
+}
+
+const SubNav = props => {
+  const { baseUrl } = appConfig;
+  return(
+    <nav
+      className="sub-nav apply-brand-styles"
+      aria-label="sub-nav"
+    >
+      <ul className="sub-nav__list">
+        <SubNavLink
+          type="search"
+          href={appConfig.baseUrl}
+          { ...props }
+          >
+          Search
+        </SubNavLink> |&nbsp;
+        <SubNavLink
+          type="shep"
+          href={`${baseUrl}/subject_headings`}
+          { ...props }
+          >
+          Subject Heading Explorer
+        </SubNavLink> |&nbsp;
+        <SubNavLink
+          type="account"
+          href={`${baseUrl}/account`}
+          { ...props }
+          >
+          My Account
+        </SubNavLink>
+      </ul>
+    </nav>
+  )
+}
+
+export default SubNav;

--- a/src/app/pages/SearchResults.jsx
+++ b/src/app/pages/SearchResults.jsx
@@ -2,7 +2,6 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import DocumentTitle from 'react-document-title';
 import { useSelector } from 'react-redux';
-import { withRouter } from 'react-router';
 
 /* eslint-disable import/no-unresolved, import/extensions */
 import SearchResultsSorter from '@SearchResultsSorter';
@@ -27,10 +26,8 @@ const SearchResults = (props, context) => {
     field,
     page,
     selectedFilters,
-    features,
   } = useSelector(state => ({
     searchResults: state.searchResults,
-    features: state.features,
     searchKeywords: state.searchKeywords,
     sortBy: state.sortBy,
     field: state.field,
@@ -42,17 +39,11 @@ const SearchResults = (props, context) => {
     router,
   } = context;
 
-  const includeDrbb = features.includes('drb-integration');
-
   const { location } = router;
 
   const [dropdownOpen, toggleDropdown] = useState(false);
 
   const totalResults = searchResults ? searchResults.totalResults : undefined;
-  const totalPages = totalResults ? Math.floor(totalResults / 50) + 1 : 0;
-  const searchKeywordsLabel = searchKeywords ? `for ${searchKeywords}` : '';
-  const pageLabel = totalPages ? `page ${page} of ${totalPages}` : '';
-  const headerLabel = `Search results ${searchKeywordsLabel} ${pageLabel}`;
 
   const createAPIQuery = basicQuery({
     searchKeywords,
@@ -69,28 +60,13 @@ const SearchResults = (props, context) => {
       value: 'Date',
     });
   }
-  const checkForSelectedFilters = () => {
-    if (selectedFilters &&
-      (selectedFilters.dateBefore !== '' ||
-        selectedFilters.dateAfter !== '' ||
-        (selectedFilters.language && selectedFilters.language.length) ||
-        (selectedFilters.materialType && selectedFilters.materialType.length) ||
-        (selectedFilters.subjectLiteral && selectedFilters.subjectLiteral.length)
-      )
-    ) {
-      if (!dropdownOpen) {
-        return true;
-      }
-    }
-    return false;
-  };
 
   const selectedFiltersAvailable = hasValidFilters(selectedFilters) && !dropdownOpen;
   const hasResults = searchResults && totalResults;
 
   return (
     <DocumentTitle title="Search Results | Shared Collection Catalog | NYPL">
-      <SccContainer>
+      <SccContainer useLoadingLayer>
         <Search
           createAPIQuery={createAPIQuery}
           router={router}
@@ -100,36 +76,29 @@ const SearchResults = (props, context) => {
           raisedErrors={dateFilterErrors}
           updateDropdownState={toggleDropdown}
         />
-        <div className={`nypl-full-width-wrapper selected-filters${includeDrbb ? ' drbb-integration' : ''}`}>
-          <div className="nypl-row">
-            <div className="nypl-column-full">
-              <SelectedFilters
-                selectedFilters={selectedFilters}
-                createAPIQuery={createAPIQuery}
-              />
-            </div>
-          </div>
-        </div>
+        {
+          selectedFiltersAvailable ? (
+            <SelectedFilters
+              selectedFilters={selectedFilters}
+              createAPIQuery={createAPIQuery}
+              selectedFiltersAvailable={selectedFiltersAvailable}
+            />
+          ) : null
+        }
         <div className="nypl-sorter-row">
-          <div className={`nypl-full-width-wrapper selected-filters${includeDrbb ? ' drbb-integration' : ''}`}>
-            <div className="nypl-row">
-              <div className="nypl-column-full">
-                <ResultsCount
-                  count={totalResults}
-                  selectedFilters={selectedFilters}
-                  field={field}
-                />
-                {
-                  hasResults ?
-                    <SearchResultsSorter
-                      createAPIQuery={createAPIQuery}
-                      key={sortBy}
-                    />
-                    : null
-                }
-              </div>
-            </div>
-          </div>
+          <ResultsCount
+            count={totalResults}
+            selectedFilters={selectedFilters}
+            field={field}
+          />
+          {
+            hasResults ?
+              <SearchResultsSorter
+                createAPIQuery={createAPIQuery}
+                key={sortBy}
+              />
+              : null
+          }
         </div>
         <SearchResultsContainer
           router={router}

--- a/src/app/pages/SearchResults.jsx
+++ b/src/app/pages/SearchResults.jsx
@@ -66,7 +66,10 @@ const SearchResults = (props, context) => {
 
   return (
     <DocumentTitle title="Search Results | Shared Collection Catalog | NYPL">
-      <SccContainer useLoadingLayer>
+      <SccContainer
+        useLoadingLayer
+        activeSection="search"
+      >
         <Search
           createAPIQuery={createAPIQuery}
           router={router}

--- a/src/app/pages/SearchResults.jsx
+++ b/src/app/pages/SearchResults.jsx
@@ -90,72 +90,52 @@ const SearchResults = (props, context) => {
 
   return (
     <DocumentTitle title="Search Results | Shared Collection Catalog | NYPL">
-      <SccContainer
-        mainContent={
-          <SearchResultsContainer
-            router={router}
-            createAPIQuery={createAPIQuery}
-          />
-        }
-        bannerOptions={
-          {
-            text: 'Search Results',
-            ariaLabel: headerLabel,
-          }
-        }
-        extraBannerElement={
-          <Search
-            createAPIQuery={createAPIQuery}
-            router={router}
-          />
-        }
-        secondaryExtraBannerElement={
-          <React.Fragment>
-            <FilterPopup
-              createAPIQuery={createAPIQuery}
-              raisedErrors={dateFilterErrors}
-              updateDropdownState={toggleDropdown}
-            />
-            {
-              selectedFiltersAvailable &&
-              <div className={`nypl-full-width-wrapper selected-filters${includeDrbb ? ' drbb-integration' : ''}`}>
-                <div className="nypl-row">
-                  <div className="nypl-column-full">
-                    <SelectedFilters
-                      selectedFilters={selectedFilters}
+      <SccContainer>
+        <Search
+          createAPIQuery={createAPIQuery}
+          router={router}
+        />
+        <FilterPopup
+          createAPIQuery={createAPIQuery}
+          raisedErrors={dateFilterErrors}
+          updateDropdownState={toggleDropdown}
+        />
+        <div className={`nypl-full-width-wrapper selected-filters${includeDrbb ? ' drbb-integration' : ''}`}>
+          <div className="nypl-row">
+            <div className="nypl-column-full">
+              <SelectedFilters
+                selectedFilters={selectedFilters}
+                createAPIQuery={createAPIQuery}
+              />
+            </div>
+          </div>
+        </div>
+        <div className="nypl-sorter-row">
+          <div className={`nypl-full-width-wrapper selected-filters${includeDrbb ? ' drbb-integration' : ''}`}>
+            <div className="nypl-row">
+              <div className="nypl-column-full">
+                <ResultsCount
+                  count={totalResults}
+                  selectedFilters={selectedFilters}
+                  field={field}
+                />
+                {
+                  hasResults ?
+                    <SearchResultsSorter
                       createAPIQuery={createAPIQuery}
+                      key={sortBy}
                     />
-                  </div>
-                </div>
-              </div>
-            }
-          </React.Fragment>
-        }
-        extraRow={
-          <div className="nypl-sorter-row">
-            <div className={`nypl-full-width-wrapper selected-filters${includeDrbb ? ' drbb-integration' : ''}`}>
-              <div className="nypl-row">
-                <div className="nypl-column-full">
-                  <ResultsCount
-                    count={totalResults}
-                    selectedFilters={selectedFilters}
-                    field={field}
-                  />
-                  {
-                    hasResults ?
-                      <SearchResultsSorter
-                        createAPIQuery={createAPIQuery}
-                        key={sortBy}
-                      />
-                      : null
-                  }
-                </div>
+                    : null
+                }
               </div>
             </div>
           </div>
-        }
-        breadcrumbsType="search"
-      />
+        </div>
+        <SearchResultsContainer
+          router={router}
+          createAPIQuery={createAPIQuery}
+        />
+      </SccContainer>
     </DocumentTitle>
   );
 };

--- a/src/client/styles/components/Drbb/Drbb.scss
+++ b/src/client/styles/components/Drbb/Drbb.scss
@@ -5,7 +5,7 @@
   margin: auto;
   margin-left: 15px;
   padding: 2.5%;
-  width: 25%;
+  width: 30%;
 
   .loadingLayer-texts-loadingWord {
     margin-bottom: unset;

--- a/src/client/styles/components/Search.scss
+++ b/src/client/styles/components/Search.scss
@@ -111,4 +111,6 @@
 
 .nypl-sorter-row {
   border-bottom: 0;
+  display: flex;
+  align-items: center;
 }

--- a/src/client/styles/components/SubNav.scss
+++ b/src/client/styles/components/SubNav.scss
@@ -1,0 +1,77 @@
+$break-breadcrumbs-mobile: max-width 599px;
+
+.sub-nav {
+  background-color: var(--ui-black);
+  margin-left: calc(-50vw + 50%);
+  margin-right: calc(-50vw + 50%);
+  padding-bottom: var(--space-xs);
+  padding-top: var(--space-xs);
+
+  &__item {
+    // @include space-inline-xxs;
+
+    align-items: center;
+    display: inline;
+    font-size: var(--font-size--1);
+    line-height: 1.5;
+    margin-right: var(--space-xxs);
+    position: relative;
+    word-break: break-word;
+
+    &:not(:last-child) {
+      &::after {
+        content: "/";
+        padding-left: var(--space-xxs);
+      }
+
+      // @include breakpoint($break-breadcrumbs-mobile) {
+      //   display: none;
+      // }
+    }
+
+    &:last-child {
+      // @include breakpoint($break-breadcrumbs-mobile) {
+      //   padding-left: var(--space-m);
+      // }
+    }
+  }
+
+  &__icon {
+    // @include icon;
+
+    left: 0;
+    position: absolute;
+    top: 50%;
+    transform: rotate(90deg) translateX(-50%);
+
+    // @include breakpoint($breakpoint-medium) {
+    //   display: none;
+    // }
+  }
+
+  &__link,
+  &__link:link,
+  &__link:visited,
+  &__link:focus {
+    color: inherit;
+    text-decoration: none;
+  }
+
+  &__link:hover {
+    text-decoration: underline;
+  }
+
+  &__list {
+    // @include list-reset;
+    margin: 0 auto;
+    max-width: 1280px;
+    padding: 0 var(--space);
+    width: 100%;
+
+    color: var(--ui-white);
+  }
+
+  .nypl--research & {
+    background-color: var(--section-research-primary);
+  }
+}

--- a/src/client/styles/components/SubNav.scss
+++ b/src/client/styles/components/SubNav.scss
@@ -30,14 +30,14 @@ $break-breadcrumbs-mobile: max-width 599px;
   &__link:focus {
     color: inherit;
     text-decoration: none;
-
-    &__active-section {
-      font-weight: 700;
-    }
   }
 
   &__link:hover {
     text-decoration: underline;
+  }
+
+  &__active-section {
+    font-weight: 700;
   }
 
   &__list {

--- a/src/client/styles/components/SubNav.scss
+++ b/src/client/styles/components/SubNav.scss
@@ -8,8 +8,6 @@ $break-breadcrumbs-mobile: max-width 599px;
   padding-top: var(--space-xs);
 
   &__item {
-    // @include space-inline-xxs;
-
     align-items: center;
     display: inline;
     font-size: var(--font-size--1);
@@ -23,30 +21,7 @@ $break-breadcrumbs-mobile: max-width 599px;
         content: "/";
         padding-left: var(--space-xxs);
       }
-
-      // @include breakpoint($break-breadcrumbs-mobile) {
-      //   display: none;
-      // }
     }
-
-    &:last-child {
-      // @include breakpoint($break-breadcrumbs-mobile) {
-      //   padding-left: var(--space-m);
-      // }
-    }
-  }
-
-  &__icon {
-    // @include icon;
-
-    left: 0;
-    position: absolute;
-    top: 50%;
-    transform: rotate(90deg) translateX(-50%);
-
-    // @include breakpoint($breakpoint-medium) {
-    //   display: none;
-    // }
   }
 
   &__link,
@@ -55,6 +30,10 @@ $break-breadcrumbs-mobile: max-width 599px;
   &__link:focus {
     color: inherit;
     text-decoration: none;
+
+    &__active-section {
+      font-weight: 700;
+    }
   }
 
   &__link:hover {
@@ -62,7 +41,6 @@ $break-breadcrumbs-mobile: max-width 599px;
   }
 
   &__list {
-    // @include list-reset;
     margin: 0 auto;
     max-width: 1280px;
     padding: 0 var(--space);

--- a/src/client/styles/main.scss
+++ b/src/client/styles/main.scss
@@ -206,3 +206,7 @@ div {
   margin-left: 0;
   margin-right: 25%;
 }
+
+.nypl-column-full {
+  padding: 0;
+}

--- a/test/unit/FilterPopup.test.js
+++ b/test/unit/FilterPopup.test.js
@@ -285,16 +285,5 @@ describe('FilterPopup', () => {
         expect(component.find('.drbb-integration')).to.have.length(0);
       });
     });
-
-    describe('with integration', () => {
-      before(() => {
-        appConfig.features = ['drb-integration'];
-        component = mount(<FilterPopup selectedFilters={selectedFilters} features={['drb-integration']} />);
-      });
-
-      it('should have components with .drbb-integration class', () => {
-        expect(component.find('.drbb-integration')).to.have.length(1);
-      });
-    });
   });
 });

--- a/test/unit/SearchResultsPage.test.js
+++ b/test/unit/SearchResultsPage.test.js
@@ -8,6 +8,7 @@ import SearchResults from '../../src/app/pages/SearchResults';
 import SearchResultsContainer from '../../src/app/components/SearchResults/SearchResultsContainer';
 import { mockRouterContext } from '../helpers/routing';
 import { mountTestRender, makeTestStore } from '../helpers/store';
+import appConfig from '../../src/app/data/appConfig';
 
 
 // Eventually, it would be nice to have mocked data in a different file and imported.
@@ -167,11 +168,10 @@ describe('SearchResultsPage', () => {
       wrapper.unmount();
     });
 
-    it('should have an h1 with "Search Results"', () => {
+    it('should have an h1 with display title', () => {
       const h1 = component.find('h1');
       expect(h1).to.have.length(1);
-      expect(h1.text()).to.equal('Search Results');
-      expect(h1.prop('aria-label')).to.equal('Search results for locofocos page 1 of 1');
+      expect(h1.text()).to.equal(appConfig.displayTitle);
     });
   });
 

--- a/test/unit/SearchResultsPage.test.js
+++ b/test/unit/SearchResultsPage.test.js
@@ -7,7 +7,7 @@ import PropTypes from 'prop-types';
 import SearchResults from '../../src/app/pages/SearchResults';
 import SearchResultsContainer from '../../src/app/components/SearchResults/SearchResultsContainer';
 import { mockRouterContext } from '../helpers/routing';
-import { mountTestRender, makeTestStore, shallowTestRender } from '../helpers/store';
+import { mountTestRender, makeTestStore } from '../helpers/store';
 
 
 // Eventually, it would be nice to have mocked data in a different file and imported.
@@ -172,14 +172,6 @@ describe('SearchResultsPage', () => {
       expect(h1).to.have.length(1);
       expect(h1.text()).to.equal('Search Results');
       expect(h1.prop('aria-label')).to.equal('Search results for locofocos page 1 of 1');
-    });
-
-    it('should a .nypl-page-header', () => {
-      expect(component.find('.nypl-page-header')).to.have.length(1);
-    });
-
-    it('should have four .nypl-full-width-wrapper elements', () => {
-      expect(component.find('.nypl-full-width-wrapper')).to.have.length(4);
     });
   });
 


### PR DESCRIPTION
**What's this do?**
Add `Hero` and `Breadcrumb` to Search Results page by refactoring `SccContainer`. `SccContainer` is refactored to render children, instead of using props for content.

**Why are we doing this? (w/ JIRA link if applicable)**
Partial PR for [SCC-2478](https://jira.nypl.org/browse/SCC-2478) covering the Search Results page, which is the only page currently using `SccContainer`. I think this would be a good time to switch the other pages over to this component hierarchy.

**Do these changes have automated tests?**
[Brief description of new automated tests]

**How should this be QAed?**
[Description of any tests that need to be performed once merged]

**Dependencies for merging? Releasing to production?**
Currently, spacing around `Search` component is off. [SCC-2539](https://jira.nypl.org/browse/SCC-2539) will cover this. Also, we might want to hold off on merging to `development` until all of the pages are converted.

**Has the application documentation been updated for these changes?**

**Did someone actually run this code to verify it works?**
I did