### PR TITLE
Add option to open only specific locations

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -17,3 +17,4 @@ export SET BASE_URL=/research/research-catalog
 export SET REDIRECT_FROM_BASE_URL=/research/collections/shared-collection-catalog
 export SET WEBPAC_BASE_URL=https://[fqdn]/
 export SET CIRCULATING_CATALOG=https://[fqdn]/
+export SET OPEN_LOCATIONS=315,300

--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ Currently used physical locations: Schwarzman;Science;Library for the Performing
 
 To close all locations, add `all`. This will also remove EDD as a request option, and the 'Request' buttons, and also disable the hold request/edd forms. If `all` is not present, EDD and 'Request' buttons will still be available.
 
-`OPEN_LOCATIONS` is a comma-delimited list of strings. Only locations matching one of these strings will be displayed.
+`OPEN_LOCATIONS` is a comma-delimited list of strings. If set to anything other than an empty string, only locations matching one of these strings will be displayed.
 
 `HOLD_REQUEST_NOTIFICATION`: This can be any string, not including html, which will be added as a notification to the HoldRequest landing page, and the EDD page.
 

--- a/README.md
+++ b/README.md
@@ -230,6 +230,8 @@ Currently used physical locations: Schwarzman;Science;Library for the Performing
 
 To close all locations, add `all`. This will also remove EDD as a request option, and the 'Request' buttons, and also disable the hold request/edd forms. If `all` is not present, EDD and 'Request' buttons will still be available.
 
+`OPEN_LOCATIONS` is a comma-delimited list of strings. Only locations matching one of these strings will be displayed.
+
 `HOLD_REQUEST_NOTIFICATION`: This can be any string, not including html, which will be added as a notification to the HoldRequest landing page, and the EDD page.
 
 `SEARCH_RESULTS_NOTIFICATION`: Same as above, but will be added on the SearchResults page

