### PR TITLE
Set header meta tags using DISPLAY_TITLE

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -991,19 +991,19 @@
       "from": "git+https://git@github.com/NYPL/dgx-header-component.git#reactupdate",
       "requires": {
         "@nypl/dgx-svg-icons": "0.3.7",
-        "axios": "0.9.1",
+        "axios": "0.21.1",
         "classnames": "2.1.3",
         "dgx-feature-flags": "git+https://git@bitbucket.org/NYPL/dgx-feature-flags.git#master",
         "dgx-react-ga": "git+https://git@bitbucket.org/NYPL/dgx-react-ga.git#master",
         "dgx-skip-navigation-link": "git+https://git@bitbucket.org/NYPL/dgx-skip-navigation-link.git#master",
         "focus-trap-react": "3.0.3",
-        "moment": "2.19.3",
+        "moment": "2.24.0",
         "prop-types": "15.5.10",
         "react": "^16.12.0",
         "react-dom": "^16.12.0",
-        "react-tappable": "1.0.0",
+        "react-tappable": "1.0.4",
         "system-font-css": "^2.0.2",
-        "underscore": "1.8.3"
+        "underscore": "1.10.2"
       },
       "dependencies": {
         "@nypl/design-toolkit": {
@@ -3657,6 +3657,16 @@
         }
       }
     },
+    "call-bind": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
+      }
+    },
     "caller-path": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
@@ -4335,6 +4345,12 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+    },
+    "cookiejar": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
+      "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA==",
+      "dev": true
     },
     "copy-concurrently": {
       "version": "1.0.5",
@@ -6246,6 +6262,12 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "fast-safe-stringify": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
+      "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA==",
+      "dev": true
+    },
     "fastparse": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.2.tgz",
@@ -6915,6 +6937,12 @@
       "requires": {
         "samsam": "1.x"
       }
+    },
+    "formidable": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.2.tgz",
+      "integrity": "sha512-V8gLm+41I/8kguQ4/o1D3RIHRmhYFG4pnNyonvua+40rqcEmT4+V71yaZ3B457xbbgCsCfjSPi65u/W6vK1U5Q==",
+      "dev": true
     },
     "forwarded": {
       "version": "0.1.2",
@@ -7650,6 +7678,17 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
       "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
+    },
+    "get-intrinsic": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1"
+      }
     },
     "get-stdin": {
       "version": "4.0.1",
@@ -15337,6 +15376,25 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
     },
+    "side-channel": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.0",
+        "get-intrinsic": "^1.0.2",
+        "object-inspect": "^1.9.0"
+      },
+      "dependencies": {
+        "object-inspect": {
+          "version": "1.10.3",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.3.tgz",
+          "integrity": "sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw==",
+          "dev": true
+        }
+      }
+    },
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
@@ -16178,6 +16236,98 @@
             "object-assign": "^4.0.1"
           }
         }
+      }
+    },
+    "superagent": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-6.1.0.tgz",
+      "integrity": "sha512-OUDHEssirmplo3F+1HWKUrUjvnQuA+nZI6i/JJBdXb5eq9IyEQwPyPpqND+SSsxf6TygpBEkUjISVRN4/VOpeg==",
+      "dev": true,
+      "requires": {
+        "component-emitter": "^1.3.0",
+        "cookiejar": "^2.1.2",
+        "debug": "^4.1.1",
+        "fast-safe-stringify": "^2.0.7",
+        "form-data": "^3.0.0",
+        "formidable": "^1.2.2",
+        "methods": "^1.1.2",
+        "mime": "^2.4.6",
+        "qs": "^6.9.4",
+        "readable-stream": "^3.6.0",
+        "semver": "^7.3.2"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+          "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+          "dev": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "mime": {
+          "version": "2.5.2",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.5.2.tgz",
+          "integrity": "sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg==",
+          "dev": true
+        },
+        "qs": {
+          "version": "6.10.1",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.1.tgz",
+          "integrity": "sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==",
+          "dev": true,
+          "requires": {
+            "side-channel": "^1.0.4"
+          }
+        },
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
+        }
+      }
+    },
+    "supertest": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-6.1.3.tgz",
+      "integrity": "sha512-v2NVRyP73XDewKb65adz+yug1XMtmvij63qIWHZzSX8tp6wiq6xBLUy4SUAd2NII6wIipOmHT/FD9eicpJwdgQ==",
+      "dev": true,
+      "requires": {
+        "methods": "^1.1.2",
+        "superagent": "^6.1.0"
       }
     },
     "supports-color": {

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "react-addons-test-utils": "15.6.0",
     "redux-mock-store": "^1.5.4",
     "sinon": "4.0.1",
+    "supertest": "^6.1.3",
     "webpack-bundle-analyzer": "^3.8.0",
     "webpack-dev-server": "^2.7.1"
   },

