### PR TITLE
SCC-2847-8: Ensure OTF records are not linked. 5.3 fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -931,7 +931,7 @@
     "@nypl/design-toolkit": {
       "version": "0.1.38",
       "resolved": "https://registry.npmjs.org/@nypl/design-toolkit/-/design-toolkit-0.1.38.tgz",
-      "integrity": "sha512-HjfeRp96wh1afuwllBKPClTiO5UDF7fJZpFpGMavjUP5LgDCW9PZ5kBKNM47zI3mS0gaC5in2Lqkw3PYX6GbWA==",
+      "integrity": "sha1-UEevj9NzqfrqMCMCiBI77vtVugQ=",
       "requires": {
         "node-sass": "4.9.0"
       },
@@ -987,7 +987,7 @@
       }
     },
     "@nypl/dgx-header-component": {
-      "version": "git+https://git@github.com/NYPL/dgx-header-component.git#2913dd935cef141f6176d40426bd8e3a330dcd40",
+      "version": "git+https://git@github.com/NYPL/dgx-header-component.git#a3d450cc41ae4c1b8f7912360eeeb20bed29b4df",
       "from": "git+https://git@github.com/NYPL/dgx-header-component.git#reactupdate",
       "requires": {
         "@nypl/dgx-svg-icons": "0.3.7",
@@ -1966,7 +1966,7 @@
     "aproba": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
+      "integrity": "sha1-aALmJk79GMeQobDVF/DyYnvyyUo="
     },
     "are-we-there-yet": {
       "version": "1.1.5",
@@ -2006,7 +2006,7 @@
     "arr-flatten": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
+      "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE="
     },
     "arr-union": {
       "version": "3.1.0",
@@ -2152,7 +2152,7 @@
     "assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "integrity": "sha1-5gtrDo8wG9l+U3UhW9pAbIURjAs=",
       "dev": true
     },
     "assign-symbols": {
@@ -2971,7 +2971,7 @@
     "babel-preset-env": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.6.1.tgz",
-      "integrity": "sha512-W6VIyA6Ch9ePMI7VptNn2wBM6dbG0eSz25HEiL40nQXCsXGTGZSTZu1Iap+cj3Q0S5a7T9+529l/5Bkvd+afNA==",
+      "integrity": "sha1-oYtWTMm5r99KrleuPBsNmRiOb0g=",
       "requires": {
         "babel-plugin-check-es2015-constants": "^6.22.0",
         "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
@@ -3230,7 +3230,7 @@
     "babylon": {
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
+      "integrity": "sha1-ry87iPpvXB5MY00aD46sT1WzleM="
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -3836,17 +3836,173 @@
       "dev": true
     },
     "cheerio": {
-      "version": "1.0.0-rc.3",
-      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.3.tgz",
-      "integrity": "sha512-0td5ijfUPuubwLUu0OBoe98gZj8C/AA+RW3v67GPlGOrvxWjZmBXiBCRU+I8VEiNyJzjth40POfHiz2RB3gImA==",
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.10.tgz",
+      "integrity": "sha512-g0J0q/O6mW8z5zxQ3A8E8J1hUgp4SMOvEoW/x84OwyHKe/Zccz83PVT4y5Crcr530FV6NgmKI1qvGTKVl9XXVw==",
       "dev": true,
       "requires": {
-        "css-select": "~1.2.0",
-        "dom-serializer": "~0.1.1",
-        "entities": "~1.1.1",
-        "htmlparser2": "^3.9.1",
-        "lodash": "^4.15.0",
-        "parse5": "^3.0.1"
+        "cheerio-select": "^1.5.0",
+        "dom-serializer": "^1.3.2",
+        "domhandler": "^4.2.0",
+        "htmlparser2": "^6.1.0",
+        "parse5": "^6.0.1",
+        "parse5-htmlparser2-tree-adapter": "^6.0.1",
+        "tslib": "^2.2.0"
+      },
+      "dependencies": {
+        "dom-serializer": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.3.2.tgz",
+          "integrity": "sha512-5c54Bk5Dw4qAxNOI1pFEizPSjVsx5+bpJKmL2kPn8JhBUq2q09tTCa3mjijun2NfK78NMouDYNMBkOrPZiS+ig==",
+          "dev": true,
+          "requires": {
+            "domelementtype": "^2.0.1",
+            "domhandler": "^4.2.0",
+            "entities": "^2.0.0"
+          }
+        },
+        "domelementtype": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
+          "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==",
+          "dev": true
+        },
+        "domhandler": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.2.0.tgz",
+          "integrity": "sha512-zk7sgt970kzPks2Bf+dwT/PLzghLnsivb9CcxkvR8Mzr66Olr0Ofd8neSbglHJHaHa2MadfoSdNlKYAaafmWfA==",
+          "dev": true,
+          "requires": {
+            "domelementtype": "^2.2.0"
+          }
+        },
+        "domutils": {
+          "version": "2.7.0",
+          "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.7.0.tgz",
+          "integrity": "sha512-8eaHa17IwJUPAiB+SoTYBo5mCdeMgdcAoXJ59m6DT1vw+5iLS3gNoqYaRowaBKtGVrOF1Jz4yDTgYKLK2kvfJg==",
+          "dev": true,
+          "requires": {
+            "dom-serializer": "^1.0.1",
+            "domelementtype": "^2.2.0",
+            "domhandler": "^4.2.0"
+          }
+        },
+        "entities": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+          "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+          "dev": true
+        },
+        "htmlparser2": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
+          "integrity": "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==",
+          "dev": true,
+          "requires": {
+            "domelementtype": "^2.0.1",
+            "domhandler": "^4.0.0",
+            "domutils": "^2.5.2",
+            "entities": "^2.0.0"
+          }
+        },
+        "parse5": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
+          "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
+          "dev": true
+        },
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "dev": true
+        }
+      }
+    },
+    "cheerio-select": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-1.5.0.tgz",
+      "integrity": "sha512-qocaHPv5ypefh6YNxvnbABM07KMxExbtbfuJoIie3iZXX1ERwYmJcIiRrr9H05ucQP1k28dav8rpdDgjQd8drg==",
+      "dev": true,
+      "requires": {
+        "css-select": "^4.1.3",
+        "css-what": "^5.0.1",
+        "domelementtype": "^2.2.0",
+        "domhandler": "^4.2.0",
+        "domutils": "^2.7.0"
+      },
+      "dependencies": {
+        "css-select": {
+          "version": "4.1.3",
+          "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.1.3.tgz",
+          "integrity": "sha512-gT3wBNd9Nj49rAbmtFHj1cljIAOLYSX1nZ8CB7TBO3INYckygm5B7LISU/szY//YmdiSLbJvDLOx9VnMVpMBxA==",
+          "dev": true,
+          "requires": {
+            "boolbase": "^1.0.0",
+            "css-what": "^5.0.0",
+            "domhandler": "^4.2.0",
+            "domutils": "^2.6.0",
+            "nth-check": "^2.0.0"
+          }
+        },
+        "css-what": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/css-what/-/css-what-5.0.1.tgz",
+          "integrity": "sha512-FYDTSHb/7KXsWICVsxdmiExPjCfRC4qRFBdVwv7Ax9hMnvMmEjP9RfxTEZ3qPZGmADDn2vAKSo9UcN1jKVYscg==",
+          "dev": true
+        },
+        "dom-serializer": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.3.2.tgz",
+          "integrity": "sha512-5c54Bk5Dw4qAxNOI1pFEizPSjVsx5+bpJKmL2kPn8JhBUq2q09tTCa3mjijun2NfK78NMouDYNMBkOrPZiS+ig==",
+          "dev": true,
+          "requires": {
+            "domelementtype": "^2.0.1",
+            "domhandler": "^4.2.0",
+            "entities": "^2.0.0"
+          }
+        },
+        "domelementtype": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
+          "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==",
+          "dev": true
+        },
+        "domhandler": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.2.0.tgz",
+          "integrity": "sha512-zk7sgt970kzPks2Bf+dwT/PLzghLnsivb9CcxkvR8Mzr66Olr0Ofd8neSbglHJHaHa2MadfoSdNlKYAaafmWfA==",
+          "dev": true,
+          "requires": {
+            "domelementtype": "^2.2.0"
+          }
+        },
+        "domutils": {
+          "version": "2.7.0",
+          "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.7.0.tgz",
+          "integrity": "sha512-8eaHa17IwJUPAiB+SoTYBo5mCdeMgdcAoXJ59m6DT1vw+5iLS3gNoqYaRowaBKtGVrOF1Jz4yDTgYKLK2kvfJg==",
+          "dev": true,
+          "requires": {
+            "dom-serializer": "^1.0.1",
+            "domelementtype": "^2.2.0",
+            "domhandler": "^4.2.0"
+          }
+        },
+        "entities": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+          "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+          "dev": true
+        },
+        "nth-check": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.0.0.tgz",
+          "integrity": "sha512-i4sc/Kj8htBrAiH1viZ0TgU8Y5XqCaV/FziYK6TBczxmeKm3AEFWqqF3195yKudrarqy7Zu80Ra5dobFjn9X/Q==",
+          "dev": true,
+          "requires": {
+            "boolbase": "^1.0.0"
+          }
+        }
       }
     },
     "chokidar": {
@@ -4364,7 +4520,7 @@
     "content-type": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
+      "integrity": "sha1-4TjMdeBAxyexlm/l5fjJruJW/js="
     },
     "convert-source-map": {
       "version": "1.7.0",
@@ -4986,7 +5142,7 @@
       }
     },
     "dgx-alt-center": {
-      "version": "git+https://bitbucket.org/NYPL/dgx-alt-center.git#b3915c1cf33ed7f70446750dcbc6fcf98faaed37",
+      "version": "git+https://bitbucket.org/NYPL/dgx-alt-center.git#f00bd9ea99925072d561ac0041fecd0b07174432",
       "from": "git+https://bitbucket.org/NYPL/dgx-alt-center.git#master",
       "requires": {
         "alt": "0.18.2"
@@ -5005,7 +5161,7 @@
       }
     },
     "dgx-feature-flags": {
-      "version": "git+https://git@bitbucket.org/NYPL/dgx-feature-flags.git#f7b1bd20f56632c71864cbe648556d03853d9f0e",
+      "version": "git+https://git@bitbucket.org/NYPL/dgx-feature-flags.git#27568b5f49f0fb853ce229b02c553e06955d3bf2",
       "from": "git+https://git@bitbucket.org/NYPL/dgx-feature-flags.git#master",
       "requires": {
         "alt-utils": "1.0.0",
@@ -5014,7 +5170,7 @@
       }
     },
     "dgx-react-ga": {
-      "version": "git+https://git@bitbucket.org/NYPL/dgx-react-ga.git#1908e78bd8704b815ec37030d0f8040f8b3cbb95",
+      "version": "git+https://git@bitbucket.org/NYPL/dgx-react-ga.git#81c24190d40904e685fc6332a8bb518241680f08",
       "from": "git+https://git@bitbucket.org/NYPL/dgx-react-ga.git#master",
       "requires": {
         "create-react-class": "15.5.3",
@@ -5044,7 +5200,7 @@
       }
     },
     "dgx-skip-navigation-link": {
-      "version": "git+https://git@bitbucket.org/NYPL/dgx-skip-navigation-link.git#d1bdcf9e5d7d54fe252c6d8a250a42908fd98a87",
+      "version": "git+https://git@bitbucket.org/NYPL/dgx-skip-navigation-link.git#20ed457bb7b3c9505357d6df15119f64a9930d8a",
       "from": "git+https://git@bitbucket.org/NYPL/dgx-skip-navigation-link.git#master"
     },
     "diff": {
@@ -5096,7 +5252,7 @@
     "doctrine": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "integrity": "sha1-XNAfwQFiG0LEzX9dGmYkNxbT850=",
       "dev": true,
       "requires": {
         "esutils": "^2.0.2"
@@ -5898,7 +6054,7 @@
     "eslint-plugin-import": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.8.0.tgz",
-      "integrity": "sha512-Rf7dfKJxZ16QuTgVv1OYNxkZcsu/hULFnC+e+w0Gzi6jMC3guQoWQgxYxc54IDRinlb6/0v5z/PxxIKmVctN+g==",
+      "integrity": "sha1-+htu8x/LPFAcCYWcG4bx/FuYaJQ=",
       "dev": true,
       "requires": {
         "builtin-modules": "^1.1.1",
@@ -6057,7 +6213,7 @@
     "eslint-plugin-react": {
       "version": "7.5.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.5.1.tgz",
-      "integrity": "sha512-YGSjB9Qu6QbVTroUZi66pYky3DfoIPLdHQ/wmrBGyBRnwxQsBXAov9j2rpXt/55i8nyMv6IRWJv2s4d4YnduzQ==",
+      "integrity": "sha1-UuVujYDIEN4ViFnvB7iA0vVu4ws=",
       "dev": true,
       "requires": {
         "doctrine": "^2.0.0",
@@ -7658,7 +7814,7 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0="
     },
     "function.prototype.name": {
       "version": "1.1.2",
@@ -7903,7 +8059,7 @@
     "growl": {
       "version": "1.10.3",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
-      "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
+      "integrity": "sha1-GSa6kM8+3+KttJJ/WIC8IsZseQ8=",
       "dev": true
     },
     "gzip-size": {
@@ -8721,7 +8877,7 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+      "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4="
     },
     "is-callable": {
       "version": "1.1.5",
@@ -9966,7 +10122,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -10036,7 +10192,7 @@
     "mocha": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.0.1.tgz",
-      "integrity": "sha512-evDmhkoA+cBNiQQQdSKZa2b9+W2mpLoj50367lhy+Klnx9OV8XlCIhigUnn1gaTFLQCa0kdNhEGDr0hCXOQFDw==",
+      "integrity": "sha1-Cu5alc9ppGGIIPXlH6MXFxF9rxs=",
       "dev": true,
       "requires": {
         "browser-stdout": "1.3.0",
@@ -10060,7 +10216,7 @@
         "debug": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -10069,7 +10225,7 @@
         "diff": {
           "version": "3.3.1",
           "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
-          "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
+          "integrity": "sha1-qoVnpu7QPFMfyJ0/cRzQ5SWd7HU=",
           "dev": true
         },
         "glob": {
@@ -10101,7 +10257,7 @@
         "supports-color": {
           "version": "4.4.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+          "integrity": "sha1-iD992rwWUUKyphQn8zUt7RldGj4=",
           "dev": true,
           "requires": {
             "has-flag": "^2.0.0"
@@ -10661,7 +10817,7 @@
     "node-fetch": {
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+      "integrity": "sha1-mA9vcthSEaU0fGsrwYxbhMPrR+8=",
       "requires": {
         "encoding": "^0.1.11",
         "is-stream": "^1.0.1"
@@ -11105,7 +11261,7 @@
     "npmlog": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+      "integrity": "sha1-CKfyqL9zRgR3mp76StXMcXq7lUs=",
       "requires": {
         "are-we-there-yet": "~1.1.2",
         "console-control-strings": "~1.1.0",
@@ -12407,7 +12563,7 @@
     "object.assign": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
-      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+      "integrity": "sha1-lovxEA15Vrs8oIbwBvhGs7xACNo=",
       "requires": {
         "define-properties": "^1.1.2",
         "function-bind": "^1.1.1",
@@ -12890,10 +13046,27 @@
     "parse5": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
-      "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
+      "integrity": "sha1-BC95L/3TaFFVHPTp4Gazh0q0W1w=",
       "dev": true,
       "requires": {
         "@types/node": "*"
+      }
+    },
+    "parse5-htmlparser2-tree-adapter": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-6.0.1.tgz",
+      "integrity": "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==",
+      "dev": true,
+      "requires": {
+        "parse5": "^6.0.1"
+      },
+      "dependencies": {
+        "parse5": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
+          "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
+          "dev": true
+        }
       }
     },
     "parseurl": {
@@ -13558,7 +13731,7 @@
     "private": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-      "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
+      "integrity": "sha1-I4Hts2ifelPWUxkAYPz4ItLzaP8="
     },
     "process": {
       "version": "0.11.10",
@@ -13579,7 +13752,7 @@
     "promise": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "integrity": "sha1-BktyYCsY+Q8pGSuLG8QY/9Hr078=",
       "requires": {
         "asap": "~2.0.3"
       }
@@ -15188,7 +15361,7 @@
     "samsam": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
-      "integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
+      "integrity": "sha1-jR2TUOJWItow3j5EumkrUiGrfFA=",
       "dev": true
     },
     "sass-graph": {
@@ -15530,7 +15703,7 @@
     "sinon": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/sinon/-/sinon-4.0.1.tgz",
-      "integrity": "sha512-4qIY0pCWCvGCJpV/1JkFu9kbsNEZ9O34cG1oru/c7OCDtrEs50Gq/VjkA2ID5ZwLyoNx1i1ws118oh/p6fVeDg==",
+      "integrity": "sha1-5GFGqKhCD4N726MuKWW9H+Q9WwU=",
       "dev": true,
       "requires": {
         "diff": "^3.1.0",
@@ -17142,7 +17315,7 @@
     "validator": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/validator/-/validator-7.2.0.tgz",
-      "integrity": "sha512-c8NGTUYeBEcUIGeMppmNVKHE7wwfm3mYbNZxV+c5mlv9fDHI7Ad3p07qfNrn/CvpdkK2k61fOLRO2sTEhgQXmg=="
+      "integrity": "sha1-pj3Lq6UdQ1C/jfIJiODVpU1xF5E="
     },
     "value-equal": {
       "version": "1.0.1",
@@ -17710,7 +17883,7 @@
     "webpack-dev-middleware": {
       "version": "1.12.2",
       "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.12.2.tgz",
-      "integrity": "sha1-+PwRIM47T8VoDO7LQ9d3lmshEF4=",
+      "integrity": "sha512-FCrqPy1yy/sN6U/SaEZcHKRXGlqU0DUaEBL45jkUYoB8foVb6wCnbIJ1HKIx+qUFTW+3JpVcCJCxZ8VATL4e+A==",
       "dev": true,
       "requires": {
         "memory-fs": "~0.4.1",

--- a/src/app/utils/accountPageUtils.js
+++ b/src/app/utils/accountPageUtils.js
@@ -83,6 +83,9 @@ export const manipulateAccountPage = (
     setIsLoading,
   );
 
+  // Remove <script> & <style> tags that refer to Webpac assets
+  accountPageContent.querySelectorAll('script[src],link[href]').forEach(asset => asset.remove())
+
   const eventListeners = [];
   if (['items', 'holds'].includes(contentType)) {
     // all <inputs> of type 'submit' are removed

--- a/src/app/utils/accountPageUtils.js
+++ b/src/app/utils/accountPageUtils.js
@@ -83,9 +83,6 @@ export const manipulateAccountPage = (
     setIsLoading,
   );
 
-  // Remove <script> & <style> tags that refer to Webpac assets
-  accountPageContent.querySelectorAll('script[src],link[href]').forEach(asset => asset.remove())
-
   const eventListeners = [];
   if (['items', 'holds'].includes(contentType)) {
     // all <inputs> of type 'submit' are removed

--- a/src/app/utils/accountPageUtils.js
+++ b/src/app/utils/accountPageUtils.js
@@ -4,7 +4,7 @@ import axios from 'axios';
 import appConfig from '../data/appConfig';
 import { CLOSED_LOCATION_REGEX } from '../data/constants';
 
-export const isClosed = optionInnerText => !!optionInnerText.match(CLOSED_LOCATION_REGEX);
+export const isClosed = optionInnerText => optionInnerText && !!optionInnerText.match(CLOSED_LOCATION_REGEX);
 
 export const makeRequest = (
   updateAccountHtml,
@@ -160,6 +160,7 @@ export const manipulateAccountPage = (
         }
       });
 
+      // Remove any left-column checkmarks, replacing them with right-column buttons
       const inputs = el.querySelectorAll('input');
       const holdActionElements = [];
       const removeTd = (element) => {
@@ -216,6 +217,8 @@ export const manipulateAccountPage = (
         removeTd(input);
         eventListeners.push({ element: button, cb: eventCb });
       });
+      // Remove any lingering .patFuncMark TDs left over because they didn't have any INPUTs
+      el.querySelectorAll('td.patFuncMark').forEach(removeTd);
 
       // add new TD with account page button(s)
       const td = document.createElement('td');

--- a/src/app/utils/logoutUtils.js
+++ b/src/app/utils/logoutUtils.js
@@ -15,11 +15,11 @@ const loadLogoutIframe = (onload) => {
   // Determine whether to use Production or Test logout pages based on whether
   // 'dev-' appears in login URL
   const isProduction = !appConfig.loginUrl.includes('//dev-')
+  const encoreDomain = isProduction ? 'browse.nypl.org' : 'nypl-encore-test.nypl.org'
 
   logoutIframe.setAttribute(
     // The endpoint is the URL for logging out from Encore
-    'src', isProduction ? 'https://browse.nypl.org/iii/encore/logoutFilterRedirect?suite=def' :
-      'https://nypl-encore-test.nypl.org//iii/encore/logoutFilterRedirect?suite=def',
+    'src', `https://${encoreDomain}/iii/encore/logoutFilterRedirect?suite=def`
   );
   // Assigns the ID for CSS ussage
   logoutIframe.setAttribute('id', 'logoutIframe');

--- a/src/app/utils/logoutUtils.js
+++ b/src/app/utils/logoutUtils.js
@@ -1,4 +1,5 @@
 import { deleteCookie } from './cookieUtils';
+import appConfig from '../data/appConfig';
 
 /**
   * loadLogoutIframe(isTest)
@@ -11,10 +12,14 @@ const loadLogoutIframe = (onload) => {
   const logoutIframe = document.createElement('iframe');
   const [body] = document.getElementsByTagName('body');
 
+  // Determine whether to use Production or Test logout pages based on whether
+  // 'dev-' appears in login URL
+  const isProduction = !appConfig.loginUrl.includes('//dev-')
+
   logoutIframe.setAttribute(
     // The endpoint is the URL for logging out from Encore
-    'src', 'https://browse.nypl.org/iii/encore/logoutFilterRedirect?suite=def',
-    // 'src', 'https://nypl-encore-test.nypl.org//iii/encore/logoutFilterRedirect?suite=def',
+    'src', isProduction ? 'https://browse.nypl.org/iii/encore/logoutFilterRedirect?suite=def' :
+      'https://nypl-encore-test.nypl.org//iii/encore/logoutFilterRedirect?suite=def',
   );
   // Assigns the ID for CSS ussage
   logoutIframe.setAttribute('id', 'logoutIframe');

--- a/src/client/styles/components/AccountPage.scss
+++ b/src/client/styles/components/AccountPage.scss
@@ -9,8 +9,13 @@
     list-style: none;
   }
 
-  th {
+  th.patFuncHeaders {
     text-transform: capitalize;
+  }
+
+  th.patFuncBibTitle {
+    text-align: left;
+    font-weight: 300;
   }
 
   td.account-table-buttons {

--- a/src/server/ApiRoutes/Account.js
+++ b/src/server/ApiRoutes/Account.js
@@ -36,6 +36,17 @@ function getAccountPage(res, req) {
   });
 }
 
+/**
+ *  Given raw Account HTML, removes <link> and remote <script> tags to ensure
+ *  they're not injected into the html sent to the client (lest they generate a
+ *  bunch of erroneous 404s or worse.
+ */
+function preprocessAccountHtml(html) {
+  html = html.replace(/<link [^>]+\/>/g, '')
+  html = html.replace(/<script type="text\/javascript" src=[^>]+>\s*<\/script>/g, '')
+  return html
+}
+
 function fetchAccountPage(req, res, resolve) {
   const requireUser = User.requireUser(req, res);
   const { redirect } = requireUser;
@@ -82,7 +93,7 @@ function fetchAccountPage(req, res, resolve) {
         throw new Error('detected state mismatch, throwing error');
       }
 
-      resolve({ accountHtml: resp.data });
+      resolve({ accountHtml: preprocessAccountHtml(resp.data) });
     })
     .catch((resp) => {
       console.error('Account page response error: ', resp);
@@ -113,6 +124,7 @@ function logError(req) {
 }
 
 export default {
+  preprocessAccountHtml,
   fetchAccountPage,
   postToAccountPage,
   getHomeLibrary,

--- a/src/server/ApiRoutes/Account.js
+++ b/src/server/ApiRoutes/Account.js
@@ -78,14 +78,14 @@ function fetchAccountPage(req, res, resolve) {
       // but patron is not actually logged in, the case below is hit
       if (resp.request && resp.request.path.includes('/login?')) {
         // need to implement
-        console.log('need to redirect, might be buggy?');
+        console.log('Encountered login redirect while fetching account page');
         throw new Error('detected state mismatch, throwing error');
       }
 
       resolve({ accountHtml: resp.data });
     })
     .catch((resp) => {
-      console.error('resp error: ', resp);
+      console.error('Account page response error: ', resp);
       resolve({ accountHtml: { error: resp } });
     });
 }

--- a/test/fixtures/sierra-5.1-patron-5035845-webpac-holds-markup.html
+++ b/test/fixtures/sierra-5.1-patron-5035845-webpac-holds-markup.html
@@ -1,0 +1,157 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!-- VERSION = $Id$ $Rev: 202541 $ $Date: 2013-02-08 13:48:24 -0800 (Fri, 08 Feb 2013) $ -->
+<html>
+<head>
+<link rel="stylesheet" type="text/css" href="/scripts/ProStyles.css" />
+<link rel="stylesheet" type="text/css" href="/screens/styles.css" />
+<script type="text/javascript" src="/scripts/elcontent.js">
+</script>
+<script type="text/javascript" src="/scripts/common.js">
+</script>
+<script type="text/javascript" src="/scripts/features.js">
+</script>
+<script type="text/javascript" src="/scripts/webbridge.js">
+</script>
+
+</head>
+<body>
+   <div class="patFuncArea">
+<form name="hold_form" method="POST" id="hold_form" ><input type="HIDDEN" id="holdpagecmd" />
+
+<input type="SUBMIT" name="sortByRequest" value="Sort by Hold Requested Date" />
+<input type="SUBMIT" name="sortByStatus" value="Sort by Status" />
+<input type="HIDDEN" name="currentsortorder" value="current_pickup" />
+<a href="#"  onClick="return submitHold( 'requestCancelAll', 'requestCancelAll' )"><div style="display:none" onmousedown="this.className='pressedState';" onmouseout="this.className='';" onmouseup="this.className='';"><div class="buttonSpriteDiv"><span class="buttonSpriteSpan1"><span class="buttonSpriteSpan2">Cancel All</span></span></div></div></a>
+<input type="SUBMIT" name="requestUpdateHoldsSome" value="UPDATE LIST" />
+<table border="0" class="patFunc"><tr class="patFuncTitle">
+<th colspan="7" class="patFuncTitle">
+<label id="items_count">4 HOLDS</label>
+</th>
+</tr>
+
+<tr class="patFuncHeaders">
+<th class="patFuncHeaders"> CANCEL </th>
+<th class="patFuncHeaders"> TITLE </th>
+<th  class="patFuncHeaders"> Ratings </th>
+<th class="patFuncHeaders"> STATUS </th>
+<th class="patFuncHeaders">PICKUP LOCATION</th>
+<th class="patFuncHeaders"> CANCEL IF NOT FILLED BY </th>
+<th class="patFuncHeaders"> FREEZE </th>
+</tr>
+
+
+<style type="text/css">
+<!--
+#ratemy1    { display: inline }
+#rateneed1  { display: none }
+#ratemy2    { display: inline }
+#rateneed2  { display: none }
+#ratemy3    { display: inline }
+#rateneed3  { display: none }
+#ratemy4    { display: inline }
+#rateneed4  { display: none }
+-->
+</style>
+<tr class="patFuncEntry">
+<td  class="patFuncMark" >
+<input type="checkbox" name="canceli38562763x00" id="canceli38562763x00" />
+</td>
+<td  class="patFuncTitle">
+<label for="canceli38562763x00"><a href="https://browse.nypl.org/iii/encore/record/C__Rb22541895?lang=eng&suite=def"><span class="patFuncTitleMain">[Standard NYPL restrictions apply] TOAST / JOZEF HEN. [RECAP]</span></a></label>
+<br />
+</td>
+<td nowrap  class="patFuncRating" >
+
+<span id="ratemy1"  onmouseover="setToolVisibility  ('ratemy1', 'none', 'rateneed1', 'inline')">_____
+</span>
+<span id="rateneed1"  onmouseout="setToolVisibility  ('ratemy1', 'inline', 'rateneed1', 'none')"><a href="/patroninfo~S1*eng/5035845/sortedbypudateholds?changerating1=b22541895">?</a><a href="/patroninfo~S1*eng/5035845/sortedbypudateholds?changerating2=b22541895">?</a><a href="/patroninfo~S1*eng/5035845/sortedbypudateholds?changerating3=b22541895">?</a><a href="/patroninfo~S1*eng/5035845/sortedbypudateholds?changerating4=b22541895">?</a><a href="/patroninfo~S1*eng/5035845/sortedbypudateholds?changerating5=b22541895">?</a>
+</span></td>
+<td  class="patFuncStatus"> Ready. Must pick up by 08-30-21 </td>
+<td class="patFuncPickup">SCHWARZMAN 300 - ONSITE USE</td>
+<td class="patFuncCancel">08-11-22</td>
+<td  class="patFuncFreeze" >&nbsp;</td>
+</tr>
+
+<tr class="patFuncEntry">
+<td  class="patFuncMark" >
+<input type="checkbox" name="canceli38574968x01" id="canceli38574968x01" />
+</td>
+<td  class="patFuncTitle">
+<label for="canceli38574968x01"><a href="https://browse.nypl.org/iii/encore/record/C__Rb22544628?lang=eng&suite=def"><span class="patFuncTitleMain">[HD] [Standard NYPL restrictions apply] OHOLE SHEM AL MASEKHET BAVA METSIA : MASA U-MATAN ... SHE-NEEMRU BA-YESHIVAH ... SHUVAH YISRAEL [HD]</span></a></label>
+<br />
+</td>
+<td nowrap  class="patFuncRating" >
+
+<span id="ratemy2"  onmouseover="setToolVisibility  ('ratemy2', 'none', 'rateneed2', 'inline')">_____
+</span>
+<span id="rateneed2"  onmouseout="setToolVisibility  ('ratemy2', 'inline', 'rateneed2', 'none')"><a href="/patroninfo~S1*eng/5035845/sortedbypudateholds?changerating1=b22544628">?</a><a href="/patroninfo~S1*eng/5035845/sortedbypudateholds?changerating2=b22544628">?</a><a href="/patroninfo~S1*eng/5035845/sortedbypudateholds?changerating3=b22544628">?</a><a href="/patroninfo~S1*eng/5035845/sortedbypudateholds?changerating4=b22544628">?</a><a href="/patroninfo~S1*eng/5035845/sortedbypudateholds?changerating5=b22544628">?</a>
+</span></td>
+<td  class="patFuncStatus"> Ready. Must pick up by 09-07-21 </td>
+<td class="patFuncPickup">SCHWARZMAN 300 - ONSITE USE</td>
+<td class="patFuncCancel">08-17-22</td>
+<td  class="patFuncFreeze" >&nbsp;</td>
+</tr>
+
+<tr class="patFuncEntry">
+<td  class="patFuncMark" >
+<input type="checkbox" name="canceli38575038x02" id="canceli38575038x02" />
+</td>
+<td  class="patFuncTitle">
+<label for="canceli38575038x02"><a href="https://browse.nypl.org/iii/encore/record/C__Rb22544635?lang=eng&suite=def"><span class="patFuncTitleMain">[Standard NYPL restrictions apply] SFARINN SOFANDI / ORSTEINN FRA HAMRI. [RECAP]</span></a></label>
+<br />
+</td>
+<td nowrap  class="patFuncRating" >
+
+<span id="ratemy3"  onmouseover="setToolVisibility  ('ratemy3', 'none', 'rateneed3', 'inline')">_____
+</span>
+<span id="rateneed3"  onmouseout="setToolVisibility  ('ratemy3', 'inline', 'rateneed3', 'none')"><a href="/patroninfo~S1*eng/5035845/sortedbypudateholds?changerating1=b22544635">?</a><a href="/patroninfo~S1*eng/5035845/sortedbypudateholds?changerating2=b22544635">?</a><a href="/patroninfo~S1*eng/5035845/sortedbypudateholds?changerating3=b22544635">?</a><a href="/patroninfo~S1*eng/5035845/sortedbypudateholds?changerating4=b22544635">?</a><a href="/patroninfo~S1*eng/5035845/sortedbypudateholds?changerating5=b22544635">?</a>
+</span></td>
+<td  class="patFuncStatus"> Ready. Must pick up by 09-07-21 </td>
+<td class="patFuncPickup">SCHWARZMAN 121 - ONSITE USE</td>
+<td class="patFuncCancel">08-17-22</td>
+<td  class="patFuncFreeze" >&nbsp;</td>
+</tr>
+
+<tr class="patFuncEntry">
+<td  class="patFuncMark" >
+<input type="checkbox" name="canceli11703515x03" id="canceli11703515x03" />
+</td>
+<td  class="patFuncTitle">
+<label for="canceli11703515x03"><a href="https://browse.nypl.org/iii/encore/record/C__Rb15347721?lang=eng&suite=def"><span class="patFuncTitleMain">A table / Jean Follain.</span></a></label>
+<br />
+</td>
+<td nowrap  class="patFuncRating" >
+
+<span id="ratemy4"  onmouseover="setToolVisibility  ('ratemy4', 'none', 'rateneed4', 'inline')">_____
+</span>
+<span id="rateneed4"  onmouseout="setToolVisibility  ('ratemy4', 'inline', 'rateneed4', 'none')"><a href="/patroninfo~S1*eng/5035845/sortedbypudateholds?changerating1=b15347721">?</a><a href="/patroninfo~S1*eng/5035845/sortedbypudateholds?changerating2=b15347721">?</a><a href="/patroninfo~S1*eng/5035845/sortedbypudateholds?changerating3=b15347721">?</a><a href="/patroninfo~S1*eng/5035845/sortedbypudateholds?changerating4=b15347721">?</a><a href="/patroninfo~S1*eng/5035845/sortedbypudateholds?changerating5=b15347721">?</a>
+</span></td>
+<td  class="patFuncStatus"> AVAILABLE </td>
+<td class="patFuncPickup">SCHWARZMAN 315 - ONSITE USE</td>
+<td class="patFuncCancel">08-24-22</td>
+<td  class="patFuncFreeze" >
+<div  class="patFuncFreezeLabel">
+<label for="freezei11703515x03" >Freeze</label>
+</div>
+<input type="checkbox" name="freezei11703515x03" /></td>
+</tr>
+
+</table>
+
+<input type="SUBMIT" name="sortByRequest" value="Sort by Hold Requested Date" />
+<input type="SUBMIT" name="sortByStatus" value="Sort by Status" />
+<input type="HIDDEN" name="currentsortorder" value="current_pickup" />
+<a href="#"  onClick="return submitHold( 'requestCancelAll', 'requestCancelAll' )"><div style="display:none" onmousedown="this.className='pressedState';" onmouseout="this.className='';" onmouseup="this.className='';"><div class="buttonSpriteDiv"><span class="buttonSpriteSpan1"><span class="buttonSpriteSpan2">Cancel All</span></span></div></div></a>
+<input type="SUBMIT" name="requestUpdateHoldsSome" value="UPDATE LIST" />
+</form><script type="text/JavaScript">
+<!--Hide the JS
+document.getElementById( 'items_count' ).innerHTML = '4 HOLDS';
+// Unhide the JS --></script>
+<!--this is customized <screens/patronview_encore.html>-->
+   </div>
+<!-- this script must be included for this template to display properly in encore -->
+<script type="text/javascript" src="/screens/setdomain.js"></script>
+</body>
+</html>
+
+

--- a/test/fixtures/sierra-5.1-patron-sb-webpac-holds-markup.html
+++ b/test/fixtures/sierra-5.1-patron-sb-webpac-holds-markup.html
@@ -1,0 +1,263 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!-- VERSION = $Id$ $Rev: 202541 $ $Date: 2013-02-08 13:48:24 -0800 (Fri, 08 Feb 2013) $ -->
+<html>
+<head>
+<link rel="stylesheet" type="text/css" href="/scripts/ProStyles.css" />
+<link rel="stylesheet" type="text/css" href="/screens/styles.css" />
+<script type="text/javascript" src="/scripts/elcontent.js">
+</script>
+<script type="text/javascript" src="/scripts/common.js">
+</script>
+<script type="text/javascript" src="/scripts/features.js">
+</script>
+<script type="text/javascript" src="/scripts/webbridge.js">
+</script>
+
+</head>
+<body>
+   <div class="patFuncArea">
+<form name="hold_form" method="POST" id="hold_form" ><input type="HIDDEN" id="holdpagecmd" />
+
+<input type="SUBMIT" name="sortByRequest" value="Sort by Hold Requested Date" />
+<input type="SUBMIT" name="sortByStatus" value="Sort by Status" />
+<input type="HIDDEN" name="currentsortorder" value="current_pickup" />
+<a href="#"  onClick="return submitHold( 'requestCancelAll', 'requestCancelAll' )"><div style="display:none" onmousedown="this.className='pressedState';" onmouseout="this.className='';" onmouseup="this.className='';"><div class="buttonSpriteDiv"><span class="buttonSpriteSpan1"><span class="buttonSpriteSpan2">Cancel All</span></span></div></div></a>
+<input type="SUBMIT" name="requestUpdateHoldsSome" value="UPDATE LIST" />
+<table border="0" class="patFunc"><tr class="patFuncTitle">
+<th colspan="7" class="patFuncTitle">
+<label id="items_count">5 HOLDS</label>
+</th>
+</tr>
+
+<tr class="patFuncHeaders">
+<th class="patFuncHeaders"> CANCEL </th>
+<th class="patFuncHeaders"> TITLE </th>
+<th  class="patFuncHeaders"> Ratings </th>
+<th class="patFuncHeaders"> STATUS </th>
+<th class="patFuncHeaders">PICKUP LOCATION</th>
+<th class="patFuncHeaders"> CANCEL IF NOT FILLED BY </th>
+<th class="patFuncHeaders"> FREEZE </th>
+</tr>
+
+
+<style type="text/css">
+<!--
+#ratemy1    { display: inline }
+#rateneed1  { display: none }
+#ratemy2    { display: inline }
+#rateneed2  { display: none }
+#ratemy3    { display: inline }
+#rateneed3  { display: none }
+#ratemy4    { display: inline }
+#rateneed4  { display: none }
+#ratemy5    { display: inline }
+#rateneed5  { display: none }
+-->
+</style>
+<tr class="patFuncEntry">
+<td  class="patFuncMark" >
+&nbsp;
+</td>
+<td  class="patFuncTitle">
+[Standard NYPL restrictions apply] ALISON\'S ZINNIA \/ BY ANITA LOBEL\. [RECAP]
+</td>
+<td nowrap  class="patFuncRating" >
+&nbsp;</td>
+<td  class="patFuncStatus"> IN TRANSIT </td>
+<td class="patFuncPickup">Performing Arts PDD - 3rd Fl</td>
+<td class="patFuncCancel">&nbsp;</td>
+<td  class="patFuncFreeze" >&nbsp;</td>
+</tr>
+
+<tr class="patFuncEntry">
+<td  class="patFuncMark" >
+&nbsp;
+</td>
+<td  class="patFuncTitle">
+[Standard NYPL restrictions apply] ABBAYE DE RUISSEAUVILLE \(62\) : ACTES ET DOCUMENTS, 1127\-1785 : AIRE\-SUR\-LA\-LYS, AMBRICOURT, AZINCOURT, CANLERS, CREQUY, ERGNY [RECAP]
+</td>
+<td nowrap  class="patFuncRating" >
+&nbsp;</td>
+<td  class="patFuncStatus"> IN TRANSIT </td>
+<td class="patFuncPickup">SCHWARZMAN 315 - ONSITE USE</td>
+<td class="patFuncCancel">&nbsp;</td>
+<td  class="patFuncFreeze" >&nbsp;</td>
+</tr>
+
+<tr class="patFuncEntry">
+<td  class="patFuncMark" >
+&nbsp;
+</td>
+<td  class="patFuncTitle">
+[Standard NYPL restrictions apply] BATS, BY GLOVER MORRILL ALLEN\. [RECAP]
+</td>
+<td nowrap  class="patFuncRating" >
+&nbsp;</td>
+<td  class="patFuncStatus"> IN TRANSIT </td>
+<td class="patFuncPickup">SCHWARZMAN 111-ONSITE USE-CLOSED</td>
+<td class="patFuncCancel">&nbsp;</td>
+<td  class="patFuncFreeze" >&nbsp;</td>
+</tr>
+
+<tr class="patFuncEntry">
+<td  class="patFuncMark" >
+&nbsp;
+</td>
+<td  class="patFuncTitle">
+[Standard NYPL restrictions apply] BOURDON, 1645\-1990 : 3500 DESCENDANTS DE JACQUES : NAISSANCES, MARIAGES, SEPULTURES DES BOURDON AU CANADA ET AUX ETATS UNIS = [RECAP]
+</td>
+<td nowrap  class="patFuncRating" >
+&nbsp;</td>
+<td  class="patFuncStatus"> IN TRANSIT </td>
+<td class="patFuncPickup">SCHWARZMAN 315 - ONSITE USE</td>
+<td class="patFuncCancel">&nbsp;</td>
+<td  class="patFuncFreeze" >&nbsp;</td>
+</tr>
+
+<tr class="patFuncEntry">
+<td  class="patFuncMark" >
+<input type="checkbox" name="canceli34258240x04" id="canceli34258240x04" />
+</td>
+<td  class="patFuncTitle">
+<label for="canceli34258240x04"><a href="https://browse.nypl.org/iii/encore/record/C__Rb21001120?lang=eng&suite=def"><span class="patFuncTitleMain">Genealogies / Brad Crenshaw.</span></a></label>
+<br />
+</td>
+<td nowrap  class="patFuncRating" >
+
+<span id="ratemy5"  onmouseover="setToolVisibility  ('ratemy5', 'none', 'rateneed5', 'inline')">_____
+</span>
+<span id="rateneed5"  onmouseout="setToolVisibility  ('ratemy5', 'inline', 'rateneed5', 'none')"><a href="/patroninfo~S1*eng/7228928/sortedbypudateholds?changerating1=b21001120">?</a><a href="/patroninfo~S1*eng/7228928/sortedbypudateholds?changerating2=b21001120">?</a><a href="/patroninfo~S1*eng/7228928/sortedbypudateholds?changerating3=b21001120">?</a><a href="/patroninfo~S1*eng/7228928/sortedbypudateholds?changerating4=b21001120">?</a><a href="/patroninfo~S1*eng/7228928/sortedbypudateholds?changerating5=b21001120">?</a>
+</span></td>
+<td  class="patFuncStatus"> AVAILABLE </td>
+<td class="patFuncPickup">
+<div  class="patFuncPickupLabel">
+<label for="loci34258240x04">Pickup Location</label></div>
+<select name=loci34258240x04 id=loci34258240x04 >
+<option value="ft+++" >53rd Street</option>
+<option value="fe+++" >58th Street</option>
+<option value="ss+++" >67th Street</option>
+<option value="ns+++" >96th Street</option>
+<option value="ag+++" >Aguilar</option>
+<option value="al+++" >Allerton</option>
+<option value="lb+++" >Andrew Heiskell</option>
+<option value="bt+++" >Battery Park</option>
+<option value="ba+++" >Baychester</option>
+<option value="be+++" >Belmont</option>
+<option value="bl+++" >Bloomingdale</option>
+<option value="bc+++" >Bronx Library Center</option>
+<option value="ct+++" >Castle Hill</option>
+<option value="ch+++" >Chatham Square</option>
+<option value="ci+++" >City Island</option>
+<option value="cp+++" >Clasons Point</option>
+<option value="cs+++" >Columbus</option>
+<option value="ht+++" >Countee Cullen</option>
+<option value="dh+++" >Dongan Hills</option>
+<option value="ea+++" >Eastchester</option>
+<option value="ew+++" >Edenwald</option>
+<option value="ep+++" >Epiphany</option>
+<option value="fx+++" >Francis Martin</option>
+<option value="br+++" >George Bruce</option>
+<option value="gd+++" >Grand Concourse</option>
+<option value="gk+++" >Great Kills</option>
+<option value="hg+++" >Hamilton Grange</option>
+<option value="hl+++" >Harlem</option>
+<option value="hu+++" >Harry Belafonte - 115th Street</option>
+<option value="hb+++" >High Bridge</option>
+<option value="hp+++" >Hudson Park</option>
+<option value="hk+++" >Huguenot Park</option>
+<option value="in+++" >Inwood</option>
+<option value="jp+++" >Jerome Park</option>
+<option value="kb+++" >Kingsbridge</option>
+<option value="kp+++" >Kips Bay</option>
+<option value="my+++" >LPA - Circulating </option>
+<option value="mb+++" >Macombs Bridge</option>
+<option value="mn+++" >Mariners Harbor</option>
+<option value="cl+++" >Morningside Heights</option>
+<option value="mp+++" >Morris Park</option>
+<option value="mr+++" >Morrisania (CLOSED)</option>
+<option value="mo+++" >Mosholu</option>
+<option value="mh+++" >Mott Haven (CLOSED)</option>
+<option value="mu+++" >Muhlenberg</option>
+<option value="ml+++" >Mulberry Street</option>
+<option value="lm+++" >New Amsterdam</option>
+<option value="nd+++" >New Dorp</option>
+<option value="ot+++" >Ottendorfer</option>
+<option value="pk+++" >Parkchester</option>
+<option value="pm+++" >Pelham Bay</option>
+<option value="vn+++" >Pelham Parkway-Van Nest</option>
+<option value="rt+++" >Richmondtown</option>
+<option value="rd+++" >Riverdale</option>
+<option value="rs+++" >Riverside</option>
+<option value="ri+++" >Roosevelt Island</option>
+<option value="sa+++" >Saint Agnes</option>
+<option value="sg+++" >Saint George</option>
+<option value="sd+++" >Sedgwick</option>
+<option value="sn+++" >SNFL (formerly Mid-Manhattan)</option>
+<option value="se+++" >Seward Park</option>
+<option value="sv+++" >Soundview</option>
+<option value="sb+++" >South Beach</option>
+<option value="dy+++" >Spuyten Duyvil</option>
+<option value="st+++" >Stapleton</option>
+<option value="tg+++" >Throgs Neck</option>
+<option value="th+++" >Todt Hill</option>
+<option value="ts+++" >Tompkins Square</option>
+<option value="tv+++" >Tottenville</option>
+<option value="tm+++" >Tremont</option>
+<option value="vc+++" >Van Cortlandt</option>
+<option value="wk+++" >Wakefield</option>
+<option value="wh+++" >Washington Heights</option>
+<option value="wb+++" >Webster</option>
+<option value="wf+++" >West Farms</option>
+<option value="nb+++" >West New Brighton</option>
+<option value="wt+++" >Westchester Square</option>
+<option value="wl+++" >Woodlawn Heights</option>
+<option value="wo+++" >Woodstock</option>
+<option value="yv+++" >Yorkville</option>
+<option value="b1+++" >Bookmobile 1 (CLOSED)</option>
+<option value="ca+++" >Cathedral Library (CLOSED)</option>
+<option value="fw+++" >Fort Washington (CLOSED)</option>
+<option value="gc+++" >Grand Central (CLOSED)</option>
+<option value="hf+++" >Hamilton Fish Park (CLOSED)</option>
+<option value="hs+++" >Hunt's Point (CLOSED)</option>
+<option value="jm+++" >Jefferson Market (CLOSED)</option>
+<option value="me+++" >Melrose (CLOSED)</option>
+<option value="pr+++" >Port Richmond (CLOSED)</option>
+<option value="mar92" >STAFF ONLY-SASB Rare Book Rm324</option>
+<option value="mao92" >STAFF ONLY-SASB Manuscript Rm328</option>
+<option value="mal17" >STAFF ONLY-SASB Scholar Rm 217</option>
+<option value="myrs+" >Performing Arts - Spec Col Desk</option>
+<option value="myaos" >STAFF ONLY - LPA ORCH</option>
+<option value="rc+++" >STAFF ONLY - ACCSVC ReCAP</option>
+<option value="qc+++" >STAFF ONLY - ACCSVC Clancy</option>
+<option value="rc+++" >STAFF ONLY - RESEARCH OFFSITE</option>
+<option value="maedd" selected="selected">STAFF ONLY - SASB EDD</option>
+<option value="myedd" >STAFF ONLY - LPA EDD</option>
+<option value="scedd" >STAFF ONLY - SCH EDD</option>
+</select>
+</td>
+<td class="patFuncCancel">07-01-22</td>
+<td  class="patFuncFreeze" >
+<div  class="patFuncFreezeLabel">
+<label for="freezei34258240x04" >Freeze</label>
+</div>
+<input type="checkbox" name="freezei34258240x04" /></td>
+</tr>
+
+</table>
+
+<input type="SUBMIT" name="sortByRequest" value="Sort by Hold Requested Date" />
+<input type="SUBMIT" name="sortByStatus" value="Sort by Status" />
+<input type="HIDDEN" name="currentsortorder" value="current_pickup" />
+<a href="#"  onClick="return submitHold( 'requestCancelAll', 'requestCancelAll' )"><div style="display:none" onmousedown="this.className='pressedState';" onmouseout="this.className='';" onmouseup="this.className='';"><div class="buttonSpriteDiv"><span class="buttonSpriteSpan1"><span class="buttonSpriteSpan2">Cancel All</span></span></div></div></a>
+<input type="SUBMIT" name="requestUpdateHoldsSome" value="UPDATE LIST" />
+</form><script type="text/JavaScript">
+<!--Hide the JS
+document.getElementById( 'items_count' ).innerHTML = '5 HOLDS';
+// Unhide the JS --></script>
+<!--this is customized <screens/patronview_encore.html>-->
+   </div>
+<!-- this script must be included for this template to display properly in encore -->
+<script type="text/javascript" src="/screens/setdomain.js"></script>
+</body>
+</html>
+

--- a/test/fixtures/sierra-5.3-patron-5427701-webpac-holds-markup.html
+++ b/test/fixtures/sierra-5.3-patron-5427701-webpac-holds-markup.html
@@ -1,0 +1,388 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!-- VERSION = $Id$ $Rev: 202541 $ $Date: 2013-02-08 13:48:24 -0800 (Fri, 08 Feb 2013) $ -->
+<html>
+<head>
+<link rel="stylesheet" type="text/css" href="/scripts/ProStyles.css" />
+<link rel="stylesheet" type="text/css" href="/screens/styles.css" />
+<script type="text/javascript" src="/scripts/elcontent.js">
+</script>
+<script type="text/javascript" src="/scripts/common.js">
+</script>
+<script type="text/javascript" src="/scripts/features.js">
+</script>
+<script type="text/javascript" src="/scripts/webbridge.js">
+</script>
+
+</head>
+<body>
+   <div class="patFuncArea">
+<form name="hold_form" method="POST" id="hold_form" ><input type="HIDDEN" id="holdpagecmd" />
+
+<input type="SUBMIT" name="sortByRequest" value="Sort by Hold Requested Date" />
+<input type="SUBMIT" name="sortByStatus" value="Sort by Status" />
+<input type="HIDDEN" name="currentsortorder" value="current_pickup" />
+<a href="#"  onClick="return submitHold( 'requestCancelAll', 'requestCancelAll' )"><div style="display:none" onmousedown="this.className='pressedState';" onmouseout="this.className='';" onmouseup="this.className='';"><div class="buttonSpriteDiv"><span class="buttonSpriteSpan1"><span class="buttonSpriteSpan2">Cancel All</span></span></div></div></a>
+<input type="SUBMIT" name="requestUpdateHoldsSome" value="UPDATE LIST" />
+
+<div class="patFuncTitle"><span id="id_pftitle_items_count">13 HOLDS</span>
+</div>
+
+<table border="0" class="patFunc"><tr class="patFuncHeaders">
+<th scope="col" class="patFuncHeaders"> CANCEL </th>
+<th scope="col" class="patFuncHeaders"> TITLE </th>
+<th scope="col" class="patFuncHeaders"> Ratings </th>
+<th scope="col" class="patFuncHeaders"> STATUS </th>
+<th scope="col" class="patFuncHeaders"> PICKUP LOCATION </th>
+<th scope="col" class="patFuncHeaders"> CANCEL IF NOT FILLED BY </th>
+<th scope="col" class="patFuncHeaders"> FREEZE </th>
+</tr>
+
+
+<style type="text/css">
+<!--
+#ratemy1    { display: inline }
+#rateneed1  { display: none }
+#ratemy2    { display: inline }
+#rateneed2  { display: none }
+#ratemy3    { display: inline }
+#rateneed3  { display: none }
+#ratemy4    { display: inline }
+#rateneed4  { display: none }
+#ratemy5    { display: inline }
+#rateneed5  { display: none }
+#ratemy6    { display: inline }
+#rateneed6  { display: none }
+#ratemy7    { display: inline }
+#rateneed7  { display: none }
+#ratemy8    { display: inline }
+#rateneed8  { display: none }
+#ratemy9    { display: inline }
+#rateneed9  { display: none }
+#ratemy10    { display: inline }
+#rateneed10  { display: none }
+#ratemy11    { display: inline }
+#rateneed11  { display: none }
+#ratemy12    { display: inline }
+#rateneed12  { display: none }
+#ratemy13    { display: inline }
+#rateneed13  { display: none }
+-->
+</style>
+<tr class="patFuncEntry">
+<td class="patFuncMark" >
+<span tabindex="-1" id="id_pfmark_canceli34162229x00" class="visually-hidden">Cancel</span><input type="checkbox" name="name_pfmark_canceli34162229x00" aria-labelledby="id_pfmark_canceli34162229x00 id_pfbibtitle_titlei34162229x00" />
+</td>
+<th class="patFuncBibTitle" scope="row">
+<a id="id_pfbibtitle_titlei34162229x00" href="https://nypl-encore-test.nypl.org/iii/encore/record/C__Rb20970375?lang=eng&suite=def"><span class="patFuncTitleMain">Toast / by Raquel Pelzel &#59; photographs by Evan Sung.</span></a>
+<br />
+</th>
+<td nowrap  class="patFuncRating" >
+
+<span id="ratemy1"  onmouseover="setToolVisibility  ('ratemy1', 'none', 'rateneed1', 'inline')">_____
+</span>
+<span id="rateneed1"  onmouseout="setToolVisibility  ('ratemy1', 'inline', 'rateneed1', 'none')"><a href="/patroninfo~S1*eng/5427701/sortedbypudateholds?changerating1=b20970375">?</a><a href="/patroninfo~S1*eng/5427701/sortedbypudateholds?changerating2=b20970375">?</a><a href="/patroninfo~S1*eng/5427701/sortedbypudateholds?changerating3=b20970375">?</a><a href="/patroninfo~S1*eng/5427701/sortedbypudateholds?changerating4=b20970375">?</a><a href="/patroninfo~S1*eng/5427701/sortedbypudateholds?changerating5=b20970375">?</a>
+</span></td>
+<td class="patFuncStatus"> AVAILABLE </td>
+<td class="patFuncPickup">STAFF ONLY - ILL - SASB S.Court</td>
+<td class="patFuncCancel">01-14-22</td>
+<td class="patFuncFreeze" >
+<span id="id_pffreeze_freezei34162229x00" tabindex="-1" class="visually-hidden">Freeze</span>
+<input aria-labelledby="id_pffreeze_freezei34162229x00 id_pfbibtitle_titlei34162229x00" name="name_pffreeze_freezei34162229x00" type="checkbox" /></td>
+</tr>
+
+<tr class="patFuncEntry">
+<td class="patFuncMark" >
+<span tabindex="-1" id="id_pfmark_canceli37920957x01" class="visually-hidden">Cancel</span><input type="checkbox" name="name_pfmark_canceli37920957x01" aria-labelledby="id_pfmark_canceli37920957x01 id_pfbibtitle_titlei37920957x01" />
+</td>
+<th class="patFuncBibTitle" scope="row">
+<a id="id_pfbibtitle_titlei37920957x01" href="https://nypl-encore-test.nypl.org/iii/encore/record/C__Rb22179168?lang=eng&suite=def"><span class="patFuncTitleMain">[Standard NYPL restrictions apply] JUSTICE, JUSTICE : SCHOOL POLITICS AND THE ECLIPSE OF LIBERALISM /     HISTORY OF SCHOOLS AND SCHOOLING &#59;  [RECAP]</span></a>
+<br />
+</th>
+<td nowrap  class="patFuncRating" >
+
+<span id="ratemy2"  onmouseover="setToolVisibility  ('ratemy2', 'none', 'rateneed2', 'inline')">_____
+</span>
+<span id="rateneed2"  onmouseout="setToolVisibility  ('ratemy2', 'inline', 'rateneed2', 'none')"><a href="/patroninfo~S1*eng/5427701/sortedbypudateholds?changerating1=b22179168">?</a><a href="/patroninfo~S1*eng/5427701/sortedbypudateholds?changerating2=b22179168">?</a><a href="/patroninfo~S1*eng/5427701/sortedbypudateholds?changerating3=b22179168">?</a><a href="/patroninfo~S1*eng/5427701/sortedbypudateholds?changerating4=b22179168">?</a><a href="/patroninfo~S1*eng/5427701/sortedbypudateholds?changerating5=b22179168">?</a>
+</span></td>
+<td class="patFuncStatus"> AVAILABLE </td>
+<td class="patFuncPickup">
+<span id="id_pfpickup_loci37920957x01" tabindex="-1" class="visually-hidden">Pickup Location</span>
+<select name="name_pfpickup_loci37920957x01" aria-labelledby="id_pfpickup_loci37920957x01 id_pfbibtitle_titlei37920957x01" >
+</select>
+</td>
+<td class="patFuncCancel">03-01-22</td>
+<td class="patFuncFreeze" >
+<span id="id_pffreeze_freezei37920957x01" tabindex="-1" class="visually-hidden">Freeze</span>
+<input aria-labelledby="id_pffreeze_freezei37920957x01 id_pfbibtitle_titlei37920957x01" name="name_pffreeze_freezei37920957x01" type="checkbox" /></td>
+</tr>
+
+<tr class="patFuncEntry">
+<td class="patFuncMark" >
+<span tabindex="-1" id="id_pfmark_canceli37921060x02" class="visually-hidden">Cancel</span><input type="checkbox" name="name_pfmark_canceli37921060x02" aria-labelledby="id_pfmark_canceli37921060x02 id_pfbibtitle_titlei37921060x02" />
+</td>
+<th class="patFuncBibTitle" scope="row">
+<a id="id_pfbibtitle_titlei37921060x02" href="https://nypl-encore-test.nypl.org/iii/encore/record/C__Rb22179316?lang=eng&suite=def"><span class="patFuncTitleMain">-2 +3 Stefano Arienti, Massimo Bartolini : la Collezione di Museion = die Sammlung Museion = the Museion collection. Minus 2 plus 3 Minus two plus three Stefano Arienti, Massimo Bartolini</span></a>
+<br />
+</th>
+<td nowrap  class="patFuncRating" >
+
+<span id="ratemy3"  onmouseover="setToolVisibility  ('ratemy3', 'none', 'rateneed3', 'inline')">_____
+</span>
+<span id="rateneed3"  onmouseout="setToolVisibility  ('ratemy3', 'inline', 'rateneed3', 'none')"><a href="/patroninfo~S1*eng/5427701/sortedbypudateholds?changerating1=b22179316">?</a><a href="/patroninfo~S1*eng/5427701/sortedbypudateholds?changerating2=b22179316">?</a><a href="/patroninfo~S1*eng/5427701/sortedbypudateholds?changerating3=b22179316">?</a><a href="/patroninfo~S1*eng/5427701/sortedbypudateholds?changerating4=b22179316">?</a><a href="/patroninfo~S1*eng/5427701/sortedbypudateholds?changerating5=b22179316">?</a>
+</span></td>
+<td class="patFuncStatus"> AVAILABLE </td>
+<td class="patFuncPickup">SCHWARZMAN 315 - ONSITE USE</td>
+<td class="patFuncCancel">05-11-22</td>
+<td class="patFuncFreeze" >
+<span id="id_pffreeze_freezei37921060x02" tabindex="-1" class="visually-hidden">Freeze</span>
+<input aria-labelledby="id_pffreeze_freezei37921060x02 id_pfbibtitle_titlei37921060x02" name="name_pffreeze_freezei37921060x02" type="checkbox" /></td>
+</tr>
+
+<tr class="patFuncEntry">
+<td class="patFuncMark" >
+<span tabindex="-1" id="id_pfmark_canceli37921070x03" class="visually-hidden">Cancel</span><input type="checkbox" name="name_pfmark_canceli37921070x03" aria-labelledby="id_pfmark_canceli37921070x03 id_pfbibtitle_titlei37921070x03" />
+</td>
+<th class="patFuncBibTitle" scope="row">
+<a id="id_pfbibtitle_titlei37921070x03" href="https://nypl-encore-test.nypl.org/iii/encore/record/C__Rb22179326?lang=eng&suite=def"><span class="patFuncTitleMain">[Standard NYPL restrictions apply] THE ANNIVERSARY AND OTHER STORIES /       [RECAP]</span></a>
+<br />
+</th>
+<td nowrap  class="patFuncRating" >
+
+<span id="ratemy4"  onmouseover="setToolVisibility  ('ratemy4', 'none', 'rateneed4', 'inline')">_____
+</span>
+<span id="rateneed4"  onmouseout="setToolVisibility  ('ratemy4', 'inline', 'rateneed4', 'none')"><a href="/patroninfo~S1*eng/5427701/sortedbypudateholds?changerating1=b22179326">?</a><a href="/patroninfo~S1*eng/5427701/sortedbypudateholds?changerating2=b22179326">?</a><a href="/patroninfo~S1*eng/5427701/sortedbypudateholds?changerating3=b22179326">?</a><a href="/patroninfo~S1*eng/5427701/sortedbypudateholds?changerating4=b22179326">?</a><a href="/patroninfo~S1*eng/5427701/sortedbypudateholds?changerating5=b22179326">?</a>
+</span></td>
+<td class="patFuncStatus"> AVAILABLE </td>
+<td class="patFuncPickup">
+<span id="id_pfpickup_loci37921070x03" tabindex="-1" class="visually-hidden">Pickup Location</span>
+<select name="name_pfpickup_loci37921070x03" aria-labelledby="id_pfpickup_loci37921070x03 id_pfbibtitle_titlei37921070x03" >
+</select>
+</td>
+<td class="patFuncCancel">05-13-22</td>
+<td class="patFuncFreeze" >
+<span id="id_pffreeze_freezei37921070x03" tabindex="-1" class="visually-hidden">Freeze</span>
+<input aria-labelledby="id_pffreeze_freezei37921070x03 id_pfbibtitle_titlei37921070x03" name="name_pffreeze_freezei37921070x03" type="checkbox" /></td>
+</tr>
+
+<tr class="patFuncEntry">
+<td class="patFuncMark" >
+<span tabindex="-1" id="id_pfmark_canceli37921134x04" class="visually-hidden">Cancel</span><input type="checkbox" name="name_pfmark_canceli37921134x04" aria-labelledby="id_pfmark_canceli37921134x04 id_pfbibtitle_titlei37921134x04" />
+</td>
+<th class="patFuncBibTitle" scope="row">
+<a id="id_pfbibtitle_titlei37921134x04" href="https://nypl-encore-test.nypl.org/iii/encore/record/C__Rb22179390?lang=eng&suite=def"><span class="patFuncTitleMain">[Standard NYPL restrictions apply] ADDRESSES DELIVERED AT THE LINCOLN DINNERS OF THE NATIONAL REPUBLICAN CLUB IN RESPONSE TO THE TOAST ABRAHAM LINCOLN, 1910-1927 [RECAP]</span></a>
+<br />
+</th>
+<td nowrap  class="patFuncRating" >
+
+<span id="ratemy5"  onmouseover="setToolVisibility  ('ratemy5', 'none', 'rateneed5', 'inline')">_____
+</span>
+<span id="rateneed5"  onmouseout="setToolVisibility  ('ratemy5', 'inline', 'rateneed5', 'none')"><a href="/patroninfo~S1*eng/5427701/sortedbypudateholds?changerating1=b22179390">?</a><a href="/patroninfo~S1*eng/5427701/sortedbypudateholds?changerating2=b22179390">?</a><a href="/patroninfo~S1*eng/5427701/sortedbypudateholds?changerating3=b22179390">?</a><a href="/patroninfo~S1*eng/5427701/sortedbypudateholds?changerating4=b22179390">?</a><a href="/patroninfo~S1*eng/5427701/sortedbypudateholds?changerating5=b22179390">?</a>
+</span></td>
+<td class="patFuncStatus"> AVAILABLE </td>
+<td class="patFuncPickup">SCHWARZMAN 315 - ONSITE USE</td>
+<td class="patFuncCancel">06-01-22</td>
+<td class="patFuncFreeze" >
+<span id="id_pffreeze_freezei37921134x04" tabindex="-1" class="visually-hidden">Freeze</span>
+<input aria-labelledby="id_pffreeze_freezei37921134x04 id_pfbibtitle_titlei37921134x04" name="name_pffreeze_freezei37921134x04" type="checkbox" /></td>
+</tr>
+
+<tr class="patFuncEntry">
+<td class="patFuncMark" >
+<span tabindex="-1" id="id_pfmark_canceli37921136x05" class="visually-hidden">Cancel</span><input type="checkbox" name="name_pfmark_canceli37921136x05" aria-labelledby="id_pfmark_canceli37921136x05 id_pfbibtitle_titlei37921136x05" />
+</td>
+<th class="patFuncBibTitle" scope="row">
+<a id="id_pfbibtitle_titlei37921136x05" href="https://nypl-encore-test.nypl.org/iii/encore/record/C__Rb22179392?lang=eng&suite=def"><span class="patFuncTitleMain">[Standard NYPL restrictions apply] &#34; ... IZ PENZY V MOSKVU I OBRATNO ...&#34; : SOVREMENNAIA FILOSOFSKAIA PUBLITSISTIKA = &#34; ... FROM PENZA TO MOSCOW AND BACK ...&#34; [RECAP]</span></a>
+<br />
+</th>
+<td nowrap  class="patFuncRating" >
+
+<span id="ratemy6"  onmouseover="setToolVisibility  ('ratemy6', 'none', 'rateneed6', 'inline')">_____
+</span>
+<span id="rateneed6"  onmouseout="setToolVisibility  ('ratemy6', 'inline', 'rateneed6', 'none')"><a href="/patroninfo~S1*eng/5427701/sortedbypudateholds?changerating1=b22179392">?</a><a href="/patroninfo~S1*eng/5427701/sortedbypudateholds?changerating2=b22179392">?</a><a href="/patroninfo~S1*eng/5427701/sortedbypudateholds?changerating3=b22179392">?</a><a href="/patroninfo~S1*eng/5427701/sortedbypudateholds?changerating4=b22179392">?</a><a href="/patroninfo~S1*eng/5427701/sortedbypudateholds?changerating5=b22179392">?</a>
+</span></td>
+<td class="patFuncStatus"> AVAILABLE </td>
+<td class="patFuncPickup">SCHWARZMAN 315 - ONSITE USE</td>
+<td class="patFuncCancel">06-01-22</td>
+<td class="patFuncFreeze" >
+<span id="id_pffreeze_freezei37921136x05" tabindex="-1" class="visually-hidden">Freeze</span>
+<input aria-labelledby="id_pffreeze_freezei37921136x05 id_pfbibtitle_titlei37921136x05" name="name_pffreeze_freezei37921136x05" type="checkbox" /></td>
+</tr>
+
+<tr class="patFuncEntry">
+<td class="patFuncMark" >
+<span tabindex="-1" id="id_pfmark_canceli37921141x06" class="visually-hidden">Cancel</span><input type="checkbox" name="name_pfmark_canceli37921141x06" aria-labelledby="id_pfmark_canceli37921141x06 id_pfbibtitle_titlei37921141x06" />
+</td>
+<th class="patFuncBibTitle" scope="row">
+<a id="id_pfbibtitle_titlei37921141x06" href="https://nypl-encore-test.nypl.org/iii/encore/record/C__Rb22179397?lang=eng&suite=def"><span class="patFuncTitleMain">[Standard NYPL restrictions apply] --ABOUT AS AUSTERE AS A DIOR GOWN-- : NEW ZEALAND ARCHITECTURE THE 1960S : A ONE DAY SYMPOSIUM : CENTRE FOR BUILDING PERFORMAN [HD]</span></a>
+<br />
+</th>
+<td nowrap  class="patFuncRating" >
+
+<span id="ratemy7"  onmouseover="setToolVisibility  ('ratemy7', 'none', 'rateneed7', 'inline')">_____
+</span>
+<span id="rateneed7"  onmouseout="setToolVisibility  ('ratemy7', 'inline', 'rateneed7', 'none')"><a href="/patroninfo~S1*eng/5427701/sortedbypudateholds?changerating1=b22179397">?</a><a href="/patroninfo~S1*eng/5427701/sortedbypudateholds?changerating2=b22179397">?</a><a href="/patroninfo~S1*eng/5427701/sortedbypudateholds?changerating3=b22179397">?</a><a href="/patroninfo~S1*eng/5427701/sortedbypudateholds?changerating4=b22179397">?</a><a href="/patroninfo~S1*eng/5427701/sortedbypudateholds?changerating5=b22179397">?</a>
+</span></td>
+<td class="patFuncStatus"> AVAILABLE </td>
+<td class="patFuncPickup">SCHWARZMAN 315 - ONSITE USE</td>
+<td class="patFuncCancel">06-01-22</td>
+<td class="patFuncFreeze" >
+<span id="id_pffreeze_freezei37921141x06" tabindex="-1" class="visually-hidden">Freeze</span>
+<input aria-labelledby="id_pffreeze_freezei37921141x06 id_pfbibtitle_titlei37921141x06" name="name_pffreeze_freezei37921141x06" type="checkbox" /></td>
+</tr>
+
+<tr class="patFuncEntry">
+<td class="patFuncMark" >
+<span tabindex="-1" id="id_pfmark_canceli37921142x07" class="visually-hidden">Cancel</span><input type="checkbox" name="name_pfmark_canceli37921142x07" aria-labelledby="id_pfmark_canceli37921142x07 id_pfbibtitle_titlei37921142x07" />
+</td>
+<th class="patFuncBibTitle" scope="row">
+<a id="id_pfbibtitle_titlei37921142x07" href="https://nypl-encore-test.nypl.org/iii/encore/record/C__Rb22179398?lang=eng&suite=def"><span class="patFuncTitleMain">[Standard NYPL restrictions apply] 1748 /       [RECAP]</span></a>
+<br />
+</th>
+<td nowrap  class="patFuncRating" >
+
+<span id="ratemy8"  onmouseover="setToolVisibility  ('ratemy8', 'none', 'rateneed8', 'inline')">_____
+</span>
+<span id="rateneed8"  onmouseout="setToolVisibility  ('ratemy8', 'inline', 'rateneed8', 'none')"><a href="/patroninfo~S1*eng/5427701/sortedbypudateholds?changerating1=b22179398">?</a><a href="/patroninfo~S1*eng/5427701/sortedbypudateholds?changerating2=b22179398">?</a><a href="/patroninfo~S1*eng/5427701/sortedbypudateholds?changerating3=b22179398">?</a><a href="/patroninfo~S1*eng/5427701/sortedbypudateholds?changerating4=b22179398">?</a><a href="/patroninfo~S1*eng/5427701/sortedbypudateholds?changerating5=b22179398">?</a>
+</span></td>
+<td class="patFuncStatus"> AVAILABLE </td>
+<td class="patFuncPickup">SCHWARZMAN 315 - ONSITE USE</td>
+<td class="patFuncCancel">06-01-22</td>
+<td class="patFuncFreeze" >
+<span id="id_pffreeze_freezei37921142x07" tabindex="-1" class="visually-hidden">Freeze</span>
+<input aria-labelledby="id_pffreeze_freezei37921142x07 id_pfbibtitle_titlei37921142x07" name="name_pffreeze_freezei37921142x07" type="checkbox" /></td>
+</tr>
+
+<tr class="patFuncEntry">
+<td class="patFuncMark" >
+<span tabindex="-1" id="id_pfmark_canceli37921148x08" class="visually-hidden">Cancel</span><input type="checkbox" name="name_pfmark_canceli37921148x08" aria-labelledby="id_pfmark_canceli37921148x08 id_pfbibtitle_titlei37921148x08" />
+</td>
+<th class="patFuncBibTitle" scope="row">
+<a id="id_pfbibtitle_titlei37921148x08" href="https://nypl-encore-test.nypl.org/iii/encore/record/C__Rb22180234?lang=eng&suite=def"><span class="patFuncTitleMain">[HD] [Standard NYPL restrictions apply] -BOBHLADI 1 : CONTE NYABOA DE ZOUKOUBOUE / -BOBHLADI 1 : CONTE DE ZOUKOUBOUE. CONTE NYABOA DE ZOUKOUBOUE. CONTE DE ZOUKOUBOU [HD]</span></a>
+<br />
+</th>
+<td nowrap  class="patFuncRating" >
+
+<span id="ratemy9"  onmouseover="setToolVisibility  ('ratemy9', 'none', 'rateneed9', 'inline')">_____
+</span>
+<span id="rateneed9"  onmouseout="setToolVisibility  ('ratemy9', 'inline', 'rateneed9', 'none')"><a href="/patroninfo~S1*eng/5427701/sortedbypudateholds?changerating1=b22180234">?</a><a href="/patroninfo~S1*eng/5427701/sortedbypudateholds?changerating2=b22180234">?</a><a href="/patroninfo~S1*eng/5427701/sortedbypudateholds?changerating3=b22180234">?</a><a href="/patroninfo~S1*eng/5427701/sortedbypudateholds?changerating4=b22180234">?</a><a href="/patroninfo~S1*eng/5427701/sortedbypudateholds?changerating5=b22180234">?</a>
+</span></td>
+<td class="patFuncStatus"> AVAILABLE </td>
+<td class="patFuncPickup">SCHWARZMAN 315 - ONSITE USE</td>
+<td class="patFuncCancel">06-03-22</td>
+<td class="patFuncFreeze" >
+<span id="id_pffreeze_freezei37921148x08" tabindex="-1" class="visually-hidden">Freeze</span>
+<input aria-labelledby="id_pffreeze_freezei37921148x08 id_pfbibtitle_titlei37921148x08" name="name_pffreeze_freezei37921148x08" type="checkbox" /></td>
+</tr>
+
+<tr class="patFuncEntry">
+<td class="patFuncMark" >
+<span tabindex="-1" id="id_pfmark_canceli37921149x09" class="visually-hidden">Cancel</span><input type="checkbox" name="name_pfmark_canceli37921149x09" aria-labelledby="id_pfmark_canceli37921149x09 id_pfbibtitle_titlei37921149x09" />
+</td>
+<th class="patFuncBibTitle" scope="row">
+<a id="id_pfbibtitle_titlei37921149x09" href="https://nypl-encore-test.nypl.org/iii/encore/record/C__Rb22180235?lang=eng&suite=def"><span class="patFuncTitleMain">[Standard NYPL restrictions apply] ... WAS IT MURDER?       [RECAP]</span></a>
+<br />
+</th>
+<td nowrap  class="patFuncRating" >
+
+<span id="ratemy10"  onmouseover="setToolVisibility  ('ratemy10', 'none', 'rateneed10', 'inline')">_____
+</span>
+<span id="rateneed10"  onmouseout="setToolVisibility  ('ratemy10', 'inline', 'rateneed10', 'none')"><a href="/patroninfo~S1*eng/5427701/sortedbypudateholds?changerating1=b22180235">?</a><a href="/patroninfo~S1*eng/5427701/sortedbypudateholds?changerating2=b22180235">?</a><a href="/patroninfo~S1*eng/5427701/sortedbypudateholds?changerating3=b22180235">?</a><a href="/patroninfo~S1*eng/5427701/sortedbypudateholds?changerating4=b22180235">?</a><a href="/patroninfo~S1*eng/5427701/sortedbypudateholds?changerating5=b22180235">?</a>
+</span></td>
+<td class="patFuncStatus"> AVAILABLE </td>
+<td class="patFuncPickup">SCHWARZMAN 315 - ONSITE USE</td>
+<td class="patFuncCancel">06-03-22</td>
+<td class="patFuncFreeze" >
+<span id="id_pffreeze_freezei37921149x09" tabindex="-1" class="visually-hidden">Freeze</span>
+<input aria-labelledby="id_pffreeze_freezei37921149x09 id_pfbibtitle_titlei37921149x09" name="name_pffreeze_freezei37921149x09" type="checkbox" /></td>
+</tr>
+
+<tr class="patFuncEntry">
+<td class="patFuncMark" >
+<span tabindex="-1" id="id_pfmark_canceli37921162x10" class="visually-hidden">Cancel</span><input type="checkbox" name="name_pfmark_canceli37921162x10" aria-labelledby="id_pfmark_canceli37921162x10 id_pfbibtitle_titlei37921162x10" />
+</td>
+<th class="patFuncBibTitle" scope="row">
+<a id="id_pfbibtitle_titlei37921162x10" href="https://nypl-encore-test.nypl.org/iii/encore/record/C__Rb22180248?lang=eng&suite=def"><span class="patFuncTitleMain">[HD] [Standard NYPL restrictions apply] --A PUBBLICO, E PERPETUO COMMODO DELLA SUA DIOCESI : LIBRI ANTICHI, RARI E PREZIOSI DELLE BIBLIOTECHE DIOCESANE DEL FRIULI (SE [HD]</span></a>
+<br />
+</th>
+<td nowrap  class="patFuncRating" >
+
+<span id="ratemy11"  onmouseover="setToolVisibility  ('ratemy11', 'none', 'rateneed11', 'inline')">_____
+</span>
+<span id="rateneed11"  onmouseout="setToolVisibility  ('ratemy11', 'inline', 'rateneed11', 'none')"><a href="/patroninfo~S1*eng/5427701/sortedbypudateholds?changerating1=b22180248">?</a><a href="/patroninfo~S1*eng/5427701/sortedbypudateholds?changerating2=b22180248">?</a><a href="/patroninfo~S1*eng/5427701/sortedbypudateholds?changerating3=b22180248">?</a><a href="/patroninfo~S1*eng/5427701/sortedbypudateholds?changerating4=b22180248">?</a><a href="/patroninfo~S1*eng/5427701/sortedbypudateholds?changerating5=b22180248">?</a>
+</span></td>
+<td class="patFuncStatus"> AVAILABLE </td>
+<td class="patFuncPickup">SCHWARZMAN 315 - ONSITE USE</td>
+<td class="patFuncCancel">06-10-22</td>
+<td class="patFuncFreeze" >
+<span id="id_pffreeze_freezei37921162x10" tabindex="-1" class="visually-hidden">Freeze</span>
+<input aria-labelledby="id_pffreeze_freezei37921162x10 id_pfbibtitle_titlei37921162x10" name="name_pffreeze_freezei37921162x10" type="checkbox" /></td>
+</tr>
+
+<tr class="patFuncEntry">
+<td class="patFuncMark" >
+<span tabindex="-1" id="id_pfmark_canceli16265438x11" class="visually-hidden">Cancel</span><input type="checkbox" name="name_pfmark_canceli16265438x11" aria-labelledby="id_pfmark_canceli16265438x11 id_pfbibtitle_titlei16265438x11" />
+</td>
+<th class="patFuncBibTitle" scope="row">
+<a id="id_pfbibtitle_titlei16265438x11" href="https://nypl-encore-test.nypl.org/iii/encore/record/C__Rb13120836?lang=eng&suite=def"><span class="patFuncTitleMain">Addresses, historical - political - sociological, by Frederic R. Coudert.</span></a>
+<br />
+</th>
+<td nowrap  class="patFuncRating" >
+
+<span id="ratemy12"  onmouseover="setToolVisibility  ('ratemy12', 'none', 'rateneed12', 'inline')">_____
+</span>
+<span id="rateneed12"  onmouseout="setToolVisibility  ('ratemy12', 'inline', 'rateneed12', 'none')"><a href="/patroninfo~S1*eng/5427701/sortedbypudateholds?changerating1=b13120836">?</a><a href="/patroninfo~S1*eng/5427701/sortedbypudateholds?changerating2=b13120836">?</a><a href="/patroninfo~S1*eng/5427701/sortedbypudateholds?changerating3=b13120836">?</a><a href="/patroninfo~S1*eng/5427701/sortedbypudateholds?changerating4=b13120836">?</a><a href="/patroninfo~S1*eng/5427701/sortedbypudateholds?changerating5=b13120836">?</a>
+</span></td>
+<td class="patFuncStatus"> AVAILABLE </td>
+<td class="patFuncPickup">SCHWARZMAN 315 - ONSITE USE</td>
+<td class="patFuncCancel">06-21-22</td>
+<td class="patFuncFreeze" >
+<span id="id_pffreeze_freezei16265438x11" tabindex="-1" class="visually-hidden">Freeze</span>
+<input aria-labelledby="id_pffreeze_freezei16265438x11 id_pfbibtitle_titlei16265438x11" name="name_pffreeze_freezei16265438x11" type="checkbox" /></td>
+</tr>
+
+<tr class="patFuncEntry">
+<td class="patFuncMark" >
+<span tabindex="-1" id="id_pfmark_canceli37921257x12" class="visually-hidden">Cancel</span><input type="checkbox" name="name_pfmark_canceli37921257x12" aria-labelledby="id_pfmark_canceli37921257x12 id_pfbibtitle_titlei37921257x12" />
+</td>
+<th class="patFuncBibTitle" scope="row">
+<a id="id_pfbibtitle_titlei37921257x12" href="https://nypl-encore-test.nypl.org/iii/encore/record/C__Rb22180563?lang=eng&suite=def"><span class="patFuncTitleMain">[Standard NYPL restrictions apply] ALISON'S ZINNIA / BY ANITA LOBEL. [RECAP]</span></a>
+<br />
+</th>
+<td nowrap  class="patFuncRating" >
+
+<span id="ratemy13"  onmouseover="setToolVisibility  ('ratemy13', 'none', 'rateneed13', 'inline')">_____
+</span>
+<span id="rateneed13"  onmouseout="setToolVisibility  ('ratemy13', 'inline', 'rateneed13', 'none')"><a href="/patroninfo~S1*eng/5427701/sortedbypudateholds?changerating1=b22180563">?</a><a href="/patroninfo~S1*eng/5427701/sortedbypudateholds?changerating2=b22180563">?</a><a href="/patroninfo~S1*eng/5427701/sortedbypudateholds?changerating3=b22180563">?</a><a href="/patroninfo~S1*eng/5427701/sortedbypudateholds?changerating4=b22180563">?</a><a href="/patroninfo~S1*eng/5427701/sortedbypudateholds?changerating5=b22180563">?</a>
+</span></td>
+<td class="patFuncStatus"> IN TRANSIT </td>
+<td class="patFuncPickup">Performing Arts PDD - 3rd Fl</td>
+<td class="patFuncCancel">08-25-22</td>
+<td class="patFuncFreeze" >&nbsp;</td>
+</tr>
+
+</table>
+
+<input type="SUBMIT" name="sortByRequest" value="Sort by Hold Requested Date" />
+<input type="SUBMIT" name="sortByStatus" value="Sort by Status" />
+<input type="HIDDEN" name="currentsortorder" value="current_pickup" />
+<a href="#"  onClick="return submitHold( 'requestCancelAll', 'requestCancelAll' )"><div style="display:none" onmousedown="this.className='pressedState';" onmouseout="this.className='';" onmouseup="this.className='';"><div class="buttonSpriteDiv"><span class="buttonSpriteSpan1"><span class="buttonSpriteSpan2">Cancel All</span></span></div></div></a>
+<input type="SUBMIT" name="requestUpdateHoldsSome" value="UPDATE LIST" />
+</form><script type="text/JavaScript">
+<!--Hide the JS
+document.getElementById( 'id_pftitle_items_count' ).innerHTML = '13 HOLDS';
+// Unhide the JS --></script>
+<script type="text/JavaScript"> var patronInfoNav = {menuItemHolds:"13 requests (holds).", menuItemChkout:"0 Items currently checked out", menuItemFines:" in unpaid fines and bills", menuItemBookings:"0 items booked for future use", menuItemIllreqs:"0 Interlibrary loan request"};
+for (var prop in patronInfoNav) {
+    var element = document.getElementById([prop]);
+    if( !!element )
+        element.innerText = patronInfoNav[prop];
+}
+</script>
+<!--this is customized <screens/patronview_encore.html>-->
+   </div>
+<!-- this script must be included for this template to display properly in encore -->
+<script type="text/javascript" src="/screens/setdomain.js"></script>
+</body>
+</html>
+
+

--- a/test/unit/Account.test.js
+++ b/test/unit/Account.test.js
@@ -1,6 +1,8 @@
 /* eslint-env mocha */
+import fs from 'fs';
 import sinon from 'sinon';
 import { expect } from 'chai';
+import { jsdom } from 'jsdom';
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
 
@@ -146,5 +148,58 @@ describe('`fetchAccountPage`', () => {
       expect(axiosGet.calledOnce).to.equal(true);
       expect(axiosGet.firstCall.args[0]).to.equal(`${appConfig.webpacBaseUrl}/dp/patroninfo*eng~Sdefault/6677666/items`);
     });
+  });
+});
+
+describe('preprocessAccountHtml', () => {
+  it('removes <link> and <script> tags from 5.1 markup (1)', () => {
+    const html = fs.readFileSync('./test/fixtures/sierra-5.1-patron-5035845-webpac-holds-markup.html', 'utf8');
+    let dom = jsdom(html);
+
+    // At the start, we expect it to have 2 <link> tags
+    expect(dom.querySelectorAll('link')).to.have.lengthOf(2);
+    // and 5 remote <script> tags
+    expect(dom.querySelectorAll('script[src]')).to.have.lengthOf(5);
+
+    dom = jsdom(Account.preprocessAccountHtml(html))
+
+    // It now has no <link> or remote <script> tags:
+    expect(dom.querySelectorAll('link,script[src]')).to.have.lengthOf(0);
+    // Ensure other critical parts of document remain
+    expect(dom.querySelectorAll('.patFuncTitle a')).to.have.lengthOf(4);
+  });
+
+  it('removes <link> and <script> tags from 5.1 markup (2)', () => {
+    const html = fs.readFileSync('./test/fixtures/sierra-5.1-patron-sb-webpac-holds-markup.html', 'utf8');
+    let dom = jsdom(html);
+
+    // At the start, we expect it to have 2 <link> tags
+    expect(dom.querySelectorAll('link')).to.have.lengthOf(2);
+    // and 5 remote <script> tags
+    expect(dom.querySelectorAll('script[src]')).to.have.lengthOf(5);
+
+    dom = jsdom(Account.preprocessAccountHtml(html))
+
+    // It now has no <link> or remote <script> tags:
+    expect(dom.querySelectorAll('link,script[src]')).to.have.lengthOf(0);
+    // Ensure other critical parts of document remain
+    expect(dom.querySelectorAll('.patFuncTitle a')).to.have.lengthOf(1);
+  });
+
+  it('removes <link> and <script> tags from 5.3 markup (1)', () => {
+    const html = fs.readFileSync('./test/fixtures/sierra-5.3-patron-5427701-webpac-holds-markup.html', 'utf8');
+    let dom = jsdom(html);
+
+    // At the start, we expect it to have 2 <link> tags
+    expect(dom.querySelectorAll('link')).to.have.lengthOf(2);
+    // And 5.3 markup has remote 5 script tags
+    expect(dom.querySelectorAll('script[src]')).to.have.lengthOf(5);
+
+    dom = jsdom(Account.preprocessAccountHtml(html))
+
+    // It now has no <link> or remote <script> tags:
+    expect(dom.querySelectorAll('link,script[src]')).to.have.lengthOf(0);
+    // Ensure other critical parts of document remain
+    expect(dom.querySelectorAll('.patFuncBibTitle a')).to.have.lengthOf(13);
   });
 });

--- a/test/unit/accountPageUtils.test.js
+++ b/test/unit/accountPageUtils.test.js
@@ -84,6 +84,23 @@ describe('manipulateAccountPage', () => {
         'Addresses, historical - political - sociological, by Frederic R. Coudert.'
       ]);
     });
+
+    it('should remove <script> and <link> elements', () => {
+      const dom = jsdom(fs.readFileSync('./test/fixtures/sierra-5.1-patron-5035845-webpac-holds-markup.html', 'utf8'));
+      expect(dom.querySelectorAll('script')).to.have.lengthOf(6);
+      expect(dom.querySelectorAll('link')).to.have.lengthOf(2);
+
+      // Establish some expectations on the original markup:
+      // Starts off with 4 links for 4 holds (some of which are OTF records)
+      // expect(dom.querySelectorAll('.patFuncTitle a')).to.have.lengthOf(4);
+
+      // Apply manipulations:
+      manipulateAccountDom(dom);
+
+      // One script tag will not have been removed because it's inline (no src)
+      expect(dom.querySelectorAll('script')).to.have.lengthOf(1);
+      expect(dom.querySelectorAll('link')).to.have.lengthOf(0);
+    });
   });
 
   describe('Sierra 5.1', () => {

--- a/test/unit/accountPageUtils.test.js
+++ b/test/unit/accountPageUtils.test.js
@@ -1,7 +1,9 @@
 /* eslint-env mocha */
 import { expect } from 'chai';
+import { jsdom } from 'jsdom';
+import fs from 'fs';
 
-import { isClosed, convertEncoreUrl, formatPatronExpirationDate } from './../../src/app/utils/accountPageUtils';
+import { isClosed, convertEncoreUrl, formatPatronExpirationDate, manipulateAccountPage } from './../../src/app/utils/accountPageUtils';
 import appConfig from './../../src/app/data/appConfig';
 
 describe('`isClosed`', () => {
@@ -42,5 +44,81 @@ describe('`formatPatronExpirationDate`', () => {
   it('should transform YYYY-MM-DD to MM-DD-YYYY', () => {
     expect(formatPatronExpirationDate('1997-08-29')).to.eq('08-29-1997')
     expect(formatPatronExpirationDate('2021-1-2')).to.eq('1-2-2021')
+  });
+});
+
+describe('manipulateAccountPage', () => {
+  const manipulateAccountDom = (dom) => {
+    // Add NodeList.forEach polyfill
+    if (window.NodeList && !NodeList.prototype.forEach) {
+      NodeList.prototype.forEach = Array.prototype.forEach;
+    }
+    manipulateAccountPage(
+      dom, // accountPageContent
+      (newContent) => null, // updateAccountHtml
+      { id: 'patronid', patronType: 'patrontype' }, // patron
+      'holds', // contentType
+      (bool) => null, // setIsLoading
+      (obj) => null, // setItemToCancel
+    );
+  };
+
+  describe('Sierra 5.3', () => {
+    it('should remove links to OTF records', () => {
+      const dom = jsdom(fs.readFileSync('./test/fixtures/sierra-5.3-patron-5427701-webpac-holds-markup.html', 'utf8'));
+
+      // Establish some expectations on the original markup:
+      // Starts off with 13 links for 13 holds (some of which are OTF records)
+      expect(dom.querySelectorAll('.patFuncBibTitle a')).to.have.lengthOf(13);
+
+      // Apply manipulations:
+      manipulateAccountDom(dom);
+
+      // 10 links have been removed from 10 OTF records
+      expect(dom.querySelectorAll('.patFuncBibTitle a')).to.have.lengthOf(3);
+      // Check that the linked bibs that remain are not OTF records:
+      const linkedBibTitles = Array.from(dom.querySelectorAll('.patFuncBibTitle a')).map(a => a.textContent);
+      expect(linkedBibTitles).to.have.members([
+        'Toast / by Raquel Pelzel ; photographs by Evan Sung.',
+        '-2 +3 Stefano Arienti, Massimo Bartolini : la Collezione di Museion = die Sammlung Museion = the Museion collection. Minus 2 plus 3 Minus two plus three Stefano Arienti, Massimo Bartolini',
+        'Addresses, historical - political - sociological, by Frederic R. Coudert.'
+      ]);
+    });
+  });
+
+  describe('Sierra 5.1', () => {
+    it('should remove links to OTF records', () => {
+      const dom = jsdom(fs.readFileSync('./test/fixtures/sierra-5.1-patron-5035845-webpac-holds-markup.html', 'utf8'));
+
+      // Establish some expectations on the original markup:
+      // Starts off with 4 links for 4 holds (some of which are OTF records)
+      expect(dom.querySelectorAll('.patFuncTitle a')).to.have.lengthOf(4);
+
+      // Apply manipulations:
+      manipulateAccountDom(dom);
+
+      // 3 links have been removed from 3 OTF records
+      const links = dom.querySelectorAll('.patFuncTitle a')
+      expect(links).to.have.lengthOf(1);
+      // Check that the linked bibs that remain are not OTF records:
+      const linkedBibTitles = Array.from(links).map(a => a.textContent)
+      expect(linkedBibTitles).to.have.members([
+        'A table / Jean Follain.'
+      ]);
+    });
+
+    it('should remove all .patFuncMark TDs whether or not they have an INPUT', () => {
+      const dom = jsdom(fs.readFileSync('./test/fixtures/sierra-5.1-patron-sb-webpac-holds-markup.html', 'utf8'));
+
+      // Establish some expectations on the original markup:
+      // 13 holds with 13 TDs (some of which have checkbox inputs):
+      expect(dom.querySelectorAll('td.patFuncMark')).to.have.lengthOf(5);
+
+      // Apply manipulations:
+      manipulateAccountDom(dom);
+
+      // All of the left-side TDs (some of which had checkboxs) have been removed:
+      expect(dom.querySelectorAll('td.patFuncMark')).to.have.lengthOf(0);
+    });
   });
 });

--- a/test/unit/accountPageUtils.test.js
+++ b/test/unit/accountPageUtils.test.js
@@ -84,23 +84,6 @@ describe('manipulateAccountPage', () => {
         'Addresses, historical - political - sociological, by Frederic R. Coudert.'
       ]);
     });
-
-    it('should remove <script> and <link> elements', () => {
-      const dom = jsdom(fs.readFileSync('./test/fixtures/sierra-5.1-patron-5035845-webpac-holds-markup.html', 'utf8'));
-      expect(dom.querySelectorAll('script')).to.have.lengthOf(6);
-      expect(dom.querySelectorAll('link')).to.have.lengthOf(2);
-
-      // Establish some expectations on the original markup:
-      // Starts off with 4 links for 4 holds (some of which are OTF records)
-      // expect(dom.querySelectorAll('.patFuncTitle a')).to.have.lengthOf(4);
-
-      // Apply manipulations:
-      manipulateAccountDom(dom);
-
-      // One script tag will not have been removed because it's inline (no src)
-      expect(dom.querySelectorAll('script')).to.have.lengthOf(1);
-      expect(dom.querySelectorAll('link')).to.have.lengthOf(0);
-    });
   });
 
   describe('Sierra 5.1', () => {


### PR DESCRIPTION
**What's this do?**

Two fixes:
 - SCC-2848: Fixes display bug with some IN TRANSIT holds where the row
 appears shifted right due to the DOM manipulation failing to remove the
 TD that holds the checkbox (because there is no checkbox for those
 holds
 - SCC-2847: Remove bib links if the hold appears to be for an OTF
 record by sniffing for key phrases in the title.

 This also addresses a few small but critical changes introduced in
 Sierra 5.3. Some selectors had to include alternate classnames. Some
 selectors had to be made more explicit. Some CSS overrides had to be
 added.

 Includes test coverage over the parts of Acct DOM manipulation that
 changed

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SCC-2848
https://jira.nypl.org/browse/SCC-2847

**Do these changes have automated tests?**
Yes

**How should this be QAed?**
Log in to QA My Account at https://qa-www.nypl.org/research/research-catalog/account (do not log in through the Header)

**Dependencies for merging? Releasing to production?**
On QA we'll need to set:
```
LOGIN_URL=http://dev-login.nypl.org/auth/login
WEBPAC_BASE_URL=https://nypl-sierra-test.nypl.org
```

This needs to go live before the production Sierra upgrade as it contains fixes for changes introduced in 5.3

**Has the application documentation been updated for these changes?**
n/a

**Did someone actually run this code to verify it works?**
I did