### PR TITLE
Fix bug where HL bibs have Full Details tab

### DIFF
--- a/src/app/pages/BibPage.jsx
+++ b/src/app/pages/BibPage.jsx
@@ -173,7 +173,8 @@ export const BibPage = (props, context) => {
 
   const additionalDetails = (<AdditionalDetailsViewer bib={bib} />);
 
-  const otherLibraries = ['Princeton University Library', 'Columbia University Libraries'];
+  // It's an NYPL item if getOwner returns nothing:
+  const isNYPL = !getOwner(bib);
 
   const tabs = [
     itemsContainer ? {
@@ -184,7 +185,7 @@ export const BibPage = (props, context) => {
       title: 'Details',
       content: tabDetails,
     },
-    !otherLibraries.includes(getOwner(bib)) && bib.annotatedMarc ? {
+    isNYPL && bib.annotatedMarc ? {
       title: 'Full Description',
       content: additionalDetails,
     } : null,

--- a/src/app/pages/BibPage.jsx
+++ b/src/app/pages/BibPage.jsx
@@ -23,7 +23,7 @@ import appConfig from '../data/appConfig';
 import Redirect404 from '../components/Redirect404/Redirect404';
 // Removed MarcRecord because the webpack MarcRecord is not working. Sep/28/2017
 // import MarcRecord from './MarcRecord';
-import { ajaxCall } from '@utils';
+import { ajaxCall, isNyplBnumber } from '@utils';
 import { updateBibPage } from '@Actions';
 import { itemBatchSize } from '../data/constants';
 
@@ -174,7 +174,7 @@ export const BibPage = (props, context) => {
   const additionalDetails = (<AdditionalDetailsViewer bib={bib} />);
 
   // It's an NYPL item if getOwner returns nothing:
-  const isNYPL = !getOwner(bib);
+  const isNYPL = isNyplBnumber(bib.uri);
 
   const tabs = [
     itemsContainer ? {

--- a/src/app/utils/utils.js
+++ b/src/app/utils/utils.js
@@ -568,6 +568,14 @@ function institutionNameByNyplSource(nyplSource) {
   }[nyplSource];
 }
 
+/**
+ * Given a bnumber (e.g. b12082323, pb123456, hb10000202040400) returns true
+ * if it's an NYPL bnumber.
+ */
+function isNyplBnumber(bnum) {
+  return /^b/.test(bnum)
+}
+
 export {
   trackDiscovery,
   ajaxCall,
@@ -590,4 +598,5 @@ export {
   extractNoticePreference,
   camelToShishKabobCase,
   institutionNameByNyplSource,
+  isNyplBnumber,
 };

--- a/src/server/ApiRoutes/Bib.js
+++ b/src/server/ApiRoutes/Bib.js
@@ -132,9 +132,12 @@ function fetchBib(bibId, cb, errorcb, reqOptions, res) {
     fetchSubjectHeadingData: true,
     features: [],
   }, reqOptions);
+  // Determine if it's an NYPL bibId by prefix:
+  const isNYPL = /^b/.test(bibId);
   return Promise.all([
     nyplApiClientCall(bibId, options.features, reqOptions.itemFrom || 0),
-    nyplApiClientCall(`${bibId}.annotated-marc`, options.features),
+    // Don't fetch annotated-marc for partner records:
+    isNYPL ? nyplApiClientCall(`${bibId}.annotated-marc`, options.features) : null,
   ])
     .then((response) => {
       // First response is jsonld formatting:

--- a/src/server/ApiRoutes/Bib.js
+++ b/src/server/ApiRoutes/Bib.js
@@ -5,6 +5,7 @@ import logger from '../../../logger';
 import appConfig from '../../app/data/appConfig';
 import extractFeatures from '../../app/utils/extractFeatures';
 import { itemBatchSize } from '../../app/data/constants';
+import { isNyplBnumber } from '../../app/utils/utils';
 
 const nyplApiClientCall = (query, urlEnabledFeatures, itemFrom) => {
   // If on-site-edd feature enabled in front-end, enable it in discovery-api:
@@ -132,8 +133,8 @@ function fetchBib(bibId, cb, errorcb, reqOptions, res) {
     fetchSubjectHeadingData: true,
     features: [],
   }, reqOptions);
-  // Determine if it's an NYPL bibId by prefix:
-  const isNYPL = /^b/.test(bibId);
+  // Determine if it's an NYPL bibId:
+  const isNYPL = isNyplBnumber(bibId);
   return Promise.all([
     nyplApiClientCall(bibId, options.features, reqOptions.itemFrom || 0),
     // Don't fetch annotated-marc for partner records:

--- a/test/unit/utils.test.js
+++ b/test/unit/utils.test.js
@@ -21,6 +21,7 @@ import {
   extractNoticePreference,
   camelToShishKabobCase,
   institutionNameByNyplSource,
+  isNyplBnumber,
 } from '../../src/app/utils/utils';
 
 /**
@@ -808,5 +809,16 @@ describe('institutionNameByNyplSource', () => {
     expect(institutionNameByNyplSource('recap-pul')).to.eq('Princeton');
     expect(institutionNameByNyplSource('recap-cul')).to.eq('Columbia');
     expect(institutionNameByNyplSource('recap-hl')).to.eq('Harvard');
+  });
+});
+
+describe('isNyplBnumber', () => {
+  it('should classify NYPL bnumbers as belonging to NYPL', () => {
+    expect(isNyplBnumber('b1234')).to.eq(true);
+  });
+  it('should classify partner bnumbers as not belonging to NYPL', () => {
+    expect(isNyplBnumber('pb1234')).to.eq(false);
+    expect(isNyplBnumber('hb1234')).to.eq(false);
+    expect(isNyplBnumber('cb1234')).to.eq(false);
   });
 });


### PR DESCRIPTION
**What's this do?**
Ensures HL bibs don't show Full Details tab. Also removes the call to
the annotated-marc endpoint for partner items, since we're not using the
data.

**Why are we doing this? (w/ JIRA link if applicable)**
NOREF for now

**Do these changes have automated tests?**
[Brief description of new automated tests]

**How should this be QAed?**
[Description of any tests that need to be performed once merged]

**Dependencies for merging? Releasing to production?**
[Description of any watchouts, dependencies, or issues we should be aware of]

**Has the application documentation been updated for these changes?**

**Did someone actually run this code to verify it works?**
