### PR TITLE
SCC-2586: Modals styling

### DIFF
--- a/src/app/components/AccountPage/CancelConfirmationModal.jsx
+++ b/src/app/components/AccountPage/CancelConfirmationModal.jsx
@@ -12,8 +12,8 @@ const CancelConfirmationModal = ({
   cancelItem,
   setItemToCancel,
 }) => (
-  <Modal className="research-modal">
-    <div className="research-modal__content cancel-confirmation">
+  <Modal className="research-modal cancel-confirmation">
+    <div className="research-modal__content">
       <p>Cancel your hold on this item?</p>
       <p>{itemToCancel.title}</p>
       <div className="button-container">

--- a/src/app/components/AccountPage/CancelConfirmationModal.jsx
+++ b/src/app/components/AccountPage/CancelConfirmationModal.jsx
@@ -12,20 +12,22 @@ const CancelConfirmationModal = ({
   cancelItem,
   setItemToCancel,
 }) => (
-  <Modal className="scc-modal">
-    <div className="scc-modal__content">
+  <Modal className="research-modal">
+    <div className="research-modal__content cancel-confirmation">
       <p>Cancel your hold on this item?</p>
       <p>{itemToCancel.title}</p>
-      <Button
-        buttonType={ButtonTypes.Secondary}
-        onClick={() => setItemToCancel(null)}
-      >Back
-      </Button>
-      <Button
-        buttonType={ButtonTypes.Primary}
-        onClick={cancelItem}
-      >Confirm
-      </Button>
+      <div className="button-container">
+        <Button
+          buttonType={ButtonTypes.Secondary}
+          onClick={() => setItemToCancel(null)}
+        >Back
+        </Button>
+        <Button
+          buttonType={ButtonTypes.Primary}
+          onClick={cancelItem}
+        >Confirm
+        </Button>
+      </div>
     </div>
   </Modal>
 );

--- a/src/app/components/AccountPage/CancelConfirmationModal.jsx
+++ b/src/app/components/AccountPage/CancelConfirmationModal.jsx
@@ -1,5 +1,4 @@
-/* global window, document */
-import React, { useEffect } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import {
   Button,
@@ -13,8 +12,8 @@ const CancelConfirmationModal = ({
   cancelItem,
   setItemToCancel,
 }) => (
-  <div className="scc-modal">
-    <Card>
+  <Modal className="scc-modal">
+    <div className="scc-modal__content">
       <p>Cancel your hold on this item?</p>
       <p>{itemToCancel.title}</p>
       <Button
@@ -27,8 +26,8 @@ const CancelConfirmationModal = ({
         onClick={cancelItem}
       >Confirm
       </Button>
-    </Card>
-  </div>
+    </div>
+  </Modal>
 );
 
 CancelConfirmationModal.propTypes = {

--- a/src/app/components/AccountPage/CancelConfirmationModal.jsx
+++ b/src/app/components/AccountPage/CancelConfirmationModal.jsx
@@ -1,0 +1,40 @@
+/* global window, document */
+import React, { useEffect } from 'react';
+import PropTypes from 'prop-types';
+import {
+  Button,
+  ButtonTypes,
+  Modal,
+  Card,
+} from '@nypl/design-system-react-components';
+
+const CancelConfirmationModal = ({
+  itemToCancel,
+  cancelItem,
+  setItemToCancel,
+}) => (
+  <div className="scc-modal">
+    <Card>
+      <p>Cancel your hold on this item?</p>
+      <p>{itemToCancel.title}</p>
+      <Button
+        buttonType={ButtonTypes.Secondary}
+        onClick={() => setItemToCancel(null)}
+      >Back
+      </Button>
+      <Button
+        buttonType={ButtonTypes.Primary}
+        onClick={cancelItem}
+      >Confirm
+      </Button>
+    </Card>
+  </div>
+);
+
+CancelConfirmationModal.propTypes = {
+  itemToCancel: PropTypes.object,
+  cancelItem: PropTypes.func,
+  setItemToCancel: PropTypes.func,
+};
+
+export default CancelConfirmationModal;

--- a/src/app/components/TimedLogoutModal/TimedLogoutModal.jsx
+++ b/src/app/components/TimedLogoutModal/TimedLogoutModal.jsx
@@ -47,23 +47,23 @@ const TimedLogoutModal = (props) => {
   }
 
   const open = minutes < 2;
-  // if (!open) return null;
+  if (!open) return null;
 
   return (
     <Modal
       open
-      className="scc-modal timedLogoutModal"
+      className="research-modal timed-logout"
     >
-      <div className="scc-modal__content">
+      <div className="research-modal__content">
         <p>
           Your session is about to time out
-          <span className="timeDisplay">
+          <span className="time-display">
             {`${minutes}:${seconds < 10 ? '0' : ''}${seconds}`}
           </span>
         </p>
         <hr />
         Do you want to stay logged in?
-        <div className="buttonContainer">
+        <div className="button-container">
           <Button
             buttonType={ButtonTypes.Secondary}
             className="button"

--- a/src/app/components/TimedLogoutModal/TimedLogoutModal.jsx
+++ b/src/app/components/TimedLogoutModal/TimedLogoutModal.jsx
@@ -47,18 +47,20 @@ const TimedLogoutModal = (props) => {
   }
 
   const open = minutes < 2;
-  if (!open) return null;
+  // if (!open) return null;
 
   return (
     <Modal
       open
-      className="timedLogoutModal"
+      className="scc-modal timedLogoutModal"
     >
-      <Card>
-        Your session is about to time out
-        <div className="timeDisplay">
-          {`${minutes}:${seconds < 10 ? '0' : ''}${seconds}`}
-        </div>
+      <div className="scc-modal__content">
+        <p>
+          Your session is about to time out
+          <span className="timeDisplay">
+            {`${minutes}:${seconds < 10 ? '0' : ''}${seconds}`}
+          </span>
+        </p>
         <hr />
         Do you want to stay logged in?
         <div className="buttonContainer">
@@ -77,7 +79,7 @@ const TimedLogoutModal = (props) => {
             Stay logged in
           </Button>
         </div>
-      </Card>
+      </div>
     </Modal>
   );
 };

--- a/src/app/components/TimedLogoutModal/TimedLogoutModal.jsx
+++ b/src/app/components/TimedLogoutModal/TimedLogoutModal.jsx
@@ -56,7 +56,7 @@ const TimedLogoutModal = (props) => {
     >
       <div className="research-modal__content">
         <p>
-          Your session is about to time out
+          Your session is about to expire
           <span className="time-display">
             {`${minutes}:${seconds < 10 ? '0' : ''}${seconds}`}
           </span>

--- a/src/app/pages/AccountPage.jsx
+++ b/src/app/pages/AccountPage.jsx
@@ -5,8 +5,6 @@ import PropTypes from 'prop-types';
 import {
   SkeletonLoader,
   Heading,
-  Button,
-  ButtonTypes,
 } from '@nypl/design-system-react-components';
 import moment from 'moment';
 
@@ -14,6 +12,7 @@ import LinkTabSet from '../components/AccountPage/LinkTabSet';
 import AccountSettings from '../components/AccountPage/AccountSettings';
 import LoadingLayer from '../components/LoadingLayer/LoadingLayer';
 import TimedLogoutModal from '../components/TimedLogoutModal/TimedLogoutModal';
+import CancelConfirmationModal from '../components/AccountPage/CancelConfirmationModal';
 import SccContainer from '../components/SccContainer/SccContainer';
 import { logOutFromEncoreAndCatalogIn } from '../utils/logoutUtils';
 
@@ -40,7 +39,6 @@ const AccountPage = (props) => {
   const [displayTimedLogoutModal, setDisplayTimedLogoutModal] = useState(false);
 
   useEffect(() => {
-
     if (typeof window !== 'undefined' && (!patron.id || accountHtml.error)) {
       const fullUrl = encodeURIComponent(window.location.href);
       logOutFromEncoreAndCatalogIn(() => {
@@ -108,7 +106,7 @@ const AccountPage = (props) => {
     setItemToCancel(null);
   };
 
-  const formattedExpirationDate = patron.expirationDate ?  moment(patron.expirationDate).format("MM-DD-YYYY") : '';
+  const formattedExpirationDate = patron.expirationDate ? moment(patron.expirationDate).format("MM-DD-YYYY") : '';
 
   if (accountHtml.error) {
     return (
@@ -141,22 +139,11 @@ const AccountPage = (props) => {
         <div>Expiration Date: {formattedExpirationDate}</div>
       </div>
       {itemToCancel ? (
-        <div className="scc-modal">
-          <div>
-            <p>Cancel your hold on this item?</p>
-            <p>{itemToCancel.title}</p>
-            <Button
-              buttonType={ButtonTypes.Secondary}
-              onClick={() => setItemToCancel(null)}
-            >Back
-            </Button>
-            <Button
-              buttonType={ButtonTypes.Primary}
-              onClick={cancelItem}
-            >Confirm
-            </Button>
-          </div>
-        </div>
+        <CancelConfirmationModal
+          itemToCancel={itemToCancel}
+          setItemToCancel={setItemToCancel}
+          cancelItem={cancelItem}
+        />
       ) : null}
       <LinkTabSet
         activeTab={content}

--- a/src/app/pages/AccountPage.jsx
+++ b/src/app/pages/AccountPage.jsx
@@ -133,11 +133,6 @@ const AccountPage = (props) => {
           /> :
           null
       }
-      <div className="nypl-patron-details">
-        <div className="name">{patron.names ? patron.names[0] : null}</div>
-        <div>{patron.barcodes ? patron.barcodes[0] : null}</div>
-        <div>Expiration Date: {formattedExpirationDate}</div>
-      </div>
       {itemToCancel ? (
         <CancelConfirmationModal
           itemToCancel={itemToCancel}
@@ -145,6 +140,11 @@ const AccountPage = (props) => {
           cancelItem={cancelItem}
         />
       ) : null}
+      <div className="nypl-patron-details">
+        <div className="name">{patron.names ? patron.names[0] : null}</div>
+        <div>{patron.barcodes ? patron.barcodes[0] : null}</div>
+        <div>Expiration Date: {formattedExpirationDate}</div>
+      </div>
       <LinkTabSet
         activeTab={content}
         tabs={[

--- a/src/client/styles/components/AccountPage.scss
+++ b/src/client/styles/components/AccountPage.scss
@@ -385,3 +385,7 @@
     text-align: center;
   }
 }
+
+.timed-logout + .cancel-confirmation {
+  display: none;
+}

--- a/src/client/styles/components/AccountPage.scss
+++ b/src/client/styles/components/AccountPage.scss
@@ -381,5 +381,7 @@
 }
 
 .cancel-confirmation {
-  text-align: center;
+  .research-modal__content {
+    text-align: center;
+  }
 }

--- a/src/client/styles/components/AccountPage.scss
+++ b/src/client/styles/components/AccountPage.scss
@@ -245,43 +245,6 @@
   }
 }
 
-.scc-modal {
-  background-color: rgba(153, 153, 153, 0.8);
-  height: 100%;
-  left: 0;
-  overflow-y: auto;
-  position: fixed;
-  top: 0;
-  width: 100vw;
-  z-index: 999;
-  padding-top: 20%;
-
-  div {
-    background-color: #F9F8F7;
-    margin: auto;
-    opacity: 100%;
-    width: 472px;
-    max-width: 100%;
-  }
-
-  span {
-    font-weight: 700;
-  }
-
-  p:nth-child(2) {
-    font-weight: 500;
-  }
-
-  button {
-    margin: 0;
-    width: 153px;
-
-    &:not(last-of-type) {
-      margin-bottom: var(--space-s);
-    }
-  }
-}
-
 .loading#account-page-content {
   display: none;
 }
@@ -415,4 +378,8 @@
       margin-bottom: var(--space-s);
     }
   }
+}
+
+.cancel-confirmation {
+  text-align: center;
 }

--- a/src/client/styles/components/AccountPage.scss
+++ b/src/client/styles/components/AccountPage.scss
@@ -12,6 +12,12 @@
 
   td.account-table-buttons {
     padding-right: 0;
+
+    button {
+      &:not(last-of-type) {
+        margin-bottom: var(--space-xs);
+      }
+    }
   }
 
   td > span {
@@ -96,7 +102,7 @@
   }
 
   #account-page-content:not(.overdues) {
-    td {
+    td:not(.account-table-buttons) {
       padding-right: 35px;
     }
   }
@@ -226,7 +232,7 @@
     dl {
       overflow: inherit;
     }
-    
+
     dt {
       font-size: 20px;
     }
@@ -254,8 +260,6 @@
     background-color: #F9F8F7;
     margin: auto;
     opacity: 100%;
-    padding: 54px 5%;
-    text-align: center;
     width: 472px;
     max-width: 100%;
   }
@@ -269,7 +273,12 @@
   }
 
   button {
+    margin: 0;
     width: 153px;
+
+    &:not(last-of-type) {
+      margin-bottom: var(--space-s);
+    }
   }
 }
 
@@ -394,7 +403,12 @@
 
       button {
         width: 85%;
+
+        &:not(last-of-type) {
+          margin-bottom: var(--space-s);
+        }
       }
+
     }
 
     .patFuncEntry {

--- a/src/client/styles/components/TimedLogoutModal.scss
+++ b/src/client/styles/components/TimedLogoutModal.scss
@@ -1,11 +1,14 @@
-.timedLogoutModal {
-  background: rgba(64, 64, 64, 0.9);
-
+.timed-logout {
   hr {
     color: #89969F;
   }
 
-  .timeDisplay {
+  p {
+    display: flex;
+    justify-content: space-between;
+  }
+
+  .time-display {
     padding-left: var(--space-m);
   }
 
@@ -13,37 +16,8 @@
     font-weight: 500;
   }
 
-  .buttonContainer {
-    display: flex;
-    justify-content: space-between;
-    margin-top: 20px;
-  }
-
   .button {
     display: inline-block;
     font-weight: 300;
-  }
-}
-
-.scc-modal__content {
-  align-items: flex-start;
-  background: #F9F8F7;
-  border: 1px solid var(--ui-gray-light);
-  border-radius: 5px;
-  flex-flow: column wrap;
-  min-height: 200px;
-  padding: var(--space) var(--space-l);
-  text-align: initial;
-
-  p {
-    display: flex;
-    justify-content: space-between;
-  }
-}
-
-@media (max-width: 400px) {
-  .scc-modal__content {
-    padding-left: var(--space);
-    padding-right: var(--space);
   }
 }

--- a/src/client/styles/components/TimedLogoutModal.scss
+++ b/src/client/styles/components/TimedLogoutModal.scss
@@ -1,38 +1,49 @@
 .timedLogoutModal {
   background: rgba(64, 64, 64, 0.9);
-  line-height: 30apx;
-
-  .timeDisplay {
-    display: inline-flex;
-    float: right;
-  }
 
   hr {
     color: #89969F;
+  }
+
+  .timeDisplay {
+    padding-left: var(--space-m);
   }
 
   :not(.button) {
     font-weight: 500;
   }
 
-  .card {
-    background: #F9F8F7;
-    position: relative;
-    left: 20vw;
-    top: 20vh;
-    width: 50vw;
-    min-height: 200px;
-  }
-
   .buttonContainer {
     display: flex;
-    justify-content: space-around;
+    justify-content: space-between;
     margin-top: 20px;
   }
 
   .button {
     display: inline-block;
-    width: 40%;
     font-weight: 300;
+  }
+}
+
+.scc-modal__content {
+  align-items: flex-start;
+  background: #F9F8F7;
+  border: 1px solid var(--ui-gray-light);
+  border-radius: 5px;
+  flex-flow: column wrap;
+  min-height: 200px;
+  padding: var(--space) var(--space-l);
+  text-align: initial;
+
+  p {
+    display: flex;
+    justify-content: space-between;
+  }
+}
+
+@media (max-width: 400px) {
+  .scc-modal__content {
+    padding-left: var(--space);
+    padding-right: var(--space);
   }
 }

--- a/src/client/styles/main.scss
+++ b/src/client/styles/main.scss
@@ -194,3 +194,64 @@ select {
 .nypl-column-full {
   padding: 0;
 }
+
+.research-modal {
+  background: rgba(64, 64, 64, 0.9);
+  padding-top: 25vh;
+
+  div {
+    background-color: #F9F8F7;
+    margin: auto;
+    opacity: 100%;
+    width: 472px;
+    max-width: 100%;
+  }
+
+  span {
+    font-weight: 700;
+  }
+
+  p:nth-child(2) {
+    font-weight: 500;
+  }
+
+  button {
+    width: 153px;
+
+    &:first-of-type {
+      margin-left: 0;
+    }
+
+    &:last-of-type {
+      margin-right: 0;
+    }
+
+    &:not(last-of-type) {
+      margin-bottom: var(--space-s);
+    }
+  }
+}
+
+
+.research-modal__content {
+  align-items: flex-start;
+  background: #F9F8F7;
+  border: 1px solid var(--ui-gray-light);
+  border-radius: 5px;
+  flex-flow: column wrap;
+  min-height: 200px;
+  padding: var(--space) var(--space-l);
+
+  .button-container {
+    display: flex;
+    justify-content: space-between;
+    margin-top: 20px;
+  }
+}
+
+@media (max-width: 400px) {
+  .research-modal__content {
+    padding-left: var(--space);
+    padding-right: var(--space);
+  }
+}

--- a/src/client/styles/main.scss
+++ b/src/client/styles/main.scss
@@ -127,6 +127,7 @@ input[type=submit]:focus {
 
 .no-scroll {
   overflow: hidden;
+  position: inherit;
 }
 
 .emailSubscription-wrapper {

--- a/test/unit/TimedLogoutModal.test.js
+++ b/test/unit/TimedLogoutModal.test.js
@@ -110,13 +110,13 @@ describe('TimedLogoutModal', () => {
     });
 
     it('should say \'Your session is about to time out\'', () => {
-      expect(component.find('Card').text()).to.include('Your session is about to time out');
+      expect(component.find('.research-modal__content').text()).to.include('Your session is about to time out');
     });
     it('should display the time', () => {
-      expect(component.find('Card').text()).to.include('1:03');
+      expect(component.find('.research-modal__content').text()).to.include('1:03');
     });
     it('should say \'Do you want to stay logged in\'', () => {
-      expect(component.find('Card').text()).to.include('Do you want to stay logged in');
+      expect(component.find('.research-modal__content').text()).to.include('Do you want to stay logged in');
     });
     it('should have a button to log out', () => {
       expect(component.find('Button').at(0).text()).to.equal('Log off');

--- a/test/unit/TimedLogoutModal.test.js
+++ b/test/unit/TimedLogoutModal.test.js
@@ -109,8 +109,8 @@ describe('TimedLogoutModal', () => {
       expect(callRecord.some(call => call.replace)).to.equal(false);
     });
 
-    it('should say \'Your session is about to time out\'', () => {
-      expect(component.find('.research-modal__content').text()).to.include('Your session is about to time out');
+    it('should say \'Your session is about to expire\'', () => {
+      expect(component.find('.research-modal__content').text()).to.include('Your session is about to expire');
     });
     it('should display the time', () => {
       expect(component.find('.research-modal__content').text()).to.include('1:03');


### PR DESCRIPTION
**What's this do?**
This modifies the styling for both modals (cancel confirmation and timed logout) to make them more consistent and responsive.

The Design System `Card` was adding extra divs. So, I nixed it and just added the necessary `border-radius`.

I am really proud of the use of adjacent sibling selector here to hide the cancel hold modal when the timed logout modal is present.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SCC-2586

**Do these changes have automated tests?**
Update to existing tests

**How should this be QAed?**
- Check responsiveness of both modals
- Check case of timed logout modal opening with cancel hold modal open - the timed logout should display, if "Stay logged in" is chosen, the cancel hold modal will display again.

**Dependencies for merging? Releasing to production?**
None

**Did someone actually run this code to verify it works?**
I did