### PR TITLE
Add tiemout in shep call for Bib

### DIFF
--- a/src/server/ApiRoutes/Bib.js
+++ b/src/server/ApiRoutes/Bib.js
@@ -13,7 +13,11 @@ const nyplApiClientCall = (query, urlEnabledFeatures, itemFrom) => {
   return nyplApiClient().then(client => client.get(`/discovery/resources/${query}${queryForItemPage}`, requestOptions));
 };
 
-const shepApiCall = bibId => axios(`${appConfig.shepApi}/bibs/${bibId}/subject_headings`);
+const shepApiCall = bibId => axios({
+  method: 'get',
+  url: `${appConfig.shepApi}/bibs/${bibId}/subject_headings`,
+  timeout: 5000,
+});
 
 const holdingsMappings = {
   Location: 'location',


### PR DESCRIPTION
**What's this do?**
Adds a 5 second timeout in the SHEP request on the bib page.

**Why are we doing this? (w/ JIRA link if applicable)**
If the SHEP request times out, we don't want the whole page to break. This is scc-2640

**Do these changes have automated tests?**
No, I'm having some trouble writing tests for this component. Since my next ticket is to expand test coverage, it seems like we might as well just get this fix in.

**How should this be QAed?**
Locally this can be tested by faking the SHEP API so that it times out, in which case bib requests should show links to subject-filtered searches, instead of links to SHEP. Not sure how to QA this in the live environment though.

**Dependencies for merging? Releasing to production?**

**Has the application documentation been updated for these changes?**

**Did someone actually run this code to verify it works?**
I tested this locally.
