### PR TITLE
SCC-2612: Subject Heading Explorer test coverage

### DIFF
--- a/src/app/components/Sorter/Sorter.jsx
+++ b/src/app/components/Sorter/Sorter.jsx
@@ -85,7 +85,6 @@ class Sorter extends React.Component {
 Sorter.propTypes = {
   sortBy: PropTypes.string,
   page: PropTypes.string,
-  updateSortValue: PropTypes.func,
 };
 
 Sorter.contextTypes = {

--- a/src/app/components/SubjectHeading/AdditionalSubjectHeadingsButton.jsx
+++ b/src/app/components/SubjectHeading/AdditionalSubjectHeadingsButton.jsx
@@ -7,15 +7,10 @@ class AdditionalSubjectHeadingsButton extends React.Component {
     super(props);
     this.state = {};
     this.onClick = this.onClick.bind(this);
-    this.hide = this.hide.bind(this);
   }
 
   onClick() {
     this.props.updateParent(this);
-  }
-
-  hide() {
-    this.setState({ hidden: true });
   }
 
   render() {
@@ -26,8 +21,6 @@ class AdditionalSubjectHeadingsButton extends React.Component {
       noEllipse,
       marginSize,
     } = this.props;
-
-    if (this.state.hidden) return null;
 
     const previous = this.props.button === 'previous';
 
@@ -103,6 +96,8 @@ AdditionalSubjectHeadingsButton.propTypes = {
   button: PropTypes.string,
   linkUrl: PropTypes.string,
   text: PropTypes.string,
+  noEllipse: PropTypes.bool,
+  marginSize: PropTypes.number,
 };
 
 export default AdditionalSubjectHeadingsButton;

--- a/src/app/components/SubjectHeading/BibsList.jsx
+++ b/src/app/components/SubjectHeading/BibsList.jsx
@@ -34,7 +34,13 @@ class BibsList extends React.Component {
   componentDidMount() {
     const stringifiedSortParams = `sort=${this.sort}&sort_direction=${this.sortDirection}&per_page=${this.perPage}&shep_bib_count=${this.props.shepBibCount}&shep_uuid=${this.props.uuid}`;
 
-    this.fetchBibs(stringifiedSortParams);
+    if (this.props.label) {
+      this.fetchBibs(stringifiedSortParams)
+    } else {
+      this.setState({
+        componentLoading: false,
+      });
+    };
   }
 
   fetchBibs(stringifiedSortParams, cb = () => {}) {
@@ -204,34 +210,37 @@ class BibsList extends React.Component {
     }
     const bibResults = bibsSource === 'discoveryApi' ? results : results.slice(this.firstBib(), this.lastBib());
 
-    const h3Text = `Viewing ${this.firstBib() + 1} - ${this.lastBib()} of ${totalResults || ''} items for Heading "${label}"`;
+    const h3Text = bibResults.length ? `Viewing ${this.firstBib() + 1} - ${this.lastBib()} of ${totalResults || ''} item${results.length === 1 ? '' : 's'} for Heading "${label}"` : '';
 
     return (
       <div
         className="nypl-column-half bibsList"
         aria-label="Titles related to this Subject Heading"
       >
-        <Sorter
-          page="shepBibs"
-          sortOptions={[
-            { val: 'date_desc', label: 'date (new to old)' },
-            { val: 'date_asc', label: 'date (old to new)' },
-            { val: 'title_asc', label: 'title (a - z)' },
-            { val: 'title_desc', label: 'title (z - a)' },
-          ]}
-          sortBy={`${sort}_${sortDirection}`}
-          updateResults={this.changeBibSorting}
-        />
-        <h3 id="titles">{h3Text}</h3>
         {
-          bibResults ?
-            <ResultsList results={bibResults} subjectHeadingShow />
-          :
-            <div className="nypl-column-half bibsList">
-              There are no titles for this subject heading.
-            </div>
-        }
-        {bibResults && bibResults.length > 0 ? this.pagination() : null}
+          bibResults && bibResults.length > 0 ?
+          (
+            <>
+              <Sorter
+                page="shepBibs"
+                sortOptions={[
+                  { val: 'date_desc', label: 'date (new to old)' },
+                  { val: 'date_asc', label: 'date (old to new)' },
+                  { val: 'title_asc', label: 'title (a - z)' },
+                  { val: 'title_desc', label: 'title (z - a)' },
+                ]}
+                sortBy={`${sort}_${sortDirection}`}
+                updateResults={this.changeBibSorting}
+              />
+              <h3 id="titles">{h3Text}</h3>
+              <ResultsList results={bibResults} subjectHeadingShow />
+              this.pagination()
+            </>
+          ) : (
+          <div className="nypl-column-half bibsList">
+            There are no titles for this subject heading.
+          </div>
+        )}
       </div>
     );
   }

--- a/src/app/components/SubjectHeading/NestedTableHeader.jsx
+++ b/src/app/components/SubjectHeading/NestedTableHeader.jsx
@@ -9,7 +9,6 @@ const NestedTableHeader = (props) => {
     indentation,
     sortBy,
     direction,
-    parentUuid,
     updateSort,
     numberOpen,
     interactive,
@@ -57,9 +56,15 @@ NestedTableHeader.propTypes = {
   indentation: PropTypes.number,
   sortBy: PropTypes.string,
   direction: PropTypes.string,
-  parentUuid: PropTypes.string,
   updateSort: PropTypes.func,
   interactive: PropTypes.bool,
+  numberOpen: PropTypes.number,
+  marginSize: PropTypes.number,
+};
+
+NestedTableHeader.defaultProps = {
+  // value used for desktop margins
+  marginSize: 30,
 };
 
 export default NestedTableHeader;

--- a/src/app/components/SubjectHeading/Search/SubjectHeadingSearch.jsx
+++ b/src/app/components/SubjectHeading/Search/SubjectHeadingSearch.jsx
@@ -86,7 +86,7 @@ class SubjectHeadingSearch extends React.Component {
 
     return (
       /*
-        * if you need style the open state
+        * if you need to style the open state
         * add the `alwaysRenderSuggestions` prop
       */
       <Autosuggest

--- a/src/app/components/SubjectHeading/SortButton.jsx
+++ b/src/app/components/SubjectHeading/SortButton.jsx
@@ -15,19 +15,21 @@ const SortButton = (props) => {
     active,
   } = props;
 
+  const columnText = {
+    bibs: 'Titles',
+    descendants: 'Subheadings',
+    alphabetical: 'Heading',
+  }[type];
+
+  if (!columnText) return null;
+
   const defaultSort = {
     alphabetical: 'ASC',
     bibs: 'DESC',
     descendants: 'DESC',
-  }[type]
+  }[type];
 
   const nextDirection = calculateDirection ? calculateDirection(type) : defaultSort;
-
-  const columnText = () => ({
-    bibs: 'Titles',
-    descendants: 'Subheadings',
-    alphabetical: 'Heading',
-  }[type]);
 
   const icon = () => {
     if (!active) return <DefaultIcon />;
@@ -42,7 +44,7 @@ const SortButton = (props) => {
       disabled={!handler || !interactive || numberOpen < 2}
     >
       <span className="emph">
-        <span className="noEmph">{columnText()}
+        <span className="noEmph">{columnText}
           {(handler && interactive) ? <span className="sortCharacter">{ icon() }</span> : null}
         </span>
       </span>
@@ -53,8 +55,10 @@ const SortButton = (props) => {
 SortButton.propTypes = {
   handler: PropTypes.func,
   type: PropTypes.string,
-  direction: PropTypes.string,
   interactive: PropTypes.bool,
+  numberOpen: PropTypes.number,
+  calculateDirection: PropTypes.func,
+  active: PropTypes.bool,
 };
 
 export default SortButton;

--- a/src/app/components/SubjectHeading/SubjectHeading.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeading.jsx
@@ -16,6 +16,7 @@ class SubjectHeading extends React.Component {
       sortBy,
       direction,
     } = this.props;
+    if (!subjectHeading) return;
     const {
       children,
       range,
@@ -39,6 +40,7 @@ class SubjectHeading extends React.Component {
       subjectHeading,
       preOpen,
     } = this.props;
+    if (!subjectHeading) return;
     if (preOpen || subjectHeading.preview) {
       this.fetchInitial();
     }
@@ -160,6 +162,8 @@ class SubjectHeading extends React.Component {
       container,
       location,
     } = this.props;
+
+    if (!subjectHeading) return null;
 
     const {
       pathname,

--- a/src/app/components/SubjectHeading/SubjectHeadingShow.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeadingShow.jsx
@@ -98,7 +98,7 @@ class SubjectHeadingShow extends React.Component {
 
   generateFullContextUrl() {
     const uuid = this.props.params.subjectHeadingUuid;
-    const path = this.props.location.pathname.replace(/\/subject_headings.*/, '');
+    const path = this.context.router.location.pathname.replace(/\/subject_headings.*/, '');
     return `${path}/subject_headings?linked=${uuid}`;
   }
 
@@ -142,7 +142,7 @@ class SubjectHeadingShow extends React.Component {
 
     const { uuid, label } = mainHeading;
 
-    const { location } = this.props;
+    const { location } = this.context.router;
 
     const linkUrl = contextHeadings && contextHeadings.length ? this.generateFullContextUrl() : '#';
 
@@ -189,7 +189,6 @@ class SubjectHeadingShow extends React.Component {
 }
 
 SubjectHeadingShow.propTypes = {
-  location: PropTypes.object,
   params: PropTypes.object,
   setBannerText: PropTypes.func,
 };

--- a/src/app/components/SubjectHeading/SubjectHeadingsTableBody.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeadingsTableBody.jsx
@@ -123,7 +123,7 @@ class SubjectHeadingsTableBody extends React.Component {
       seeMoreText,
       seeMoreLinkUrl,
       preOpen,
-      marginSize
+      marginSize,
     } = this.props;
     const { container, router } = this.context;
     const { location } = this.context.router;
@@ -167,6 +167,8 @@ class SubjectHeadingsTableBody extends React.Component {
       subjectHeadings,
     } = this.state;
 
+    if (!subjectHeadings) return null;
+
     const {
       nested,
       parentUuid,
@@ -201,18 +203,14 @@ class SubjectHeadingsTableBody extends React.Component {
           />
           : null
         }
-        {
-          subjectHeadings ?
-          inRange.map(this.tableRow) :
-          null
-        }
+        {inRange.map(this.tableRow)}
       </React.Fragment>
     );
   }
 }
 
 SubjectHeadingsTableBody.propTypes = {
-  nested: PropTypes.string,
+  nested: PropTypes.bool,
   subjectHeadings: PropTypes.array,
   indentation: PropTypes.number,
   linked: PropTypes.string,
@@ -223,6 +221,8 @@ SubjectHeadingsTableBody.propTypes = {
   seeMoreText: PropTypes.string,
   seeMoreLinkUrl: PropTypes.string,
   direction: PropTypes.string,
+  preOpen: PropTypes.bool,
+  marginSize: PropTypes.number,
 };
 
 SubjectHeadingsTableBody.defaultProps = {

--- a/src/app/components/SubjectHeading/SubjectHeadingsTableBody.jsx
+++ b/src/app/components/SubjectHeading/SubjectHeadingsTableBody.jsx
@@ -219,7 +219,7 @@ SubjectHeadingsTableBody.propTypes = {
   sortBy: PropTypes.string,
   parentUuid: PropTypes.string,
   updateSort: PropTypes.func,
-  pathname: PropTypes.string,
+  nextUrl: PropTypes.string,
   seeMoreText: PropTypes.string,
   seeMoreLinkUrl: PropTypes.string,
   direction: PropTypes.string,

--- a/test/unit/AdditionalSubjectHeadingsButton.test.js
+++ b/test/unit/AdditionalSubjectHeadingsButton.test.js
@@ -1,0 +1,37 @@
+/* eslint-disable react/jsx-filename-extension */
+/* eslint-env mocha */
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+
+import AdditionalSubjectHeadingsButton from './../../src/app/components/SubjectHeading/AdditionalSubjectHeadingsButton';
+
+describe('AdditionalSubjectHeadingsButton', () => {
+  describe('default rendering', () => {
+    let component;
+    before(() => {
+      component = shallow(<AdditionalSubjectHeadingsButton />);
+    });
+
+    it('should render a `tr`', () => {
+      expect(component.is('tr')).to.equal(true);
+    });
+  });
+
+  describe('with `linkUrl`', () => {
+    let component;
+    before(() => {
+      component = shallow(
+        <AdditionalSubjectHeadingsButton
+          linkUrl="linkforheading.com"
+        />
+      );
+    });
+
+    it('should render a `Link`', () => {
+      const link = component.find('Link');
+      expect(link.length).to.equal(1);
+      expect(link.prop('to')).to.equal('linkforheading.com');
+    });
+  });
+});

--- a/test/unit/BibsList.test.js
+++ b/test/unit/BibsList.test.js
@@ -1,0 +1,105 @@
+/* eslint-disable react/jsx-filename-extension */
+/* eslint-env mocha */
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
+
+import BibsList from './../../src/app/components/SubjectHeading/BibsList';
+import Pagination from './../../src/app/components/Pagination/Pagination';
+import resultsBibs from '../fixtures/resultsBibs';
+import { mockRouterContext } from '../helpers/routing';
+import appConfig from './../../src/app/data/appConfig';
+
+const context = mockRouterContext();
+
+describe('BibsList (for Subject Heading Explorer)', () => {
+  describe('before componentDidMount', () => {
+    let component;
+    before(() => {
+      component = shallow(<BibsList />, {
+        disableLifecycleMethods: true,
+        context,
+      });
+    });
+
+    it('should render LocalLoadingLayer', () => {
+      expect(component.find('LocalLoadingLayer').length).to.equal(1);
+    });
+  });
+
+  describe('default rendering, no results', () => {
+    let component;
+    before(() => {
+      component = shallow(<BibsList />, { context });
+    });
+
+    it('should not render LocalLoadingLayer', () => {
+      expect(component.find('LocalLoadingLayer').length).to.equal(0);
+    });
+
+    it('should render no results text', () => {
+      expect(component.text()).to.include('There are no titles for this subject heading.');
+    });
+  });
+
+  describe('with props, has results from `shepApi`', () => {
+    let component;
+    before(() => {
+      const mock = new MockAdapter(axios);
+      mock.onGet(
+        `${appConfig.baseUrl}/api/subjectHeading/${encodeURIComponent('Subject Heading')}?&sort=date&sort_direction=desc&per_page=6&shep_bib_count=100&shep_uuid=1234`
+      ).reply(200, {
+        newResults: resultsBibs,
+        bibsSource: 'shepApi',
+        totalResults: 100,
+        page: 1,
+      });
+      component = shallow(
+        <BibsList
+          label="Subject Heading"
+          shepBibCount="100"
+          uuid="1234"
+        />, { context });
+    });
+
+    it('should have `Sorter`', () => {
+      expect(component.find('Sorter').length).to.equal(1);
+    });
+
+    it('should have `h3`', () => {
+      expect(component.find('h3').length).to.equal(1);
+    });
+
+    it('should have `ResultsList`', () => {
+      expect(component.find('ResultsList').length).to.equal(1);
+    });
+
+    // Testing a child component rendered via a function with `shallow` render
+    it('`pagination()` should return `Pagination` component', () => {
+      const pagination = component.instance().pagination();
+      expect(pagination.type).to.equal(Pagination);
+    });
+  });
+
+  describe('API error', () => {
+    let component;
+    before(() => {
+      const mock = new MockAdapter(axios);
+      mock.onGet(
+        `${appConfig.baseUrl}/api/subjectHeading/${encodeURIComponent('Will Error')}?&sort=date&sort_direction=desc&per_page=6&shep_bib_count=100&shep_uuid=1234`
+      ).reply(404);
+      component = shallow(
+        <BibsList
+          label="Will Error"
+          shepBibCount="100"
+          uuid="1234"
+        />, { context });
+    });
+
+    it('should not render LocalLoadingLayer', () => {
+      expect(component.find('LocalLoadingLayer').length).to.equal(0);
+    });
+  });
+});

--- a/test/unit/NeighboringHeadingsBox.test.js
+++ b/test/unit/NeighboringHeadingsBox.test.js
@@ -1,0 +1,30 @@
+/* eslint-disable react/jsx-filename-extension */
+/* eslint-env mocha */
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+
+import NeighboringHeadingsBox from './../../src/app/components/SubjectHeading/NeighboringHeadingsBox';
+
+describe('NeighboringHeadingsBox', () => {
+  describe('default rendering', () => {
+    it('should render a `SubjectHeadingsTable`', () => {
+      const component = shallow(<NeighboringHeadingsBox />);
+      expect(component.find('SubjectHeadingsTable').length).to.equal(1);
+    });
+  });
+
+  describe('with `contextError` true', () => {
+    it('should render error text', () => {
+      const component = shallow(<NeighboringHeadingsBox contextError />);
+      expect(component.text()).to.include('Error loading neighboring headings');
+    });
+  });
+
+  describe('with `contextIsLoading` true', () => {
+    it('should render error text', () => {
+      const component = shallow(<NeighboringHeadingsBox contextIsLoading />);
+      expect(component.find('LocalLoadingLayer').length).to.equal(1);
+    });
+  });
+});

--- a/test/unit/NestedTableHeader.test.js
+++ b/test/unit/NestedTableHeader.test.js
@@ -1,0 +1,29 @@
+/* eslint-disable react/jsx-filename-extension */
+/* eslint-env mocha */
+import React from 'react';
+import { expect } from 'chai';
+import { mount } from 'enzyme';
+
+import NestedTableHeader from './../../src/app/components/SubjectHeading/NestedTableHeader';
+
+describe('NestedTableHeader', () => {
+  describe('default rendering', () => {
+    let component;
+    before(() => {
+      component = mount(<NestedTableHeader />, {
+        attachTo: document.createElement('tbody'),
+      });
+    });
+    it('should render a `tr`', () => {
+      expect(component.find('tr').length).to.equal(1);
+    });
+
+    it('should render 3 `th`s', () => {
+      const ths = component.find('th');
+      expect(ths.length).to.equal(3);
+      expect(ths.at(0).text()).to.equal('Heading');
+      expect(ths.at(1).text()).to.equal('Subheadings');
+      expect(ths.at(2).text()).to.equal('Titles');
+    });
+  });
+});

--- a/test/unit/SortButton.test.js
+++ b/test/unit/SortButton.test.js
@@ -1,0 +1,86 @@
+/* eslint-disable react/jsx-filename-extension */
+/* eslint-env mocha */
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+
+import SortButton from './../../src/app/components/SubjectHeading/SortButton';
+
+describe('SortButton', () => {
+  describe('default rendering', () => {
+    it('should not render without a `type`', () => {
+      const component = shallow(<SortButton />);
+      expect(component.isEmptyRender()).to.equal(true);
+    });
+  });
+
+  describe('with props', () => {
+    it('should render disabled button with text with just valid `type` prop', () => {
+      const component = shallow(<SortButton type="alphabetical" />);
+      const button = component.find('button');
+      expect(button.length).to.equal(1);
+      expect(button.prop('disabled')).to.equal(true);
+      expect(button.text()).to.equal('Heading');
+    });
+    it('should not render with unsupported `type` prop', () => {
+      const component = shallow(<SortButton type="not-a-type" />);
+      expect(component.isEmptyRender()).to.equal(true);
+    });
+    describe('icons, when `interactive` and `handler` props are truthy', () => {
+      it('should render `DefaultIcon` for inactive sort type', () => {
+        const component = shallow(
+          <SortButton
+            type="alphabetical"
+            active={false}
+            handler={() => {}}
+            interactive
+          />);
+        expect(component.find('DefaultIcon').length).to.equal(1);
+      });
+
+      it('should render `DefaultIcon` for inactive sort type', () => {
+        const component = shallow(
+          <SortButton
+            type="alphabetical"
+            active={false}
+            handler={() => {}}
+            interactive
+          />);
+        expect(component.find('DefaultIcon').length).to.equal(1);
+      });
+
+      it('should render `DescendingIcon` for default alphabetical/"Heading" sort', () => {
+        const component = shallow(
+          <SortButton
+            type="alphabetical"
+            active
+            handler={() => {}}
+            interactive
+          />);
+        expect(component.find('DescendingIcon').length).to.equal(1);
+      });
+
+      it('should render `AscendingIcon` for default bibs/"Titles" sort', () => {
+        const component = shallow(
+          <SortButton
+            type="bibs"
+            active
+            handler={() => {}}
+            interactive
+          />);
+        expect(component.find('AscendingIcon').length).to.equal(1);
+      });
+
+      it('should render `AscendingIcon` for default descendants/"Subheadings" sort', () => {
+        const component = shallow(
+          <SortButton
+            type="descendants"
+            active
+            handler={() => {}}
+            interactive
+          />);
+        expect(component.find('AscendingIcon').length).to.equal(1);
+      });
+    });
+  });
+});

--- a/test/unit/SubjectHeading.test.js
+++ b/test/unit/SubjectHeading.test.js
@@ -1,0 +1,130 @@
+/* eslint-disable react/jsx-filename-extension */
+/* eslint-env mocha */
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
+
+import SubjectHeading from './../../src/app/components/SubjectHeading/SubjectHeading';
+import appConfig from './../../src/app/data/appConfig';
+
+describe('SubjectHeading', () => {
+  describe('default rendering', () => {
+    it('should not render without a `subjectHeading` prop', () => {
+      const component = shallow(<SubjectHeading />);
+      expect(component.isEmptyRender()).to.equal(true);
+    });
+  });
+
+  describe('Index View', () => {
+    describe('no subheadings/descendants', () => {
+      let component;
+      before(() => {
+        component = shallow(
+          <SubjectHeading
+            subjectHeading={{
+              label: 'Testing',
+              desc_count: 0,
+            }}
+            location={{
+              query: {},
+              pathname: '',
+              search: '',
+            }}
+          />);
+      });
+
+      it('should render one `tr`', () => {
+        expect(component.find('tr').length).to.equal(1);
+      });
+
+      it('should not have a toggle', () => {
+        expect(component.find('td').at(0).find('button').length).to.equal(0);
+      });
+
+      it('should use "-" placeholder if there are no subheadings', () => {
+        expect(component.find('td').at(1).text()).to.equal('-');
+      });
+    });
+
+    describe('has subheadings/descendants', () => {
+      let component;
+      before(() => {
+        component = shallow(
+          <SubjectHeading
+            subjectHeading={{
+              label: 'Testing',
+              desc_count: 10,
+              uuid: '1234',
+            }}
+            location={{
+              query: {},
+              pathname: '',
+              search: '',
+            }}
+          />);
+      });
+
+      it('should render one `tr`', () => {
+        expect(component.find('tr').length).to.equal(1);
+      });
+
+      it('should have a toggle with `+`', () => {
+        const button = component.find('td').at(0).find('button');
+        expect(button.length).to.equal(1);
+        expect(button.text()).to.equal('+');
+      });
+
+      it('should have count in second td', () => {
+        expect(component.find('td').at(1).text()).to.equal('10');
+      });
+    });
+  });
+
+  describe('`preOpen` prop', () => {
+    let component;
+    let mock;
+    before(() => {
+      mock = new MockAdapter(axios);
+      mock
+        .onGet(`${appConfig.baseUrl}/api/subjectHeadings/subject_headings/1234/narrower?sort_by=alphabetical&direction=ASC`)
+        .reply(200, {
+          narrower: [{
+            label: 'Testing -- Child',
+            desc_count: 1,
+            uuid: '1235',
+          }],
+          next_url: 'nextUrl.com',
+        });
+      component = shallow(
+        <SubjectHeading
+          subjectHeading={{
+            label: 'Testing',
+            desc_count: 10,
+            uuid: '1234',
+          }}
+          location={{
+            query: {},
+            pathname: '',
+            search: '',
+          }}
+          preOpen
+        />);
+    });
+
+    it('should render one `tr`', () => {
+      expect(component.find('tr').length).to.equal(1);
+    });
+
+    it('should have a toggle with `-`', () => {
+      const button = component.find('td').at(0).find('button');
+      expect(button.length).to.equal(1);
+      expect(button.text()).to.equal('-');
+    });
+
+    it('should have a `SubjectHeadingsTableBody`', () => {
+      expect(component.find('SubjectHeadingsTableBody').length).to.equal(1);
+    });
+  });
+});

--- a/test/unit/SubjectHeadingShow.test.js
+++ b/test/unit/SubjectHeadingShow.test.js
@@ -3,12 +3,16 @@
 import React from 'react';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
+import MockAdapter from 'axios-mock-adapter';
+import axios from 'axios';
 
 import SubjectHeadingShow from '@SubjectHeadingShow';
 import SubjectHeadingShowPage from './../../src/app/pages/SubjectHeadingShowPage';
+import appConfig from './../../src/app/data/appConfig';
 
-describe('SubjectHeadingsIndexPage', () => {
+describe('SubjectHeadingShowPage', () => {
   let component;
+
   before(() => {
     component = shallow(
       <SubjectHeadingShowPage
@@ -22,14 +26,45 @@ describe('SubjectHeadingsIndexPage', () => {
 });
 
 describe('SubjectHeadingShow', () => {
-  const params = {
-    subjectHeadingUuid: '1',
-  };
-  const wrapper = shallow(
-    <SubjectHeadingShow params={params} />,
-    { context: { router: { location: { search: '' } } } },
-  );
-  const instance = wrapper.instance();
+  let instance;
+  let mock;
+  let component;
+  before(() => {
+    mock = new MockAdapter(axios);
+    mock
+      .onGet('/research/collections/shared-collection-catalog/api/subjectHeadings/subject_headings/1/context')
+      .reply(200, {
+        subject_headings: [{
+          label: 'Testing -- Related',
+          desc_count: 1,
+          uuid: '1234',
+        }],
+        main_heading: {
+          label: 'Testing -- Related',
+          bib_count: 1,
+          uuid: '1235',
+        },
+      });
+    mock
+      .onGet('/research/collections/shared-collection-catalog/api/subjectHeadings/subject_headings/1/related')
+      .reply(200, {
+        related_headings: [{
+          label: 'Testing -- Related',
+          desc_count: 1,
+          uuid: '1234',
+        }],
+      });
+
+    const params = {
+      subjectHeadingUuid: '1',
+    };
+    component = shallow(
+      <SubjectHeadingShow params={params} setBannerText={() => {}} />,
+      { context: { router: { location: { search: '', pathname: '' } } } },
+    );
+    instance = component.instance();
+  });
+
   describe('finding uuid', () => {
     it('should accept a list containing a subject heading with correct uuid', () => {
       const headings = [
@@ -70,7 +105,7 @@ describe('SubjectHeadingShow', () => {
 
   describe('should not have .drbb-integration classes', () => {
     it('should not have any components with .drbb-integration class', () => {
-      expect(wrapper.find('.drbb-integration')).to.have.length(0);
+      expect(component.find('.drbb-integration')).to.have.length(0);
     });
   });
 });

--- a/test/unit/SubjectHeadingShow.test.js
+++ b/test/unit/SubjectHeadingShow.test.js
@@ -8,7 +8,6 @@ import axios from 'axios';
 
 import SubjectHeadingShow from '@SubjectHeadingShow';
 import SubjectHeadingShowPage from './../../src/app/pages/SubjectHeadingShowPage';
-import appConfig from './../../src/app/data/appConfig';
 
 describe('SubjectHeadingShowPage', () => {
   let component;

--- a/test/unit/SubjectHeadingsIndex.test.js
+++ b/test/unit/SubjectHeadingsIndex.test.js
@@ -3,6 +3,8 @@
 import React from 'react';
 import { expect } from 'chai';
 import { mount, shallow } from 'enzyme';
+import MockAdapter from 'axios-mock-adapter';
+import axios from 'axios';
 
 import SubjectHeadingsIndex from '@SubjectHeadingsIndex';
 import SubjectHeadingsIndexPage from './../../src/app/pages/SubjectHeadingsIndexPage';
@@ -29,30 +31,39 @@ describe('SubjectHeadingsIndexPage', () => {
 describe('SubjectHeadingsIndex', () => {
   const context = mockRouterContext();
   let component;
+  let mock;
   describe('Unfiltered index', () => {
     before(() => {
+      mock = new MockAdapter(axios);
+      mock
+        .onGet('/research/collections/shared-collection-catalog/api/subjectHeadings/subject_headings?from_comparator=start&from_label=Aac')
+        .reply(200, {
+          subject_headings: [{
+            label: 'Testing -- Related',
+            desc_count: 1,
+            uuid: '1234',
+          }],
+          previous_url: 'previous.com',
+          next_url: 'next.com',
+        });
+    });
+    it('should render `Alphabetical Pagination`', () => {
       component = mount(
         <SubjectHeadingsIndex />,
         { context });
-    });
-    it('should render `Alphabetical Pagination`', () => {
       expect(component.find('AlphabeticalPagination').length).to.equal(1);
     });
   });
 
   describe('Filtered index', () => {
-    before(() => {
+    it('should not render `Alphabetical Pagination`', () => {
       context.router.location.query.filter = 'pottery';
       component = mount(
         <SubjectHeadingsIndex />,
         { context },
       );
-    });
-    after(() => {
-      context.router.location.query.filter = undefined;
-    });
-    it('should not render `Alphabetical Pagination`', () => {
       expect(component.find('AlphabeticalPagination').length).to.equal(0);
+      context.router.location.query.filter = undefined;
     });
   });
 });

--- a/test/unit/SubjectHeadingsTableBody.test.js
+++ b/test/unit/SubjectHeadingsTableBody.test.js
@@ -1,0 +1,127 @@
+/* eslint-env mocha */
+/* eslint-disable react/jsx-filename-extension */
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+
+import SubjectHeadingsTableBody from './../../src/app/components/SubjectHeading/SubjectHeadingsTableBody';
+import { mockRouterContext } from '../helpers/routing';
+
+describe('SubjectHeadingsTableBody', () => {
+  const routerContext = mockRouterContext();
+  describe('default render', () => {
+    it('should not render without `subjectHeadings`', () => {
+      const component = shallow(<SubjectHeadingsTableBody />);
+      expect(component.isEmptyRender()).to.equal(true);
+    });
+  });
+
+  describe('with `subjectHeadings`', () => {
+    describe('one subject heading', () => {
+      it('should render one `SubjectHeading`', () => {
+        const component = shallow(
+          <SubjectHeadingsTableBody
+            subjectHeadings={[
+              {
+                label: 'Testing',
+                desc_count: 10,
+                uuid: '1234',
+              },
+            ]}
+          />, {
+            context: routerContext,
+          });
+        expect(component.find('SubjectHeading').length).to.equal(1);
+      });
+    });
+
+    describe('multiple subject headings', () => {
+      it('should render multiple `SubjectHeading`s, wrapped in `Fragment`', () => {
+        const component = shallow(
+          <SubjectHeadingsTableBody
+            subjectHeadings={[
+              {
+                label: 'Testing',
+                desc_count: 10,
+                uuid: '1234',
+              },
+              {
+                label: 'Test',
+                desc_count: 10,
+                uuid: '1235',
+              }
+            ]}
+          />, {
+            context: routerContext,
+          });
+        expect(component.is('Fragment')).to.equal(true);
+        expect(component.find('SubjectHeading').length).to.equal(2);
+      });
+    });
+
+    describe('nested subject headings table', () => {
+      it('should render `NestedTableHeader`', () => {
+        const component = shallow(
+          <SubjectHeadingsTableBody
+            subjectHeadings={[
+              {
+                label: 'Testing',
+                desc_count: 10,
+                uuid: '1234',
+              }
+            ]}
+            nested
+          />, {
+            context: routerContext,
+          });
+        expect(component.is('Fragment')).to.equal(true);
+        expect(component.find('NestedTableHeader').length).to.equal(1);
+      });
+    });
+
+    describe('With a `nextUrl`', () => {
+      it('should render `AdditionalSubjectHeadingsButton` with `next` button', () => {
+        const component = shallow(
+          <SubjectHeadingsTableBody
+            subjectHeadings={[
+              {
+                label: 'Testing',
+                desc_count: 10,
+                uuid: '1234',
+              }
+            ]}
+            nextUrl="nextHeadings.com"
+          />, {
+            context: {
+              ...routerContext,
+            },
+          });
+        const additionalSubjectHeadingsButton = component.find('AdditionalSubjectHeadingsButton');
+        expect(additionalSubjectHeadingsButton.length).to.equal(1);
+        expect(additionalSubjectHeadingsButton.prop('button')).to.equal('next');
+      });
+
+      it('context view, should render `AdditionalSubjectHeadingsButton` with `contextMore` button', () => {
+        const component = shallow(
+          <SubjectHeadingsTableBody
+            subjectHeadings={[
+              {
+                label: 'Testing',
+                desc_count: 10,
+                uuid: '1234',
+              }
+            ]}
+            nextUrl="nextHeadings.com"
+          />, {
+            context: {
+              ...routerContext,
+              container: 'context',
+            },
+          });
+        const additionalSubjectHeadingsButton = component.find('AdditionalSubjectHeadingsButton');
+        expect(additionalSubjectHeadingsButton.length).to.equal(1);
+        expect(additionalSubjectHeadingsButton.prop('button')).to.equal('contextMore');
+      });
+    });
+  });
+});


### PR DESCRIPTION
**What's this do?**
Adds test coverage for Subject Heading Explorer components. Some small code cleanup.
Mostly this gets all the components to have at least 70% coverage of "Statements" (over 80% for all but two), according to the coverage report. Hopefully now that there is baseline coverage for all components, it will be easier to write more tests if these components need to be touched again, if a bug is found, etc.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SCC-2612

**Do these changes have automated tests?**
Is mostly test coverage

**How should this be QAed?**
Do a little bit of regression testing for SHEP pages. Changes made should not have introduced any regressions

**Dependencies for merging? Releasing to production?**
None. This can be launched post-launch of Research Catalog.

**Has the application documentation been updated for these changes?**

**Did someone actually run this code to verify it works?**
I did