### PR TITLE
Scc 2812

### DIFF
--- a/src/app/components/Drbb/DrbbContainer.jsx
+++ b/src/app/components/Drbb/DrbbContainer.jsx
@@ -63,7 +63,7 @@ const DrbbContainer = ({ drbbResults }) => {
           <a
             className="link"
             target="_blank"
-            href={`${appConfig.drbbFrontEnd[appConfig.environment]}/about`}
+            href={`${appConfig.drbbFrontEnd[appConfig.environment]}/about?source=catalog`}
           >
           Read more about the project
           </a>.

--- a/src/app/components/Drbb/DrbbResult.jsx
+++ b/src/app/components/Drbb/DrbbResult.jsx
@@ -11,6 +11,7 @@ import {
 } from '../../utils/researchNowUtils';
 import {
   truncateStringOnWhitespace,
+  addSource,
 } from '../../utils/utils';
 
 // TODO: When the EDD integration is turned on in DRB we will need to handle application/edd+html media types as well
@@ -85,7 +86,7 @@ const DrbbResult = (props) => {
       <Link
         target="_blank"
         to={{
-          pathname: `${drbbFrontEnd}/read/${selectedLink.link_id}`,
+          pathname: addSource(`${drbbFrontEnd}/read/${selectedLink.link_id}`),
         }}
         className="drbb-read-online"
       >
@@ -124,7 +125,7 @@ const DrbbResult = (props) => {
     <li className="drbb-result">
       <Link
         target="_blank"
-        to={`${drbbFrontEnd}/work/${work.uuid}`}
+        to={addSource(`${drbbFrontEnd}/work/${work.uuid}`)}
         className="drbb-result-title"
       >
         {truncateStringOnWhitespace(title, 92)}

--- a/src/app/utils/researchNowUtils.js
+++ b/src/app/utils/researchNowUtils.js
@@ -49,7 +49,6 @@ const mapFilters = (filters = {}) => {
  */
 const createResearchNowQuery = (params) => {
 
-  console.log('creating research now query');
   const {
     q,
     sort,
@@ -100,7 +99,6 @@ const createResearchNowQuery = (params) => {
     query.filter = mapFilters({ dateAfter, dateBefore, language });
   }
 
-  console.log('query: ', query);
   return query;
 };
 

--- a/src/app/utils/researchNowUtils.js
+++ b/src/app/utils/researchNowUtils.js
@@ -1,5 +1,7 @@
 /* eslint-disable camelcase */
 
+import { addSource } from './utils';
+
 const mapSearchScope = {
   all: 'keyword',
   contributor: 'author',
@@ -46,6 +48,8 @@ const mapFilters = (filters = {}) => {
  *  Returns a hash representing an equivalent query against DRBAPI
  */
 const createResearchNowQuery = (params) => {
+
+  console.log('creating research now query');
   const {
     q,
     sort,
@@ -63,6 +67,7 @@ const createResearchNowQuery = (params) => {
   const query = {
     query: [ mainQuery ],
     page: 1,
+    source: 'catalog',
   };
 
   if (sort) {
@@ -95,12 +100,13 @@ const createResearchNowQuery = (params) => {
     query.filter = mapFilters({ dateAfter, dateBefore, language });
   }
 
+  console.log('query: ', query);
   return query;
 };
 
-const authorQuery = author => ({query: `author:${author.name}`});
+const authorQuery = author => ({ query: `author:${author.name}`, source: 'catalog' });
 
-const formatUrl = link => (link.startsWith('http') ? link : `https://${link}`);
+const formatUrl = link => addSource((link.startsWith('http') ? link : `https://${link}`));
 
 /**
  *  Given a hash representation of a query string, e.g.

--- a/src/app/utils/researchNowUtils.v3.js
+++ b/src/app/utils/researchNowUtils.v3.js
@@ -1,3 +1,5 @@
+import { addSource } from './utils';
+
 /*
   `createResearchNowQuery()` currently handles:
   `search_scope`, `dateAfter`, `dateBefore`,
@@ -34,6 +36,7 @@ const mapFilters = (filters = {}) => {
 };
 
 const createResearchNowQuery = (params) => {
+  console.log('creating research now query v3');
   const {
     q,
     sort,
@@ -50,6 +53,7 @@ const createResearchNowQuery = (params) => {
   const query = {
     queries: [mainQuery],
     page: 0,
+    source: 'catalog',
   };
 
   if (sort) {
@@ -79,6 +83,8 @@ const createResearchNowQuery = (params) => {
     query.filters = mapFilters({ dateAfter, dateBefore, language });
   }
 
+  console.log('query: ', query);
+
   return query;
 };
 
@@ -89,10 +95,10 @@ const authorQuery = author => ({
     query: author[getAuthorIdentifier(author)[0]],
     field: getAuthorIdentifier(author)[1],
   }]),
-  showQueries: JSON.stringify([{ query: author.name, field: 'author' }]),
+  showQueries: JSON.stringify([{ query: author.name, field: 'author', source: 'catalog' }]),
 });
 
-const formatUrl = link => (link.startsWith('http') ? link : `https://${link}`);
+const formatUrl = addSource(link => (link.startsWith('http') ? link : `https://${link}`));
 
 const generateStreamedReaderUrl = (url, eReaderUrl) => {
   const base64BookUrl = Buffer.from(formatUrl(url)).toString('base64');

--- a/src/app/utils/researchNowUtils.v3.js
+++ b/src/app/utils/researchNowUtils.v3.js
@@ -36,7 +36,6 @@ const mapFilters = (filters = {}) => {
 };
 
 const createResearchNowQuery = (params) => {
-  console.log('creating research now query v3');
   const {
     q,
     sort,
@@ -82,8 +81,6 @@ const createResearchNowQuery = (params) => {
   if (language || dateAfter || dateBefore) {
     query.filters = mapFilters({ dateAfter, dateBefore, language });
   }
-
-  console.log('query: ', query);
 
   return query;
 };

--- a/src/app/utils/utils.js
+++ b/src/app/utils/utils.js
@@ -568,6 +568,22 @@ function institutionNameByNyplSource(nyplSource) {
   }[nyplSource];
 }
 
+/**
+ * Given a url, returns the same url with the added parameter source=catalog
+ * Used for DRB
+ */
+
+function addSource(url) {
+  try {
+    const parsedUrl = new URL(url);
+    const searchParams = parsedUrl.searchParams;
+    if (!searchParams.has('source')) searchParams.append('source', 'catalog');
+    return parsedUrl.toString();
+  } catch (error) {
+    return url;
+  }
+}
+
 export {
   trackDiscovery,
   ajaxCall,
@@ -590,4 +606,5 @@ export {
   extractNoticePreference,
   camelToShishKabobCase,
   institutionNameByNyplSource,
+  addSource,
 };

--- a/src/server/ApiRoutes/ResearchNow.js
+++ b/src/server/ApiRoutes/ResearchNow.js
@@ -35,6 +35,7 @@ const drbQueryFromRequest = (req) => {
   // Return a promise resolving the DRB API response and the query string used
   return drbCall
     .then((resp) => {
+      console.log('drbQueryString', drbQueryString);
       return {
         response: resp,
         researchNowQueryString: drbQueryString

--- a/src/server/ApiRoutes/ResearchNow.js
+++ b/src/server/ApiRoutes/ResearchNow.js
@@ -35,7 +35,6 @@ const drbQueryFromRequest = (req) => {
   // Return a promise resolving the DRB API response and the query string used
   return drbCall
     .then((resp) => {
-      console.log('drbQueryString', drbQueryString);
       return {
         response: resp,
         researchNowQueryString: drbQueryString

--- a/test/unit/DrbbContainer.test.js
+++ b/test/unit/DrbbContainer.test.js
@@ -30,7 +30,7 @@ describe('DrbbContainer', () => {
       expect(component.find('p').find('span').length).to.equal(1);
       expect(component.find('p').find('span').text()).to.equal('Read more about the project.');
       expect(component.find('p').find('span').find('a').text()).to.equal('Read more about the project');
-      expect(component.find('p').find('span').find('a').prop('href')).to.equal(`${appConfig.drbbFrontEnd[appConfig.environment]}/about`);
+      expect(component.find('p').find('span').find('a').prop('href')).to.equal(`${appConfig.drbbFrontEnd[appConfig.environment]}/about?source=catalog`);
     });
   });
 

--- a/test/unit/ResearchNow.test.js
+++ b/test/unit/ResearchNow.test.js
@@ -26,7 +26,7 @@ describe('ResearchNow', () => {
       return ResearchNow.search({ query: { q: '' } })
         .then((res) => {
           expect(NyplApiClient.prototype.get.calledOnce).to.be.true;
-          expect(NyplApiClient.prototype.get.args[0][0]).to.equal('?query=keyword%3A*&page=1&size=3')
+          expect(NyplApiClient.prototype.get.args[0][0]).to.equal('?query=keyword%3A*&page=1&source=catalog&size=3')
           expect(res.works).to.be.a('array');
         });
     });
@@ -35,7 +35,7 @@ describe('ResearchNow', () => {
       return ResearchNow.search({ query: { q: 'toast' } })
         .then((res) => {
           expect(NyplApiClient.prototype.get.calledOnce).to.be.true;
-          expect(NyplApiClient.prototype.get.args[0][0]).to.equal('?query=keyword%3Atoast&page=1&size=3')
+          expect(NyplApiClient.prototype.get.args[0][0]).to.equal('?query=keyword%3Atoast&page=1&source=catalog&size=3')
           expect(res.works).to.be.a('array');
         });
     });
@@ -44,7 +44,7 @@ describe('ResearchNow', () => {
       return ResearchNow.search({ query: { q: 'toast', filters: { contributorLiteral: 'Poe' } } })
         .then((res) => {
           expect(NyplApiClient.prototype.get.calledOnce).to.be.true;
-          expect(NyplApiClient.prototype.get.args[0][0]).to.equal('?query=keyword%3Atoast,author%3APoe&page=1&size=3')
+          expect(NyplApiClient.prototype.get.args[0][0]).to.equal('?query=keyword%3Atoast,author%3APoe&page=1&source=catalog&size=3')
           expect(res.works).to.be.a('array');
         });
     });
@@ -56,7 +56,7 @@ describe('ResearchNow', () => {
         // Set DRB_API_BASE_URL to something resembling a v3 endpoint:
         process.env.DRB_API_BASE_URL = 'http://example.com/v3/search/'
       });
-  
+
       after(() => {
         // Set DRB_API_BASE_URL back to test.env val
         process.env.DRB_API_BASE_URL = 'http://example.com/search/'
@@ -85,7 +85,8 @@ describe('ResearchNow', () => {
                   field: "keyword",
                   query: "*"
                 }
-              ]
+              ],
+              source: 'catalog',
             });
             expect(res.works).to.be.a('array');
           });

--- a/test/unit/researchNowUtils.test.js
+++ b/test/unit/researchNowUtils.test.js
@@ -23,39 +23,39 @@ describe('researchNowUtils', () => {
 
   describe('getResearchNowQueryString', () => {
     it('should handle empty query', () => {
-      expect(getResearchNowQueryString({})).to.equal('?query=keyword%3A*&page=1')
+      expect(getResearchNowQueryString({})).to.equal('?query=keyword%3A*&page=1&source=catalog')
     })
 
     it('should handle simple keyword query', () => {
-      expect(getResearchNowQueryString({ q: 'toast' })).to.equal('?query=keyword%3Atoast&page=1')
+      expect(getResearchNowQueryString({ q: 'toast' })).to.equal('?query=keyword%3Atoast&page=1&source=catalog')
     })
 
     it('should handle field', () => {
-      expect(getResearchNowQueryString({ q: 'toast', field: 'title' })).to.equal('?query=title%3Atoast&page=1')
+      expect(getResearchNowQueryString({ q: 'toast', field: 'title' })).to.equal('?query=title%3Atoast&page=1&source=catalog')
     })
 
     it('should handle keyword & subject query', () => {
-      expect(getResearchNowQueryString({ q: 'toast', filters: { subjectLiteral: 'Snacks' } })).to.equal('?query=keyword%3Atoast,subject%3ASnacks&page=1')
+      expect(getResearchNowQueryString({ q: 'toast', filters: { subjectLiteral: 'Snacks' } })).to.equal('?query=keyword%3Atoast,subject%3ASnacks&page=1&source=catalog')
     })
 
     it('should handle contributor filter', () => {
-      expect(getResearchNowQueryString({ filters: { contributorLiteral: 'Poe' } })).to.equal('?query=keyword%3A*,author%3APoe&page=1')
+      expect(getResearchNowQueryString({ filters: { contributorLiteral: 'Poe' } })).to.equal('?query=keyword%3A*,author%3APoe&page=1&source=catalog')
     })
 
     it('should handle lang filter', () => {
-      expect(getResearchNowQueryString({ filters: { language: 'lang:en' } })).to.equal('?query=keyword%3A*&page=1&filter=language%3Aen')
+      expect(getResearchNowQueryString({ filters: { language: 'lang:en' } })).to.equal('?query=keyword%3A*&page=1&source=catalog&filter=language%3Aen')
     })
 
     it('should handle dateAfter filter', () => {
-      expect(getResearchNowQueryString({ filters: { dateAfter: 2000 } })).to.equal('?query=keyword%3A*&page=1&filter=startYear%3A2000')
+      expect(getResearchNowQueryString({ filters: { dateAfter: 2000 } })).to.equal('?query=keyword%3A*&page=1&source=catalog&filter=startYear%3A2000')
     })
 
     it('should handle dateBefore filter', () => {
-      expect(getResearchNowQueryString({ filters: { dateBefore: 2020 } })).to.equal('?query=keyword%3A*&page=1&filter=endYear%3A2020')
+      expect(getResearchNowQueryString({ filters: { dateBefore: 2020 } })).to.equal('?query=keyword%3A*&page=1&source=catalog&filter=endYear%3A2020')
     })
 
     it('should handle dateAfter & dateBefore filter', () => {
-      expect(getResearchNowQueryString({ filters: { dateAfter: 2000, dateBefore: 2020 } })).to.equal('?query=keyword%3A*&page=1&filter=startYear%3A2000,endYear%3A2020')
+      expect(getResearchNowQueryString({ filters: { dateAfter: 2000, dateBefore: 2020 } })).to.equal('?query=keyword%3A*&page=1&source=catalog&filter=startYear%3A2000,endYear%3A2020')
     })
   })
 })


### PR DESCRIPTION
**What's this do?**
Adds query parameter `source=catalog` to all DRB links and API calls

**Why are we doing this? (w/ JIRA link if applicable)**
This is a request from the DRB team, see scc-2812

**Do these changes have automated tests?**
Yes

**How should this be QAed?**
The param should be visible in the href of the DRB links on the search page

**Dependencies for merging? Releasing to production?**
No

**Has the application documentation been updated for these changes?**
NA

**Did someone actually run this code to verify it works?**
Yes