### PR TITLE
Add casting item batch size as int

### DIFF
--- a/src/app/pages/BibPage.jsx
+++ b/src/app/pages/BibPage.jsx
@@ -57,7 +57,7 @@ const checkForMoreItems = (bib, dispatch) => {
               bib,
               { items: bib.items.concat((bibResp && bibResp.items) || []),
                 done,
-                itemFrom: itemFrom + itemBatchSize,
+                itemFrom: parseInt(itemFrom, 10) + parseInt(itemBatchSize, 10),
               },
             ),
         }));


### PR DESCRIPTION
**What's this do?**
At some point, the `itemFrom` param became a string, but it needs to be an integer. This PR modifies api call to make sure we are treating `itemFrom` and `itemBatchSize` as ints.
