### PR TITLE
Adjustable item batch size

### DIFF
--- a/server.js
+++ b/server.js
@@ -67,7 +67,7 @@ app.use('/', (req, res, next) => {
 
 app.use('/*', (req, res, next) => {
   const initialStore = { ...initialState, lastLoaded: req._parsedUrl.path };
-  global.store = configureStore(initialStore);
+  req.store = configureStore(initialStore);
   next();
 });
 
@@ -79,7 +79,7 @@ app.use('/', apiRoutes);
 
 app.get('/*', (req, res) => {
   const appRoutes = (req.url).indexOf(appConfig.baseUrl) !== -1 ? routes.client : routes.server;
-  const store = global.store;
+  const store = req.store;
 
   match({ routes: appRoutes, location: req.url }, (error, redirectLocation, renderProps) => {
     if (error) {

--- a/src/app/data/appConfig.js
+++ b/src/app/data/appConfig.js
@@ -64,6 +64,7 @@ const appConfig = {
   },
   sourceEmail: process.env.SOURCE_EMAIL,
   libAnswersEmail: process.env.LIB_ANSWERS_EMAIL,
+  itemBatchSize: process.env.ITEM_BATCH_SIZE
 };
 
 export default appConfig;

--- a/src/app/data/constants.js
+++ b/src/app/data/constants.js
@@ -1,3 +1,5 @@
+import appConfig from "@appConfig";
+
 // breakpoints ordered by `maxValue` ascending
 const breakpoints = [
   {
@@ -40,7 +42,7 @@ const itemFilters = [
 
 const bibPageItemsListLimit = 20;
 const searchResultItemsListLimit = 3;
-const itemBatchSize = 1000;
+const itemBatchSize = appConfig.itemBatchSize;
 
 
 export {

--- a/src/server/ApiRoutes/ApiRoutes.js
+++ b/src/server/ApiRoutes/ApiRoutes.js
@@ -49,7 +49,7 @@ Object.keys(routes).forEach((routeName) => {
         resolve => routeMethods[routeName](req, res, resolve)
       )
         .then(data => (
-          api ? res.json(data) : successCb(routeName, global.store.dispatch)({ data })))
+          api ? res.json(data) : successCb(routeName, req.store.dispatch)({ data })))
         .then(() => (api ? null : next()))
         .catch(console.error)
       );

--- a/src/server/ApiRoutes/Hold.js
+++ b/src/server/ApiRoutes/Hold.js
@@ -192,7 +192,7 @@ function confirmRequestServer(req, res, next) {
 
   if (redirect) return false;
 
-  const { dispatch } = global.store;
+  const { dispatch } = req.store;
   if (!requestId) {
     dispatch(updateHoldRequestPage({
       bib: {},
@@ -350,7 +350,7 @@ function newHoldRequest(req, res, resolve) {
 }
 
 function newHoldRequestServerEdd(req, res, next) {
-  const { dispatch } = global.store;
+  const { dispatch } = req.store;
   const requireUser = User.requireUser(req, res);
   const { redirect } = requireUser;
   const error = req.query.error ? JSON.parse(req.query.error) : {};

--- a/src/server/routes/api/index.js
+++ b/src/server/routes/api/index.js
@@ -8,7 +8,7 @@ import { updatePatronData } from '../../../app/actions/Actions';
 
 
 export function getPatronData(req, res, next) {
-  const { dispatch } = global.store;
+  const { dispatch } = req.store;
   if (req.patronTokenResponse.isTokenValid
     && req.patronTokenResponse.decodedPatron
     && req.patronTokenResponse.decodedPatron.sub

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -54,6 +54,7 @@ const commonSettings = {
         CLOSED_LOCATIONS: JSON.stringify(process.env.CLOSED_LOCATIONS),
         RECAP_CLOSED_LOCATIONS: JSON.stringify(process.env.RECAP_CLOSED_LOCATIONS),
         NON_RECAP_CLOSED_LOCATIONS: JSON.stringify(process.env.NON_RECAP_CLOSED_LOCATIONS),
+        ITEM_BATCH_SIZE: JSON.stringify(process.env.ITEM_BATCH_SIZE),
       },
     }),
     // new BundleAnalyzerPlugin({
@@ -226,6 +227,7 @@ if (ENV === 'production') {
           CLOSED_LOCATIONS: process.env.CLOSED_LOCATIONS,
           RECAP_CLOSED_LOCATIONS: JSON.stringify(process.env.RECAP_CLOSED_LOCATIONS),
           NON_RECAP_CLOSED_LOCATIONS: JSON.stringify(process.env.NON_RECAP_CLOSED_LOCATIONS),
+          ITEM_BATCH_SIZE: JSON.stringify(process.env.ITEM_BATCH_SIZE),
         },
       }),
     ],


### PR DESCRIPTION
Edit: It looks like some of the changes related to getting rid of `global.store` got pulled into this PR.

**What's this do?**
Makes the `itemBatchSize` , which controls how many items we allow in each bib request, adjustable. Currently it is set to 1000, but that seems to be too big. This change will allow us to experiment with different values.

**Did someone actually run this code to verify it works?**
PR author tested locally.
