### PR TITLE
Scc 2510

### DIFF
--- a/src/app/components/AccountPage/AccountPage.jsx
+++ b/src/app/components/AccountPage/AccountPage.jsx
@@ -45,6 +45,7 @@ const AccountPage = (props) => {
     if (typeof window !== 'undefined' && (!patron.id || accountHtml.error)) {
       logOutFromEncoreAndCatalogIn();
       const fullUrl = encodeURIComponent(window.location.href);
+      // timeout 0 is here to make sure that we don't redirect until after the logout iframe is loaded
       setTimeout(() => {
         window.location.replace(`${appConfig.loginUrl}?redirect_uri=${fullUrl}`);
       }, 0);

--- a/src/app/components/AccountPage/AccountPage.jsx
+++ b/src/app/components/AccountPage/AccountPage.jsx
@@ -41,16 +41,18 @@ const AccountPage = (props) => {
   const [itemToCancel, setItemToCancel] = useState(null);
 
   console.log('accountHtml: ', accountHtml, 'patronid: ', patron.id);
-  if (typeof window !== 'undefined' && accountHtml.error) {
-    logOutFromEncoreAndCatalogIn();
-    console.log('body: ', document.getElementsByTagName('body')[0].children)
-    window.location.replace(`${appConfig.loginUrl}`)
-  }
   useEffect(() => {
+    // if (typeof window !== 'undefined' && accountHtml.error) {
+    //   console.log('body: ', document.getElementsByTagName('body')[0].children)
+    //   window.location.replace(`${appConfig.loginUrl}`)
+    // }
 
-    if (typeof window !== 'undefined' && (!patron.id)) {
+    if (typeof window !== 'undefined' && (!patron.id || accountHtml.error)) {
+      logOutFromEncoreAndCatalogIn();
       const fullUrl = encodeURIComponent(window.location.href);
-      window.location.replace(`${appConfig.loginUrl}?redirect_uri=${fullUrl}`);
+      setTimeout(() => {
+        window.location.replace(`${appConfig.loginUrl}?redirect_uri=${fullUrl}`);
+      }, 0);
     }
   }, [patron]);
 

--- a/src/app/components/AccountPage/AccountPage.jsx
+++ b/src/app/components/AccountPage/AccountPage.jsx
@@ -40,12 +40,7 @@ const AccountPage = (props) => {
   const [isLoading, setIsLoading] = useState(true);
   const [itemToCancel, setItemToCancel] = useState(null);
 
-  console.log('accountHtml: ', accountHtml, 'patronid: ', patron.id);
   useEffect(() => {
-    // if (typeof window !== 'undefined' && accountHtml.error) {
-    //   console.log('body: ', document.getElementsByTagName('body')[0].children)
-    //   window.location.replace(`${appConfig.loginUrl}`)
-    // }
 
     if (typeof window !== 'undefined' && (!patron.id || accountHtml.error)) {
       logOutFromEncoreAndCatalogIn();

--- a/src/app/components/AccountPage/AccountPage.jsx
+++ b/src/app/components/AccountPage/AccountPage.jsx
@@ -16,6 +16,8 @@ import moment from 'moment'
 
 import LinkTabSet from './LinkTabSet';
 import AccountSettings from './AccountSettings';
+import LoadingLayer from '../LoadingLayer/LoadingLayer';
+import { logOutFromEncoreAndCatalogIn } from '../../utils/logoutUtils';
 
 import { manipulateAccountPage, makeRequest, buildReqBody } from '../../utils/accountPageUtils';
 
@@ -38,8 +40,15 @@ const AccountPage = (props) => {
   const [isLoading, setIsLoading] = useState(true);
   const [itemToCancel, setItemToCancel] = useState(null);
 
+  console.log('accountHtml: ', accountHtml, 'patronid: ', patron.id);
+  if (typeof window !== 'undefined' && accountHtml.error) {
+    logOutFromEncoreAndCatalogIn();
+    console.log('body: ', document.getElementsByTagName('body')[0].children)
+    window.location.replace(`${appConfig.loginUrl}`)
+  }
   useEffect(() => {
-    if (!patron.id) {
+
+    if (typeof window !== 'undefined' && (!patron.id)) {
       const fullUrl = encodeURIComponent(window.location.href);
       window.location.replace(`${appConfig.loginUrl}?redirect_uri=${fullUrl}`);
     }
@@ -93,6 +102,12 @@ const AccountPage = (props) => {
   };
 
   const formattedExpirationDate = patron.expirationDate ?  moment(patron.expirationDate).format("MM-DD-YYYY") : '';
+
+  if (accountHtml.error) {
+    return (
+      <LoadingLayer loading={true} />
+    );
+  }
 
   return (
     <div className="nypl-ds nypl--research layout-container">

--- a/src/app/utils/logoutUtils.js
+++ b/src/app/utils/logoutUtils.js
@@ -1,0 +1,43 @@
+/**
+   * deleteCookie(sKey)
+   * Delete the cookie by having it expired.
+   *
+   * @param {string} sKey - The name of the cookie to be looked up.
+   */
+const deleteCookie = (sKey) => {
+  document.cookie = `${sKey}=; expires=Thu, 01 Jan 1970 00:00:00 UTC; ` +
+      'path=/; domain=.nypl.org;';
+};
+
+/**
+  * loadLogoutIframe(isTest)
+  * The function that loads a temporary iframe with the log out endpoint
+  * to completely log out the user from Encore and Catalog. It then deletes the iframe right away.
+  * The reason to use this way to load the endpoint is to bypass the CORS loading from the client
+  * since III does not want to provide us a real log out API URI.
+  */
+const loadLogoutIframe = () => {
+  const logoutIframe = document.createElement('iframe');
+  const [body] = document.getElementsByTagName('body');
+
+  logoutIframe.setAttribute(
+    // The endpoint is the URL for logging out from Encore
+    'src', 'https://browse.nypl.org/iii/encore/logoutFilterRedirect?suite=def',
+    // 'src', 'https://nypl-encore-test.nypl.org//iii/encore/logoutFilterRedirect?suite=def',
+  );
+  // Assigns the ID for CSS ussage
+  logoutIframe.setAttribute('id', 'logoutIframe');
+  body.appendChild(logoutIframe);
+};
+
+/**
+  * logOutFromEncoreAndCatalogIn(time, isTest)
+  * The timer to delete log in related cookies and call the method to completely log out from Encore
+  * and Catalog. It is called by setEncoreLoggedInTimer.
+  */
+export const logOutFromEncoreAndCatalogIn = () => {
+  // deleteCookie('PAT_LOGGED_IN');
+  // deleteCookie('VALID_DOMAIN_LAST_VISITED');
+  // deleteCookie('nyplIdentityPatron');
+  loadLogoutIframe();
+};

--- a/src/app/utils/logoutUtils.js
+++ b/src/app/utils/logoutUtils.js
@@ -36,8 +36,8 @@ const loadLogoutIframe = () => {
   * and Catalog. It is called by setEncoreLoggedInTimer.
   */
 export const logOutFromEncoreAndCatalogIn = () => {
-  // deleteCookie('PAT_LOGGED_IN');
-  // deleteCookie('VALID_DOMAIN_LAST_VISITED');
-  // deleteCookie('nyplIdentityPatron');
+  deleteCookie('PAT_LOGGED_IN');
+  deleteCookie('VALID_DOMAIN_LAST_VISITED');
+  deleteCookie('nyplIdentityPatron');
   loadLogoutIframe();
 };

--- a/src/server/ApiRoutes/Account.js
+++ b/src/server/ApiRoutes/Account.js
@@ -5,6 +5,7 @@ import User from './User';
 import appConfig from '../../app/data/appConfig';
 
 function fetchAccountPage(req, res, resolve) {
+  console.log('fetching account page');
   const requireUser = User.requireUser(req, res);
   const { redirect } = requireUser;
   if (redirect) {
@@ -23,6 +24,8 @@ function fetchAccountPage(req, res, resolve) {
     return;
   }
 
+  console.log('getting axios');
+
   axios.get(`${appConfig.legacyCatalog}/dp/patroninfo*eng~Sdefault/${patronId}/${content}`, {
     headers: {
       Cookie: req.headers.cookie,
@@ -31,19 +34,23 @@ function fetchAccountPage(req, res, resolve) {
     .then((resp) => {
       // If Header thinks patron is logged in,
       // but patron is not actually logged in, the case below is hit
+      // console.log('resp: ', JSON.stringify(resp, null, 2));
       if (resp.request.path.includes('/login?')) {
+        console.log("login resp: ");
         // need to implement
         console.log('need to redirect, might be buggy?');
         // redirect to login
-        const fullUrl = encodeURIComponent(`${req.protocol}://${req.get('host')}${req.originalUrl}`);
-        if (!fullUrl.includes('%2Fapi%2F')) {
-          res.redirect(`${appConfig.loginUrl}?redirect_uri=${fullUrl}`);
-        }
+        // const fullUrl = encodeURIComponent(`${req.protocol}://${req.get('host')}${req.originalUrl}`);
+        // if (!fullUrl.includes('%2Fapi%2F')) {
+        //   res.redirect(`${appConfig.loginUrl}?redirect_uri=${fullUrl}`);
+        // }
+        throw new Error('thrown');
       }
       resolve(resp.data);
     })
     .catch((resp) => {
-      res.json({ error: resp });
+      console.log('resp error: ');
+      resolve({ error: resp });
     });
 }
 

--- a/src/server/ApiRoutes/Account.js
+++ b/src/server/ApiRoutes/Account.js
@@ -36,7 +36,6 @@ function getAccountPage(res, req) {
 }
 
 function fetchAccountPage(req, res, resolve) {
-  console.log('fetching account page');
   const requireUser = User.requireUser(req, res);
   const { redirect } = requireUser;
   if (redirect) {
@@ -78,7 +77,7 @@ function fetchAccountPage(req, res, resolve) {
       if (resp.request && resp.request.path.includes('/login?')) {
         // need to implement
         console.log('need to redirect, might be buggy?');
-        throw new Error('thrown');
+        throw new Error('detected state mismatch, throwing error');
       }
 
       resolve({ accountHtml: resp.data });

--- a/src/server/ApiRoutes/Account.js
+++ b/src/server/ApiRoutes/Account.js
@@ -78,11 +78,6 @@ function fetchAccountPage(req, res, resolve) {
       if (resp.request && resp.request.path.includes('/login?')) {
         // need to implement
         console.log('need to redirect, might be buggy?');
-        // redirect to login
-        // const fullUrl = encodeURIComponent(`${req.protocol}://${req.get('host')}${req.originalUrl}`);
-        // if (!fullUrl.includes('%2Fapi%2F')) {
-        //   res.redirect(`${appConfig.loginUrl}?redirect_uri=${fullUrl}`);
-        // }
         throw new Error('thrown');
       }
 

--- a/src/server/ApiRoutes/Account.js
+++ b/src/server/ApiRoutes/Account.js
@@ -90,7 +90,7 @@ function fetchAccountPage(req, res, resolve) {
     })
     .catch((resp) => {
       console.error('resp error: ', resp);
-      resolve({ error: resp });
+      resolve({ accountHtml: { error: resp } });
     });
 }
 


### PR DESCRIPTION
**What's this do?**
[Description of what this PR does]

Changes the way we handle state mismatches in the account page

- If the account request results in an error or a prompt to login, we send an error to the front end
- If the front end receives an error, it deletes cookies and loads the logout iframe. This should synchronize the patron's state as logged out
- the front end handles the redirect to login, which should be safe now that the patron state is synchronized.

WARNING: I have seen at least once that the browser displays an error message from the auth server. I am not sure how to reproduce this error, but it seems rare, so I think this is an improvement. Let me know if you see it.

**How should this be QAed?**
Log in, delete cookies, and navigate to the accounts page. You should see a login prompt. Upon logging in, you should be returned to the account page.

We should watch out for any possible error from auth.

**Dependencies for merging? Releasing to production?**


**Has the application documentation been updated for these changes?**

**Did someone actually run this code to verify it works?**
PR author tested locally.
