### PR TITLE
Fix flash for ineligible patron on hold request

### DIFF
--- a/src/app/pages/HoldRequest.jsx
+++ b/src/app/pages/HoldRequest.jsx
@@ -49,6 +49,7 @@ export class HoldRequest extends React.Component {
       delivery: defaultDelivery,
       checkedLocNum,
       serverRedirect: true,
+      checkingPatronEligibility: true
     };
 
     this.onRadioSelect = this.onRadioSelect.bind(this);
@@ -183,9 +184,12 @@ export class HoldRequest extends React.Component {
   }
   // checks whether a patron is eligible to place a hold. Uses cookie to get the patron's id
   checkEligibility() {
+    this.setState({ checkingPatronEligibility: true })
+
     return axios.get(`${appConfig.baseUrl}/api/patronEligibility`)
       .then(response => response.data)
-      .catch(() => ({ eligibility: true }));
+      .catch(() => ({ eligibility: true }))
+      .finally(() => this.setState({ checkingPatronEligibility: false }));
   }
 
   redirectWithErrors(path, status, message) {
@@ -270,7 +274,7 @@ export class HoldRequest extends React.Component {
       loading,
       params,
     } = this.props;
-    const { serverRedirect } = this.state;
+    const { serverRedirect, checkingPatronEligibility } = this.state;
     const bib = (this.props.bib && !_isEmpty(this.props.bib)) ?
       this.props.bib : null;
     const title = (bib && _isArray(bib.title) && bib.title.length) ?
@@ -365,7 +369,7 @@ export class HoldRequest extends React.Component {
     return (
       <>
         {
-          !userLoggedIn || loading ? <LoadingLayer loading /> : null
+          !userLoggedIn || loading || checkingPatronEligibility ? <LoadingLayer loading /> : null
         }
         <SccContainer
           activeSection="search"
@@ -388,7 +392,7 @@ export class HoldRequest extends React.Component {
                 </div>
               </div>
 
-              {form}
+              {!checkingPatronEligibility ? form : null}
             </div>
           </div>
         </SccContainer>

--- a/test/unit/HoldRequest.test.js
+++ b/test/unit/HoldRequest.test.js
@@ -11,12 +11,18 @@ import WrappedHoldRequest, { HoldRequest } from './../../src/app/pages/HoldReque
 import mockedItem from '../fixtures/mocked-item';
 
 describe('HoldRequest', () => {
+  let mock;
+  before(() => {
+    mock = new MockAdapter(axios);
+    // All tests below (except the ineligible patron test) are premised on patron eligibility
+    mock.onGet(
+      '/research/collections/shared-collection-catalog/api/patronEligibility').reply(200, { eligibility: true });
+  });
+
   describe('When component did mount', () => {
-    let mock;
     let component;
     let redirect;
     before(() => {
-      mock = new MockAdapter(axios);
       redirect = stub(HoldRequest.prototype, 'redirectWithErrors').callsFake(() => true);
     });
     describe('ineligible patrons', () => {
@@ -39,11 +45,16 @@ describe('HoldRequest', () => {
           expect(redirect.called).to.equal(true);
         });
       });
+      it('should not show form', () => {
+        setImmediate(() => {
+          const form = component.find('form').first();
+
+          expect(form.find('fieldset')).to.have.length(0);
+        });
+      });
     });
     describe('eligible patrons', () => {
       before(() => {
-        mock.onGet(
-          '/research/collections/shared-collection-catalog/api/patronEligibility').reply(200, { eligibility: true });
         component = mountTestRender(
           <WrappedHoldRequest />, {
             attachTo: document.body,
@@ -171,12 +182,14 @@ describe('HoldRequest', () => {
     it('should display the error message for invalid delivery locations.', () => {
       const form = component.find('form');
 
-      expect(form.find('h2')).to.have.length(1);
-      expect(form.contains(
-        <h2 className="nypl-request-form-title">
-          Delivery options for this item are currently unavailable. Please try again later or
-          contact 917-ASK-NYPL (<a href="tel:917-275-6975">917-275-6975</a>).
-        </h2>)).to.equal(true);
+      setImmediate(() => {
+        expect(form.find('h2')).to.have.length(1);
+        expect(form.contains(
+          <h2 className="nypl-request-form-title">
+            Delivery options for this item are currently unavailable. Please try again later or
+            contact 917-ASK-NYPL (<a href="tel:917-275-6975">917-275-6975</a>).
+          </h2>)).to.equal(true);
+      });
     });
   });
 
@@ -231,62 +244,73 @@ describe('HoldRequest', () => {
     it('should display the sentence "Choose a delivery option or location".', () => {
       const form = component.find('form');
 
-      expect(form.find('h2')).to.have.length(1);
-      expect(form.contains(
-        <h2 className="nypl-request-form-title">
-          Choose a delivery option or location
-        </h2>)).to.equal(true);
+      setImmediate(() => {
+        expect(form.find('h2')).to.have.length(1);
+        expect(form.contains(
+          <h2 className="nypl-request-form-title">
+            Choose a delivery option or location
+          </h2>)).to.equal(true);
+      });
     });
 
     it('should display the form of the display locations.', () => {
       const form = component.find('form');
 
-      expect(form.props().method).to.equal('POST');
+      setImmediate(() => {
+        expect(form.props().method).to.equal('POST');
+      });
     });
 
     it('should display the avaialbe delivery locations, and the first location is selected ' +
       'by default.', () => {
-      const form = component.find('form');
-      const fieldset = component.find('fieldset');
 
-      expect(form.find('fieldset')).to.have.length(1);
-      expect(fieldset.find('label')).to.have.length(3);
-      expect(fieldset.find('legend')).to.have.length(1);
-      expect(fieldset.find('label').at(0).find('input').props().type).to.equal('radio');
-      expect(fieldset.find('label').at(1).find('input').props().type).to.equal('radio');
-      expect(fieldset.find('label').at(2).find('input').props().type).to.equal('radio');
-      expect(fieldset.find('label').at(0).find('input').props().checked).to.equal(true);
-      expect(fieldset.find('label').at(1).find('input').props().checked).to.equal(false);
-      expect(fieldset.find('label').at(2).find('input').props().checked).to.equal(false);
+      setImmediate(() => {
+        const form = component.find('form');
+        const fieldset = component.find('fieldset');
+
+        expect(form.find('fieldset')).to.have.length(1);
+        expect(fieldset.find('label')).to.have.length(3);
+        expect(fieldset.find('legend')).to.have.length(1);
+        expect(fieldset.find('label').at(0).find('input').props().type).to.equal('radio');
+        expect(fieldset.find('label').at(1).find('input').props().type).to.equal('radio');
+        expect(fieldset.find('label').at(2).find('input').props().type).to.equal('radio');
+        expect(fieldset.find('label').at(0).find('input').props().checked).to.equal(true);
+        expect(fieldset.find('label').at(1).find('input').props().checked).to.equal(false);
+        expect(fieldset.find('label').at(2).find('input').props().checked).to.equal(false);
+      });
     });
 
     it('should display the names and the addresses of the delivery locations.', () => {
-      const fieldset = component.find('fieldset');
-      const label0 = fieldset.find('label').at(0);
-      const label1 = fieldset.find('label').at(1);
-      const label2 = fieldset.find('label').at(2);
+      setImmediate(() => {
+        const fieldset = component.find('fieldset');
+        const label0 = fieldset.find('label').at(0);
+        const label1 = fieldset.find('label').at(1);
+        const label2 = fieldset.find('label').at(2);
 
-      expect(label0.find('.nypl-screenreader-only').text()).to.equal('Send to:');
-      expect(label0.find('.nypl-location-name').text()).to.equal('Library for the Performing Arts');
-      expect(label0.find('.nypl-location-address').text()).to.equal('40 Lincoln Center Plaza');
+        expect(label0.find('.nypl-screenreader-only').text()).to.equal('Send to:');
+        expect(label0.find('.nypl-location-name').text()).to.equal('Library for the Performing Arts');
+        expect(label0.find('.nypl-location-address').text()).to.equal('40 Lincoln Center Plaza');
 
-      expect(label1.find('.nypl-screenreader-only').text()).to.equal('Send to:');
-      expect(label1.find('.nypl-location-name').text()).to.equal('Schomburg Center');
-      expect(label1.find('.nypl-location-address').text()).to.equal('515 Malcolm X Boulevard');
+        expect(label1.find('.nypl-screenreader-only').text()).to.equal('Send to:');
+        expect(label1.find('.nypl-location-name').text()).to.equal('Schomburg Center');
+        expect(label1.find('.nypl-location-address').text()).to.equal('515 Malcolm X Boulevard');
 
-      expect(label2.find('.nypl-screenreader-only').text()).to.equal('Send to:');
-      expect(label2.find('.nypl-location-name').text())
-        .to.equal('Schwarzman Building - Allen Scholar Room');
-      expect(label2.find('.nypl-location-address').text())
-        .to.equal('476 Fifth Avenue (42nd St and Fifth Ave)');
+        expect(label2.find('.nypl-screenreader-only').text()).to.equal('Send to:');
+        expect(label2.find('.nypl-location-name').text())
+          .to.equal('Schwarzman Building - Allen Scholar Room');
+        expect(label2.find('.nypl-location-address').text())
+          .to.equal('476 Fifth Avenue (42nd St and Fifth Ave)');
+      });
     });
 
     it('should deliver request button with the respective URL on the page.', () => {
-      const form = component.find('form');
-      const requestBtn = form.find('button');
+      setImmediate(() => {
+        const form = component.find('form');
+        const requestBtn = form.find('button');
 
-      expect(requestBtn.props().type).to.equal('submit');
-      expect(requestBtn.text()).to.equal('Submit Request');
+        expect(requestBtn.props().type).to.equal('submit');
+        expect(requestBtn.text()).to.equal('Submit Request');
+      });
     });
   });
 
@@ -343,16 +367,18 @@ describe('HoldRequest', () => {
     });
 
     it('should display the EDD option.', () => {
-      const form = component.find('form');
-      const fieldset = component.find('fieldset');
+      setImmediate(() => {
+        const form = component.find('form');
+        const fieldset = component.find('fieldset');
 
-      expect(form.find('fieldset')).to.have.length(1);
-      expect(fieldset.find('label')).to.have.length(4);
-      expect(fieldset.find('legend')).to.have.length(1);
-      expect(fieldset.find('label').at(0).find('input').props().type).to.equal('radio');
-      expect(fieldset.find('label').at(0).find('input').props().checked).to.equal(true);
-      expect(fieldset.find('label').at(0).text())
-        .to.equal('Have a small portion scanned and sent to you via electronic mail.');
+        expect(form.find('fieldset')).to.have.length(1);
+        expect(fieldset.find('label')).to.have.length(4);
+        expect(fieldset.find('legend')).to.have.length(1);
+        expect(fieldset.find('label').at(0).find('input').props().type).to.equal('radio');
+        expect(fieldset.find('label').at(0).find('input').props().checked).to.equal(true);
+        expect(fieldset.find('label').at(0).text())
+          .to.equal('Have a small portion scanned and sent to you via electronic mail.');
+      });
     });
   });
 
@@ -410,12 +436,14 @@ describe('HoldRequest', () => {
     });
 
     it('should not display the EDD option.', () => {
-      const form = component.find('form');
-      const fieldset = component.find('fieldset');
+      setImmediate(() => {
+        const form = component.find('form');
+        const fieldset = component.find('fieldset');
 
-      expect(form.find('fieldset')).to.have.length(1);
-      expect(fieldset.find('label')).to.have.length(3);
-      expect(fieldset.find('legend')).to.have.length(1);
+        expect(form.find('fieldset')).to.have.length(1);
+        expect(fieldset.find('label')).to.have.length(3);
+        expect(fieldset.find('legend')).to.have.length(1);
+      });
     });
   });
 
@@ -476,8 +504,10 @@ describe('HoldRequest', () => {
 
 
       it('should display nothing ', () => {
-        const form = component.find('form');
-        expect(form.find('fieldset')).to.have.length(0);
+        setImmediate(() => {
+          const form = component.find('form');
+          expect(form.find('fieldset')).to.have.length(0);
+        });
       });
     });
 
@@ -534,9 +564,11 @@ describe('HoldRequest', () => {
       });
 
       it('should display nothing ', () => {
-        const form = component.find('form');
+        setImmediate(() => {
+          const form = component.find('form');
 
-        expect(form.find('fieldset')).to.have.length(0);
+          expect(form.find('fieldset')).to.have.length(0);
+        });
       });
     });
 
@@ -589,9 +621,11 @@ describe('HoldRequest', () => {
       });
 
       it('should display everything', () => {
-        const form = component.find('form');
+        setImmediate(() => {
+          const form = component.find('form');
 
-        expect(form.find('fieldset')).to.have.length(1);
+          expect(form.find('fieldset')).to.have.length(1);
+        });
       });
     });
   });


### PR DESCRIPTION
**What's this do?**
Adds a checkingPatronElibility state var to HoldRequest page to track
status of the patron eligibility call that is made on-mount. Show
loading layer while awaiting patron eligibility call. Also, don't show
delivery option form at all while awaiting eligibility call even though
obscured by loading layer because it suggests the loading layer is the
mechanism by which we block ineligible patrons, and it is not..

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SCC-2585

**Do these changes have automated tests?**
Yes. Several HoldRequest tests had to be updated to mock the patron eligibility call and then wait for the mocked call to trigger the right render. Also added a specific test to confirm that the form is now shown if patron is ineligible

**How should this be QAed?**
Verify via:
 - while logged out
 - click a Request button
 - log in with an ineligible patron
 - observe that the loading layer is shown over basic details about the item (no delivery options form) followed by rendering patron ineligibility message (previously, the patron would not see the loading layer and/or would see the delivery options flashed momentarily before seeing the ineligibility message)

**Dependencies for merging? Releasing to production?**
No

**Has the application documentation been updated for these changes?**
n/a

**Did someone actually run this code to verify it works?**
Me