### PR TITLE
Add 404 status to redirect 404

### DIFF
--- a/src/server/ApiRoutes/ApiRoutes.js
+++ b/src/server/ApiRoutes/ApiRoutes.js
@@ -58,6 +58,10 @@ Object.keys(routes).forEach((routeName) => {
 });
 
 router
+  .route(`${appConfig.baseUrl}/404/redirect`)
+  .get((req, res, next) => { res.status(404); next(); });
+
+router
   .route(`${appConfig.baseUrl}/api/account/:content?`)
   .post(Account.postToAccountPage);
 


### PR DESCRIPTION
**What's this do?**
Add some logic to make the http status of the redirect 404 page actually 404.

**Why are we doing this? (w/ JIRA link if applicable)**
This is for scc-2577. This page handles redirects from the Redirect Service, in case we cannot find a Research Catalog URL that matches the original catalog.nypl.org URL. We want these non-matching responses to properly 404.

**How should this be QAed?**
Navigate to /404/redirect, in the network tab the http status should be 404.

**Did someone actually run this code to verify it works?**
PR author tested locally.