### PR TITLE
SCC-2595: Design enhancements mobile/tablet

### DIFF
--- a/src/client/styles/components/Notification.scss
+++ b/src/client/styles/components/Notification.scss
@@ -5,7 +5,7 @@
   display: flex;
   font-size: var(--font-size--1);
   margin: var(--space-m) 0;
-  padding: var(--space-m) var(--space-xl);
+  padding: var(--space-m) 4vw;
 
   a {
     color: var(--ui-link-primary);

--- a/src/client/styles/components/Search.scss
+++ b/src/client/styles/components/Search.scss
@@ -24,3 +24,16 @@
   display: flex;
   width: 100%;
 }
+
+
+@media (max-width: 490px) {
+  .nypl-sorter-row {
+    display: block;
+  }
+}
+
+.select {
+  // manipulate padding coming from DS a bit because of longer option labels
+  padding-left: var(--space-xs);
+  padding-right: var(--space-l);
+}

--- a/src/client/styles/components/SubjectHeadings.scss
+++ b/src/client/styles/components/SubjectHeadings.scss
@@ -12,6 +12,12 @@ $table-row-border: 1px solid rgb(215, 210, 205);
   justify-content: space-between;
 }
 
+@media (max-width: 600px) {
+  .subject-heading-page-header {
+    display: block;
+  }
+}
+
 .subject-heading-page {
   .page-title {
     padding-top: var(--space-l);

--- a/src/client/styles/components/SubjectHeadings/SubjectHeadingSearch.scss
+++ b/src/client/styles/components/SubjectHeadings/SubjectHeadingSearch.scss
@@ -1,8 +1,14 @@
 .react-autosuggest__container {
   width: 40%;
-
   li {
     margin-bottom: 0;
+  }
+}
+
+@media (max-width: 600px) {
+  .react-autosuggest__container {
+    display: block;
+    width: 100%;
   }
 }
 

--- a/src/client/styles/style-v2.scss
+++ b/src/client/styles/style-v2.scss
@@ -57,7 +57,14 @@
     }
   }
 
-} // /.nypl-item-details
+}
+
+@media (max-width: 600px) {
+  .nypl-item-details__heading {
+    display: block;
+  }
+}
+// /.nypl-item-details
 
 .tabbed dl {
   border-bottom: 1px solid var(--ui-gray-light);


### PR DESCRIPTION
**What's this do?**
- Makes Notification horizontal padding respond to screenwidth using `vw` 
- Make SHEP search full width for smaller screens
- Adjust padding in search bar select because of long option labels, like "Author/Contributor"
- Make the description of the search results full width and on separate line from sorter for small screens

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SCC-2595

**Do these changes have automated tests?**
Just CSS

**How should this be QAed?**
Check mobile view for Notification, SHEP (search), search bar select with long option selected, search results description text

**Dependencies for merging? Releasing to production?**
None

**Did someone actually run this code to verify it works?**
I did