### PR TITLE
Add min-height to scc container to avoid cutting off subject heading results

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -931,7 +931,7 @@
     "@nypl/design-toolkit": {
       "version": "0.1.38",
       "resolved": "https://registry.npmjs.org/@nypl/design-toolkit/-/design-toolkit-0.1.38.tgz",
-      "integrity": "sha1-UEevj9NzqfrqMCMCiBI77vtVugQ=",
+      "integrity": "sha512-HjfeRp96wh1afuwllBKPClTiO5UDF7fJZpFpGMavjUP5LgDCW9PZ5kBKNM47zI3mS0gaC5in2Lqkw3PYX6GbWA==",
       "requires": {
         "node-sass": "4.9.0"
       },
@@ -987,7 +987,7 @@
       }
     },
     "@nypl/dgx-header-component": {
-      "version": "git+https://git@github.com/NYPL/dgx-header-component.git#a3d450cc41ae4c1b8f7912360eeeb20bed29b4df",
+      "version": "git+https://git@github.com/NYPL/dgx-header-component.git#2913dd935cef141f6176d40426bd8e3a330dcd40",
       "from": "git+https://git@github.com/NYPL/dgx-header-component.git#reactupdate",
       "requires": {
         "@nypl/dgx-svg-icons": "0.3.7",
@@ -1966,7 +1966,7 @@
     "aproba": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-      "integrity": "sha1-aALmJk79GMeQobDVF/DyYnvyyUo="
+      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
     },
     "are-we-there-yet": {
       "version": "1.1.5",
@@ -2006,7 +2006,7 @@
     "arr-flatten": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-      "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE="
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
     },
     "arr-union": {
       "version": "3.1.0",
@@ -2152,7 +2152,7 @@
     "assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-      "integrity": "sha1-5gtrDo8wG9l+U3UhW9pAbIURjAs=",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
       "dev": true
     },
     "assign-symbols": {
@@ -2971,7 +2971,7 @@
     "babel-preset-env": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.6.1.tgz",
-      "integrity": "sha1-oYtWTMm5r99KrleuPBsNmRiOb0g=",
+      "integrity": "sha512-W6VIyA6Ch9ePMI7VptNn2wBM6dbG0eSz25HEiL40nQXCsXGTGZSTZu1Iap+cj3Q0S5a7T9+529l/5Bkvd+afNA==",
       "requires": {
         "babel-plugin-check-es2015-constants": "^6.22.0",
         "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
@@ -3230,7 +3230,7 @@
     "babylon": {
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-      "integrity": "sha1-ry87iPpvXB5MY00aD46sT1WzleM="
+      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -4364,7 +4364,7 @@
     "content-type": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-      "integrity": "sha1-4TjMdeBAxyexlm/l5fjJruJW/js="
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
     },
     "convert-source-map": {
       "version": "1.7.0",
@@ -4986,7 +4986,7 @@
       }
     },
     "dgx-alt-center": {
-      "version": "git+https://bitbucket.org/NYPL/dgx-alt-center.git#f00bd9ea99925072d561ac0041fecd0b07174432",
+      "version": "git+https://bitbucket.org/NYPL/dgx-alt-center.git#b3915c1cf33ed7f70446750dcbc6fcf98faaed37",
       "from": "git+https://bitbucket.org/NYPL/dgx-alt-center.git#master",
       "requires": {
         "alt": "0.18.2"
@@ -5005,7 +5005,7 @@
       }
     },
     "dgx-feature-flags": {
-      "version": "git+https://git@bitbucket.org/NYPL/dgx-feature-flags.git#27568b5f49f0fb853ce229b02c553e06955d3bf2",
+      "version": "git+https://git@bitbucket.org/NYPL/dgx-feature-flags.git#f7b1bd20f56632c71864cbe648556d03853d9f0e",
       "from": "git+https://git@bitbucket.org/NYPL/dgx-feature-flags.git#master",
       "requires": {
         "alt-utils": "1.0.0",
@@ -5014,7 +5014,7 @@
       }
     },
     "dgx-react-ga": {
-      "version": "git+https://git@bitbucket.org/NYPL/dgx-react-ga.git#81c24190d40904e685fc6332a8bb518241680f08",
+      "version": "git+https://git@bitbucket.org/NYPL/dgx-react-ga.git#1908e78bd8704b815ec37030d0f8040f8b3cbb95",
       "from": "git+https://git@bitbucket.org/NYPL/dgx-react-ga.git#master",
       "requires": {
         "create-react-class": "15.5.3",
@@ -5044,7 +5044,7 @@
       }
     },
     "dgx-skip-navigation-link": {
-      "version": "git+https://git@bitbucket.org/NYPL/dgx-skip-navigation-link.git#20ed457bb7b3c9505357d6df15119f64a9930d8a",
+      "version": "git+https://git@bitbucket.org/NYPL/dgx-skip-navigation-link.git#d1bdcf9e5d7d54fe252c6d8a250a42908fd98a87",
       "from": "git+https://git@bitbucket.org/NYPL/dgx-skip-navigation-link.git#master"
     },
     "diff": {
@@ -5096,7 +5096,7 @@
     "doctrine": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-      "integrity": "sha1-XNAfwQFiG0LEzX9dGmYkNxbT850=",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
       "dev": true,
       "requires": {
         "esutils": "^2.0.2"
@@ -5898,7 +5898,7 @@
     "eslint-plugin-import": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.8.0.tgz",
-      "integrity": "sha1-+htu8x/LPFAcCYWcG4bx/FuYaJQ=",
+      "integrity": "sha512-Rf7dfKJxZ16QuTgVv1OYNxkZcsu/hULFnC+e+w0Gzi6jMC3guQoWQgxYxc54IDRinlb6/0v5z/PxxIKmVctN+g==",
       "dev": true,
       "requires": {
         "builtin-modules": "^1.1.1",
@@ -6057,7 +6057,7 @@
     "eslint-plugin-react": {
       "version": "7.5.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.5.1.tgz",
-      "integrity": "sha1-UuVujYDIEN4ViFnvB7iA0vVu4ws=",
+      "integrity": "sha512-YGSjB9Qu6QbVTroUZi66pYky3DfoIPLdHQ/wmrBGyBRnwxQsBXAov9j2rpXt/55i8nyMv6IRWJv2s4d4YnduzQ==",
       "dev": true,
       "requires": {
         "doctrine": "^2.0.0",
@@ -7658,7 +7658,7 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0="
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "function.prototype.name": {
       "version": "1.1.2",
@@ -7903,7 +7903,7 @@
     "growl": {
       "version": "1.10.3",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
-      "integrity": "sha1-GSa6kM8+3+KttJJ/WIC8IsZseQ8=",
+      "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
       "dev": true
     },
     "gzip-size": {
@@ -8721,7 +8721,7 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4="
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "is-callable": {
       "version": "1.1.5",
@@ -9966,7 +9966,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -10036,7 +10036,7 @@
     "mocha": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.0.1.tgz",
-      "integrity": "sha1-Cu5alc9ppGGIIPXlH6MXFxF9rxs=",
+      "integrity": "sha512-evDmhkoA+cBNiQQQdSKZa2b9+W2mpLoj50367lhy+Klnx9OV8XlCIhigUnn1gaTFLQCa0kdNhEGDr0hCXOQFDw==",
       "dev": true,
       "requires": {
         "browser-stdout": "1.3.0",
@@ -10060,7 +10060,7 @@
         "debug": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -10069,7 +10069,7 @@
         "diff": {
           "version": "3.3.1",
           "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
-          "integrity": "sha1-qoVnpu7QPFMfyJ0/cRzQ5SWd7HU=",
+          "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
           "dev": true
         },
         "glob": {
@@ -10101,7 +10101,7 @@
         "supports-color": {
           "version": "4.4.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-          "integrity": "sha1-iD992rwWUUKyphQn8zUt7RldGj4=",
+          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
           "dev": true,
           "requires": {
             "has-flag": "^2.0.0"
@@ -10661,7 +10661,7 @@
     "node-fetch": {
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-      "integrity": "sha1-mA9vcthSEaU0fGsrwYxbhMPrR+8=",
+      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
       "requires": {
         "encoding": "^0.1.11",
         "is-stream": "^1.0.1"
@@ -11105,7 +11105,7 @@
     "npmlog": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-      "integrity": "sha1-CKfyqL9zRgR3mp76StXMcXq7lUs=",
+      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
       "requires": {
         "are-we-there-yet": "~1.1.2",
         "console-control-strings": "~1.1.0",
@@ -12407,7 +12407,7 @@
     "object.assign": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
-      "integrity": "sha1-lovxEA15Vrs8oIbwBvhGs7xACNo=",
+      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
       "requires": {
         "define-properties": "^1.1.2",
         "function-bind": "^1.1.1",
@@ -12890,7 +12890,7 @@
     "parse5": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
-      "integrity": "sha1-BC95L/3TaFFVHPTp4Gazh0q0W1w=",
+      "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -13558,7 +13558,7 @@
     "private": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-      "integrity": "sha1-I4Hts2ifelPWUxkAYPz4ItLzaP8="
+      "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
     },
     "process": {
       "version": "0.11.10",
@@ -13579,7 +13579,7 @@
     "promise": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-      "integrity": "sha1-BktyYCsY+Q8pGSuLG8QY/9Hr078=",
+      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
       "requires": {
         "asap": "~2.0.3"
       }
@@ -15188,7 +15188,7 @@
     "samsam": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
-      "integrity": "sha1-jR2TUOJWItow3j5EumkrUiGrfFA=",
+      "integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
       "dev": true
     },
     "sass-graph": {
@@ -15530,7 +15530,7 @@
     "sinon": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/sinon/-/sinon-4.0.1.tgz",
-      "integrity": "sha1-5GFGqKhCD4N726MuKWW9H+Q9WwU=",
+      "integrity": "sha512-4qIY0pCWCvGCJpV/1JkFu9kbsNEZ9O34cG1oru/c7OCDtrEs50Gq/VjkA2ID5ZwLyoNx1i1ws118oh/p6fVeDg==",
       "dev": true,
       "requires": {
         "diff": "^3.1.0",
@@ -17142,7 +17142,7 @@
     "validator": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/validator/-/validator-7.2.0.tgz",
-      "integrity": "sha1-pj3Lq6UdQ1C/jfIJiODVpU1xF5E="
+      "integrity": "sha512-c8NGTUYeBEcUIGeMppmNVKHE7wwfm3mYbNZxV+c5mlv9fDHI7Ad3p07qfNrn/CvpdkK2k61fOLRO2sTEhgQXmg=="
     },
     "value-equal": {
       "version": "1.0.1",
@@ -17710,7 +17710,7 @@
     "webpack-dev-middleware": {
       "version": "1.12.2",
       "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.12.2.tgz",
-      "integrity": "sha512-FCrqPy1yy/sN6U/SaEZcHKRXGlqU0DUaEBL45jkUYoB8foVb6wCnbIJ1HKIx+qUFTW+3JpVcCJCxZ8VATL4e+A==",
+      "integrity": "sha1-+PwRIM47T8VoDO7LQ9d3lmshEF4=",
       "dev": true,
       "requires": {
         "memory-fs": "~0.4.1",

--- a/src/app/components/SccContainer/SccContainer.jsx
+++ b/src/app/components/SccContainer/SccContainer.jsx
@@ -24,6 +24,7 @@ const SccContainer = (props) => {
     activeSection,
     className,
     pageTitle,
+    primaryId,
   } = props;
 
   const documentTitle = `${pageTitle ? `${pageTitle} | ` : ''}${appConfig.displayTitle} | NYPL`;
@@ -59,7 +60,7 @@ const SccContainer = (props) => {
             </div>
             <SubNav activeSection={activeSection} />
           </div>
-          <div className={`content-primary ${className || ''}`}>
+          <div className={`content-primary ${className || ''}`} id={primaryId}>
             {children}
           </div>
         </main>
@@ -74,10 +75,12 @@ SccContainer.propTypes = {
   activeSection: PropTypes.string,
   className: PropTypes.string,
   pageTitle: PropTypes.string,
+  primaryId: PropTypes.string,
 };
 
 SccContainer.defaultProps = {
   useLoadingLayer: true,
+  primaryId: 'SccContainer-content-primary',
 };
 
 SccContainer.contextTypes = {

--- a/src/app/components/SccContainer/SccContainer.jsx
+++ b/src/app/components/SccContainer/SccContainer.jsx
@@ -25,6 +25,7 @@ const SccContainer = (props) => {
     className,
     pageTitle,
     primaryId,
+    contentPrimaryStyle,
   } = props;
 
   const documentTitle = `${pageTitle ? `${pageTitle} | ` : ''}${appConfig.displayTitle} | NYPL`;
@@ -60,7 +61,7 @@ const SccContainer = (props) => {
             </div>
             <SubNav activeSection={activeSection} />
           </div>
-          <div className={`content-primary ${className || ''}`} id={primaryId}>
+          <div className={`content-primary ${className || ''}`} id={primaryId} style={contentPrimaryStyle}>
             {children}
           </div>
         </main>
@@ -76,11 +77,13 @@ SccContainer.propTypes = {
   className: PropTypes.string,
   pageTitle: PropTypes.string,
   primaryId: PropTypes.string,
+  contentPrimaryStyle: PropTypes.object,
 };
 
 SccContainer.defaultProps = {
   useLoadingLayer: true,
   primaryId: 'SccContainer-content-primary',
+  contentPrimaryStyle: {},
 };
 
 SccContainer.contextTypes = {

--- a/src/app/components/SubjectHeading/Search/SubjectHeadingSearch.jsx
+++ b/src/app/components/SubjectHeading/Search/SubjectHeadingSearch.jsx
@@ -36,12 +36,9 @@ class SubjectHeadingSearch extends React.Component {
         return axios(`${appConfig.baseUrl}/api/subjectHeadings/autosuggest?query=${this.state.userInput}`)
           .then((res) => {
             const numberOfResults = res.data.autosuggest.length;
-            const subjectHeadingStyle = document
-              .getElementById('subject-heading-content-primary-style');
-            if (subjectHeadingStyle) {
-              subjectHeadingStyle.innerHTML = `.content-primary.subject-heading-page#subject-heading-content-primary { min-height: ${(numberOfResults > 12 ? numberOfResults : 12) * 50}px}`;
-            }
-
+            document
+              .getElementById('subject-heading-content-primary-style')
+              .innerHTML = `.content-primary.subject-heading-page#subject-heading-content-primary { min-height: ${(numberOfResults > 12 ? numberOfResults : 12) * 50}px}`;
             if (res.data.request.query.trim() === this.state.userInput.trim()) {
               this.setState({
                 suggestions: res.data.autosuggest,

--- a/src/app/components/SubjectHeading/Search/SubjectHeadingSearch.jsx
+++ b/src/app/components/SubjectHeading/Search/SubjectHeadingSearch.jsx
@@ -102,7 +102,6 @@ class SubjectHeadingSearch extends React.Component {
           value: userInput,
           onChange,
         }}
-        alwaysRenderSuggestions
         renderSuggestion={(suggestion) => {
           const subjectComponent = suggestion.class === 'subject_component';
 

--- a/src/app/components/SubjectHeading/Search/SubjectHeadingSearch.jsx
+++ b/src/app/components/SubjectHeading/Search/SubjectHeadingSearch.jsx
@@ -35,6 +35,8 @@ class SubjectHeadingSearch extends React.Component {
       if (this.state.userInput) {
         return axios(`${appConfig.baseUrl}/api/subjectHeadings/autosuggest?query=${this.state.userInput}`)
           .then((res) => {
+            const numberOfResults = res.data.autosuggest.length;
+            document.getElementById('subject-heading-content-primary').style['min-height'] = `${(numberOfResults > 12 ? numberOfResults : 12) * 50}px`
             if (res.data.request.query.trim() === this.state.userInput.trim()) {
               this.setState({
                 suggestions: res.data.autosuggest,
@@ -100,6 +102,7 @@ class SubjectHeadingSearch extends React.Component {
           value: userInput,
           onChange,
         }}
+        alwaysRenderSuggestions
         renderSuggestion={(suggestion) => {
           const subjectComponent = suggestion.class === 'subject_component';
 

--- a/src/app/components/SubjectHeading/Search/SubjectHeadingSearch.jsx
+++ b/src/app/components/SubjectHeading/Search/SubjectHeadingSearch.jsx
@@ -36,9 +36,7 @@ class SubjectHeadingSearch extends React.Component {
         return axios(`${appConfig.baseUrl}/api/subjectHeadings/autosuggest?query=${this.state.userInput}`)
           .then((res) => {
             const numberOfResults = res.data.autosuggest.length;
-            document
-              .getElementById('subject-heading-content-primary-style')
-              .innerHTML = `.content-primary.subject-heading-page#subject-heading-content-primary { min-height: ${(numberOfResults > 12 ? numberOfResults : 12) * 50}px}`;
+            this.props.setContentPrimaryStyle({ 'min-height': `${(numberOfResults > 12 ? numberOfResults : 12) * 50}px` });
             if (res.data.request.query.trim() === this.state.userInput.trim()) {
               this.setState({
                 suggestions: res.data.autosuggest,
@@ -128,6 +126,14 @@ class SubjectHeadingSearch extends React.Component {
 
 SubjectHeadingSearch.contextTypes = {
   router: PropTypes.object,
+};
+
+SubjectHeadingSearch.propTypes = {
+  setContentPrimaryStyle: PropTypes.func,
+};
+
+SubjectHeadingSearch.defaultProps = {
+  setContentPrimaryStyle: () => {},
 };
 
 export default SubjectHeadingSearch;

--- a/src/app/components/SubjectHeading/Search/SubjectHeadingSearch.jsx
+++ b/src/app/components/SubjectHeading/Search/SubjectHeadingSearch.jsx
@@ -36,9 +36,12 @@ class SubjectHeadingSearch extends React.Component {
         return axios(`${appConfig.baseUrl}/api/subjectHeadings/autosuggest?query=${this.state.userInput}`)
           .then((res) => {
             const numberOfResults = res.data.autosuggest.length;
-            document
-              .getElementById('subject-heading-content-primary-style')
-              .innerHTML = `.content-primary.subject-heading-page#subject-heading-content-primary { min-height: ${(numberOfResults > 12 ? numberOfResults : 12) * 50}px}`;
+            const subjectHeadingStyle = document
+              .getElementById('subject-heading-content-primary-style');
+            if (subjectHeadingStyle) {
+              subjectHeadingStyle.innerHTML = `.content-primary.subject-heading-page#subject-heading-content-primary { min-height: ${(numberOfResults > 12 ? numberOfResults : 12) * 50}px}`;
+            }
+
             if (res.data.request.query.trim() === this.state.userInput.trim()) {
               this.setState({
                 suggestions: res.data.autosuggest,

--- a/src/app/components/SubjectHeading/Search/SubjectHeadingSearch.jsx
+++ b/src/app/components/SubjectHeading/Search/SubjectHeadingSearch.jsx
@@ -36,7 +36,9 @@ class SubjectHeadingSearch extends React.Component {
         return axios(`${appConfig.baseUrl}/api/subjectHeadings/autosuggest?query=${this.state.userInput}`)
           .then((res) => {
             const numberOfResults = res.data.autosuggest.length;
-            document.getElementById('subject-heading-content-primary').style['min-height'] = `${(numberOfResults > 12 ? numberOfResults : 12) * 50}px`
+            document
+              .getElementById('subject-heading-content-primary-style')
+              .innerHTML = `.content-primary.subject-heading-page#subject-heading-content-primary { min-height: ${(numberOfResults > 12 ? numberOfResults : 12) * 50}px}`;
             if (res.data.request.query.trim() === this.state.userInput.trim()) {
               this.setState({
                 suggestions: res.data.autosuggest,

--- a/src/app/components/SubjectHeading/Search/SubjectHeadingSearch.jsx
+++ b/src/app/components/SubjectHeading/Search/SubjectHeadingSearch.jsx
@@ -36,7 +36,7 @@ class SubjectHeadingSearch extends React.Component {
         return axios(`${appConfig.baseUrl}/api/subjectHeadings/autosuggest?query=${this.state.userInput}`)
           .then((res) => {
             const numberOfResults = res.data.autosuggest.length;
-            this.props.setContentPrimaryStyle({ 'min-height': `${(numberOfResults > 12 ? numberOfResults : 12) * 50}px` });
+            this.props.setContentPrimaryStyle({ 'min-height': `${Math.max(numberOfResults, 12) * 50}px` });
             if (res.data.request.query.trim() === this.state.userInput.trim()) {
               this.setState({
                 suggestions: res.data.autosuggest,

--- a/src/app/pages/SubjectHeadingsIndexPage.jsx
+++ b/src/app/pages/SubjectHeadingsIndexPage.jsx
@@ -35,6 +35,7 @@ const SubjectHeadingsIndexPage = (props) => {
       activeSection="shep"
       pageTitle="Subject Headings"
       className="subject-heading-page"
+      primaryId="subject-heading-content-primary"
     >
       <div
         className="subject-heading-page-header"

--- a/src/app/pages/SubjectHeadingsIndexPage.jsx
+++ b/src/app/pages/SubjectHeadingsIndexPage.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 
 import {
@@ -28,6 +28,8 @@ const SubjectHeadingsIndexPage = (props) => {
 
   const bannerInnerHtml = filter ? <span key="bannerText">Subject Headings containing <em>{filter}</em></span> : <span key="bannerText">Subject Headings</span>
 
+  const [contentPrimaryStyle, setContentPrimaryStyle] = useState({});
+
   return (
     <SccContainer
       key={componentKey}
@@ -35,6 +37,7 @@ const SubjectHeadingsIndexPage = (props) => {
       activeSection="shep"
       pageTitle="Subject Headings"
       className="subject-heading-page"
+      contentPrimaryStyle={contentPrimaryStyle}
       primaryId="subject-heading-content-primary"
     >
       <div
@@ -46,7 +49,9 @@ const SubjectHeadingsIndexPage = (props) => {
         >
           {filter ? 'Subject Heading Results' : 'Subject Heading Index'}
         </Heading>
-        <SubjectHeadingSearch />
+        <SubjectHeadingSearch
+          setContentPrimaryStyle={setContentPrimaryStyle}
+        />
       </div>
       <SubjectHeadingsIndex
         {...props}

--- a/src/client/styles/components/SubjectHeadings/SubjectHeading.scss
+++ b/src/client/styles/components/SubjectHeadings/SubjectHeading.scss
@@ -1,5 +1,9 @@
 @import "utils/colors.scss";
 
+#subject-heading-content-primary {
+  min-height: 600px;
+}
+
 .subjectHeadingLabel.mainLabel {
   font-style: italic;
 }

--- a/src/views/index.ejs
+++ b/src/views/index.ejs
@@ -21,6 +21,7 @@
     <meta name="twitter:site" content="@nypl">
     <meta name="twitter:creator" content="@nypl">
     <meta name="twitter:image" content="">
+    <style id="subject-heading-content-primary-style"></style>
 
 
 <% if (isProduction) { %>

--- a/src/views/index.ejs
+++ b/src/views/index.ejs
@@ -21,7 +21,6 @@
     <meta name="twitter:site" content="@nypl">
     <meta name="twitter:creator" content="@nypl">
     <meta name="twitter:image" content="">
-    <style id="subject-heading-content-primary-style"></style>
 
 
 <% if (isProduction) { %>


### PR DESCRIPTION

**What's this do?**

- Adds a configurable class to the content of the SCC container
- For subjects page, configures this class to indicate the subjects page
- Adds styling to give primary content on subjects page a min height
- Adds logic to adjust the min-height if necessary.

**Why are we doing this? (w/ JIRA link if applicable)**
- We want to stop the subject search box results from being cut off when there are no results for the current search

**How should this be QAed?**
- On the main page, select subject search and enter some nonsense
- You should see the subject index page with a message that there are no results. Now start typing into the search box. It should not be cut off

**Dependencies for merging? Releasing to production?**
No

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Yes.
