### PR TITLE
Travis tag deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,18 +31,19 @@ deploy:
   on:
     repo: NYPL/discovery-front-end
     branch: production
-- provider: elasticbeanstalk
-  skip_cleanup: false
-  access_key_id: "$AWS_ACCESS_KEY_ID_QA"
-  secret_access_key: "$AWS_SECRET_ACCESS_KEY_QA"
-  region: us-east-1
-  app: discovery-ui-qwerty
-  env: DiscoveryUi-10-17-qa-qwerty
-  bucket_name: elasticbeanstalk-us-east-1-946183545209
-  bucket_path: discovery-ui-shep
-  on:
-    repo: NYPL/discovery-front-end
-    condition: $TRAVIS_TAG = qa-tag
+if: tag ~= /^qa-.*/
+  deploy:
+  - provider: elasticbeanstalk
+    skip_cleanup: false
+    access_key_id: "$AWS_ACCESS_KEY_ID_QA"
+    secret_access_key: "$AWS_SECRET_ACCESS_KEY_QA"
+    region: us-east-1
+    app: discovery-ui-qwerty
+    env: DiscoveryUi-10-17-qa-qwerty
+    bucket_name: elasticbeanstalk-us-east-1-946183545209
+    bucket_path: discovery-ui-shep
+    on:
+      repo: NYPL/discovery-front-end
 
 after_deploy: echo 'Successfully executed deploy trigger for Discovery Research
   Catalog on AWS'

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,19 +42,8 @@ deploy:
   bucket_path: discovery-ui-shep
   on:
     repo: NYPL/discovery-front-end
-    branch: qa
-- provider: elasticbeanstalk
-  skip_cleanup: false
-  access_key_id: "$AWS_ACCESS_KEY_ID_QA"
-  secret_access_key: "$AWS_SECRET_ACCESS_KEY_QA"
-  region: us-east-1
-  app: discovery-ui
-  env: DiscoveryUi-edd-training
-  bucket_name: elasticbeanstalk-us-east-1-946183545209
-  bucket_path: discovery-ui-shep
-  on:
-    repo: NYPL/discovery-front-end
-    branch: accounts
+    condition: tag = qa
+
 after_deploy: echo 'Successfully executed deploy trigger for Discovery Research
   Catalog on AWS'
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ node_js:
 - 10.17.0
 install: npm rebuild node-sass && npm install
 before_script: npm run dist
-script: npm test
+script: echo "$TRAVIS_TAG"
 before_deploy: echo 'All unit tests passed; Successfull built distribution assets;
   Preparing to deploy Discovery Research Catalog to AWS.'
 deploy:
@@ -42,6 +42,7 @@ deploy:
   bucket_path: discovery-ui-shep
   on:
     repo: NYPL/discovery-front-end
+    all_branches: true
     condition: $TRAVIS_TAG =~ ^qa-.*
 
 after_deploy: echo 'Successfully executed deploy trigger for Discovery Research

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ deploy:
   bucket_path: discovery-ui-shep
   on:
     repo: NYPL/discovery-front-end
-    condition: tag = qa-tag
+    condition: $TRAVIS_TAG = qa-tag
 
 after_deploy: echo 'Successfully executed deploy trigger for Discovery Research
   Catalog on AWS'

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ deploy:
   bucket_path: discovery-ui-shep
   on:
     repo: NYPL/discovery-front-end
-    condition: tag = qa
+    condition: tag = qa-tag
 
 after_deploy: echo 'Successfully executed deploy trigger for Discovery Research
   Catalog on AWS'

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,8 +36,8 @@ deploy:
   access_key_id: "$AWS_ACCESS_KEY_ID_QA"
   secret_access_key: "$AWS_SECRET_ACCESS_KEY_QA"
   region: us-east-1
-  app: discovery-ui
-  env: DiscoveryUi-10-17-qa
+  app: discovery-ui-qwerty
+  env: DiscoveryUi-10-17-qa-qwerty
   bucket_name: elasticbeanstalk-us-east-1-946183545209
   bucket_path: discovery-ui-shep
   on:

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,19 +31,18 @@ deploy:
   on:
     repo: NYPL/discovery-front-end
     branch: production
-if: tag ~= /^qa-.*/
-  deploy:
-  - provider: elasticbeanstalk
-    skip_cleanup: false
-    access_key_id: "$AWS_ACCESS_KEY_ID_QA"
-    secret_access_key: "$AWS_SECRET_ACCESS_KEY_QA"
-    region: us-east-1
-    app: discovery-ui-qwerty
-    env: DiscoveryUi-10-17-qa-qwerty
-    bucket_name: elasticbeanstalk-us-east-1-946183545209
-    bucket_path: discovery-ui-shep
-    on:
-      repo: NYPL/discovery-front-end
+- provider: elasticbeanstalk
+  skip_cleanup: false
+  access_key_id: "$AWS_ACCESS_KEY_ID_QA"
+  secret_access_key: "$AWS_SECRET_ACCESS_KEY_QA"
+  region: us-east-1
+  app: discovery-ui-qwerty
+  env: DiscoveryUi-10-17-qa-qwerty
+  bucket_name: elasticbeanstalk-us-east-1-946183545209
+  bucket_path: discovery-ui-shep
+  on:
+    repo: NYPL/discovery-front-end
+    condition: $TRAVIS_TAG =~ ^qa-.*
 
 after_deploy: echo 'Successfully executed deploy trigger for Discovery Research
   Catalog on AWS'

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,8 +36,8 @@ deploy:
   access_key_id: "$AWS_ACCESS_KEY_ID_QA"
   secret_access_key: "$AWS_SECRET_ACCESS_KEY_QA"
   region: us-east-1
-  app: discovery-ui-qwerty
-  env: DiscoveryUi-10-17-qa-qwerty
+  app: discovery-ui
+  env: DiscoveryUi-10-17-qa
   bucket_name: elasticbeanstalk-us-east-1-946183545209
   bucket_path: discovery-ui-shep
   on:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ node_js:
 - 10.17.0
 install: npm rebuild node-sass && npm install
 before_script: npm run dist
-script: echo "$TRAVIS_TAG"
+script: npm test
 before_deploy: echo 'All unit tests passed; Successfull built distribution assets;
   Preparing to deploy Discovery Research Catalog to AWS.'
 deploy:


### PR DESCRIPTION
**What's this do?**
Changes the way we deploy to `qa` to listen to tags with prefix `qa-` (We had discussed just calling the tag `qa`, but it turns out this is confusing on travis' interface as long as we still have the qa branch. Also, it involves less fighting with git).

Also removes the automatic deployment on the `accounts` branch, which has been merged.

**Why are we doing this? (w/ JIRA link if applicable)**
For our now git workflow strategy.

**Do these changes have automated tests?**
No

**How should this be QAed?**
We can try pushing a branch with `qa-` tags and see it deploy

**Dependencies for merging? Releasing to production?**
No.

**Has the application documentation been updated for these changes?**
We don't have documentation about our Git workflow in Discovery Front End, but maybe we should?

**Did someone actually run this code to verify it works?**
I did.