### PR TITLE
SCC-2533: Bug fix and styling fix for location urls

### DIFF
--- a/src/client/styles/main.scss
+++ b/src/client/styles/main.scss
@@ -163,6 +163,7 @@ select {
   margin-top: 20px;
 
   th, td {
+    overflow: inherit;
     padding-right: 15px;
     width: 16%;
 

--- a/src/server/ApiRoutes/Bib.js
+++ b/src/server/ApiRoutes/Bib.js
@@ -79,15 +79,12 @@ export const fetchLocationUrls = codes => nyplApiClient()
   .then(client => client.get(`/locations?location_codes=${codes}`));
 
 const addLocationUrls = (bib) => {
-  const holdingCodes = [];
-
-  if (bib.holdings) {
-    bib.holdings.forEach(({ location }) => {
-      if (location) {
-        location.forEach(locationEntry => holdingCodes.push(locationEntry.code));
-      }
-    });
-  }
+  const { holdings } = bib;
+  const holdingCodes = holdings ?
+    holdings
+      .map(holding => (holding.location || []).map(location => location.code))
+      .reduce((acc, el) => acc.concat(el), [])
+    : [];
 
   const itemCodes = bib.items ?
     bib.items.map(item =>
@@ -96,7 +93,6 @@ const addLocationUrls = (bib) => {
     : [];
 
   const codes = holdingCodes.concat(itemCodes).join(',');
-
   // get locations data by codes
   return fetchLocationUrls(codes)
     .then((resp) => {
@@ -207,4 +203,5 @@ export default {
   bibSearch,
   fetchBib,
   nyplApiClientCall,
+  addLocationUrls,
 };

--- a/src/server/ApiRoutes/Bib.js
+++ b/src/server/ApiRoutes/Bib.js
@@ -79,16 +79,19 @@ export const fetchLocationUrls = codes => nyplApiClient()
   .then(client => client.get(`/locations?location_codes=${codes}`));
 
 const addLocationUrls = (bib) => {
-  const holdingCodes = bib.holdings ?
-    bib
-      .holdings
-      .map(holding => holding.location.reduce((acc, el) => acc.concat([el.code]), []))
-      .reduce((acc, el) => acc.concat(el), [])
-    : [];
+  const holdingCodes = [];
+
+  if (bib.holdings) {
+    bib.holdings.forEach(({ location }) => {
+      if (location) {
+        location.forEach(locationEntry => holdingCodes.push(locationEntry.code));
+      }
+    });
+  }
 
   const itemCodes = bib.items ?
     bib.items.map(item =>
-      (item.holdingLocation || []).map(location => location['@id']),
+      (item.holdingLocation || []).map(location => location['@id'] || location.code),
     ).reduce((acc, el) => acc.concat(el), [])
     : [];
 
@@ -100,9 +103,11 @@ const addLocationUrls = (bib) => {
       // add location urls for holdings
       if (Array.isArray(bib.holdings)) {
         bib.holdings.forEach((holding) => {
-          holding.location.forEach((location) => {
-            location.url = findUrl(location, resp);
-          });
+          if (holding.location) {
+            holding.location.forEach((location) => {
+              location.url = findUrl(location, resp);
+            });
+          };
         });
       }
       // add item location urls;

--- a/test/fixtures/locations-service-mm.json
+++ b/test/fixtures/locations-service-mm.json
@@ -1,0 +1,1 @@
+{"mm":[{"code":"mm*","url":"http://www.nypl.org/locations/mid-manhattan-library","label":"Mid-Manhattan"}]}

--- a/test/unit/Bib.test.js
+++ b/test/unit/Bib.test.js
@@ -4,6 +4,7 @@ import { expect } from 'chai';
 import Bib from './../../src/server/ApiRoutes/Bib';
 
 describe('addCheckInItems', () => {
+  /* holding could lack location, as shown in second holding */
   const mockBib = {
     holdings: [
       {
@@ -28,10 +29,6 @@ describe('addCheckInItems', () => {
         ],
       },
       {
-        location: [{
-          label: 'mock',
-          code: 'mock:mock',
-        }],
         format: 'AV',
         checkInBoxes: [
           {
@@ -48,28 +45,12 @@ describe('addCheckInItems', () => {
           },
         ],
       },
-      {
-        format: 'Text',
-        checkInBoxes: [
-          {
-            position: 1,
-            status: 'available',
-            coverage: '1000',
-            shelfMark: 'abcd',
-          },
-          {
-            position: 3,
-            status: 'available',
-            coverage: '1001',
-            shelfMark: 'efgh',
-          },
-        ],
-      }
     ],
   };
 
   it('should add correctly structured checkInItems', () => {
     Bib.addCheckInItems(mockBib);
+    console.log(mockBib.checkInItems);
     expect(mockBib.checkInItems).to.deep.equal([
       {
         accessMessage: {
@@ -99,9 +80,9 @@ describe('addCheckInItems', () => {
         callNumber: 'ijkl',
         format: 'AV',
         isSerial: true,
-        location: 'mock',
+        location: '',
         locationUrl: undefined,
-        holdingLocationCode: 'mock:mock',
+        holdingLocationCode: '',
         position: 2,
         requestable: false,
         status: {

--- a/test/unit/Bib.test.js
+++ b/test/unit/Bib.test.js
@@ -48,6 +48,23 @@ describe('addCheckInItems', () => {
           },
         ],
       },
+      {
+        format: 'Text',
+        checkInBoxes: [
+          {
+            position: 1,
+            status: 'available',
+            coverage: '1000',
+            shelfMark: 'abcd',
+          },
+          {
+            position: 3,
+            status: 'available',
+            coverage: '1001',
+            shelfMark: 'efgh',
+          },
+        ],
+      }
     ],
   };
 

--- a/test/unit/Bib.test.js
+++ b/test/unit/Bib.test.js
@@ -1,16 +1,20 @@
 /* eslint-env mocha */
 import { expect } from 'chai';
-// Import the component that is going to be tested
-import Bib from './../../src/server/ApiRoutes/Bib';
+import { stub } from 'sinon';
+import fs from 'fs';
 
-describe('addCheckInItems', () => {
+import NyplApiClient from '@nypl/nypl-data-api-client';
+
+import Bib, { addCheckInItems } from './../../src/server/ApiRoutes/Bib';
+
+describe('Bib', () => {
   /* holding could lack location, as shown in second holding */
   const mockBib = {
     holdings: [
       {
         location: [{
-          label: 'fake',
-          code: 'fake:fake',
+          label: 'Mid-Manhattan',
+          code: 'mm',
         }],
         format: 'Text',
         checkInBoxes: [
@@ -48,67 +52,121 @@ describe('addCheckInItems', () => {
     ],
   };
 
-  it('should add correctly structured checkInItems', () => {
-    Bib.addCheckInItems(mockBib);
-    console.log(mockBib.checkInItems);
-    expect(mockBib.checkInItems).to.deep.equal([
-      {
-        accessMessage: {
-          '@id': 'accessMessage: 1',
-          prefLabel: 'Use in library',
+  describe('addCheckInItems', () => {
+    it('should add correctly structured checkInItems', () => {
+      addCheckInItems(mockBib);
+      expect(mockBib.checkInItems).to.deep.equal([
+        {
+          accessMessage: {
+            '@id': 'accessMessage: 1',
+            prefLabel: 'Use in library',
+          },
+          available: true,
+          callNumber: 'efgh',
+          format: 'Text',
+          holdingLocationCode: 'mm',
+          isSerial: true,
+          location: 'Mid-Manhattan',
+          locationUrl: undefined,
+          position: 3,
+          requestable: false,
+          status: {
+            prefLabel: 'available',
+          },
+          volume: '1001',
         },
-        available: true,
-        callNumber: 'efgh',
-        format: 'Text',
-        holdingLocationCode: 'fake:fake',
-        isSerial: true,
-        location: 'fake',
-        locationUrl: undefined,
-        position: 3,
-        requestable: false,
-        status: {
-          prefLabel: 'available',
+        {
+          accessMessage: {
+            '@id': 'accessMessage: 1',
+            prefLabel: 'Use in library',
+          },
+          available: true,
+          callNumber: 'ijkl',
+          format: 'AV',
+          isSerial: true,
+          location: '',
+          locationUrl: undefined,
+          holdingLocationCode: '',
+          position: 2,
+          requestable: false,
+          status: {
+            prefLabel: 'available',
+          },
+          volume: '1002',
         },
-        volume: '1001',
-      },
-      {
-        accessMessage: {
-          '@id': 'accessMessage: 1',
-          prefLabel: 'Use in library',
+        {
+          accessMessage: {
+            '@id': 'accessMessage: 1',
+            prefLabel: 'Use in library',
+          },
+          available: true,
+          callNumber: 'abcd',
+          format: 'Text',
+          holdingLocationCode: 'mm',
+          isSerial: true,
+          location: 'Mid-Manhattan',
+          locationUrl: undefined,
+          position: 1,
+          requestable: false,
+          status: {
+            prefLabel: 'available',
+          },
+          volume: '1000',
         },
-        available: true,
-        callNumber: 'ijkl',
-        format: 'AV',
-        isSerial: true,
-        location: '',
-        locationUrl: undefined,
-        holdingLocationCode: '',
-        position: 2,
-        requestable: false,
-        status: {
-          prefLabel: 'available',
-        },
-        volume: '1002',
-      },
-      {
-        accessMessage: {
-          '@id': 'accessMessage: 1',
-          prefLabel: 'Use in library',
-        },
-        available: true,
-        callNumber: 'abcd',
-        format: 'Text',
-        holdingLocationCode: 'fake:fake',
-        isSerial: true,
-        location: 'fake',
-        locationUrl: undefined,
-        position: 1,
-        requestable: false,
-        status: {
-          prefLabel: 'available',
-        },
-        volume: '1000',
-      },
-    ]);
+      ]);
+    });
+  });
+  describe('addLocationUrls', () => {
+    before(() => {
+      stub(NyplApiClient.prototype, 'get').callsFake(() => Promise.resolve(
+        JSON.parse(
+          fs.readFileSync(
+            './test/fixtures/locations-service-mm.json', 'utf8'))));
+    });
+    it('should add location URLs', () => {
+      Bib.addLocationUrls(mockBib).then((resp) => {
+        expect(resp.holdings).to.deep.equal([
+          {
+            location: [{
+              label: 'Mid-Manhattan',
+              code: 'mm',
+              url: 'http://www.nypl.org/locations/mid-manhattan-library',
+            }],
+            format: 'Text',
+            checkInBoxes: [
+              {
+                position: 1,
+                status: 'available',
+                coverage: '1000',
+                shelfMark: 'abcd',
+              },
+              {
+                position: 3,
+                status: 'available',
+                coverage: '1001',
+                shelfMark: 'efgh',
+              },
+            ],
+          },
+          {
+            format: 'AV',
+            checkInBoxes: [
+              {
+                position: 2,
+                status: 'available',
+                coverage: '1002',
+                shelfMark: 'ijkl',
+              },
+              {
+                position: 4,
+                status: 'Expected',
+                coverage: '1003',
+                shelfMark: 'mnop',
+              },
+            ],
+          },
+        ]);
+      });
+    });
   });
 });

--- a/test/unit/Redirect404.test.js
+++ b/test/unit/Redirect404.test.js
@@ -13,7 +13,7 @@ const {
 } = appConfig;
 
 
-describe.only('Redirect404', () => {
+describe('Redirect404', () => {
   const component = mount(
     <Redirect404 />,
     {


### PR DESCRIPTION
**What's this do?**
Prevents display of empty bib page when a holding lacks a `location` property.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SCC-2533

**Do these changes have automated tests?**
I updated the existing `holdings` mock to reflect that a holding could be lacking `location`

**How should this be QAed?**
Check that http://qa-discovery.nypl.org/research/collections/shared-collection-catalog/bib/b10122523 displays the bib data

**Dependencies for merging? Releasing to production?**
[Description of any watchouts, dependencies, or issues we should be aware of]

**Has the application documentation been updated for these changes?**

**Did someone actually run this code to verify it works?**
I did