### PR TITLE
Scc 2608

### DIFF
--- a/src/app/components/Account404/Account404.jsx
+++ b/src/app/components/Account404/Account404.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import DocumentTitle from 'react-document-title';
+import { Link } from 'react-router';
+
+import appConfig from '../../data/appConfig';
+
+const Account404 = () => (
+  <DocumentTitle title={`404 | ${appConfig.displayTitle} | NYPL`}>
+    <main id="mainContent" className="not-found-404">
+      <div className="nypl-full-width-wrapper">
+        <div className="nypl-row">
+          <div className="nypl-column-three-quarters">
+            <h1>404 Not Found</h1>
+            <p>We're sorry...</p>
+            <p>Something went wrong loading your account information.</p>
+            <p>Please try again in a few minutes</p>
+          </div>
+        </div>
+      </div>
+    </main>
+  </DocumentTitle>
+);
+
+export default Account404;

--- a/src/app/pages/AccountPage.jsx
+++ b/src/app/pages/AccountPage.jsx
@@ -98,6 +98,7 @@ const AccountPage = (props, context) => {
 
   // Detect a redirect loop and 404 if we can't solve it any other way
   useEffect(() => {
+    console.log('Account page check', new Date().toUTCString());
     const nyplAccountRedirectTracker = document
       .cookie
       .split(';')
@@ -105,7 +106,10 @@ const AccountPage = (props, context) => {
     if (nyplAccountRedirectTracker) {
       const currentValue = nyplAccountRedirectTracker.split('=')[1].split('exp');
       const currentCount = parseInt(currentValue[0], 10);
-      if (currentCount > 20) window.location.replace(`${baseUrl}/404`);
+      if (currentCount > 20) {
+        console.log('Detected redirect loop, 404ing');
+        window.location.replace(`${baseUrl}/404/account`);
+      }
       const currentExp = currentValue[1];
       document.cookie = `nyplAccountRedirectTracker=${currentCount + 1}exp${currentExp}`;
     } else {

--- a/src/app/pages/AccountPage.jsx
+++ b/src/app/pages/AccountPage.jsx
@@ -42,6 +42,8 @@ const AccountPage = (props, context) => {
   const [itemToCancel, setItemToCancel] = useState(null);
   const [displayTimedLogoutModal, setDisplayTimedLogoutModal] = useState(false);
 
+  const { baseUrl } = appConfig;
+
   useEffect(() => {
     if (typeof window !== 'undefined' && (!patron.id || accountHtml.error)) {
       const fullUrl = encodeURIComponent(window.location.href);
@@ -78,10 +80,14 @@ const AccountPage = (props, context) => {
     }
   }, [accountHtml]);
 
-  const resetCountdown = () => {
+  const incrementTime = (minutes, seconds = 0) => {
     const now = new Date();
-    now.setTime(now.getTime() + (5 * 60 * 1000));
-    const inFive = now.toUTCString();
+    now.setTime(now.getTime() + (minutes * 60 * 1000) + (seconds * 1000));
+    return now.toUTCString();
+  };
+
+  const resetCountdown = () => {
+    const inFive = incrementTime(5);
     document.cookie = `accountPageExp=${inFive}; expires=${inFive}`;
     setDisplayTimedLogoutModal(true);
   };
@@ -90,7 +96,23 @@ const AccountPage = (props, context) => {
     resetCountdown();
   });
 
-  const { baseUrl } = appConfig;
+  // Detect a redirect loop and 404 if we can't solve it any other way
+  useEffect(() => {
+    const nyplAccountRedirectTracker = document
+      .cookie
+      .split(';')
+      .find(el => el.includes('nyplAccountRedirectTracker'));
+    if (nyplAccountRedirectTracker) {
+      const currentValue = nyplAccountRedirectTracker.split('=')[1].split('exp');
+      const currentCount = parseInt(currentValue[0], 10);
+      if (currentCount > 20) window.location.replace(`${baseUrl}/404`);
+      const currentExp = currentValue[1];
+      document.cookie = `nyplAccountRedirectTracker=${currentCount + 1}exp${currentExp}`;
+    } else {
+      const expirationTime = incrementTime(0, 10);
+      document.cookie = `nyplAccountRedirectTracker=1exp${expirationTime}; expires=${expirationTime}`;
+    }
+  });
 
   const cancelItem = () => {
     const body = buildReqBody(content, {

--- a/src/app/pages/AccountPage.jsx
+++ b/src/app/pages/AccountPage.jsx
@@ -98,7 +98,6 @@ const AccountPage = (props, context) => {
 
   // Detect a redirect loop and 404 if we can't solve it any other way
   useEffect(() => {
-    console.log('Account page check', new Date().toUTCString());
     const nyplAccountRedirectTracker = document
       .cookie
       .split(';')
@@ -106,7 +105,7 @@ const AccountPage = (props, context) => {
     if (nyplAccountRedirectTracker) {
       const currentValue = nyplAccountRedirectTracker.split('=')[1].split('exp');
       const currentCount = parseInt(currentValue[0], 10);
-      if (currentCount > 20) {
+      if (currentCount > 6) {
         console.log('Detected redirect loop, 404ing');
         window.location.replace(`${baseUrl}/404/account`);
       }

--- a/src/app/routes/routes.jsx
+++ b/src/app/routes/routes.jsx
@@ -21,6 +21,7 @@ import AccountPage from '../pages/AccountPage';
 import Application from '../components/Application/Application';
 import NotFound404 from '../components/NotFound404/NotFound404';
 import Redirect404 from '../components/Redirect404/Redirect404';
+import Account404 from '../components/Account404/Account404';
 
 import appConfig from '../data/appConfig';
 
@@ -40,6 +41,7 @@ const routes = {
       <Route path="/subject_headings" component={SubjectHeadingsIndexPage} />
       <Route path="/account(/:content)" component={AccountPage} />
       <Route path="/404/redirect" component={Redirect404} />
+      <Route path="/404/account" component={Account404} />
       <Route path="/404" component={NotFound404} />
       <Redirect from="*" to="/404" />
     </Route>
@@ -58,6 +60,7 @@ const routes = {
       <Route path={`${baseUrl}/subject_headings`} component={SubjectHeadingsIndexPage} />
       <Route path={`${baseUrl}/account(/:content)`} component={AccountPage} />
       <Route path={`${baseUrl}/404/redirect`} component={Redirect404} />
+      <Route path={`${baseUrl}/404/account`} component={Account404} />
       <Route path={`${baseUrl}/404`} component={NotFound404} />
       <Redirect from="*" to={`${baseUrl}/404`} />
     </Route>

--- a/src/app/utils/logoutUtils.js
+++ b/src/app/utils/logoutUtils.js
@@ -22,7 +22,7 @@ const loadLogoutIframe = (onload) => {
 
   logoutIframe.setAttribute(
     // The endpoint is the URL for logging out from Encore
-    'src', 'https://browsse.nypl.org/iii/encore/logoutFilterRedirect?suite=def',
+    'src', 'https://browse.nypl.org/iii/encore/logoutFilterRedirect?suite=def',
     // 'src', 'https://nypl-encore-test.nypl.org//iii/encore/logoutFilterRedirect?suite=def',
   );
   // Assigns the ID for CSS ussage

--- a/src/app/utils/logoutUtils.js
+++ b/src/app/utils/logoutUtils.js
@@ -22,7 +22,7 @@ const loadLogoutIframe = (onload) => {
 
   logoutIframe.setAttribute(
     // The endpoint is the URL for logging out from Encore
-    'src', 'https://browse.nypl.org/iii/encore/logoutFilterRedirect?suite=def',
+    'src', 'https://browsse.nypl.org/iii/encore/logoutFilterRedirect?suite=def',
     // 'src', 'https://nypl-encore-test.nypl.org//iii/encore/logoutFilterRedirect?suite=def',
   );
   // Assigns the ID for CSS ussage

--- a/src/app/utils/logoutUtils.js
+++ b/src/app/utils/logoutUtils.js
@@ -22,8 +22,7 @@ const loadLogoutIframe = (onload) => {
 
   logoutIframe.setAttribute(
     // The endpoint is the URL for logging out from Encore
-    // 'src', 'https://browse.nypl.org/iii/encore/logoutFilterRedirect?suite=def',
-    'src', 'https://browse.nypl.org',
+    'src', 'https://browse.nypl.org/iii/encore/logoutFilterRedirect?suite=def',
     // 'src', 'https://nypl-encore-test.nypl.org//iii/encore/logoutFilterRedirect?suite=def',
   );
   // Assigns the ID for CSS ussage

--- a/src/app/utils/logoutUtils.js
+++ b/src/app/utils/logoutUtils.js
@@ -22,7 +22,8 @@ const loadLogoutIframe = (onload) => {
 
   logoutIframe.setAttribute(
     // The endpoint is the URL for logging out from Encore
-    'src', 'https://browse.nypl.org/iii/encore/logoutFilterRedirect?suite=def',
+    // 'src', 'https://browse.nypl.org/iii/encore/logoutFilterRedirect?suite=def',
+    'src', 'https://browse.nypl.org',
     // 'src', 'https://nypl-encore-test.nypl.org//iii/encore/logoutFilterRedirect?suite=def',
   );
   // Assigns the ID for CSS ussage

--- a/test/unit/Account404.test.js
+++ b/test/unit/Account404.test.js
@@ -1,0 +1,28 @@
+/* eslint-env mocha */
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+
+import config from '../../src/app/data/appConfig';
+
+import Account404 from '../../src/app/components/Account404/Account404';
+
+describe('Account404', () => {
+  let component;
+
+  before(() => {
+    component = shallow(<Account404 />);
+  });
+
+  it('should be wrapped in a .not-found-404 class', () => {
+    expect(component.find('.not-found-404').length).to.equal(1);
+  });
+
+  it('should have the right text', () => {
+    const html = component.html();
+    expect(html).to.include('404 Not Found');
+    expect(html).to.include('We&#x27;re sorry...');
+    expect(html).to.include('Something went wrong loading your account information.');
+    expect(html).to.include('Please try again in a few minutes');
+  });
+});

--- a/test/unit/AccountPage.test.js
+++ b/test/unit/AccountPage.test.js
@@ -90,4 +90,54 @@ describe('AccountPage', () => {
       expect(component.find('h3').first().text()).to.equal('Personal Information');
     });
   });
+
+  describe.only('redirect loop check', () => {
+    describe('when cookie not set', () => {
+      let component;
+      before(() => {
+        const mockStore = makeTestStore({});
+        component = mountTestRender(<AccountPage params={{}} />, { store: mockStore });
+      });
+
+      it('should set the cookie', () => {
+        console.log('document: ', document.cookie);
+        const nyplAccountRedirectTracker = document.cookie.split(';').find(el => el.includes('nyplAccountRedirectTracker'));
+        expect(!!nyplAccountRedirectTracker).to.equal(true);
+        expect(nyplAccountRedirectTracker).to.match(/\d+exp.*/);
+        const match = nyplAccountRedirectTracker.match(/\d+exp(.*)/)[1];
+        expect(Number.isNaN(Date.parse(match))).to.equal(false);
+      });
+    });
+
+    describe('when cookie is set but below threshold', () => {
+      let component;
+      before(() => {
+        const mockStore = makeTestStore({});
+        document.cookie = 'nyplAccountRedirectTracker=2expMon, 05 Apr 2021 20:06:13 GMT';
+        component = mountTestRender(<AccountPage params={{}} />, { store: mockStore });
+      });
+
+      it('should update the cookie', () => {
+        console.log('updated cookie: ', document.cookie);
+        const nyplAccountRedirectTracker = document.cookie.split(';').find(el => el.includes('nyplAccountRedirectTracker'));
+        expect(nyplAccountRedirectTracker).to.match(/\d+expMon, 05 Apr 2021 20:06:13 GMT/);
+        expect(parseInt(nyplAccountRedirectTracker.match(/(\d+).*/)[1], 10)).to.be.closeTo(4, 1);
+      });
+    });
+
+    describe('when cookie is above threshold', () => {
+      let component;
+      let replaceSpy;
+      before(() => {
+        replaceSpy = sandbox.stub(window.location, 'replace').callsFake(() => {});
+        const mockStore = makeTestStore({});
+        document.cookie = 'nyplAccountRedirectTracker=25expMon, 05 Apr 2021 20:06:13 GMT';
+        component = mountTestRender(<AccountPage params={{}} />, { store: mockStore });
+      });
+
+      it('should redirect', () => {
+        expect(replaceSpy.called).to.equal(true);
+      });
+    });
+  });
 });

--- a/test/unit/AccountPage.test.js
+++ b/test/unit/AccountPage.test.js
@@ -91,11 +91,12 @@ describe('AccountPage', () => {
     });
   });
 
-  describe.only('redirect loop check', () => {
+  describe('redirect loop check', () => {
     describe('when cookie not set', () => {
       let component;
       before(() => {
         const mockStore = makeTestStore({});
+        document.cookie = 'nyplAccountRedirectTracker=; expires=Thu, 01 Jan 1970 00:00:00 UTC;';
         component = mountTestRender(<AccountPage params={{}} />, { store: mockStore });
       });
 

--- a/test/unit/NotFound404.test.js
+++ b/test/unit/NotFound404.test.js
@@ -18,11 +18,6 @@ describe('NotFound404', () => {
     expect(component.find('.not-found-404').length).to.equal(1);
   });
 
-  it('should contain a Link and an `a` element', () => {
-    expect(component.find('Link')).to.have.length(1);
-    expect(component.find('a')).to.have.length(1);
-  });
-
   it('should contain a link to the homepage', () => {
     expect(component.find('Link').prop('to')).to.equal(`${config.baseUrl}/`);
   });

--- a/test/unit/NotFound404.test.js
+++ b/test/unit/NotFound404.test.js
@@ -18,6 +18,11 @@ describe('NotFound404', () => {
     expect(component.find('.not-found-404').length).to.equal(1);
   });
 
+  it('should contain a Link and an `a` element', () => {
+    expect(component.find('Link')).to.have.length(1);
+    expect(component.find('a')).to.have.length(1);
+  });
+
   it('should contain a link to the homepage', () => {
     expect(component.find('Link').prop('to')).to.equal(`${config.baseUrl}/`);
   });


### PR DESCRIPTION
**What's this do?**
Adds a check to see if the account page is stuck in a redirect loop. If so, redirect to a special 404 page.

**Why are we doing this? (w/ JIRA link if applicable)**
This is scc-2608

**Do these changes have automated tests?**

Yes

**How should this be QAed?**

Reproducing the loop: modify the line

```'src', 'https://browse.nypl.org/iii/encore/logoutFilterRedirect?suite=def'```

in `logoutUtils.js` to something else. I have been using

```'src', 'https://browse.nypl.org'```

This simulates an error in the logout page.

Navigate to the account page and log in. Then delete cookies (this simulates `III_SESSION` not being set properly), and reload. You should see the redirect loop, and eventually be redirected to a 404 page.

**Dependencies for merging? Releasing to production?**

No.

**Has the application documentation been updated for these changes?**

NA

**Did someone actually run this code to verify it works?**
PR author.