### PR TITLE
Remove global.store and replace with req.store

### DIFF
--- a/server.js
+++ b/server.js
@@ -67,7 +67,7 @@ app.use('/', (req, res, next) => {
 
 app.use('/*', (req, res, next) => {
   const initialStore = { ...initialState, lastLoaded: req._parsedUrl.path };
-  global.store = configureStore(initialStore);
+  req.store = configureStore(initialStore);
   next();
 });
 
@@ -79,7 +79,7 @@ app.use('/', apiRoutes);
 
 app.get('/*', (req, res) => {
   const appRoutes = (req.url).indexOf(appConfig.baseUrl) !== -1 ? routes.client : routes.server;
-  const store = global.store;
+  const store = req.store;
 
   match({ routes: appRoutes, location: req.url }, (error, redirectLocation, renderProps) => {
     if (error) {

--- a/src/server/ApiRoutes/ApiRoutes.js
+++ b/src/server/ApiRoutes/ApiRoutes.js
@@ -49,7 +49,7 @@ Object.keys(routes).forEach((routeName) => {
         resolve => routeMethods[routeName](req, res, resolve)
       )
         .then(data => (
-          api ? res.json(data) : successCb(routeName, global.store.dispatch)({ data })))
+          api ? res.json(data) : successCb(routeName, req.store.dispatch)({ data })))
         .then(() => (api ? null : next()))
         .catch(console.error)
       );

--- a/src/server/ApiRoutes/Hold.js
+++ b/src/server/ApiRoutes/Hold.js
@@ -192,7 +192,7 @@ function confirmRequestServer(req, res, next) {
 
   if (redirect) return false;
 
-  const { dispatch } = global.store;
+  const { dispatch } = req.store;
   if (!requestId) {
     dispatch(updateHoldRequestPage({
       bib: {},
@@ -350,7 +350,7 @@ function newHoldRequest(req, res, resolve) {
 }
 
 function newHoldRequestServerEdd(req, res, next) {
-  const { dispatch } = global.store;
+  const { dispatch } = req.store;
   const requireUser = User.requireUser(req, res);
   const { redirect } = requireUser;
   const error = req.query.error ? JSON.parse(req.query.error) : {};

--- a/src/server/routes/api/index.js
+++ b/src/server/routes/api/index.js
@@ -8,7 +8,7 @@ import { updatePatronData } from '../../../app/actions/Actions';
 
 
 export function getPatronData(req, res, next) {
-  const { dispatch } = global.store;
+  const { dispatch } = req.store;
   if (req.patronTokenResponse.isTokenValid
     && req.patronTokenResponse.decodedPatron
     && req.patronTokenResponse.decodedPatron.sub


### PR DESCRIPTION
**What's this do?**
Updates `development` to use `req.store` instead of `global.store`, in keeping with the recently merged hotfix