--- a/src/app/data/appConfig.js
+++ b/src/app/data/appConfig.js
@@ -48,7 +48,7 @@ const appConfig = {
   closedLocations: mapLocations(process.env.CLOSED_LOCATIONS),
   recapClosedLocations: mapLocations(process.env.RECAP_CLOSED_LOCATIONS),
   nonRecapClosedLocations: mapLocations(process.env.NON_RECAP_CLOSED_LOCATIONS),
-  openLocationsMust: process.env.OPEN_LOCATIONS_MUST ? process.env.OPEN_LOCATIONS_MUST.split(',') : null,
+  openLocations: process.env.OPEN_LOCATIONS ? process.env.OPEN_LOCATIONS.split(',') : null,
   holdRequestNotification: process.env.HOLD_REQUEST_NOTIFICATION,
   searchResultsNotification: process.env.SEARCH_RESULTS_NOTIFICATION,
   drbbFrontEnd: {

--- a/src/app/data/appConfig.js
+++ b/src/app/data/appConfig.js
@@ -48,6 +48,7 @@ const appConfig = {
   closedLocations: mapLocations(process.env.CLOSED_LOCATIONS),
   recapClosedLocations: mapLocations(process.env.RECAP_CLOSED_LOCATIONS),
   nonRecapClosedLocations: mapLocations(process.env.NON_RECAP_CLOSED_LOCATIONS),
+  openLocationsMust: process.env.OPEN_LOCATIONS_MUST ? process.env.OPEN_LOCATIONS_MUST.split(',') : null,
   holdRequestNotification: process.env.HOLD_REQUEST_NOTIFICATION,
   searchResultsNotification: process.env.SEARCH_RESULTS_NOTIFICATION,
   drbbFrontEnd: {

--- a/src/app/pages/HoldRequest.jsx
+++ b/src/app/pages/HoldRequest.jsx
@@ -204,7 +204,7 @@ export class HoldRequest extends React.Component {
      */
   renderDeliveryLocation(deliveryLocations = []) {
     const { closedLocations } = this.props;
-    const { openLocationsMust } = appConfig;
+    const { openLocations } = appConfig;
     return deliveryLocations.map((location, i) => {
       const displayName = this.modelDeliveryLocationName(location.prefLabel, location.shortName);
       const value = (location['@id'] && typeof location['@id'] === 'string') ?
@@ -212,7 +212,7 @@ export class HoldRequest extends React.Component {
 
       if (
         closedLocations.some(closedLocation => displayName.startsWith(closedLocation)) ||
-        (openLocationsMust && !openLocationsMust.some(openLocation => displayName.includes(openLocation)))
+        (openLocations && !openLocations.some(openLocation => displayName.includes(openLocation)))
       ) {
         return null;
       }

--- a/src/app/pages/HoldRequest.jsx
+++ b/src/app/pages/HoldRequest.jsx
@@ -204,12 +204,16 @@ export class HoldRequest extends React.Component {
      */
   renderDeliveryLocation(deliveryLocations = []) {
     const { closedLocations } = this.props;
+    const { openLocationsMust } = appConfig;
     return deliveryLocations.map((location, i) => {
       const displayName = this.modelDeliveryLocationName(location.prefLabel, location.shortName);
       const value = (location['@id'] && typeof location['@id'] === 'string') ?
         location['@id'].replace('loc:', '') : '';
 
-      if (closedLocations.some(closedLocation => displayName.startsWith(closedLocation))) {
+      if (
+        closedLocations.some(closedLocation => displayName.startsWith(closedLocation)) ||
+        (openLocationsMust && !openLocationsMust.some(openLocation => displayName.includes(openLocation)))
+      ) {
         return null;
       }
 

--- a/test/unit/HoldRequest.test.js
+++ b/test/unit/HoldRequest.test.js
@@ -1,6 +1,7 @@
 /* eslint-disable react/jsx-filename-extension */
 /* eslint-env mocha */
 import React from 'react';
+import appConfig from '@appConfig';
 import { stub, spy } from 'sinon';
 import { expect } from 'chai';
 import axios from 'axios';
@@ -626,6 +627,64 @@ describe('HoldRequest', () => {
 
           expect(form.find('fieldset')).to.have.length(1);
         });
+      });
+    });
+
+    describe('when opening locations selectively', () => {
+      let component;
+      const bib = {
+        title: ['Harry Potter'],
+        '@id': 'res:b17688688',
+        items: mockedItem,
+      };
+
+      const deliveryLocations = [
+        {
+          '@id': 'loc:myr',
+          address: '40 Lincoln Center Plaza',
+          prefLabel: 'Performing Arts Research Collections',
+          shortName: 'Library for the Performing Arts',
+        },
+        {
+          '@id': 'loc:sc',
+          prefLabel: 'Schomburg Center',
+          address: '515 Malcolm X Boulevard',
+          shortName: 'Schomburg Center',
+        },
+        {
+          '@id': 'loc:mala',
+          prefLabel: 'Schwarzman Building - Allen Scholar Room',
+          address: '476 Fifth Avenue (42nd St and Fifth Ave)',
+          shortName: 'Schwarzman Building',
+        },
+      ];
+
+      before(() => {
+        appConfig.openLocationsMust = ['Schwarzman'];
+        component = mountTestRender(
+          <WrappedHoldRequest
+            params={{ itemId: 'i10000003' }}
+          />, {
+            attachTo: document.body,
+            store: makeTestStore({
+              patron: { id: 1 },
+              bib,
+              isEddRequestable: true,
+              deliveryLocations,
+            }),
+          });
+      });
+
+      after(() => {
+        appConfig.openLocationsMust = null;
+        component.unmount();
+      });
+
+      it('should display only the specifically open locations', () => {
+        const html = component.html();
+        expect(html).to.include('Schwarzman Building');
+        expect(html).to.not.include('Performing Arts');
+        expect(html).to.not.include('Schomburg');
       });
     });
   });

--- a/test/unit/HoldRequest.test.js
+++ b/test/unit/HoldRequest.test.js
@@ -660,7 +660,7 @@ describe('HoldRequest', () => {
       ];
 
       before(() => {
-        appConfig.openLocationsMust = ['Schwarzman'];
+        appConfig.openLocations = ['Schwarzman'];
         component = mountTestRender(
           <WrappedHoldRequest
             params={{ itemId: 'i10000003' }}
@@ -676,7 +676,7 @@ describe('HoldRequest', () => {
       });
 
       after(() => {
-        appConfig.openLocationsMust = null;
+        appConfig.openLocations = null;
         component.unmount();
       });
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -54,6 +54,7 @@ const commonSettings = {
         CLOSED_LOCATIONS: JSON.stringify(process.env.CLOSED_LOCATIONS),
         RECAP_CLOSED_LOCATIONS: JSON.stringify(process.env.RECAP_CLOSED_LOCATIONS),
         NON_RECAP_CLOSED_LOCATIONS: JSON.stringify(process.env.NON_RECAP_CLOSED_LOCATIONS),
+        OPEN_LOCATIONS_MUST: JSON.stringify(process.env.OPEN_LOCATIONS_MUST),
         DISPLAY_TITLE: JSON.stringify(process.env.DISPLAY_TITLE),
         ITEM_BATCH_SIZE: JSON.stringify(process.env.ITEM_BATCH_SIZE),
         CIRCULATING_CATALOG: JSON.stringify(process.env.CIRCULATING_CATALOG),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -54,7 +54,7 @@ const commonSettings = {
         CLOSED_LOCATIONS: JSON.stringify(process.env.CLOSED_LOCATIONS),
         RECAP_CLOSED_LOCATIONS: JSON.stringify(process.env.RECAP_CLOSED_LOCATIONS),
         NON_RECAP_CLOSED_LOCATIONS: JSON.stringify(process.env.NON_RECAP_CLOSED_LOCATIONS),
-        OPEN_LOCATIONS_MUST: JSON.stringify(process.env.OPEN_LOCATIONS_MUST),
+        OPEN_LOCATIONS: JSON.stringify(process.env.OPEN_LOCATIONS),
         DISPLAY_TITLE: JSON.stringify(process.env.DISPLAY_TITLE),
         ITEM_BATCH_SIZE: JSON.stringify(process.env.ITEM_BATCH_SIZE),
         CIRCULATING_CATALOG: JSON.stringify(process.env.CIRCULATING_CATALOG),


### PR DESCRIPTION
**What's this do?**
Adds an environment variable that allows us to only open specific locations, as well as necessary tests.

**Why are we doing this? (w/ JIRA link if applicable)**
This is for scc-2749: we want only 3 specific locations to be open.

**Do these changes have automated tests?**
Yes. However, unrelatedly, it looks like some of the other tests for this component are broken (i.e. always pass)

**How should this be QAed?**
Once this is deployed to QA we can set the variable and check that only allowed locations show up.

**Dependencies for merging? Releasing to production?**
No.

**Has the application documentation been updated for these changes?**
NA

**Did someone actually run this code to verify it works?**
Yes.
