### PR TITLE
Scc 2543

### DIFF
--- a/src/app/data/constants.js
+++ b/src/app/data/constants.js
@@ -47,6 +47,7 @@ const noticePreferenceMapping = {
   '-': 'None',
 };
 
+const CLOSED_LOCATION_REGEX = /\(CLOSED\)|STAFF ONLY|SCHWARZMAN|Performing Arts|^[^a-z]+$/;
 
 export {
   breakpoints,
@@ -54,4 +55,5 @@ export {
   bibPageItemsListLimit,
   searchResultItemsListLimit,
   noticePreferenceMapping,
+  CLOSED_LOCATION_REGEX,
 };

--- a/src/app/utils/accountPageUtils.js
+++ b/src/app/utils/accountPageUtils.js
@@ -3,6 +3,10 @@ import axios from 'axios';
 
 import appConfig from '../data/appConfig';
 
+const CLOSED_LOCATION_REGEX = /\(CLOSED\)|STAFF ONLY|SCHWARZMAN|Performing Arts|^[^a-z]+$/;
+
+export const isClosed = optionInnerText => !!optionInnerText.match(CLOSED_LOCATION_REGEX);
+
 export const makeRequest = (
   updateAccountHtml,
   patronId,
@@ -102,8 +106,10 @@ export const manipulateAccountPage = (
         if (locationSelect) {
           const locationProp = locationSelect.name;
           let locationValue;
-          el.querySelectorAll('option').forEach((option) => {
+          locationSelect.querySelectorAll('option').forEach((option) => {
+            // hide closed locations
             if (option.selected) locationValue = `${option.value.trim()}+++`;
+            else if (isClosed(option.innerText)) option.remove();
           });
           locationData[locationProp] = locationValue;
           const locationChangeCb = (e) => {

--- a/src/app/utils/accountPageUtils.js
+++ b/src/app/utils/accountPageUtils.js
@@ -2,8 +2,7 @@
 import axios from 'axios';
 
 import appConfig from '../data/appConfig';
-
-const CLOSED_LOCATION_REGEX = /\(CLOSED\)|STAFF ONLY|SCHWARZMAN|Performing Arts|^[^a-z]+$/;
+import { CLOSED_LOCATION_REGEX } from '../data/constants';
 
 export const isClosed = optionInnerText => !!optionInnerText.match(CLOSED_LOCATION_REGEX);
 

--- a/test/unit/accountPageUtils.test.js
+++ b/test/unit/accountPageUtils.test.js
@@ -1,0 +1,19 @@
+/* eslint-env mocha */
+import { expect } from 'chai';
+
+import { isClosed } from './../../src/app/utils/accountPageUtils';
+
+describe('isClosed', () => {
+  it('should return true for string with "CLOSED"', () => {
+    expect(isClosed('Andrew Heiskell (CLOSED)')).to.equal(true);
+  });
+  it('should return true for string with "STAFF ONLY"', () => {
+    expect(isClosed('STAFF ONLY-SASB Rare Book Rm324')).to.equal(true);
+  });
+  it('should return true for string with "Performing Arts"', () => {
+    expect(isClosed('Performing Arts - Spec Col Desk')).to.equal(true);
+  });
+  it('should return false for string without above cases', () => {
+    expect(isClosed('53rd Street')).to.equal(false);
+  });
+});


### PR DESCRIPTION
**What's this do?**
Add code to hide locations based on regex coming from code used for Encore.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SCC-2543

**Do these changes have automated tests?**
Yes

**How should this be QAed?**
Check that closed locations, performing arts, and staff only are not displaying on new my account page.

**Dependencies for merging? Releasing to production?**
Necessary for launch.

**Has the application documentation been updated for these changes?**

**Did someone actually run this code to verify it works?**
I did