### PR TITLE
Security Update: change CDN URLs to point to nypl.org CNAMES

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## CHANGE LOG
 
+### 1.7.1
+- Security Update: change CDN URL to point to ux-static.nypl.org.
+
 ### 1.7.0
 - Replace Alt with Redux for state management
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## Discovery
 
 ### Version
-> 1.7.0
+> 1.7.1
 
 ### Research Catalog (formerly Shared Collection Catalog)
 [![GitHub version](https://badge.fury.io/gh/nypl-discovery%2Fdiscovery-front-end.svg)](https://badge.fury.io/gh/nypl-discovery%2Fdiscovery-front-end)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nypl-discovery",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Isomorphic React App for NYPL Research Catalog.",
   "main": "index.js",
   "scripts": {

--- a/src/app/data/appConfig.js
+++ b/src/app/data/appConfig.js
@@ -8,7 +8,7 @@ const appConfig = {
   baseUrl: process.env.BASE_URL || '/research/collections/shared-collection-catalog',
   redirectFromBaseUrl: process.env.REDIRECT_FROM_BASE_URL,
   legacyBaseUrl: process.env.LEGACY_BASE_URL,
-  favIconPath: '//d2znry4lg8s0tq.cloudfront.net/images/favicon.ico',
+  favIconPath: 'https://ux-static.nypl.org/images/favicon.ico',
   port: 3001,
   webpackDevServerPort: 3000,
   environment: process.env.APP_ENV || 'production',

--- a/src/app/pages/Home.jsx
+++ b/src/app/pages/Home.jsx
@@ -51,7 +51,7 @@ const Home = (props, context) => (
 
       <div className="nypl-row nypl-quarter-image">
         <div className="nypl-column-one-quarter image-column-one-quarter">
-          <img className="nypl-quarter-image" src="https://d2720ur5668dri.cloudfront.net/sites/default/media/styles/extralarge/public/archives-portal.jpg?itok=-oYtHmeO" alt="" role="presentation" />
+          <img className="nypl-quarter-image" src="https://ux-static.nypl.org/sites/default/media/styles/extralarge/public/archives-portal.jpg?itok=-oYtHmeO" alt="" role="presentation" />
         </div>
         <div className="nypl-column-three-quarters image-column-three-quarters">
           <Heading
@@ -67,7 +67,7 @@ const Home = (props, context) => (
 
       <div className="nypl-row nypl-quarter-image">
         <div className="nypl-column-one-quarter image-column-one-quarter">
-          <img className="nypl-quarter-image" src="https://d2720ur5668dri.cloudfront.net/sites/default/media/styles/extralarge/public/sasb.jpg?itok=sdQBITR7" alt="" role="presentation" />
+          <img className="nypl-quarter-image" src="https://ux-static.nypl.org/sites/default/media/styles/extralarge/public/sasb.jpg?itok=sdQBITR7" alt="" role="presentation" />
         </div>
         <div className="nypl-column-three-quarters image-column-three-quarters">
           <Heading
@@ -81,7 +81,7 @@ const Home = (props, context) => (
 
       <div className="nypl-row nypl-quarter-image">
         <div className="nypl-column-one-quarter image-column-one-quarter">
-          <img className="nypl-quarter-image" src="https://d2720ur5668dri.cloudfront.net/sites/default/media/styles/extralarge/public/divisions.jpg?itok=O4uSedcp" alt="" role="presentation" />
+          <img className="nypl-quarter-image" src="https://ux-static.nypl.org/sites/default/media/styles/extralarge/public/divisions.jpg?itok=O4uSedcp" alt="" role="presentation" />
         </div>
         <div className="nypl-column-three-quarters image-column-three-quarters">
           <Heading
@@ -95,7 +95,7 @@ const Home = (props, context) => (
 
       <div className="nypl-row nypl-quarter-image">
         <div className="nypl-column-one-quarter image-column-one-quarter">
-          <img className="nypl-quarter-image" src="https://d2720ur5668dri.cloudfront.net/sites/default/media/styles/extralarge/public/plan-you-visit.jpg?itok=scG6cFgy" alt="" role="presentation" />
+          <img className="nypl-quarter-image" src="https://ux-static.nypl.org/sites/default/media/styles/extralarge/public/plan-you-visit.jpg?itok=scG6cFgy" alt="" role="presentation" />
         </div>
         <div className="nypl-column-three-quarters image-column-three-quarters">
           <Heading
@@ -112,7 +112,7 @@ const Home = (props, context) => (
 
       <div className="nypl-row nypl-quarter-image">
         <div className="nypl-column-one-quarter image-column-one-quarter">
-          <img className="nypl-quarter-image" src="https://d2720ur5668dri.cloudfront.net/sites/default/media/styles/extralarge/public/research-services.jpg?itok=rSo9t1VF" alt="" role="presentation" />
+          <img className="nypl-quarter-image" src="https://ux-static.nypl.org/sites/default/media/styles/extralarge/public/research-services.jpg?itok=rSo9t1VF" alt="" role="presentation" />
         </div>
         <div className="nypl-column-three-quarters image-column-three-quarters">
           <Heading

--- a/src/app/pages/Home.jsx
+++ b/src/app/pages/Home.jsx
@@ -51,7 +51,7 @@ const Home = (props, context) => (
 
       <div className="nypl-row nypl-quarter-image">
         <div className="nypl-column-one-quarter image-column-one-quarter">
-          <img className="nypl-quarter-image" src="https://ux-static.nypl.org/sites/default/media/styles/extralarge/public/archives-portal.jpg?itok=-oYtHmeO" alt="" role="presentation" />
+          <img className="nypl-quarter-image" src="https://cdn-petrol.nypl.org/sites/default/media/styles/extralarge/public/archives-portal.jpg?itok=-oYtHmeO" alt="" role="presentation" />
         </div>
         <div className="nypl-column-three-quarters image-column-three-quarters">
           <Heading
@@ -67,7 +67,7 @@ const Home = (props, context) => (
 
       <div className="nypl-row nypl-quarter-image">
         <div className="nypl-column-one-quarter image-column-one-quarter">
-          <img className="nypl-quarter-image" src="https://ux-static.nypl.org/sites/default/media/styles/extralarge/public/sasb.jpg?itok=sdQBITR7" alt="" role="presentation" />
+          <img className="nypl-quarter-image" src="https://cdn-petrol.nypl.org/sites/default/media/styles/extralarge/public/sasb.jpg?itok=sdQBITR7" alt="" role="presentation" />
         </div>
         <div className="nypl-column-three-quarters image-column-three-quarters">
           <Heading
@@ -81,7 +81,7 @@ const Home = (props, context) => (
 
       <div className="nypl-row nypl-quarter-image">
         <div className="nypl-column-one-quarter image-column-one-quarter">
-          <img className="nypl-quarter-image" src="https://ux-static.nypl.org/sites/default/media/styles/extralarge/public/divisions.jpg?itok=O4uSedcp" alt="" role="presentation" />
+          <img className="nypl-quarter-image" src="https://cdn-petrol.nypl.org/sites/default/media/styles/extralarge/public/divisions.jpg?itok=O4uSedcp" alt="" role="presentation" />
         </div>
         <div className="nypl-column-three-quarters image-column-three-quarters">
           <Heading
@@ -95,7 +95,7 @@ const Home = (props, context) => (
 
       <div className="nypl-row nypl-quarter-image">
         <div className="nypl-column-one-quarter image-column-one-quarter">
-          <img className="nypl-quarter-image" src="https://ux-static.nypl.org/sites/default/media/styles/extralarge/public/plan-you-visit.jpg?itok=scG6cFgy" alt="" role="presentation" />
+          <img className="nypl-quarter-image" src="https://cdn-petrol.nypl.org/sites/default/media/styles/extralarge/public/plan-you-visit.jpg?itok=scG6cFgy" alt="" role="presentation" />
         </div>
         <div className="nypl-column-three-quarters image-column-three-quarters">
           <Heading
@@ -112,7 +112,7 @@ const Home = (props, context) => (
 
       <div className="nypl-row nypl-quarter-image">
         <div className="nypl-column-one-quarter image-column-one-quarter">
-          <img className="nypl-quarter-image" src="https://ux-static.nypl.org/sites/default/media/styles/extralarge/public/research-services.jpg?itok=rSo9t1VF" alt="" role="presentation" />
+          <img className="nypl-quarter-image" src="https://cdn-petrol.nypl.org/sites/default/media/styles/extralarge/public/research-services.jpg?itok=rSo9t1VF" alt="" role="presentation" />
         </div>
         <div className="nypl-column-three-quarters image-column-three-quarters">
           <Heading

--- a/src/client/styles/utils/fonts.scss
+++ b/src/client/styles/utils/fonts.scss
@@ -1,7 +1,7 @@
 @import 'mixins';
 @import url('//fonts.googleapis.com/css?family=Roboto+Slab:400,300,100,700');
 
-$FONT_PATH: '//d2znry4lg8s0tq.cloudfront.net';
+$FONT_PATH: 'https://ux-static.nypl.org';
 
 $SECONDARY_FONT_KIEVIT: 'Helvetica';
 $THIRD_FONT_KIEVIT: 'arial';


### PR DESCRIPTION
## Description

* Updates the CDN CNAME in use to ux-static.nypl.org and cdn-petrol.nypl.org instead of their respective cloudfront.net CNAMEs

## Motivation and Context

This change allows us to use NYPL's shared SSL certificate and update the TLS version for this CDN distribution.

## How Has This Been Tested?

Verify favicon.ico file is using ux-static.nypl.org and renders properly.
Verify landing page (research/research-catalog) images are using the cdn-petrol.nypl.org CNAME, and render properly.
Local compiling was successful via `npm i; npm run start` and the favicon.ico and images were rendered using their respective nypl.org CDN CNAMEs.

## Checklist:

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.

** Some tests were marked as pending.