### PR TITLE
SCC-2430: fix behavior

### DIFF
--- a/src/app/components/Item/ItemFilter.jsx
+++ b/src/app/components/Item/ItemFilter.jsx
@@ -86,12 +86,11 @@ const ItemFilter = ({
   );
   const open = mobile ? mobileIsOpen : isOpen;
   const clear = () => {
-    const newSelections = {
-      ...selectedFilters,
+    setSelectionMade(true);
+    setSelectedFilters(prevSelectedFilters => ({
+      ...prevSelectedFilters,
       [filter]: [],
-    };
-
-    submitFilterSelections(newSelections);
+    }));
   };
 
   return (
@@ -138,6 +137,7 @@ const ItemFilter = ({
                 <Button
                   buttonType="link"
                   onClick={() => clear()}
+                  disabled={!selectedFilters[filter].length}
                 >Clear
                 </Button>
                 <Button

--- a/src/app/components/Item/ItemFilter.jsx
+++ b/src/app/components/Item/ItemFilter.jsx
@@ -28,7 +28,7 @@ const ItemFilter = ({
   isOpen,
   initialFilters,
 }) => {
-  if (!options) return null;
+  if (!options || !filter) return null;
   const [selectionMade, setSelectionMade] = useState(false);
 
   const selectFilter = (value) => {
@@ -166,9 +166,14 @@ ItemFilter.propTypes = {
   initialFilters: PropTypes.object,
 };
 
-ItemFilter.defaultTypes = {
+ItemFilter.defaultProps = {
   isOpen: false,
   mobile: false,
+  selectedFilters: {
+    location: [],
+    format: [],
+    status: [],
+  },
 };
 
 ItemFilter.contextTypes = {

--- a/test/unit/ItemFilter.test.js
+++ b/test/unit/ItemFilter.test.js
@@ -8,56 +8,86 @@ import ItemFilter from './../../src/app/components/Item/ItemFilter';
 import { locationFilters } from '../fixtures/itemFilterOptions';
 
 describe('ItemFilters', () => {
-  describe('default rendering', () => {
+  describe('missing props', () => {
     let component;
-    it('should not render without an `items` prop', () => {
+    it('should not render without props', () => {
       component = shallow(<ItemFilter />);
+      expect(component.type()).to.equal(null);
+    });
+    it('should not render without `options`', () => {
+      component = shallow(
+        <ItemFilter
+          filter="category"
+        />,
+      );
+      expect(component.type()).to.equal(null);
+    });
+    it('should not render without `filter`', () => {
+      component = shallow(
+        <ItemFilter
+          options={locationFilters}
+        />,
+      );
       expect(component.type()).to.equal(null);
     });
   });
 
-  describe('with `options`', () => {
+  describe('with `options` and `filter`', () => {
     let component;
     it('should render a `div` and a `button`', () => {
-      component = mount(<ItemFilter options={locationFilters} />);
+      component = mount(
+        <ItemFilter
+          options={locationFilters}
+          filter="location"
+        />);
       expect(component.find('div').length).to.equal(1);
       expect(component.find('button').length).to.equal(1);
     });
   });
 
-  describe('with `options` open state', () => {
+  describe('with required props, open state', () => {
     let component;
-    it('should render a fieldset, 3 buttons', () => {
+    it('should render a fieldset, 3 buttons, 2nd two buttons disabled', () => {
       component = mount(
         <ItemFilter
           options={locationFilters}
+          filter="location"
           isOpen
         />);
       expect(component.find('fieldset').length).to.equal(1);
       expect(component.find('button').length).to.equal(3);
+      expect(component.find('button').at(1).prop('disabled')).to.equal(true);
+      expect(component.find('button').at(2).prop('disabled')).to.equal(true);
     });
   });
 
   describe('with `selectedFilters`', () => {
+    /*
+      Example of how to test state update when using
+      `useState` and passing a function to manipulate the
+      previous state
+    */
     it('clear button should remove selected filters for corresponding `filter`', () => {
-      let filterSubmission;
+      let updatedFilters;
+      const selectedFilters = {
+        location: ['loc:maj03', 'offsite'],
+        status: ['status:a'],
+      };
       const component = mount(
         <ItemFilter
           options={locationFilters}
           isOpen
-          selectedFilters={{
-            location: ['loc:maj03', 'offsite'],
-            status: ['status:a'],
-          }}
+          selectedFilters={selectedFilters}
           filter="location"
-          submitFilterSelections={(input) => {
-            filterSubmission = input;
+          setSelectedFilters={(reactGeneratedFunc) => {
+            updatedFilters = reactGeneratedFunc(selectedFilters);
           }}
         />);
       const clearButton = component.find('button').at(1);
+      expect(clearButton.prop('disabled')).to.equal(false);
       expect(clearButton.text()).to.equal('Clear');
       clearButton.simulate('click');
-      expect(filterSubmission).to.deep.equal({ location: [], status: ['status:a'] });
+      expect(updatedFilters).to.deep.equal({ location: [], status: ['status:a'] });
     });
   });
 });


### PR DESCRIPTION
**What's this do?**
I made a wrong assumption and implemented something different than was decided on. The behavior should be:
> - Clicking 'clear' should uncheck filters but does not close the dropdown box
> - User would still have to click apply to save the changes

This also makes the "Clear" button disabled if there are no selected options, which is necessary for this ticket either way.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SCC-2430

**Do these changes have automated tests?**
Yes! Kind of fun to figure out how to test state update when using `useState` and passing a function to manipulate the previous state. 

**How should this be QAed?**
> - Clicking 'clear' should uncheck filters but does not close the dropdown box
> - User would still have to click apply to save the changes

**Dependencies for merging? Releasing to production?**
None


**Did someone actually run this code to verify it works?**
I did