### PR TITLE
SCC-2331: Remove `title` attribute causing popup with JSON

### DIFF
--- a/src/app/components/BibPage/AdditionalDetailsViewer.jsx
+++ b/src/app/components/BibPage/AdditionalDetailsViewer.jsx
@@ -24,7 +24,7 @@ class AdditionalDetailsViewer extends React.Component {
     );
 
     return (
-      <div title={JSON.stringify(value.source, null, 2)} key={index}>
+      <div key={index}>
         { value.label ? link : value.content }
         { value.parallels ? value.parallels : null }
       </div>


### PR DESCRIPTION
**What's this do?**
Remove `title` attribute causing popup with JSON

**Why are we doing this? (w/ JIRA link if applicable)**
Important product specification

**Do these changes have automated tests?**
They did not have them to begin with. Weird thing to test the lack of.

**How should this be QAed?**
Check that hovering over a value in the "Additional Details" tab does not have the JSON popup anymore

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
Not needed

**Did someone actually run this code to verify it works?**
I did