### PR TITLE
SCC-2610: "My Account" Search Bar should not be pre-populated

### DIFF
--- a/src/app/actions/Actions.js
+++ b/src/app/actions/Actions.js
@@ -21,6 +21,7 @@ export const Actions = {
   UPDATE_FEATURES: 'UPDATE_FEATURES',
 };
 
+// Reset state except appConfig, patron, features
 export const resetState = () => ({
   type: Actions.RESET_STATE,
   payload: null,

--- a/src/app/utils/dataLoaderUtil.js
+++ b/src/app/utils/dataLoaderUtil.js
@@ -66,7 +66,7 @@ const successCb = (pathType, dispatch) => (response) => {
 
 function loadDataForRoutes(location, dispatch) {
   const { pathname, search } = location;
-  if (pathname === `${baseUrl}/`) {
+  if (pathname === `${baseUrl}/` || pathname.includes('/account')) {
     dispatch(resetState());
   }
 

--- a/test/unit/dataLoaderUtil.test.js
+++ b/test/unit/dataLoaderUtil.test.js
@@ -303,9 +303,9 @@ describe('dataLoaderUtil', () => {
 
         it('should call dispatch with the account action and the response', () => {
           // 4 calls: loading true, account page action, updateLastLoaded, loading false
-          expect(mockDispatch.getCalls()).to.have.lengthOf(4);
-          expect(mockDispatch.secondCall.args).to.have.lengthOf(1);
-          expect(mockDispatch.secondCall.args[0]).to.equal('mockAccountPageAction response');
+          expect(mockDispatch.getCalls()).to.have.lengthOf(5);
+          expect(mockDispatch.thirdCall.args).to.have.lengthOf(1);
+          expect(mockDispatch.thirdCall.args[0]).to.equal('mockAccountPageAction response');
           expect(mockAccountPageArgs).to.have.lengthOf(1);
           expect(mockAccountPageArgs[0]).to.equal('<div>html for account page default view</div>');
         });
@@ -334,9 +334,9 @@ describe('dataLoaderUtil', () => {
 
         it('should call dispatch with the account action and the response', () => {
           // 4 calls: loading true, account page action, updateLastLoaded, loading false
-          expect(mockDispatch.getCalls()).to.have.lengthOf(4);
-          expect(mockDispatch.secondCall.args).to.have.lengthOf(1);
-          expect(mockDispatch.secondCall.args[0]).to.equal('mockAccountPageAction response');
+          expect(mockDispatch.getCalls()).to.have.lengthOf(5);
+          expect(mockDispatch.thirdCall.args).to.have.lengthOf(1);
+          expect(mockDispatch.thirdCall.args[0]).to.equal('mockAccountPageAction response');
           expect(mockAccountPageArgs).to.have.lengthOf(1);
           expect(mockAccountPageArgs[0]).to.equal('<div>html for account page items view</div>');
         });
@@ -364,9 +364,9 @@ describe('dataLoaderUtil', () => {
 
         it('should call dispatch with the account action and the response', () => {
           // 4 calls: loading true, account page action, updateLastLoaded, loading false
-          expect(mockDispatch.getCalls()).to.have.lengthOf(4);
-          expect(mockDispatch.secondCall.args).to.have.lengthOf(1);
-          expect(mockDispatch.secondCall.args[0]).to.equal('mockAccountPageAction response');
+          expect(mockDispatch.getCalls()).to.have.lengthOf(5);
+          expect(mockDispatch.thirdCall.args).to.have.lengthOf(1);
+          expect(mockDispatch.thirdCall.args[0]).to.equal('mockAccountPageAction response');
           expect(mockAccountPageArgs).to.have.lengthOf(1);
           expect(mockAccountPageArgs[0]).to.equal('');
         });


### PR DESCRIPTION
**What's this do?**
Uses `resetState` when navigating to 'My Account' to prevent the search bar from being pre-populated. This function resets everything except patron, appConfig, and features. 

We only really need to reset the search keywords and field. This approaches follows patterns we already have. Alternatives would be to add in logic here for My Account to clear just those to, either in the action, in the express code, or in the `dataLoaderUtil`. Any strong feelings here?

**Why are we doing this? (w/ JIRA link if applicable)**
Bug ticket I created for myself basically... This bug will not be visible until we turn on the 'my-account' feature.
https://jira.nypl.org/browse/SCC-2600

**Do these changes have automated tests?**
Updates to existing tests

**How should this be QAed?**
- With the 'my-account' feature flag enabled and logged in, do a search
- Click "My Account"
- The search bar on My Account should not be pre-populated with the search keyword and field with the values of that search

**Dependencies for merging? Releasing to production?**
Can wait until after code freeze

**Did someone actually run this code to verify it works?**
I did