### PR TITLE
Display error message for freeze attempt

### DIFF
--- a/src/app/utils/accountPageUtils.js
+++ b/src/app/utils/accountPageUtils.js
@@ -132,7 +132,7 @@ export const manipulateAccountPage = (
       });
 
       const inputs = el.querySelectorAll('input');
-      const buttons = [];
+      const holdActionElements = [];
       const removeTd = (element) => {
         if (element.tagName === 'TD') {
           element.remove();
@@ -171,7 +171,7 @@ export const manipulateAccountPage = (
         } else {
           button.addEventListener('click', eventCb);
         }
-        buttons.push(button);
+        holdActionElements.push(button);
         removeTd(input);
         eventListeners.push({ element: button, cb: eventCb });
       });
@@ -179,12 +179,27 @@ export const manipulateAccountPage = (
       // add new TD with account page button(s)
       const td = document.createElement('td');
       td.classList.add('account-table-buttons');
-      buttons.forEach((button) => {
+
+      /**
+       * If the freeze cell did not have an `input`, it still needs to be removed.
+       * There may be an error message, probably "This hold can not be frozen."
+       * If so, create an element to display it and then remove the cell.
+      */
+      const freezeCells = el.querySelectorAll('.patFuncFreeze');
+      if (freezeCells) {
+        freezeCells.forEach((cell) => {
+          if (cell.textContent) {
+            const freezeMessage = document.createElement('em');
+            freezeMessage.textContent = cell.textContent;
+            holdActionElements.push(freezeMessage);
+          }
+          cell.remove();
+        });
+      }
+      holdActionElements.forEach((button) => {
         td.appendChild(button);
       });
       el.appendChild(td);
-      const freezeCells = el.querySelectorAll('.patFuncFreeze');
-      if (freezeCells) freezeCells.forEach(cell => cell.remove());
     });
     accountPageContent.querySelectorAll('.patFuncRating').forEach(el => el.remove());
 

--- a/src/client/styles/components/AccountPage.scss
+++ b/src/client/styles/components/AccountPage.scss
@@ -21,6 +21,10 @@
         margin-bottom: var(--space-xs);
       }
     }
+
+    em {
+      display: block;
+    }
   }
 
   td > span {


### PR DESCRIPTION
**What's this do?**
Some messaging around freezes was getting lost due to the DOM manipulation. This is a pitfall of the approach. Hopefully there are no other surprises. I think this case was missed because both Chris and I were trying to use items that had a lot of holds, to avoid placing holds on available items. 

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SCC-2654

**Do these changes have automated tests?**
No automated tests for DOM manipulation.

**How should this be QAed?**
Place a hold on an item with an available copy, wait for it to show up in "Holds". Try freezing, the error message should display. The item is still cancelable soon after.

**Dependencies for merging? Releasing to production?**
QA might have some code that is in limbo. This branch was cut from `development`... Can figure out merging later if this is approved and QA'ed

**Has the application documentation been updated for these changes?**

**Did someone actually run this code to verify it works?**
I did