### PR TITLE
SCC-2717: Change Pin to Pin/Password

### DIFF
--- a/src/app/components/AccountPage/AccountSettings.jsx
+++ b/src/app/components/AccountPage/AccountSettings.jsx
@@ -32,7 +32,7 @@ const AccountSettings = ({ patron, legacyBaseUrl }) => (
     <hr />
     <div className="pin">
       <dl>
-        <dt>Pin</dt>
+        <dt>Pin/Password</dt>
         <dd><span>&middot;&middot;&middot;&middot;</span></dd>
         <Link
           href={`${legacyBaseUrl}/patroninfo*eng~Sdefault/${patron.id}/newpin`}


### PR DESCRIPTION
**What's this do?**
Change "Pin" label to "Pin/Password" to reflect account security change in Sierra

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SCC-2717

**Do these changes have automated tests?**
n/a

**How should this be QAed?**
Verify Account Settings page shows "Pin/Password"

**Dependencies for merging? Releasing to production?**
To aid clarity for patrons, should go to production at roughly same time (or shortly after) ILS Team makes change to allow full alphanumeric passwords.

**Has the application documentation been updated for these changes?**
n/a

**Did someone actually run this code to verify it works?**
I did.
