### PR TITLE
Fix logger to not swallow runtime errors in test

### DIFF
--- a/logger.js
+++ b/logger.js
@@ -72,7 +72,10 @@ const formatter = (options) => {
 const loggerTransports = [
   new winston.transports.File({
     filename: './log/discovery-ui.log',
-    handleExceptions: true,
+    // winston should not attempt to catch and log uncaught exceptions when
+    // running test suite, as that causes them to be hidden (and causes mocha
+    // to return exit code 0, causing the test suite to appear as passed).
+    handleExceptions: process.env.NODE_ENV !== 'test',
     maxsize: 5242880, // 5MB
     maxFiles: 5,
     colorize: false,


### PR DESCRIPTION
**What's this do?**
Our use of [winston](https://github.com/winstonjs/winston/tree/2.3.1) used to specify that both transports
"handleExceptions" unconditionally. This causes winston to attempt
to catch uncaught exceptions (like missing modules) and log them
through the transport (i.e. format them in the nypl json log
format). This seems/seemed a reasonable feature to enable at one
point because it ensures that uncaught exceptions are rendered as
json and thus queryable in CloudWatch via $.level. (If we do not
have winston catch excptions, uncaught exceptions will be logged
to stdout and CW in plain text, which means they may not be picked up by
metrics listening on $.level)

This changes the primary winston transport to not `handleExceptions`
when running the test suite so that missing modules and other uncaught
exceptions are dumped to stdout and mocha's nonzero exit code isn't
swallowed.

I believe this has always been a bug in a sense. Once winston is loaded, if `handleExceptions` is enabled, uncaught exceptions are quietly diverted to discovery-ui.log. We've just not seen it silence a broken test suite before because 1) missing modules are a rare mistake and 2) many errors benefited from load order (i.e. if the runtime error happened to occur before winston was loaded, winston was not able to interfere).

**Why are we doing this? (w/ JIRA link if applicable)**
When we forget a module/fixture or commit code that throws uncaught errors, if the error occurs after winston has loaded, winston quietly swallows the error and prevents the nonzero exit code from flagging the failed test suite (causing travis-ci to consider the build as having passed.

**Do these changes have automated tests?**
n/a

**How should this be QAed?**
Verify mocha runs all tests and reports on all failures (both failed asserts and runtime errors like missing modules, uncaught errors). To confirm exit code is `1` for all failures: `npm test; echo $?`

**Dependencies for merging? Releasing to production?**
n/a

**Has the application documentation been updated for these changes?**
n/a

**Did someone actually run this code to verify it works?**
I did