### PR TITLE
Add "LEGACY_BASE_URL" to webpac config

### DIFF
--- a/src/app/pages/BibPage.jsx
+++ b/src/app/pages/BibPage.jsx
@@ -72,7 +72,6 @@ export const BibPage = (props, context) => {
   const {
     location,
     searchKeywords,
-    features,
     field,
     selectedFilters,
     page,
@@ -200,7 +199,7 @@ export const BibPage = (props, context) => {
   ].filter(tab => tab);
 
   const classicLink = (
-    bibId.startsWith('b') && features.includes('catalog-link') ?
+    bibId.startsWith('b') ?
       <a href={`${appConfig.legacyBaseUrl}/record=${bibId}~S1`} id="legacy-catalog-link">View in Legacy Catalog</a>
       :
       null
@@ -260,16 +259,11 @@ BibPage.propTypes = {
   searchKeywords: PropTypes.string,
   location: PropTypes.object,
   bib: PropTypes.object,
-  features: PropTypes.array,
   field: PropTypes.string,
   selectedFilters: PropTypes.object,
   page: PropTypes.string,
   sortBy: PropTypes.string,
   dispatch: PropTypes.func,
-};
-
-BibPage.defaultProps = {
-  features: [],
 };
 
 BibPage.contextTypes = {
@@ -279,7 +273,6 @@ BibPage.contextTypes = {
 const mapStateToProps = ({
   bib,
   searchKeywords,
-  features,
   field,
   selectedFilters,
   page,
@@ -287,7 +280,6 @@ const mapStateToProps = ({
 }) => ({
   bib,
   searchKeywords,
-  features,
   field,
   selectedFilters,
   page,

--- a/test/unit/BibPage.test.js
+++ b/test/unit/BibPage.test.js
@@ -37,6 +37,13 @@ describe('BibPage', () => {
       expect(tabs.length).to.equal(3);
       expect(tabTitles).to.deep.equal(['Availability', 'Details', 'Full Description']);
     });
+
+    it('has "View in Legacy Catalog" link', () => {
+      const linkToLegacy = component.find('#legacy-catalog-link');
+      expect(linkToLegacy.length).to.equal(1);
+      expect(linkToLegacy.is('a')).to.equal(true);
+      expect(linkToLegacy.prop('href')).to.equal('https://legacyBaseUrl.nypl.org/record=b11417539~S1');
+    });
   });
 
   describe('Serial', () => {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -50,7 +50,7 @@ const commonSettings = {
       'process.env': {
         SHEP_API: JSON.stringify(process.env.SHEP_API),
         LOGIN_URL: JSON.stringify(process.env.LOGIN_URL),
-        CLASSIC_CATALOG: JSON.stringify(process.env.CLASSIC_CATALOG),
+        LEGACY_BASE_URL: JSON.stringify(process.env.LEGACY_BASE_URL),
         CLOSED_LOCATIONS: JSON.stringify(process.env.CLOSED_LOCATIONS),
         RECAP_CLOSED_LOCATIONS: JSON.stringify(process.env.RECAP_CLOSED_LOCATIONS),
         NON_RECAP_CLOSED_LOCATIONS: JSON.stringify(process.env.NON_RECAP_CLOSED_LOCATIONS),
@@ -226,7 +226,7 @@ if (ENV === 'production') {
           GA_ENV: JSON.stringify(process.env.GA_ENV),
           SHEP_API: process.env.SHEP_API,
           LOGIN_URL: process.env.LOGIN_URL,
-          CLASSIC_CATALOG: process.env.CLASSIC_CATALOG,
+          LEGACY_BASE_URL: process.env.LEGACY_BASE_URL,
           CLOSED_LOCATIONS: process.env.CLOSED_LOCATIONS,
           RECAP_CLOSED_LOCATIONS: JSON.stringify(process.env.RECAP_CLOSED_LOCATIONS),
           NON_RECAP_CLOSED_LOCATIONS: JSON.stringify(process.env.NON_RECAP_CLOSED_LOCATIONS),


### PR DESCRIPTION
**What's this do?**
- Fixes the "View In Legacy" link by adding "LEGACY_BASE_URL" to Webpac config
- Remove feature flag for "catalog-link" making this an integrated feature

**Do these changes have automated tests?**
Wrote more test coverage. But it seems like our test suite does not reflect Webpac's involvement in making these environment variables available?

**How should this be QAed?**
Check that "View In Legacy" links  on bib page works

**Dependencies for merging? Releasing to production?**
None. This bug is currently just on QA because of the change of terminology (classic -> legacy) in variable names.

**Has the application documentation been updated for these changes?**

**Did someone actually run this code to verify it works?**
I did