### PR TITLE
Add fix to specific undefined value

### DIFF
--- a/src/app/pages/HoldRequest.jsx
+++ b/src/app/pages/HoldRequest.jsx
@@ -296,7 +296,7 @@ export class HoldRequest extends React.Component {
           <span>Call number:</span><br />{selectedItem.callNumber}
         </div>) : null;
     let itemClosedLocations = closedLocations;
-    if (selectedItem.isRecap) {
+    if (selectedItem && selectedItem.isRecap) {
       itemClosedLocations = itemClosedLocations.concat(recapClosedLocations);
     } else {
       itemClosedLocations = itemClosedLocations.concat(nonRecapClosedLocations);


### PR DESCRIPTION
**What's this do?**
Fixes very specific issue on HoldRequest page when one navigates directly from search result where `selectedItem` var is not set because the bib is still loading. Given that the bib is loading (and assuming it will soon load), the fix proposed simply skips checking `selectedItem.isRecap`. This creates the new known issue that the page will temporarily classify the requested item as being non-ReCAP (i.e. on-site). This may cause the full set of ReCAP delivery locations to be shown even if they are "closed" via `process.env.RECAP_CLOSED_LOCATIONS`. This is expected to be true for the time following when delivery locations are shown and ending when the bib has been loaded, which anecdotally seems unnoticeably short.

Note the `loading` prop didn't appear to be `true` while the bib was loading. Long term it would be nice to know if the set of required data needed for a page has yet loaded or not because rendering anything at all probably doesn't make sense until that's true.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SCC-2552

**Do these changes have automated tests?**
Not yet

**How should this be QAed?**
From Serena:
> From a search for "Cats"
> 
>     Click "Request" for "Cats, cats, cats / Andy Warhol."
>     then go back to search results
>     Click "Request" for "Cats cats cats cats cats. Drawing and design by Bill Sokol."
> 
> Error from console:
> TypeError: Cannot read property 'isRecap' of undefined at t.value (HoldRequest.jsx:299)


**Dependencies for merging? Releasing to production?**
[Description of any watchouts, dependencies, or issues we should be aware of]

**Has the application documentation been updated for these changes?**

**Did someone actually run this code to verify it works?**
