### PR TITLE
Scc 2764

### DIFF
--- a/src/app/components/BibPage/BibDetails.jsx
+++ b/src/app/components/BibPage/BibDetails.jsx
@@ -444,7 +444,7 @@ class BibDetails extends React.Component {
       });
 
     singleSubjectHeadingArray.forEach((heading, index) => {
-      const urlWithFilterQuery = `subject=${urlArray[index]}`;
+      const urlWithFilterQuery = `${filterQueryForSubjectHeading}${urlArray[index]}`;
 
       const subjectHeadingLink = (
         <Link

--- a/src/app/components/BibPage/BibDetails.jsx
+++ b/src/app/components/BibPage/BibDetails.jsx
@@ -444,7 +444,7 @@ class BibDetails extends React.Component {
       });
 
     singleSubjectHeadingArray.forEach((heading, index) => {
-      const urlWithFilterQuery = `${filterQueryForSubjectHeading}${urlArray[index]}`;
+      const urlWithFilterQuery = `subject=${urlArray[index]}`;
 
       const subjectHeadingLink = (
         <Link

--- a/src/app/utils/utils.js
+++ b/src/app/utils/utils.js
@@ -389,7 +389,6 @@ function displayContext({ searchKeywords, contributor, title, subject, selectedF
     // Currently from links on the bib page:
     creatorLiteral: 'author',
     contributorLiteral: 'author',
-    subjectLiteral: 'subject',
     titleDisplay: 'title',
     // From the search field dropdown:
     contributor: 'author/contributor',

--- a/src/app/utils/utils.js
+++ b/src/app/utils/utils.js
@@ -389,6 +389,7 @@ function displayContext({ searchKeywords, contributor, title, subject, selectedF
     // Currently from links on the bib page:
     creatorLiteral: 'author',
     contributorLiteral: 'author',
+    subjectLiteral: 'subject',
     titleDisplay: 'title',
     // From the search field dropdown:
     contributor: 'author/contributor',

--- a/test/unit/ResultsCount.test.js
+++ b/test/unit/ResultsCount.test.js
@@ -233,7 +233,7 @@ describe('ResultsCount', () => {
         it('should output that no results were found', () => {
           expect(component.find('h2').length).to.equal(1);
           expect(component.find('h2').text())
-            .to.equal('Displaying 1-50 of 6,789 results for subject "Children\'s art El Salvador"');
+            .to.equal('Displaying 1-50 of 6,789 results ');
         });
       });
     });

--- a/test/unit/ResultsCount.test.js
+++ b/test/unit/ResultsCount.test.js
@@ -233,7 +233,7 @@ describe('ResultsCount', () => {
         it('should output that no results were found', () => {
           expect(component.find('h2').length).to.equal(1);
           expect(component.find('h2').text())
-            .to.equal('Displaying 1-50 of 6,789 results ');
+            .to.equal('Displaying 1-50 of 6,789 results for subject "Children\'s art El Salvador"');
         });
       });
     });


### PR DESCRIPTION
**What's this do?**
Following our discussion, this will _only_ remove the subject from the announcement.
- Removes the `subject` field from the results announcement
- ~~Changes Bib-page links to use subject search for subjects instead of an empty search with a subject filter~~
- Fixes tests

**Why are we doing this? (w/ JIRA link if applicable)**
This is scc-2764. We are doing this because there are several different ways subjects get handled in RC, which is confusing, and we want to have more consistency.

**Do these changes have automated tests?**
Updated existing tests to match new expectations

**How should this be QAed?**
- Applying a subject filter to a search, you should see a button for that subject but no change in the results announcement

**Dependencies for merging? Releasing to production?**
NA

**Has the application documentation been updated for these changes?**
NA

**Did someone actually run this code to verify it works?**
Yes