--- a/server.js
+++ b/server.js
@@ -29,6 +29,7 @@ const DIST_PATH = path.resolve(ROOT_PATH, 'dist');
 const VIEWS_PATH = path.resolve(ROOT_PATH, 'src/views');
 const WEBPACK_DEV_PORT = appConfig.webpackDevServerPort || 3000;
 const isProduction = process.env.NODE_ENV === 'production';
+const isTest = process.env.NODE_ENV === 'test';
 const app = express();
 
 let application;
@@ -118,13 +119,16 @@ app.get('/*', (req, res) => {
   });
 });
 
-const server = app.listen(app.get('port'), (error) => {
-  if (error) {
-    logger.error(error);
-  }
+let server = null;
+if (!isTest) {
+  server = app.listen(app.get('port'), (error) => {
+    if (error) {
+      logger.error(error);
+    }
 
-  logger.info(`App - Express server is listening at localhost: ${app.get('port')}.`);
-});
+    logger.info(`App - Express server is listening at localhost: ${app.get('port')}.`);
+  });
+}
 
 // This function is called when you want the server to die gracefully
 // i.e. wait for existing connections
@@ -145,12 +149,11 @@ process.on('SIGTERM', gracefulShutdown);
 // listen for INT signal e.g. Ctrl-C
 process.on('SIGINT', gracefulShutdown);
 
-
 /* Development Environment Configuration
  * -------------------------------------
  * - Using Webpack Dev Server
 */
