### PR TITLE
Scc 2668

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -18,3 +18,4 @@ export SET REDIRECT_FROM_BASE_URL=/research/collections/shared-collection-catalo
 export SET WEBPAC_BASE_URL=https://[fqdn]/
 export SET CIRCULATING_CATALOG=https://[fqdn]/
 export SET OPEN_LOCATIONS=315,300
+export SET SHEP_BIBS_LIMIT=25

--- a/src/app/components/SubjectHeading/BibsList.jsx
+++ b/src/app/components/SubjectHeading/BibsList.jsx
@@ -25,7 +25,7 @@ class BibsList extends React.Component {
     this.updateBibPage = this.updateBibPage.bind(this);
     this.lastBib = this.lastBib.bind(this);
     this.firstBib = this.firstBib.bind(this);
-    this.perPage = 6;
+    this.perPage = appConfig.shepBibsLimit;
     this.changeBibSorting = this.changeBibSorting.bind(this);
     this.fetchBibs = this.fetchBibs.bind(this);
     this.pagination = this.pagination.bind(this);

--- a/src/app/components/SubjectHeading/BibsList.jsx
+++ b/src/app/components/SubjectHeading/BibsList.jsx
@@ -1,13 +1,13 @@
 /* global window */
 import React from 'react';
 import PropTypes from 'prop-types';
-import axios from 'axios';
 import Pagination from '../Pagination/Pagination';
 import ResultsList from '../ResultsList/ResultsList';
 import LocalLoadingLayer from './LocalLoadingLayer';
 /* eslint-disable import/first, import/no-unresolved, import/extensions */
 import Sorter from '@Sorter';
 import appConfig from '@appConfig';
+import CachedAxios from '../../utils/CachedAxios';
 /* eslint-enable import/first, import/no-unresolved, import/extensions */
 
 class BibsList extends React.Component {
@@ -29,6 +29,7 @@ class BibsList extends React.Component {
     this.changeBibSorting = this.changeBibSorting.bind(this);
     this.fetchBibs = this.fetchBibs.bind(this);
     this.pagination = this.pagination.bind(this);
+    this.cachedAxios = new CachedAxios();
   }
 
   componentDidMount() {
@@ -40,7 +41,7 @@ class BibsList extends React.Component {
   fetchBibs(stringifiedSortParams, cb = () => {}) {
     const { label } = this.props;
 
-    return axios(`${appConfig.baseUrl}/api/subjectHeading/${encodeURIComponent(label)}?&${stringifiedSortParams}`)
+    return this.cachedAxios.call(`${appConfig.baseUrl}/api/subjectHeading/${encodeURIComponent(label)}?&${stringifiedSortParams}`)
       .then((res) => {
         const {
           results,
@@ -125,7 +126,7 @@ class BibsList extends React.Component {
   fetchBibsFromShep(newPage) {
     const { nextUrl } = this.state;
 
-    return axios(nextUrl)
+    return this.cachedAxios.call(nextUrl)
       .then((res) => {
         const results = this.state.results.concat(res.data.results);
         this.setState({

--- a/src/app/data/appConfig.js
+++ b/src/app/data/appConfig.js
@@ -69,6 +69,7 @@ const appConfig = {
   libAnswersEmail: process.env.LIB_ANSWERS_EMAIL,
   itemBatchSize: process.env.ITEM_BATCH_SIZE || 100,
   webpacBaseUrl: process.env.WEBPAC_BASE_URL,
+  shepBibsLimit: process.env.SHEP_BIBS_LIMIT || 50,
 };
 
 export default appConfig;

--- a/src/app/utils/CachedAxios.js
+++ b/src/app/utils/CachedAxios.js
@@ -4,9 +4,7 @@ function CachedAxios() {
   this.cache = {};
   this.call = (url) => {
     if (this.cache[url]) {
-      return new Promise((resolve) => {
-        resolve(this.cache[url]);
-      });
+      return Promise.resolve(this.cache[url]);
     }
 
     return axios(url)

--- a/src/app/utils/CachedAxios.js
+++ b/src/app/utils/CachedAxios.js
@@ -1,0 +1,20 @@
+import axios from 'axios';
+
+function CachedAxios() {
+  this.cache = {};
+  this.call = (url) => {
+    if (this.cache[url]) {
+      return new Promise((resolve) => {
+        resolve(this.cache[url]);
+      });
+    }
+
+    return axios(url)
+      .then((res) => {
+        this.cache[url] = res;
+        return res;
+      });
+  };
+}
+
+export default CachedAxios;

--- a/test/unit/BibsList.test.js
+++ b/test/unit/BibsList.test.js
@@ -25,6 +25,19 @@ describe('BibsList', () => {
 
 
   it('should have correct heading for one result', () => {
+    // set up component
+    component = mount(
+      <BibsList />,
+      {
+        context: {
+          router: {
+            location: {
+              query: {},
+            },
+          },
+        },
+      },
+    );
 
     return new Promise((resolve) => {
       nock('http://test-server.com')
@@ -47,24 +60,24 @@ describe('BibsList', () => {
             bibsSource: 'discoveryApi',
           };
         });
-
-      // set up component
-      component = mount(
-        <BibsList />,
-        {
-          context: {
-            router: {
-              location: {
-                query: {},
-              },
-            },
-          },
-        },
-      );
     });
   });
 
   it('should have correct heading for multiple results', () => {
+
+    // set up component
+    component = mount(
+      <BibsList />,
+      {
+        context: {
+          router: {
+            location: {
+              query: {},
+            },
+          },
+        },
+      },
+    );
 
     return new Promise((resolve) => {
       nock('http://test-server.com')
@@ -77,7 +90,7 @@ describe('BibsList', () => {
           setTimeout(() => {
             component.setProps({});
             setImmediate(() => {
-              expect(component.find('h3').at(0).text()).to.equal('Viewing 1 - 6 of 10 items');
+              expect(component.find('h3').at(0).text()).to.equal('Viewing 1 - 10 of 10 items');
             });
             setImmediate(() => resolve());
           }, 100);
@@ -87,24 +100,24 @@ describe('BibsList', () => {
             bibsSource: 'discoveryApi',
           };
         });
-
-      // set up component
-      component = mount(
-        <BibsList />,
-        {
-          context: {
-            router: {
-              location: {
-                query: {},
-              },
-            },
-          },
-        },
-      );
     });
   });
 
   it('should have heading and sorter in correct order', () => {
+
+    // set up component
+    component = mount(
+      <BibsList />,
+      {
+        context: {
+          router: {
+            location: {
+              query: {},
+            },
+          },
+        },
+      },
+    );
 
     return new Promise((resolve) => {
       nock('http://test-server.com')
@@ -128,10 +141,16 @@ describe('BibsList', () => {
             bibsSource: 'discoveryApi',
           };
         });
+    });
+  });
 
+  describe('api calls', () => {
+    it('should make correct api call when mounted', () => {
       // set up component
       component = mount(
-        <BibsList />,
+        <BibsList
+          label="abcdefg"
+        />,
         {
           context: {
             router: {
@@ -142,6 +161,77 @@ describe('BibsList', () => {
           },
         },
       );
+
+      return new Promise((resolve) => {
+        nock('http://test-server.com')
+          .defaultReplyHeaders({
+            'access-control-allow-origin': '*',
+            'access-control-allow-credentials': 'true',
+          })
+          .get(/\/api/)
+          .reply(200, (uri) => {
+            console.log('uri: ', uri);
+            setTimeout(() => {
+              component.setProps({});
+              setImmediate(() => {
+                expect(uri).to.equal('/api/subjectHeading/abcdefg?&sort=date&sort_direction=desc&per_page=50&shep_bib_count=undefined&shep_uuid=undefined');
+              });
+              setImmediate(() => resolve());
+            }, 100);
+            return {
+              page: 1,
+              totalResults: '10',
+              bibsSource: 'discoveryApi',
+            };
+          });
+      });
+    });
+
+    it('should use configured shepBibsLimit when mounting, if configured', () => {
+      const oldShepBibsLimit = appConfig.shepBibsLimit;
+      appConfig.shepBibsLimit = 10;
+      // set up component
+      component = mount(
+        <BibsList
+          label="abcdefg"
+        />,
+        {
+          context: {
+            router: {
+              location: {
+                query: {},
+              },
+            },
+          },
+        },
+      );
+
+      return new Promise((resolve) => {
+        nock('http://test-server.com')
+          .defaultReplyHeaders({
+            'access-control-allow-origin': '*',
+            'access-control-allow-credentials': 'true',
+          })
+          .get(/\/api/)
+          .reply(200, (uri) => {
+            console.log('uri: ', uri);
+            setTimeout(() => {
+              component.setProps({});
+              setImmediate(() => {
+                expect(uri).to.equal('/api/subjectHeading/abcdefg?&sort=date&sort_direction=desc&per_page=10&shep_bib_count=undefined&shep_uuid=undefined');
+              });
+              setImmediate(() => {
+                appConfig.shepBibsLimit = oldShepBibsLimit;
+                resolve();
+              });
+            }, 100);
+            return {
+              page: 1,
+              totalResults: '10',
+              bibsSource: 'discoveryApi',
+            };
+          });
+      });
     });
   });
 });

--- a/test/unit/BibsList.test.js
+++ b/test/unit/BibsList.test.js
@@ -170,7 +170,6 @@ describe('BibsList', () => {
           })
           .get(/\/api/)
           .reply(200, (uri) => {
-            console.log('uri: ', uri);
             setTimeout(() => {
               component.setProps({});
               setImmediate(() => {
@@ -214,7 +213,6 @@ describe('BibsList', () => {
           })
           .get(/\/api/)
           .reply(200, (uri) => {
-            console.log('uri: ', uri);
             setTimeout(() => {
               component.setProps({});
               setImmediate(() => {

--- a/test/unit/CachedAxios.test.js
+++ b/test/unit/CachedAxios.test.js
@@ -1,0 +1,56 @@
+/* eslint-env mocha */
+/* eslint-disable react/jsx-filename-extension */
+import nock from 'nock';
+import { expect } from 'chai';
+import appConfig from '../../src/app/data/appConfig';
+import CachedAxios from '../../src/app/utils/CachedAxios';
+
+describe.only('Cached Axios', () => {
+  let callCount = 0;
+  let savedBaseUrl;
+  const cachedAxios = new CachedAxios();
+
+  before(() => {
+    // set up mock api
+    savedBaseUrl = appConfig.baseUrl;
+    appConfig.baseUrl = 'http://test-server.com';
+    nock('http://test-server.com')
+      .defaultReplyHeaders({
+        'access-control-allow-origin': '*',
+        'access-control-allow-credentials': 'true',
+      })
+      .get(/\/api/)
+      .reply(200, () => {
+        callCount += 1;
+        return 'fake response';
+      });
+  });
+
+  after(() => {
+    appConfig.baseUrl = savedBaseUrl;
+  });
+
+  it('should call the api the first time', () => {
+    return new Promise((resolve) => {
+      cachedAxios.call('http://test-server.com/api');
+      setTimeout(() => {
+        expect(callCount).to.equal(1);
+        resolve();
+      }, 100);
+    });
+  });
+
+  it('should not call the api the second time', () => {
+    return new Promise((resolve) => {
+      let returnedValue;
+      cachedAxios.call('http://test-server.com/api').then((ret) => {
+        returnedValue = ret.data;
+      });
+      setTimeout(() => {
+        expect(callCount).to.equal(1);
+        expect(returnedValue).to.equal('fake response');
+        resolve();
+      }, 100);
+    });
+  });
+});

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -63,6 +63,7 @@ const commonSettings = {
         BASE_URL: JSON.stringify(process.env.BASE_URL),
         WEBPAC_BASE_URL: JSON.stringify(process.env.WEBPAC_BASE_URL),
         FEATURES: JSON.stringify(process.env.FEATURES),
+        SHEP_BIBS_LIMIT: JSON.stringify(process.env.SHEP_BIBS_LIMIT),
       },
     }),
     // new BundleAnalyzerPlugin({


### PR DESCRIPTION
**What's this do?**
- Adds a configurable parameter `SHEP_BIBS_LIMIT`, with default value 50
- used this parameter in the `BibsList` to set the number of bibs received from SHEP.
- Also adds some caching to the `BibsList`. Strictly speaking this is not in the scope of the ticket, but the ticket does ask us to minimize potential performance issues. I think this component is particularly likely to have a bunch of repeated calls for the same data in a short amount of time (since people will page back and forth), so is a good place to cache. If you don't like this I can remove it. If you like it, it can be expanded to other components that make axios calls.

**Why are we doing this? (w/ JIRA link if applicable)**
This is scc-2668. We want to start displaying 50 results instead of 6, and we want this to be easily changed in the future.

**Do these changes have automated tests?**
Yes

**How should this be QAed?**
Should be obvious on any SHEP show page with >50 titles.

**Dependencies for merging? Releasing to production?**
The backend changes need to deploy before these take effect.

**Has the application documentation been updated for these changes?**
NA

**Did someone actually run this code to verify it works?**
Yes.
