### PR TITLE
Quick fix for account settings issue

### DIFF
--- a/src/server/ApiRoutes/Account.js
+++ b/src/server/ApiRoutes/Account.js
@@ -55,11 +55,12 @@ function fetchAccountPage(req, res, resolve) {
               ...patron,
               homeLibraryName: resp.label,
             },
+            accountHtml: {}
           });
         });
       return;
     }
-    resolve({ patron, accountHtml: '' });
+    resolve({ patron, accountHtml: {} });
 
     return;
   }


### PR DESCRIPTION
The return object for the Account Settings tab did not provide an `accountHtml` value. I think this highlights an issue in this approach though that until the most recent changes `accountHtml` was always a string. Now it could be a string or an object. Maybe `error` should be its own slice of state/store. I'm leaning more toward adding more properties to the store, rather than manipulating existing properties to contain necessary data - i.e. status code and errors