### PR TITLE
SCC-2719: Add support for HL

### DIFF
--- a/src/app/pages/ElectronicDelivery.jsx
+++ b/src/app/pages/ElectronicDelivery.jsx
@@ -22,6 +22,7 @@ import Notification from '../components/Notification/Notification';
 import LibraryItem from '../utils/item';
 import {
   trackDiscovery,
+  institutionNameByNyplSource,
 } from '../utils/utils';
 import { updateLoadingStatus } from '../actions/Actions';
 
@@ -142,12 +143,8 @@ class ElectronicDelivery extends React.Component {
     const path = `${appConfig.baseUrl}/hold/confirmation/${bibId}-${itemId}`;
     const { searchKeywords } = this.props;
     const searchKeywordsQuery = searchKeywords ? `&q=${searchKeywords}` : '';
-    const itemSourceMapping = {
-      'recap-pul': 'Princeton',
-      'recap-cul': 'Columbia',
-    };
     const partnerEvent = itemSource !== 'sierra-nypl' ?
-      ` - Partner item - ${itemSourceMapping[itemSource]}` : '';
+      ` - Partner item - ${institutionNameByNyplSource(itemSource)}` : '';
 
     // This is to remove the error box on the top of the page on a successfull submission.
     this.setState({ raiseError: null });

--- a/src/app/pages/HoldRequest.jsx
+++ b/src/app/pages/HoldRequest.jsx
@@ -20,6 +20,7 @@ import appConfig from '../data/appConfig';
 import LibraryItem from '../utils/item';
 import {
   trackDiscovery,
+  institutionNameByNyplSource,
 } from '../utils/utils';
 import { updateLoadingStatus } from '../actions/Actions';
 
@@ -83,17 +84,13 @@ export class HoldRequest extends React.Component {
    */
   submitRequest(e, bibId, itemId, itemSource, title) {
     e.preventDefault();
-    const itemSourceMapping = {
-      'recap-pul': 'Princeton',
-      'recap-cul': 'Columbia',
-    };
     const searchKeywordsQuery =
       (this.props.searchKeywords) ? `q=${this.props.searchKeywords}` : '';
     const searchKeywordsQueryPhysical = searchKeywordsQuery ? `&${searchKeywordsQuery}` : '';
     const fromUrlQuery = this.props.location.query && this.props.location.query.fromUrl ?
       `&fromUrl=${encodeURIComponent(this.props.location.query.fromUrl)}` : '';
     const partnerEvent = itemSource !== 'sierra-nypl' ?
-      ` - Partner item - ${itemSourceMapping[itemSource]}` : '';
+      ` - Partner item - ${institutionNameByNyplSource(itemSource)}` : '';
     let path = `${appConfig.baseUrl}/hold/confirmation/${bibId}-${itemId}`;
 
     if (this.state.delivery === 'edd') {

--- a/src/app/utils/getOwner.js
+++ b/src/app/utils/getOwner.js
@@ -4,38 +4,20 @@ import {
 /*
 * getOwner(bib)
 * This is currently only for non-NYPL partner items. If it's NYPL, it should return undefined.
-* Requirement: Look at all the owners of all the items and if they were all the same and
-* not NYPL, show that as the owning institution and otherwise show nothing.
-* @param {object} bibId
+* @param {object} bib
 * @return {string}
 */
 
 
 export default function getOwner(bib) {
-  if (!bib) return null;
+  if (!bib || !bib.items) return null;
 
-  const items = bib.items;
-  const ownerArr = [];
-  let owner;
-
-  if (!items || !items.length) {
-    return null;
-  }
-
-  items.forEach((item) => {
-    const ownerObj = item.owner && item.owner.length ? item.owner[0].prefLabel : undefined;
-
-    ownerArr.push(ownerObj);
-  });
-
-  // From above, check to see if all the owners are the same, and if so, proceed if the owner
-  // is either Princeton or Columbia.
-  if (_every(ownerArr, o => (o === ownerArr[0]))) {
-    if ((ownerArr[0] === 'Princeton University Library') ||
-    (ownerArr[0] === 'Columbia University Libraries')) {
-      owner = ownerArr[0];
-    }
-  }
-
-  return owner;
+  return bib.items
+    // Only consider items with a Recap source id
+    .filter((item) => item.idNyplSourceId && item.idNyplSourceId['@type'] && /^Recap/.test(item.idNyplSourceId['@type']))
+    // Only consider items with an `owner` (should be all, in practice)
+    .filter((item) => item.owner && item.owner.length && item.owner[0] && item.owner[0].prefLabel)
+    // Map to owner `prefLabel`
+    .map((item) => item.owner[0].prefLabel)
+    [0];
 }

--- a/src/app/utils/item.js
+++ b/src/app/utils/item.js
@@ -3,12 +3,7 @@ import {
   isEmpty as _isEmpty,
 } from 'underscore';
 import LocationCodes from '../data/locationCodes';
-
-const itemSourceMappings = {
-  SierraNypl: 'sierra-nypl',
-  RecapCul: 'recap-cul',
-  RecapPul: 'recap-pul',
-};
+import { camelToShishKabobCase } from './utils';
 
 // Map local identifier names to their @type and urn: indicators:
 const itemIdentifierTypeMappings = {
@@ -211,7 +206,7 @@ function LibraryItem() {
     const identifiersArray = [{ name: 'barcode', value: 'bf:Barcode' }];
     const bibIdentifiers = this.getIdentifiers(item.identifier, identifiersArray);
     const barcode = bibIdentifiers.barcode || '';
-    const mappedItemSource = itemSourceMappings[itemSource];
+    const mappedItemSource = camelToShishKabobCase(itemSource);
     const isOffsite = this.isOffsite(holdingLocation.prefLabel.toLowerCase());
     let url = null;
     const isSerial = !!(bib && bib.issuance && bib.issuance[0]['@id'] === 'urn:biblevel:s');

--- a/src/app/utils/utils.js
+++ b/src/app/utils/utils.js
@@ -537,6 +537,37 @@ function extractNoticePreference(fixedFields) {
   return noticePreferenceMapping[noticePreferenceField.value] || 'None';
 }
 
+/**
+ * Converts camel case string to shish kabob case
+ *
+ * e.g. camelToShishKabobCase("RecapPul")
+ *        => "recap-pul"
+ *      camelToShishKabobCase("firstCharCanBeLowerCase")
+ *        => "first-char-can-be-lower-case"
+ */
+function camelToShishKabobCase(s) {
+  return s
+    // Change capital letters into "-{lowercase letter}"
+    .replace(/([A-Z])/g, (c, p1, i) => {
+      // If capital letter is not first character, precede with '-':
+      return (i > 0 ? '-' : '')
+        + c.toLowerCase();
+    })
+}
+
+/**
+ * Given an nypl-source (e.g. 'recap-pul') returns a short institution name
+ * (e.g. "Princeton")
+ */
+function institutionNameByNyplSource(nyplSource) {
+  return {
+    'recap-pul': 'Princeton',
+    'recap-cul': 'Columbia',
+    'recap-hl': 'Harvard',
+    'sierra-nypl': 'NYPL'
+  }[nyplSource];
+}
+
 export {
   trackDiscovery,
   ajaxCall,
@@ -557,4 +588,6 @@ export {
   hasValidFilters,
   encodeHTML,
   extractNoticePreference,
+  camelToShishKabobCase,
+  institutionNameByNyplSource,
 };

--- a/src/server/ApiRoutes/SubjectHeadings.js
+++ b/src/server/ApiRoutes/SubjectHeadings.js
@@ -11,6 +11,7 @@ const convertShepBibsToDiscoveryBibs = response =>
       const institutionCode = {
         'recap-pul': 'pb',
         'recap-cul': 'cb',
+        'recap-hl': 'hb',
       }[bib.institution] || 'b';
 
       const prefixedIdentifier = [institutionCode, bib.bnumber].join('');

--- a/test/unit/utils-getowner.test.js
+++ b/test/unit/utils-getowner.test.js
@@ -1,0 +1,81 @@
+import getOwner from './../../src/app/utils/getOwner';
+import { expect } from 'chai';
+
+describe('utils/getOwner', () => {
+  it('returns undefined if owner is NYPL', () => {
+    // Make a SASB bib:
+    const bib = {
+      items: [
+        {
+          owner: [{
+            '@id': 'orgs:1000',
+            prefLabel: 'Stephen A. Schwarzman Building',
+          }],
+          idNyplSourceId: {
+            '@type': 'SierraNypl'
+          },
+        }
+      ]
+    }
+
+    expect(getOwner(bib)).to.be.a('undefined')
+  })
+
+  it('returns Princeton if owner is PUL', () => {
+    // Make a PUL bib:
+    const bib = {
+      items: [
+        {
+          owner: [{
+            '@id': 'orgs:0003',
+            prefLabel: 'Princeton University Library',
+          }],
+          idNyplSourceId: {
+            '@type': 'RecapPul'
+          },
+        }
+      ]
+    }
+
+    expect(getOwner(bib)).to.eq('Princeton University Library')
+  })
+
+  it('returns Columbia if owner is CUL', () => {
+    // Make a CUL bib:
+    const bib = {
+      items: [
+        {
+          owner: [{
+            '@id': 'orgs:0002',
+            prefLabel: 'Columbia University Libraries',
+          }],
+          idNyplSourceId: {
+            '@type': 'RecapCul'
+          },
+        }
+      ]
+    }
+
+    expect(getOwner(bib)).to.eq('Columbia University Libraries')
+  })
+
+
+  it('returns Harvard if owner is HL', () => {
+    // Make a HL bib:
+    const bib = {
+      items: [
+        {
+          owner: [{
+            '@id': 'orgs:0004',
+            prefLabel: 'Harvard Library',
+          }],
+          idNyplSourceId: {
+            '@type': 'RecapHl'
+          },
+        }
+      ]
+    }
+
+    expect(getOwner(bib)).to.eq('Harvard Library')
+  })
+})

--- a/test/unit/utils.test.js
+++ b/test/unit/utils.test.js
@@ -19,6 +19,8 @@ import {
   truncateStringOnWhitespace,
   hasValidFilters,
   extractNoticePreference,
+  camelToShishKabobCase,
+  institutionNameByNyplSource,
 } from '../../src/app/utils/utils';
 
 /**
@@ -791,3 +793,20 @@ describe('extractNoticePreference', () => {
     expect(extractNoticePreference({ '268': {'value': '-'} })).to.equal('None');
   });
 })
+
+describe('camelToShishKabobCase', () => {
+  it('should convert camel to shish kabob case', () => {
+    expect(camelToShishKabobCase('SierraNypl')).to.eq('sierra-nypl');
+    expect(camelToShishKabobCase('RecapPul')).to.eq('recap-pul');
+    expect(camelToShishKabobCase('firstCharCanBeLowerCase')).to.eq('first-char-can-be-lower-case');
+  });
+});
+
+describe('institutionNameByNyplSource', () => {
+  it('should resolve all institution names', () => {
+    expect(institutionNameByNyplSource('sierra-nypl')).to.eq('NYPL');
+    expect(institutionNameByNyplSource('recap-pul')).to.eq('Princeton');
+    expect(institutionNameByNyplSource('recap-cul')).to.eq('Columbia');
+    expect(institutionNameByNyplSource('recap-hl')).to.eq('Harvard');
+  });
+});


### PR DESCRIPTION
**What's this do?**
Add support for recap-hl institution identifier in all the places where
partner identifiers are handled.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SCC-2719

**Do these changes have automated tests?**
Unit tests on added utility functions

**How should this be QAed?**
Should be able to view and place a hold on HL items.

**Dependencies for merging? Releasing to production?**
Dependent on forthcoming actual HL records

**Has the application documentation been updated for these changes?**

**Did someone actually run this code to verify it works?**
