### PR TITLE
Fix settings validation

### DIFF
--- a/src/app/pages/AccountPage.jsx
+++ b/src/app/pages/AccountPage.jsx
@@ -39,7 +39,7 @@ const AccountPage = (props) => {
 
   useEffect(() => {
 
-    if (typeof window !== 'undefined' && (!patron.id || (content !== 'settings' && accountHtml.error))) {
+    if (typeof window !== 'undefined' && (!patron.id || (accountHtml && accountHtml.error))) {
       logOutFromEncoreAndCatalogIn();
       const fullUrl = encodeURIComponent(window.location.href);
       // timeout 0 is here to make sure that we don't redirect until after the logout iframe is loaded
@@ -98,7 +98,7 @@ const AccountPage = (props) => {
 
   const formattedExpirationDate = patron.expirationDate ?  moment(patron.expirationDate).format("MM-DD-YYYY") : '';
 
-  if (content !== 'settings' && accountHtml.error) {
+  if (content !== 'settings' && (!accountHtml || accountHtml.error)) {
     return (
       <LoadingLayer loading={true} />
     );

--- a/src/app/pages/AccountPage.jsx
+++ b/src/app/pages/AccountPage.jsx
@@ -39,7 +39,7 @@ const AccountPage = (props) => {
 
   useEffect(() => {
 
-    if (typeof window !== 'undefined' && (!patron.id || accountHtml.error)) {
+    if (typeof window !== 'undefined' && (!patron.id || (content !== 'settings' && accountHtml.error))) {
       logOutFromEncoreAndCatalogIn();
       const fullUrl = encodeURIComponent(window.location.href);
       // timeout 0 is here to make sure that we don't redirect until after the logout iframe is loaded
@@ -98,7 +98,7 @@ const AccountPage = (props) => {
 
   const formattedExpirationDate = patron.expirationDate ?  moment(patron.expirationDate).format("MM-DD-YYYY") : '';
 
-  if (accountHtml.error) {
+  if (content !== 'settings' && accountHtml.error) {
     return (
       <LoadingLayer loading={true} />
     );


### PR DESCRIPTION
**What's this do?**
Fixes some validations so they don't break on the `Account Settings` tab

**Why are we doing this? (w/ JIRA link if applicable)**
Right now we get an error on the `Account Settings` tab because we are checking for `accountHtml`, but the `Account Settings` tab doesn't actually require this.

**Did someone actually run this code to verify it works?**
PR author tested locally.
