### PR TITLE
Add expiration of account cookie when redirecting

### DIFF
--- a/src/app/components/TimedLogoutModal/TimedLogoutModal.jsx
+++ b/src/app/components/TimedLogoutModal/TimedLogoutModal.jsx
@@ -21,6 +21,7 @@ const TimedLogoutModal = (props) => {
 
   const logOutAndRedirect = () => {
     logOutFromEncoreAndCatalogIn(() => {
+      document.cookie = 'accountPageExp=; expires=Thu, 01 Jan 1970 00:00:00 UTC;';
       window.location.replace(baseUrl);
     });
   };


### PR DESCRIPTION
**What's this do?**
Expire the account page cookie when the user logs out

**Why are we doing this? (w/ JIRA link if applicable)**
This is scc-2537. This change is intended to help users with multiple tabs open to the accounts page by making sure they are logged out consistently in all tabs.

**How should this be QAed?**

Open two tabs to the account page. When the logout prompt shows up, log out in one and switch to the other tab. There may be a 1 second delay but you should be logged out in the other tab.

**Dependencies for merging? Releasing to production?**


**Has the application documentation been updated for these changes?**

**Did someone actually run this code to verify it works?**
PR author checked locally.
