### PR TITLE
Advanced search visual touchup

### DIFF
--- a/src/app/components/AdvancedSearch/AdvancedSearch.jsx
+++ b/src/app/components/AdvancedSearch/AdvancedSearch.jsx
@@ -99,7 +99,7 @@ class AdvancedSearch extends React.Component {
             </aside>
           )
         }
-        <h1 id="advancedSearchHeading">Advanced Search</h1>
+        <h2 id="advancedSearchHeading">Advanced Search</h2>
         <form id="advancedSearchForm" onSubmit={this.submitForm} method="POST" action={`${appConfig.baseUrl}/search`}>
           <div id="fields">
             <div className="advancedSearchColumnLeft">

--- a/src/app/components/AdvancedSearch/AdvancedSearch.jsx
+++ b/src/app/components/AdvancedSearch/AdvancedSearch.jsx
@@ -87,6 +87,7 @@ class AdvancedSearch extends React.Component {
       <SccContainer
         activeSection="search"
         pageTitle="Advanced Search"
+        className="advancedSearchContainer"
       >
         { this.state.alarm &&
           (

--- a/src/client/styles/components/AdvancedSearch.scss
+++ b/src/client/styles/components/AdvancedSearch.scss
@@ -1,3 +1,7 @@
+.advancedSearchContainer.content-primary {
+    min-height: 650px;
+}
+
 #advancedSearchAside {
   color: #A4241E;
   background-color: #F9F9F9;

--- a/test/unit/AdvancedSearch.test.js
+++ b/test/unit/AdvancedSearch.test.js
@@ -39,7 +39,7 @@ describe('AdvancedSearch', () => {
     });
 
     it('should have an h2 announcing advanced search', () => {
-      expect(component.find('h2').at(1).text()).to.eql('Advanced Search');
+      expect(component.find('h2').at(0).text()).to.eql('Advanced Search');
     });
 
     it('should have an advanced search form', () => {

--- a/test/unit/AdvancedSearch.test.js
+++ b/test/unit/AdvancedSearch.test.js
@@ -38,8 +38,8 @@ describe('AdvancedSearch', () => {
       expect(component.find('aside').length).to.eql(0);
     });
 
-    it('should have an h1 announcing advanced search', () => {
-      expect(component.find('h1').at(1).text()).to.eql('Advanced Search');
+    it('should have an h2 announcing advanced search', () => {
+      expect(component.find('h2').at(1).text()).to.eql('Advanced Search');
     });
 
     it('should have an advanced search form', () => {


### PR DESCRIPTION
**What's this do?**
Some minor styling tweaks

**Why are we doing this? (w/ JIRA link if applicable)**
These were requested in Ellen's review. Relevant JIRA tickets are SCC-2778 and SCC-2779

**Do these changes have automated tests?**
Existing tests were adjusted for new requirements

**How should this be QAed?**
Changes should be apparent on /search/advanced page.

- Advanced Search heading text size matching heading text size in SHEP
- some more space between submit button and footer

**Dependencies for merging? Releasing to production?**
No

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Yes
