### PR TITLE
Add 404 for missing bib

### DIFF
--- a/server.js
+++ b/server.js
@@ -96,7 +96,7 @@ app.get('/*', (req, res) => {
       const title = DocumentTitle.rewind();
 
       res
-        .status(200)
+        .status(res.nyplStatus || 200)
         .render('index', {
           application,
           appData: JSON.stringify(store.getState()).replace(/</g, '\\u003c'),

--- a/server.js
+++ b/server.js
@@ -96,7 +96,7 @@ app.get('/*', (req, res) => {
       const title = DocumentTitle.rewind();
 
       res
-        .status(res.nyplStatus || 200)
+        .status(res.statusCode || 200)
         .render('index', {
           application,
           appData: JSON.stringify(store.getState()).replace(/</g, '\\u003c'),

--- a/src/app/components/BibPage/BibPage.jsx
+++ b/src/app/components/BibPage/BibPage.jsx
@@ -13,6 +13,7 @@ import LibraryItem from '../../utils/item';
 import BackLink from './BackLink';
 import AdditionalDetailsViewer from './AdditionalDetailsViewer';
 import Tabbed from './Tabbed';
+import NotFound404 from '../NotFound404/NotFound404';
 import LibraryHoldings from './LibraryHoldings';
 import getOwner from '../../utils/getOwner';
 import appConfig from '../../data/appConfig';
@@ -75,6 +76,7 @@ export const BibPage = (props) => {
     dispatch,
   } = props;
 
+  if (!props.bib || props.bib.status === '404') return (<NotFound404 />);
   const bib = props.bib ? props.bib : {};
   // check whether this is a server side or client side render
   // by whether 'window' is defined. After the first render on the client side

--- a/src/server/ApiRoutes/Bib.js
+++ b/src/server/ApiRoutes/Bib.js
@@ -122,7 +122,7 @@ const addLocationUrls = (bib) => {
     .catch((err) => { console.log('catching nypl client ', err); });
 };
 
-function fetchBib(bibId, cb, errorcb, reqOptions) {
+function fetchBib(bibId, cb, errorcb, reqOptions, res) {
   const options = Object.assign({
     fetchSubjectHeadingData: true,
     features: [],
@@ -140,6 +140,11 @@ function fetchBib(bibId, cb, errorcb, reqOptions) {
       if (!data.annotatedMarc || !data.annotatedMarc.bib) data.annotatedMarc = null;
 
       return data;
+    })
+    .then((bib) => {
+      const status = (!bib || !bib.uri || bib.uri !== bibId) ? '404' : '200';
+      if (status === '404') res.nyplStatus = 404;
+      return Object.assign({ status }, bib);
     })
     .then(bib => addLocationUrls(bib))
     .then((bib) => {
@@ -187,6 +192,7 @@ function bibSearch(req, res, resolve) {
       fetchSubjectHeadingData: true,
       itemFrom,
     },
+    res,
   );
 }
 

--- a/src/server/ApiRoutes/Bib.js
+++ b/src/server/ApiRoutes/Bib.js
@@ -143,7 +143,7 @@ function fetchBib(bibId, cb, errorcb, reqOptions, res) {
     })
     .then((bib) => {
       const status = (!bib || !bib.uri || bib.uri !== bibId) ? '404' : '200';
-      if (status === '404') res.nyplStatus = 404;
+      if (status === '404') res.status(404);
       return Object.assign({ status }, bib);
     })
     .then(bib => addLocationUrls(bib))


### PR DESCRIPTION
**What's this do?**
Render the content of the 404 page when the Bib page can't find a given bib id.

**Why are we doing this? (w/ JIRA link if applicable)**
Right now we are rendering either an empty page (in prod) or an incorrect bib (in qa), which is misleading and confusing. This is scc-2499

**Do these changes have automated tests?**
[Brief description of new automated tests]

**How should this be QAed?**
- Navigate to an existing bib, there should be no change
- Navigate to a made up bib, e.g. https://www.nypl.org/research/collections/shared-collection-catalog/bib/foo, you should see the following:
1. A 404 message
2. A 404 status in the network tab
3. The url should _not_ change, i.e. it should be the bib url and not the 404 url.

**Dependencies for merging? Releasing to production?**
NA

**Has the application documentation been updated for these changes?**
NA

**Did someone actually run this code to verify it works?**
PR author tested locally.
