### PR TITLE
Add parsing totalResults and default for urlEnabledFeatures

### DIFF
--- a/src/app/components/SubjectHeading/BibsList.jsx
+++ b/src/app/components/SubjectHeading/BibsList.jsx
@@ -205,7 +205,9 @@ class BibsList extends React.Component {
     }
     const bibResults = bibsSource === 'discoveryApi' ? results : results.slice(this.firstBib(), this.lastBib());
 
-    const h3Text = `Viewing ${this.firstBib() + 1} - ${Number.isInteger(parseInt(totalResults, 10)) ? `${this.lastBib()} of ${totalResults} item${totalResults === 1 ? '' : 's'}` : ''}`;
+    const numberOfResults = parseInt(totalResults, 10);
+
+    const h3Text = `Viewing ${this.firstBib() + 1} - ${Number.isInteger(numberOfResults) ? `${this.lastBib()} of ${numberOfResults} item${numberOfResults === 1 ? '' : 's'}` : ''}`;
 
     return (
       <div

--- a/src/app/components/SubjectHeading/BibsList.jsx
+++ b/src/app/components/SubjectHeading/BibsList.jsx
@@ -205,7 +205,7 @@ class BibsList extends React.Component {
     }
     const bibResults = bibsSource === 'discoveryApi' ? results : results.slice(this.firstBib(), this.lastBib());
 
-    const h3Text = `Viewing ${this.firstBib() + 1} - ${Number.isInteger(totalResults) ? `${this.lastBib()} of ${totalResults} item${totalResults === 1 ? '' : 's'}` : ''}`;
+    const h3Text = `Viewing ${this.firstBib() + 1} - ${Number.isInteger(parseInt(totalResults, 10)) ? `${this.lastBib()} of ${totalResults} item${totalResults === 1 ? '' : 's'}` : ''}`;
 
     return (
       <div

--- a/src/server/ApiRoutes/Bib.js
+++ b/src/server/ApiRoutes/Bib.js
@@ -9,7 +9,7 @@ import { itemBatchSize } from '../../app/data/constants';
 const nyplApiClientCall = (query, urlEnabledFeatures, itemFrom) => {
   // If on-site-edd feature enabled in front-end, enable it in discovery-api:
   const queryForItemPage = typeof itemFrom !== 'undefined' ? `?items_size=${itemBatchSize}&items_from=${itemFrom}` : '';
-  const requestOptions = appConfig.features.includes('on-site-edd') || urlEnabledFeatures.includes('on-site-edd') ? { headers: { 'X-Features': 'on-site-edd' } } : {};
+  const requestOptions = appConfig.features.includes('on-site-edd') || (urlEnabledFeatures || []).includes('on-site-edd') ? { headers: { 'X-Features': 'on-site-edd' } } : {};
   return nyplApiClient().then(client => client.get(`/discovery/resources/${query}${queryForItemPage}`, requestOptions));
 };
 

--- a/test/unit/BibsList.test.js
+++ b/test/unit/BibsList.test.js
@@ -43,7 +43,7 @@ describe('BibsList', () => {
           }, 100);
           return {
             page: 1,
-            totalResults: 1,
+            totalResults: '1',
             bibsSource: 'discoveryApi',
           };
         });
@@ -83,7 +83,7 @@ describe('BibsList', () => {
           }, 100);
           return {
             page: 1,
-            totalResults: 10,
+            totalResults: '10',
             bibsSource: 'discoveryApi',
           };
         });
@@ -124,7 +124,7 @@ describe('BibsList', () => {
           }, 100);
           return {
             page: 1,
-            totalResults: 10,
+            totalResults: '10',
             bibsSource: 'discoveryApi',
           };
         });


### PR DESCRIPTION
**What's this do?**
Fixes some minor bugs introduced in scc-2795

- `totalResults` needs to be parsed from a string
- `urlEnabledFeatures` needs a default value
- corresponding fixes to tests

**Do these changes have automated tests?**

Fixes existing automated tests

**Did someone actually run this code to verify it works?**
Yes
