### PR TITLE
SCC-2542: integrate LocationsService update

### DIFF
--- a/src/app/actions/Actions.js
+++ b/src/app/actions/Actions.js
@@ -153,3 +153,9 @@ export const updateHoldRequestPage = data => dispatch => new Promise(() => {
   if (searchKeywords) dispatch(updateSearchKeywords(searchKeywords));
   return data;
 });
+
+export const updateAccountPage = data => dispatch => new Promise(() => {
+  const { accountHtml, patron } = data;
+  dispatch(updateAccountHtml(accountHtml));
+  if (patron) dispatch(updatePatronData(patron));
+});

--- a/src/app/components/AccountPage/AccountSettings.jsx
+++ b/src/app/components/AccountPage/AccountSettings.jsx
@@ -25,7 +25,7 @@ const AccountSettings = ({ patron, legacyCatalog }) => (
       <dt>Email</dt>
       <dd>{patron.emails ? patron.emails[0] : 'None'}</dd>
       <dt>Preferred Pick Up Location</dt>
-      <dd>{patron.homeLibraryCode || 'None'}</dd>
+      <dd>{patron.homeLibraryName || patron.homeLibraryCode || 'None'}</dd>
       <dt>Preferred Contact Method</dt>
       <dd>{patron.noticePreference}</dd>
     </dl>

--- a/src/app/utils/dataLoaderUtil.js
+++ b/src/app/utils/dataLoaderUtil.js
@@ -6,7 +6,7 @@ import {
   updateHoldRequestPage,
   resetState,
   updateLastLoaded,
-  updateAccountHtml,
+  updateAccountPage,
 } from '@Actions';
 import appConfig from '@appConfig';
 import { updateLoadingStatus } from '../actions/Actions';
@@ -36,7 +36,7 @@ const routes = {
     params: '/:bibId-:itemId',
   },
   account: {
-    action: updateAccountHtml,
+    action: updateAccountPage,
     path: 'account',
     params: '/:content?',
   },

--- a/src/server/ApiRoutes/Account.js
+++ b/src/server/ApiRoutes/Account.js
@@ -113,4 +113,5 @@ function postToAccountPage(req, res) {
 export default {
   fetchAccountPage,
   postToAccountPage,
+  getHomeLibrary,
 };

--- a/test/fixtures/locations-service-mm.json
+++ b/test/fixtures/locations-service-mm.json
@@ -1,0 +1,1 @@
+{"mm":[{"code":"mm*","url":"http://www.nypl.org/locations/mid-manhattan-library","label":"Mid-Manhattan"}]}

--- a/test/unit/Account.test.js
+++ b/test/unit/Account.test.js
@@ -23,7 +23,7 @@ const validMockPatronTokenResponse = {
   errorCode: null,
 };
 
-const renderMockReq = (content, mockPatronTokenResponse=validMockPatronTokenResponse) => ({
+const renderMockReq = (content, mockPatronTokenResponse = validMockPatronTokenResponse) => ({
   params: { content },
   get: n => n,
   patronTokenResponse: mockPatronTokenResponse,
@@ -103,7 +103,6 @@ describe('`fetchAccountPage`', () => {
   });
 
   describe('"settings" content', () => {
-    let nyplApiClientStub;
     before(() => {
       global.store = {
         getState: () => ({

--- a/test/unit/Account.test.js
+++ b/test/unit/Account.test.js
@@ -51,12 +51,18 @@ describe('`fetchAccountPage`', () => {
       return ({ redirect: !req.patronTokenResponse.isTokenValid })
     });
     axiosGet = sinon.spy(axios, 'get');
+    global.store = {
+      getState: () => ({
+        patron: {},
+      }),
+    };
   });
 
   after(() => {
     fetchAccountPage.restore();
     requireUser.restore();
     axiosGet.restore();
+    global.store = undefined;
   });
 
   beforeEach(() => {

--- a/test/unit/Account.test.js
+++ b/test/unit/Account.test.js
@@ -32,12 +32,7 @@ const renderMockReq = (content, mockPatronTokenResponse = validMockPatronTokenRe
   },
 });
 
-let urlToTest = '';
-
 const mockRes = {
-  redirect: (url) => {
-    urlToTest = url;
-  },
   json: resp => ({ resp }),
 };
 const mockResolve = resp => resp;
@@ -46,6 +41,7 @@ describe('`fetchAccountPage`', () => {
   let requireUser;
   let axiosGet;
   let mock;
+  let redirectedTo = '';
 
   before(() => {
     requireUser = sinon.stub(User, 'requireUser').callsFake(req => ({ redirect: !req.patronTokenResponse.isTokenValid }));
@@ -73,6 +69,11 @@ describe('`fetchAccountPage`', () => {
 
   beforeEach(() => {
     axiosGet.reset();
+    redirectedTo = '';
+
+    mockRes.redirect = (url) => {
+      redirectedTo = url;
+    }
   });
 
   describe('patron not logged in', () => {
@@ -94,7 +95,7 @@ describe('`fetchAccountPage`', () => {
     it('should redirect', () => {
       Account.fetchAccountPage(renderMockReq('blahblah'), mockRes, mockResolve);
 
-      expect(urlToTest).to.equal('/research/collections/shared-collection-catalog/account');
+      expect(redirectedTo).to.equal('/research/collections/shared-collection-catalog/account');
     });
 
     it('should not make axios request', () => {

--- a/test/unit/Account.test.js
+++ b/test/unit/Account.test.js
@@ -103,18 +103,24 @@ describe('`fetchAccountPage`', () => {
   });
 
   describe('"settings" content', () => {
+    let getHomeLibrarySpy;
     before(() => {
       global.store = {
         getState: () => ({
           patron,
         }),
       };
+      getHomeLibrarySpy = sinon.spy(Account, 'getHomeLibrary');
     });
 
     it('should not make axios request', () => {
       Account.fetchAccountPage(renderMockReq('settings'), mockRes, mockResolve);
       expect(axiosGet.notCalled).to.equal(true);
     });
+    xit('should call getHomeLibrary', () => {
+      // not working :/
+      expect(getHomeLibrarySpy.called).to.equal(true);
+    })
   });
 
   describe('content to get from Webpac', () => {

--- a/test/unit/SearchResultsSorter.test.js
+++ b/test/unit/SearchResultsSorter.test.js
@@ -11,7 +11,6 @@ import sinon from 'sinon';
 import { basicQuery } from '../../src/app/utils/utils';
 import { SearchResultsSorter } from '@SearchResultsSorter';
 import appConfig from '../../src/app/data/appConfig';
-import { makeTestStore, shallowTestRender } from '../helpers/store';
 
 describe('SearchResultsSorter', () => {
   describe('Default - no javascript', () => {


### PR DESCRIPTION
**What's this do?**
Adds the Home Library name to `discovery-front-end` coming from `LocationsService`

**Why are we doing this? (w/ JIRA link if applicable)**
[SCC-2402](https://jira.nypl.org/browse/SCC-2402)

**Do these changes have automated tests?**
Had no luck mocking the functions used for this part (`getHomeLibrary` or `nyplApiClient`), but see that logging from inside the functions logs... Left some code showing something I tried. Feel free to suggest another way to test this.

**How should this be QAed?**
Check that "Home Library" on "Account Settings" is the name, not just the code.

**Dependencies for merging? Releasing to production?**
`LocationsService` changes are currently on QA. Will need to be released to prod before launching My Account.

**Has the application documentation been updated for these changes?**

**Did someone actually run this code to verify it works?**
I did