-if (!isProduction) {
+if (!isProduction && !isTest) {
   const WebpackDevServer = require('webpack-dev-server');
 
   new WebpackDevServer(webpack(webpackConfig), {
@@ -170,3 +173,5 @@ if (!isProduction) {
     logger.info(`Webpack Dev Server listening at localhost: ${WEBPACK_DEV_PORT}.`);
   });
 }
+
+module.exports = app

--- a/src/views/index.ejs
+++ b/src/views/index.ejs
@@ -9,13 +9,13 @@
     <link rel="icon" type="image/png" href="<%- favicon %>">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
-    <meta property="og:title" content="Shared Collection Catalog | NYPL">
+    <meta property="og:title" content="<%- appTitle %>">
     <meta property="og:description" content="">
     <meta property="og:type" content="website">
     <meta property="og:image" content="">
-    <meta property="og:site_name" content="Shared Collection Catalog | NYPL">
+    <meta property="og:site_name" content="<%- appTitle %>">
     <meta property="og:url" content="https://www.nypl.org/research/collections/shared-collection-catalog">
-    <meta name="twitter:title" content="Shared Collection Catalog | NYPL">
+    <meta name="twitter:title" content="<%- appTitle %>">
     <meta name="twitter:description" content="">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:site" content="@nypl">

--- a/test.env
+++ b/test.env
@@ -7,3 +7,5 @@ export SET LEGACY_BASE_URL=https://legacyBaseUrl.nypl.org
 export SET SEARCH_RESULTS_NOTIFICATION="Some info for our patrons"
 export SET HOLD_REQUEST_NOTIFICATION="Some info for our patrons"
 export SET WEBPAC_BASE_URL=http://webpac.nypl.org
+export SET KMS_ENV=unencrypted
+export SET BASE_URL=/research/research-catalog

--- a/test/unit/Account.test.js
+++ b/test/unit/Account.test.js
@@ -92,7 +92,7 @@ describe('`fetchAccountPage`', () => {
     it('should redirect', () => {
       Account.fetchAccountPage(renderMockReq('blahblah', validMockPatronTokenResponse, patron), mockRes, mockResolve);
 
-      expect(redirectedTo).to.equal('/research/collections/shared-collection-catalog/account');
+      expect(redirectedTo).to.equal(`${process.env.BASE_URL}/account`);
     });
 
     it('should not make axios request', () => {

--- a/test/unit/dataLoaderUtil.test.js
+++ b/test/unit/dataLoaderUtil.test.js
@@ -269,9 +269,9 @@ describe('dataLoaderUtil', () => {
     const realAccountAction = routes.account.action;
     before(() => {
       mock = new MockAdapter(axios);
-      mock.onGet('/research/collections/shared-collection-catalog/api/account').reply(200, '<div>html for account page default view</div>');
-      mock.onGet('/research/collections/shared-collection-catalog/api/account/items').reply(200, '<div>html for account page items view</div>');
-      mock.onGet('/research/collections/shared-collection-catalog/api/account/settings').reply(200, '');
+      mock.onGet(`${process.env.BASE_URL}/api/account`).reply(200, '<div>html for account page default view</div>');
+      mock.onGet(`${process.env.BASE_URL}/api/account/items`).reply(200, '<div>html for account page items view</div>');
+      mock.onGet(`${process.env.BASE_URL}/api/account/settings`).reply(200, '');
       routes.account.action = mockAccountPageAction;
     });
 
@@ -302,7 +302,12 @@ describe('dataLoaderUtil', () => {
         });
 
         it('should call dispatch with the account action and the response', () => {
-          // 4 calls: loading true, account page action, updateLastLoaded, loading false
+          // We expect `dataLoaderUtil.loadDataForRoutes` to have triggered 5 calls:
+          //  1. { type: 'RESET_STATE', payload: null }
+          //  2. { type: 'UPDATE_LOADING_STATUS', payload: true }
+          //  3. "mockAccountPageAction response"
+          //  4. { type: 'UPDATE_LAST_LOADED', payload: '/research/collections/shared-collection-catalog/account' }
+          //  5. { type: 'UPDATE_LOADING_STATUS', payload: false }
           expect(mockDispatch.getCalls()).to.have.lengthOf(5);
           expect(mockDispatch.thirdCall.args).to.have.lengthOf(1);
           expect(mockDispatch.thirdCall.args[0]).to.equal('mockAccountPageAction response');
@@ -376,7 +381,7 @@ describe('dataLoaderUtil', () => {
     describe('unsuccessful request', () => {
       before(() => {
         axiosSpy = sandbox.spy(axios, 'get');
-        mock.onGet('/research/collections/shared-collection-catalog/api/account').reply(400, {});
+        mock.onGet(`${process.env.BASE_URL}/api/account`).reply(400, {});
         consoleStub = sandbox.stub(console, 'error');
         const mockLocation = {
           pathname: `${appConfig.baseUrl}/account/random`,

--- a/test/unit/server.test.js
+++ b/test/unit/server.test.js
@@ -1,0 +1,56 @@
+const request = require('supertest');
+const sinon = require('sinon');
+import { expect } from 'chai';
+import DocumentTitle from 'react-document-title';
+
+let app = require('./../../server');
+
+describe('server', () => {
+  let sandbox;
+
+  before(() => {
+    sandbox = sinon.sandbox.create();
+
+    // DocumentTitle.rewind() is used in server.js to build the document title
+    // but it can only be used "server-side". It's built on `react-side-effect`,
+    // which determines whether or not it is "server-side" through this:
+    // https://github.com/gaearon/react-side-effect/blob/19401cd1767fc5593f14fe14912bd66788494986/src/index.js#L3-L7
+    // So, because global.window is set when `react-document-title` is included,
+    // `DocumentTitle.rewind()` throws an error.
+    // The important thing is that our template uses the value that
+    // `DocumentTitle.rewind()` returns, so let's stub it:
+    sandbox.stub(DocumentTitle, 'rewind').callsFake(() => process.env.DISPLAY_TITLE);
+  });
+
+  after(() => {
+    sandbox.restore();
+  });
+
+  it('redirects to baseurl', (done) => {
+    request(app)
+      .get('/')
+      .expect('Content-Type', /text/)
+      .expect('Location', `${process.env.BASE_URL}/`)
+      .expect(302)
+      .then((response) => {
+        done();
+      })
+      .catch(err => done(err));
+    ;
+  });
+
+  it('serves meta tags with DISPLAY_TITLE', (done) => {
+    request(app)
+      .get(`${process.env.BASE_URL}/`)
+      .expect(200)
+      .then((response) => {
+        expect(response.text).to.include(`<title>${process.env.DISPLAY_TITLE}</title>`)
+        expect(response.text).to.include(`<meta property="og:title" content="${process.env.DISPLAY_TITLE}">`)
+        expect(response.text).to.include(`<meta property="og:site_name" content="${process.env.DISPLAY_TITLE}">`)
+        expect(response.text).to.include(`<meta name="twitter:title" content="${process.env.DISPLAY_TITLE}">`)
+        done();
+      })
+      .catch(err => done(err));
+    ;
+  });
+});


### PR DESCRIPTION
Updates src/views/index.ejs to use process.env.DISPLAY_TITLE in relevant
meta tags. Includes new test coverage on server.js, which entailed light
modifications to server.js to:
 - Identify when it is being invoked by tests (`isTest`)
 - Skip spinning up any listening server when invoked by tests
 - Export `app` for use in tests

I added KMS_ENV=unencrypted to `test.env` as a simple way to skip
KMS decryption calls - made to authenticate the NyplDataApiClient, which
is invoked by `server.js`

I also added the current `BASE_URL` to `test.env` so that various
Account and server tests don't have to hard-code the fallback value
established by src/app/data/appConfig.js#L8 . This entailed updating a
few Account tests to also use `process.env.BASE_URL`.

https://jira.nypl.org/browse/SCC-2686

**What's this do?**
[Description of what this PR does]

**Why are we doing this? (w/ JIRA link if applicable)**
[Quick blurb about why the code is needed and Jira link/ Do these changes meet the business requirements of the story?]

**Do these changes have automated tests?**
[Brief description of new automated tests]

**How should this be QAed?**
[Description of any tests that need to be performed once merged]

**Dependencies for merging? Releasing to production?**
[Description of any watchouts, dependencies, or issues we should be aware of]

**Has the application documentation been updated for these changes?**

**Did someone actually run this code to verify it works?**
