### PR TITLE
SCC-2460: post-merge bug fix - Clear suggestions when search term is cleared

### DIFF
--- a/src/app/components/SubjectHeading/Search/SubjectHeadingSearch.jsx
+++ b/src/app/components/SubjectHeading/Search/SubjectHeadingSearch.jsx
@@ -92,7 +92,7 @@ class SubjectHeadingSearch extends React.Component {
       <Autosuggest
         suggestions={suggestions}
         onSuggestionsFetchRequested={() => makeApiCallWithThrottle()}
-        onSuggestionsClearRequested={() => {}}
+        onSuggestionsClearRequested={() => this.setState({ suggestions: [] })}
         onSuggestionSelected={(e, secondArg) => onSubmit(e, secondArg)}
         getSuggestionValue={suggestion => suggestion.label}
         inputProps={{


### PR DESCRIPTION
One line change to clear suggestions when search term is cleared. The problem - if a search term is cleared (e.g. 'h') and a new one entered ('z') you will see the results for 'h' for a second before seeing the ones for 'z'.