### PR TITLE
Fix copy for landing page h2

### DIFF
--- a/src/app/pages/Home.jsx
+++ b/src/app/pages/Home.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { useSelector } from 'react-redux';
 
 import {
   Heading,
@@ -14,122 +15,125 @@ import {
   trackDiscovery,
 } from '../utils/utils';
 
-const Home = (props, context) => (
-  <SccContainer
-    className="home"
-    activeSection="search"
-  >
-    <div className="content-header research-search">
-      <div className="research-search__inner-content">
-        <Search
-          createAPIQuery={basicQuery(props)}
-          router={context.router}
-        />
-      </div>
-    </div>
+const Home = (props, context) => {
+  const displayTitle = useSelector(state => state.appConfig.displayTitle);
 
-    <Notification notificationType="searchResultsNotification" />
-
-    <Heading
-      level={2}
+  return (
+    <SccContainer
+      className="home"
+      activeSection="search"
     >
-      Research at NYPL
-    </Heading>
+      <div className="content-header research-search">
+        <div className="research-search__inner-content">
+          <Search
+            createAPIQuery={basicQuery(props)}
+            router={context.router}
+          />
+        </div>
+      </div>
 
-    <div className="nypl-column-full">
-      <p className="nypl-lead">
-        The New York Public Library’s Shared Collection Catalog provides researchers with access to materials from NYPL, Columbia University, and Princeton University.
-        <br />
-        Coming Soon: After undergoing significant enhancements, the Shared Collection Catalog will become the Research Catalog and serve as the primary catalog for NYPL’s research collections in early 2021. <a href="https://www.nypl.org/research/collections/about/shared-collection-catalog">Learn more.</a>
-      </p>
-    </div>
-    <div>
+      <Notification notificationType="searchResultsNotification" />
+
       <Heading
-        level={3}
-      >
-        Research at NYPL
-      </Heading>
+        level={2}
+        text={`Welcome to ${displayTitle}`}
+      />
 
-      <div className="nypl-row nypl-quarter-image">
-        <div className="nypl-column-one-quarter image-column-one-quarter">
-          <img className="nypl-quarter-image" src="https://d2720ur5668dri.cloudfront.net/sites/default/media/styles/extralarge/public/archives-portal.jpg?itok=-oYtHmeO" alt="" role="presentation" />
+      <div className="nypl-column-full">
+        <p className="nypl-lead">
+          The New York Public Library’s Shared Collection Catalog provides researchers with access to materials from NYPL, Columbia University, and Princeton University.
+          <br />
+          Coming Soon: After undergoing significant enhancements, the Shared Collection Catalog will become the Research Catalog and serve as the primary catalog for NYPL’s research collections in early 2021. <a href="https://www.nypl.org/research/collections/about/shared-collection-catalog">Learn more.</a>
+        </p>
+      </div>
+      <div>
+        <Heading
+          level={3}
+        >
+          Research at NYPL
+        </Heading>
+
+        <div className="nypl-row nypl-quarter-image">
+          <div className="nypl-column-one-quarter image-column-one-quarter">
+            <img className="nypl-quarter-image" src="https://d2720ur5668dri.cloudfront.net/sites/default/media/styles/extralarge/public/archives-portal.jpg?itok=-oYtHmeO" alt="" role="presentation" />
+          </div>
+          <div className="nypl-column-three-quarters image-column-three-quarters">
+            <Heading
+              level={4}
+            >
+              <a href="/research/collections" onClick={() => trackDiscovery('Research Links', 'Collections')}>Collections</a>
+            </Heading>
+            <p>Discover our world-renowned research collections, featuring more than 46
+              million items.
+            </p>
+          </div>
         </div>
-        <div className="nypl-column-three-quarters image-column-three-quarters">
-          <Heading
-            level={4}
-          >
-            <a href="/research/collections" onClick={() => trackDiscovery('Research Links', 'Collections')}>Collections</a>
-          </Heading>
-          <p>Discover our world-renowned research collections, featuring more than 46
-            million items.
-          </p>
+
+        <div className="nypl-row nypl-quarter-image">
+          <div className="nypl-column-one-quarter image-column-one-quarter">
+            <img className="nypl-quarter-image" src="https://d2720ur5668dri.cloudfront.net/sites/default/media/styles/extralarge/public/sasb.jpg?itok=sdQBITR7" alt="" role="presentation" />
+          </div>
+          <div className="nypl-column-three-quarters image-column-three-quarters">
+            <Heading
+              level={4}
+            >
+              <a href="/locations/map?libraries=research" onClick={() => trackDiscovery('Research Links', 'Locations')}>Locations</a>
+            </Heading>
+            <p>Access items, one-on-one reference help, and dedicated research study rooms.</p>
+          </div>
+        </div>
+
+        <div className="nypl-row nypl-quarter-image">
+          <div className="nypl-column-one-quarter image-column-one-quarter">
+            <img className="nypl-quarter-image" src="https://d2720ur5668dri.cloudfront.net/sites/default/media/styles/extralarge/public/divisions.jpg?itok=O4uSedcp" alt="" role="presentation" />
+          </div>
+          <div className="nypl-column-three-quarters image-column-three-quarters">
+            <Heading
+              level={4}
+            >
+              <a href="/research-divisions/" onClick={() => trackDiscovery('Research Links', 'Divisions')}>Divisions</a>
+            </Heading>
+            <p>Learn about the subject and media specializations of our research divisions.</p>
+          </div>
+        </div>
+
+        <div className="nypl-row nypl-quarter-image">
+          <div className="nypl-column-one-quarter image-column-one-quarter">
+            <img className="nypl-quarter-image" src="https://d2720ur5668dri.cloudfront.net/sites/default/media/styles/extralarge/public/plan-you-visit.jpg?itok=scG6cFgy" alt="" role="presentation" />
+          </div>
+          <div className="nypl-column-three-quarters image-column-three-quarters">
+            <Heading
+              level={4}
+            >
+              <a href="/research/support" onClick={() => trackDiscovery('Research Links', 'Support')}>Support</a>
+            </Heading>
+            <p>
+              Plan your in-person research visit and discover resources for scholars and
+              writers.
+            </p>
+          </div>
+        </div>
+
+        <div className="nypl-row nypl-quarter-image">
+          <div className="nypl-column-one-quarter image-column-one-quarter">
+            <img className="nypl-quarter-image" src="https://d2720ur5668dri.cloudfront.net/sites/default/media/styles/extralarge/public/research-services.jpg?itok=rSo9t1VF" alt="" role="presentation" />
+          </div>
+          <div className="nypl-column-three-quarters image-column-three-quarters">
+            <Heading
+              level={4}
+            >
+              <a href="/research/services" onClick={() => trackDiscovery('Research Links', 'Services')}>Services</a>
+            </Heading>
+            <p>
+              Explore services for online and remote researchers,
+              as well as our interlibrary services.
+            </p>
+          </div>
         </div>
       </div>
-
-      <div className="nypl-row nypl-quarter-image">
-        <div className="nypl-column-one-quarter image-column-one-quarter">
-          <img className="nypl-quarter-image" src="https://d2720ur5668dri.cloudfront.net/sites/default/media/styles/extralarge/public/sasb.jpg?itok=sdQBITR7" alt="" role="presentation" />
-        </div>
-        <div className="nypl-column-three-quarters image-column-three-quarters">
-          <Heading
-            level={4}
-          >
-            <a href="/locations/map?libraries=research" onClick={() => trackDiscovery('Research Links', 'Locations')}>Locations</a>
-          </Heading>
-          <p>Access items, one-on-one reference help, and dedicated research study rooms.</p>
-        </div>
-      </div>
-
-      <div className="nypl-row nypl-quarter-image">
-        <div className="nypl-column-one-quarter image-column-one-quarter">
-          <img className="nypl-quarter-image" src="https://d2720ur5668dri.cloudfront.net/sites/default/media/styles/extralarge/public/divisions.jpg?itok=O4uSedcp" alt="" role="presentation" />
-        </div>
-        <div className="nypl-column-three-quarters image-column-three-quarters">
-          <Heading
-            level={4}
-          >
-            <a href="/research-divisions/" onClick={() => trackDiscovery('Research Links', 'Divisions')}>Divisions</a>
-          </Heading>
-          <p>Learn about the subject and media specializations of our research divisions.</p>
-        </div>
-      </div>
-
-      <div className="nypl-row nypl-quarter-image">
-        <div className="nypl-column-one-quarter image-column-one-quarter">
-          <img className="nypl-quarter-image" src="https://d2720ur5668dri.cloudfront.net/sites/default/media/styles/extralarge/public/plan-you-visit.jpg?itok=scG6cFgy" alt="" role="presentation" />
-        </div>
-        <div className="nypl-column-three-quarters image-column-three-quarters">
-          <Heading
-            level={4}
-          >
-            <a href="/research/support" onClick={() => trackDiscovery('Research Links', 'Support')}>Support</a>
-          </Heading>
-          <p>
-            Plan your in-person research visit and discover resources for scholars and
-            writers.
-          </p>
-        </div>
-      </div>
-
-      <div className="nypl-row nypl-quarter-image">
-        <div className="nypl-column-one-quarter image-column-one-quarter">
-          <img className="nypl-quarter-image" src="https://d2720ur5668dri.cloudfront.net/sites/default/media/styles/extralarge/public/research-services.jpg?itok=rSo9t1VF" alt="" role="presentation" />
-        </div>
-        <div className="nypl-column-three-quarters image-column-three-quarters">
-          <Heading
-            level={4}
-          >
-            <a href="/research/services" onClick={() => trackDiscovery('Research Links', 'Services')}>Services</a>
-          </Heading>
-          <p>
-            Explore services for online and remote researchers,
-            as well as our interlibrary services.
-          </p>
-        </div>
-      </div>
-    </div>
-  </SccContainer>
-);
+    </SccContainer>
+  );
+};
 
 Home.contextTypes = {
   router: PropTypes.object,

--- a/test/unit/Home.test.js
+++ b/test/unit/Home.test.js
@@ -2,7 +2,9 @@
 /* eslint-env mocha */
 import React from 'react';
 import { expect } from 'chai';
-import { shallow } from 'enzyme';
+import { mount } from 'enzyme';
+import { Provider } from 'react-redux';
+import { makeTestStore } from '../helpers/store';
 
 import Home from '../../src/app/pages/Home';
 
@@ -10,16 +12,25 @@ describe('Home', () => {
   let component;
 
   before(() => {
-    component = shallow(<Home />);
+    const testStore = makeTestStore({
+      appConfig: {
+        displayTitle: 'Shared Collection Catalog',
+      },
+    });
+    component = mount(
+      <Provider store={testStore}>
+        <Home />
+      </Provider>
+    );
   });
 
   it('should be wrapped in a .home class', () => {
-    expect(component.find('.home').length).to.equal(1);
+    expect(component.find('.home').hostNodes().length).to.equal(1);
   });
 
   it('should contain an h2', () => {
-    const h2 = component.find('Heading').at(0).dive();
-    expect(h2.text()).to.equal('Research at NYPL');
+    const h2 = component.find('Heading').at(1);
+    expect(h2.text()).to.equal('Welcome to Shared Collection Catalog');
   });
 
   it('should contain five images', () => {


### PR DESCRIPTION
**What's this do?**
Uses the environment variable for the h2 and fixes copy mistake I made. Should be "Welcome to [catalog name]"

**Did someone actually run this code to verify it works?**
I did