### PR TITLE
scc-2759 Add error handling for drbb timeouts

### DIFF
--- a/src/server/ApiRoutes/Search.js
+++ b/src/server/ApiRoutes/Search.js
@@ -57,6 +57,26 @@ function fetchResults(searchKeywords = '', page, sortBy, order, field, filters, 
     query: { q: searchKeywords, sortBy, order, field, filters },
   };
 
+  let drbRequesting = true;
+  const drbPromise = appConfig.features.includes('drb-integration') ?
+    Promise.race([
+      new Promise((resolve) => {
+        setTimeout(() => {
+          if (!drbRequesting) return false;
+          console.error('Drb timeout');
+          return resolve([]);
+        }, 3000);
+      }),
+      ResearchNow.search(queryObj)
+        .then((res) => { drbRequesting = false; return res; })
+        .catch((e) => {
+          console.error('Drb error: ', e);
+          return [];
+        }),
+    ])
+    :
+    null;
+
   // Get the following in parallel:
   //  - search results
   //  - aggregations
@@ -64,7 +84,7 @@ function fetchResults(searchKeywords = '', page, sortBy, order, field, filters, 
   Promise.all([
     nyplApiClientCall(resultsQuery, features),
     nyplApiClientCall(aggregationQuery, features),
-    ResearchNow.search(queryObj).catch(console.error),
+    drbPromise,
   ])
     .then((response) => {
       const [results, aggregations, drbbResults] = response;

--- a/src/server/ApiRoutes/Search.js
+++ b/src/server/ApiRoutes/Search.js
@@ -62,15 +62,15 @@ function fetchResults(searchKeywords = '', page, sortBy, order, field, filters, 
     Promise.race([
       new Promise((resolve) => {
         setTimeout(() => {
-          if (!drbRequesting) return false;
-          console.error('Drb timeout');
+          if (drbRequesting) logger.error('Drb timeout');
           return resolve([]);
         }, 3000);
       }),
       ResearchNow.search(queryObj)
         .then((res) => { drbRequesting = false; return res; })
         .catch((e) => {
-          console.error('Drb error: ', e);
+          drbRequesting = false;
+          logger.error('Drb error: ', e);
           return [];
         }),
     ])

--- a/src/server/ApiRoutes/Search.js
+++ b/src/server/ApiRoutes/Search.js
@@ -64,7 +64,7 @@ function fetchResults(searchKeywords = '', page, sortBy, order, field, filters, 
         setTimeout(() => {
           if (drbRequesting) logger.error('Drb timeout');
           return resolve([]);
-        }, 3000);
+        }, 5000);
       }),
       ResearchNow.search(queryObj)
         .then((res) => { drbRequesting = false; return res; })


### PR DESCRIPTION
**What's this do?**
Adds some extra error handling around drb requests to handle timeouts.

**Why are we doing this? (w/ JIRA link if applicable)**
Currently getting 504's that are breaking the rest of the page.

**Do these changes have automated tests?**
The Search route doesn't have any tests, so that is a big lift for this change, but we do need to start writing tests for the API routes

**How should this be QAed?**
We should be able to turn DRB integration on in QA and not see any errors/timing out pages.

**Dependencies for merging? Releasing to production?**
[Description of any watchouts, dependencies, or issues we should be aware of]

**Has the application documentation been updated for these changes?**

**Did someone actually run this code to verify it works?**
Yes
