### PR TITLE
SCC-2598: Redirect 404 links and copy update

### DIFF
--- a/src/app/components/Redirect404/Redirect404.jsx
+++ b/src/app/components/Redirect404/Redirect404.jsx
@@ -15,6 +15,8 @@ const Redirect404 = (props, context) => {
   const {
     circulatingCatalog,
     legacyBaseUrl,
+    displayTitle,
+    baseUrl,
   } = appConfig;
 
   return (
@@ -30,9 +32,9 @@ const Redirect404 = (props, context) => {
               <span>{ originalUrl ? `URL: ${originalUrl}` : ''}</span>
             </div>
             {"You may be able to find what you're looking for in the "}
-            <a href={legacyBaseUrl}>Legacy Catalog</a>
+            <a href={baseUrl}>{displayTitle}</a>
             {' or the '}
-            <a href={circulatingCatalog}>Circulating Catalog.</a>
+            <a href={circulatingCatalog}>Circulating Catalog</a>{'. You can also try the '}<a href={legacyBaseUrl}>Legacy Catalog</a>.
           </p>
         </div>
       </div>

--- a/test/unit/Redirect404.test.js
+++ b/test/unit/Redirect404.test.js
@@ -10,6 +10,8 @@ import appConfig from '@appConfig';
 const {
   circulatingCatalog,
   legacyBaseUrl,
+  displayTitle,
+  baseUrl,
 } = appConfig;
 
 
@@ -43,14 +45,19 @@ describe('Redirect404', () => {
     expect(component.find('p').text()).to.include('URL: https://catalog.nypl.org/missing');
   });
 
-  it('should have a  link to the legacy catalog', () => {
-    expect(component.find('a').length).to.equal(2);
-    expect(component.find('a').at(0).prop('href')).to.equal(legacyBaseUrl);
-    expect(component.find('a').at(0).text()).to.equal('Legacy Catalog');
+  it('should have a  link to this catalog', () => {
+    expect(component.find('a').length).to.equal(3);
+    expect(component.find('a').at(0).prop('href')).to.equal(baseUrl);
+    expect(component.find('a').at(0).text()).to.equal(displayTitle);
   });
 
-  it('should have a link to the circulatingCatalog', () => {
+  it('should have a link to the circulating catalog', () => {
     expect(component.find('a').at(1).prop('href')).to.equal(circulatingCatalog);
-    expect(component.find('a').at(1).text()).to.equal('Circulating Catalog.');
+    expect(component.find('a').at(1).text()).to.equal('Circulating Catalog');
+  });
+
+  it('should have a link to the Legacy Catalog', () => {
+    expect(component.find('a').at(2).prop('href')).to.equal(legacyBaseUrl);
+    expect(component.find('a').at(2).text()).to.equal('Legacy Catalog');
   });
 });


### PR DESCRIPTION
**What's this do?**
Puts "Research Catalog" link where legacy was. Add another sentence: "You can also try the [Legacy Catalog]".

**Why are we doing this? (w/ JIRA link if applicable)**
Page is missing link to Research Catalog. https://jira.nypl.org/browse/SCC-2598
Does my interpretation of the ticket description seem right?

**Do these changes have automated tests?**
Yes - relevant changes and add test for third link.

**How should this be QAed?**
Check http://qa-discovery.nypl.org/research/collections/shared-collection-catalog/404/redirect

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**

**Did someone actually run this code to verify it works?**
I did