### PR TITLE
Add 404 in case of patron mismatch for hold confirmation

### DIFF
--- a/src/server/ApiRoutes/Hold.js
+++ b/src/server/ApiRoutes/Hold.js
@@ -269,6 +269,8 @@ function confirmRequestServer(req, res, next) {
         );
       }
 
+      res.status(404).redirect(`${appConfig.baseUrl}/404`);
+
       return false;
     })
     .catch((requestIdError) => {

--- a/src/server/ApiRoutes/Hold.js
+++ b/src/server/ApiRoutes/Hold.js
@@ -211,67 +211,66 @@ function confirmRequestServer(req, res, next) {
     .then((response) => {
       const patronIdFromHoldRequest = response.data.patron;
 
-      // The patron who is seeing the confirmation made the Hold Request
-      if (patronIdFromHoldRequest === patronId) {
-        // Retrieve item
-        return Bib.fetchBib(
-          bibId,
-          (bibResponseData) => {
-            const { bib } = bibResponseData;
-            barcode = LibraryItem.getItem(bib, req.params.itemId).barcode;
-            getDeliveryLocations(
-              barcode,
-              patronId,
-              (deliveryLocations, isEddRequestable) => {
-                dispatch(updateHoldRequestPage({
-                  bib,
-                  deliveryLocations,
-                  isEddRequestable,
-                  searchKeywords,
-                }));
-                next();
-              },
-              (deliveryLocationError) => {
-                logger.error(
-                  'Error retrieving server side delivery locations in confirmRequestServer' +
-                  `, bibId: ${bibId}`,
-                  deliveryLocationError,
-                );
-
-                dispatch(updateHoldRequestPage({
-                  bib,
-                  searchKeywords,
-                  error,
-                  deliveryLocations: [],
-                  isEddRequestable: false,
-                }));
-                next();
-              },
-            );
-          },
-          (bibResponseError) => {
-            logger.error(
-              `Error retrieving server side bib record in confirmRequestServer, id: ${bibId}`,
-              bibResponseError,
-            );
-            dispatch(updateHoldRequestPage({
-              bib: {},
-              searchKeywords,
-              error,
-              deliveryLocations: [],
-            }));
-            next();
-          },
-          {
-            fetchSubjectHeadingData: false,
-            features: urlEnabledFeatures,
-          },
-        );
+      // The patron who is seeing the confirmation did not make the Hold Request
+      if (patronIdFromHoldRequest !== patronId) {
+        res.status(404).redirect(`${appConfig.baseUrl}/404`);
+        return false;
       }
 
-      res.status(404).redirect(`${appConfig.baseUrl}/404`);
+      // Retrieve item
+      return Bib.fetchBib(
+        bibId,
+        (bibResponseData) => {
+          const { bib } = bibResponseData;
+          barcode = LibraryItem.getItem(bib, req.params.itemId).barcode;
+          getDeliveryLocations(
+            barcode,
+            patronId,
+            (deliveryLocations, isEddRequestable) => {
+              dispatch(updateHoldRequestPage({
+                bib,
+                deliveryLocations,
+                isEddRequestable,
+                searchKeywords,
+              }));
+              next();
+            },
+            (deliveryLocationError) => {
+              logger.error(
+                'Error retrieving server side delivery locations in confirmRequestServer' +
+                `, bibId: ${bibId}`,
+                deliveryLocationError,
+              );
 
-      return false;
+              dispatch(updateHoldRequestPage({
+                bib,
+                searchKeywords,
+                error,
+                deliveryLocations: [],
+                isEddRequestable: false,
+              }));
+              next();
+            },
+          );
+        },
+        (bibResponseError) => {
+          logger.error(
+            `Error retrieving server side bib record in confirmRequestServer, id: ${bibId}`,
+            bibResponseError,
+          );
+          dispatch(updateHoldRequestPage({
+            bib: {},
+            searchKeywords,
+            error,
+            deliveryLocations: [],
+          }));
+          next();
+        },
+        {
+          fetchSubjectHeadingData: false,
+          features: urlEnabledFeatures,
+        },
+      );
     })
     .catch((requestIdError) => {
       logger.error(


### PR DESCRIPTION
**What's this do?**

Adds logic to respond with 404 in case patron requests a hold confirmation page that doesn't match any of their holds

**Why are we doing this? (w/ JIRA link if applicable)**
Currently the response is a 504, which is confusing. This is scc-2637

**Do these changes have automated tests?**
No, we need to add tests for API methods to Discovery Front End, but I think that is a larger task outside the scope of this ticket.

**How should this be QAed?**
Navigate to a hold request page (there is an example in the ticket) using a non-matching patron. You should be redirected to the 404 page.

**Dependencies for merging? Releasing to production?**
No

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
Yes.
