### PR TITLE
Add list-style instead of tab-style bib info

### DIFF
--- a/src/app/components/BibPage/BibDetails.jsx
+++ b/src/app/components/BibPage/BibDetails.jsx
@@ -14,6 +14,7 @@ import DefinitionList from './DefinitionList';
 import appConfig from '../../data/appConfig';
 import getOwner from '../../utils/getOwner';
 import LibraryItem from '../../utils/item';
+import { combineBibDetailsData } from '../../utils/bibDetailsUtils';
 
 class BibDetails extends React.Component {
   constructor(props) {
@@ -537,8 +538,13 @@ class BibDetails extends React.Component {
     }
 
     const bibDetails = this.getDisplayFields(this.props.bib);
+    const data = combineBibDetailsData(bibDetails, this.props.additionalData);
 
-    return (<DefinitionList data={bibDetails} headings={this.props.bib.subjectHeadingData} />);
+    return (
+      <DefinitionList
+        data={data}
+        headings={this.props.bib.subjectHeadingData}
+      />);
   }
 }
 
@@ -546,10 +552,12 @@ BibDetails.propTypes = {
   bib: PropTypes.object.isRequired,
   fields: PropTypes.array.isRequired,
   electronicResources: PropTypes.array,
+  additionalData: PropTypes.array,
 };
 
 BibDetails.defaultProps = {
   electronicResources: [],
+  additionalData: [],
 };
 
 BibDetails.contextTypes = {

--- a/src/app/components/BibPage/LibraryHoldings.jsx
+++ b/src/app/components/BibPage/LibraryHoldings.jsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import DefinitionList from './DefinitionList';
+import {
+  Heading,
+} from '@nypl/design-system-react-components';
 
 const LibraryHoldings = ({ holdings }) => {
   if (!holdings) {
@@ -36,6 +39,11 @@ const LibraryHoldings = ({ holdings }) => {
 
   return (
     <React.Fragment>
+      <Heading
+        level={3}
+      >
+        Holdings
+      </Heading>
       {
         holdings
         .map(holding =>

--- a/src/app/pages/BibPage.jsx
+++ b/src/app/pages/BibPage.jsx
@@ -31,6 +31,10 @@ import {
   getAggregatedElectronicResources,
 } from '../utils/utils';
 
+import {
+  annotatedMarcDetails,
+} from '../utils/bibDetailsUtils';
+
 const ItemsContainer = itemsContainerModule.ItemsContainer;
 
 const checkForMoreItems = (bib, dispatch) => {
@@ -162,38 +166,47 @@ export const BibPage = (props, context) => {
   ) : null;
   // Related to removing MarcRecord because the webpack MarcRecord is not working. Sep/28/2017
   // const marcRecord = isNYPLReCAP ? <MarcRecord bNumber={bNumber[0]} /> : null;
+  const isNYPL = isNyplBnumber(bib.uri);
 
   const tabDetails = (
-    <BibDetails
-      bib={bib}
-      fields={tabFields}
-      electronicResources={aggregatedElectronicResources}
-    />
+    <React.Fragment>
+      <Heading
+        level={3}
+      >
+        Details
+      </Heading>
+      <BibDetails
+        bib={bib}
+        fields={tabFields}
+        electronicResources={aggregatedElectronicResources}
+        additionalData={isNYPL && bib.annotatedMarc ? annotatedMarcDetails(bib) : []}
+      />
+    </React.Fragment>
   );
 
-  const additionalDetails = (<AdditionalDetailsViewer bib={bib} />);
+  // const additionalDetails = (<AdditionalDetailsViewer bib={bib} />);
 
   // It's an NYPL item if getOwner returns nothing:
-  const isNYPL = isNyplBnumber(bib.uri);
 
   const tabs = [
     itemsContainer ? {
       title: 'Availability',
       content: itemsContainer,
     } : null,
-    {
-      title: 'Details',
-      content: tabDetails,
-    },
-    isNYPL && bib.annotatedMarc ? {
-      title: 'Full Description',
-      content: additionalDetails,
-    } : null,
     bib.holdings ? {
       title: 'Library Holdings',
       content: <LibraryHoldings holdings={bib.holdings} />,
     } : null,
-  ].filter(tab => tab);
+    {
+      title: 'Details',
+      content: tabDetails,
+    },
+    // isNYPL && bib.annotatedMarc ? {
+    //   title: 'Full Description',
+    //   content: additionalDetails,
+    // } : null,
+  ].filter(tab => tab)
+    .map(tab => <React.Fragment><br /> { tab.content }</React.Fragment>);
 
   const classicLink = (
     bibId.startsWith('b') ?
@@ -234,10 +247,13 @@ export const BibPage = (props, context) => {
         logging
         electronicResources={aggregatedElectronicResources}
       />
-      <Tabbed
-        tabs={tabs}
-        hash={location.hash}
-      />
+      {
+        // <Tabbed
+        // tabs={tabs}
+        // hash={location.hash}
+        // />
+        tabs
+      }
       {classicLink}
     </SccContainer>
   );

--- a/src/app/pages/BibPage.jsx
+++ b/src/app/pages/BibPage.jsx
@@ -239,10 +239,6 @@ export const BibPage = (props, context) => {
         electronicResources={aggregatedElectronicResources}
       />
       {
-        // <Tabbed
-        // tabs={tabs}
-        // hash={location.hash}
-        // />
         tabs
       }
       {classicLink}

--- a/src/app/pages/BibPage.jsx
+++ b/src/app/pages/BibPage.jsx
@@ -15,7 +15,6 @@ import itemsContainerModule from '../components/Item/ItemsContainer';
 import BibDetails from '../components/BibPage/BibDetails';
 import LibraryItem from '../utils/item';
 import AdditionalDetailsViewer from '../components/BibPage/AdditionalDetailsViewer';
-import Tabbed from '../components/BibPage/Tabbed';
 import NotFound404 from '../components/NotFound404/NotFound404';
 import LibraryHoldings from '../components/BibPage/LibraryHoldings';
 import getOwner from '../utils/getOwner';
@@ -120,7 +119,7 @@ export const BibPage = (props, context) => {
     { label: 'Supplementary Content', value: 'supplementaryContent', selfLinkable: true },
   ];
 
-  const tabFields = [
+  const detailsFields = [
     { label: 'Additional Authors', value: 'contributorLiteral', linkable: true },
     { label: 'Found In', value: 'partOf' },
     { label: 'Publication Date', value: 'serialPublicationDates' },
@@ -148,7 +147,7 @@ export const BibPage = (props, context) => {
   // we will use the subjectLiteral property from the
   // Discovery API response instead
   if (!bib.subjectHeadingData) {
-    tabFields.push({
+    detailsFields.push({
       label: 'Subject', value: 'subjectLiteral', linkable: true,
     });
   }
@@ -167,7 +166,7 @@ export const BibPage = (props, context) => {
 
   const isNYPL = isNyplBnumber(bib.uri);
 
-  const tabDetails = (
+  const details = (
     <React.Fragment>
       <Heading
         level={3}
@@ -176,14 +175,14 @@ export const BibPage = (props, context) => {
       </Heading>
       <BibDetails
         bib={bib}
-        fields={tabFields}
+        fields={detailsFields}
         electronicResources={aggregatedElectronicResources}
         additionalData={isNYPL && bib.annotatedMarc ? annotatedMarcDetails(bib) : []}
       />
     </React.Fragment>
   );
 
-  const tabs = [
+  const contentAreas = [
     itemsContainer ? {
       title: 'Availability',
       content: itemsContainer,
@@ -194,10 +193,10 @@ export const BibPage = (props, context) => {
     } : null,
     {
       title: 'Details',
-      content: tabDetails,
+      content: details,
     },
-  ].filter(tab => tab)
-    .map(tab => <React.Fragment><br /> { tab.content }</React.Fragment>);
+  ].filter(area => area)
+    .map(area => <React.Fragment><br /> { area.content }</React.Fragment>);
 
   const classicLink = (
     bibId.startsWith('b') ?
@@ -239,7 +238,7 @@ export const BibPage = (props, context) => {
         electronicResources={aggregatedElectronicResources}
       />
       {
-        tabs
+        contentAreas
       }
       {classicLink}
     </SccContainer>

--- a/src/app/pages/BibPage.jsx
+++ b/src/app/pages/BibPage.jsx
@@ -164,8 +164,7 @@ export const BibPage = (props, context) => {
       holdings={bib.holdings}
     />
   ) : null;
-  // Related to removing MarcRecord because the webpack MarcRecord is not working. Sep/28/2017
-  // const marcRecord = isNYPLReCAP ? <MarcRecord bNumber={bNumber[0]} /> : null;
+
   const isNYPL = isNyplBnumber(bib.uri);
 
   const tabDetails = (
@@ -184,10 +183,6 @@ export const BibPage = (props, context) => {
     </React.Fragment>
   );
 
-  // const additionalDetails = (<AdditionalDetailsViewer bib={bib} />);
-
-  // It's an NYPL item if getOwner returns nothing:
-
   const tabs = [
     itemsContainer ? {
       title: 'Availability',
@@ -201,10 +196,6 @@ export const BibPage = (props, context) => {
       title: 'Details',
       content: tabDetails,
     },
-    // isNYPL && bib.annotatedMarc ? {
-    //   title: 'Full Description',
-    //   content: additionalDetails,
-    // } : null,
   ].filter(tab => tab)
     .map(tab => <React.Fragment><br /> { tab.content }</React.Fragment>);
 

--- a/src/app/utils/bibDetailsUtils.jsx
+++ b/src/app/utils/bibDetailsUtils.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+
+const definitionItem = (value, index = 0) => {
+  const link = (
+    <a href={value.content} title={JSON.stringify(value.source, null, 2)}>
+      {value.label}
+    </a>
+  );
+
+  return (
+    <div key={index}>
+      { value.label ? link : value.content }
+      { value.parallels ? value.parallels : null }
+    </div>
+  );
+};
+
+const annotatedMarcDetails = bib =>
+  bib.annotatedMarc.bib.fields.map(field => (
+    {
+      term: field.label,
+      definition: field.values.map(definitionItem),
+    }
+  ));
+
+const combineBibDetailsData = (bibDetails, additionalData) => {
+  const bibDetailsTerms = new Set(bibDetails.map(item => item.term));
+  const filteredAdditionalData = additionalData.filter(item => !bibDetailsTerms.has(item.term));
+  return bibDetails.concat(filteredAdditionalData);
+};
+
+export {
+  definitionItem,
+  annotatedMarcDetails,
+  combineBibDetailsData,
+};

--- a/test/unit/BibPage.test.js
+++ b/test/unit/BibPage.test.js
@@ -20,27 +20,40 @@ import { mockRouterContext } from '../helpers/routing';
 describe('BibPage', () => {
   const context = mockRouterContext();
   describe('Non-serial bib', () => {
+    const testStore = makeTestStore({
+      bib: {
+        done: true,
+        numItems: 0,
+      },
+    });
     let component;
     before(() => {
       const bib = { ...bibs[0], ...annotatedMarc };
-      component = shallow(
-        <BibPage
-          location={{ search: 'search', pathname: '' }}
-          bib={bib}
-          dispatch={() => {}}
-          resultSelection={{
-            fromUrl: '',
-            bibId: '',
-          }}
-        />, { context });
-      });
-    it('has Tabbed component with three tabs', () => {
-      const tabbed = component.find('Tabbed');
-      const tabs = tabbed.props().tabs;
-      const tabTitles = tabs.map(tab => tab.title);
-      expect(tabbed.length).to.equal(1);
-      expect(tabs.length).to.equal(3);
-      expect(tabTitles).to.deep.equal(['Availability', 'Details', 'Full Description']);
+      component = mount(
+        <Provider store={testStore}>
+          <BibPage
+            location={{ search: 'search', pathname: '' }}
+            bib={bib}
+            dispatch={() => {}}
+            resultSelection={{
+              fromUrl: '',
+              bibId: '',
+            }}
+          />
+        </Provider>, { context, childContextTypes: { router: PropTypes.object } });
+    });
+
+
+    it('has ItemsContainer', () => {
+      expect(component.find('ItemsContainer').length).to.equal(1);
+    });
+
+    it('has Details section', () => {
+      expect(component.find('Heading').at(3).prop('children')).to.equal('Details');
+    });
+
+    it('combines details sections', () => {
+      expect(component.findWhere(el => el.type() === 'dt' && el.text() === 'Abbreviated Title').length).to.equal(1);
     });
 
     it('has "View in Legacy Catalog" link', () => {
@@ -83,13 +96,16 @@ describe('BibPage', () => {
       itemTable = component.find('ItemTable');
     });
 
-    it('has Tabbed component with four tabs', () => {
-      const tabbed = component.find('Tabbed');
-      const tabs = tabbed.props().tabs;
-      const tabTitles = tabs.map(tab => tab.title);
-      expect(tabbed.length).to.equal(1);
-      expect(tabs.length).to.equal(4);
-      expect(tabTitles).to.deep.equal(['Availability', 'Details', 'Full Description', 'Library Holdings']);
+    it('has ItemsContainer', () => {
+      expect(component.find('ItemsContainer').length).to.equal(1);
+    });
+
+    it('has Details section', () => {
+      expect(component.find('Heading').at(4).prop('children')).to.equal('Details');
+    });
+
+    it('has holdings section', () => {
+      expect(component.find('LibraryHoldings').length).to.equal(1);
     });
 
     it('has item table with volume column', () => {

--- a/test/unit/bibDetailsUtils.test.js
+++ b/test/unit/bibDetailsUtils.test.js
@@ -1,0 +1,153 @@
+/* eslint-env mocha */
+
+import React from 'react';
+import { expect } from 'chai';
+import { shallow, mount } from 'enzyme';
+
+import {
+  definitionItem,
+  annotatedMarcDetails,
+  combineBibDetailsData,
+} from '../../src/app/utils/bibDetailsUtils';
+
+describe.only('bibDetailsUtils', () => {
+  describe('definitionItem', () => {
+    const value = {
+      label: 'ItemLabel',
+      content: 'ItemContent',
+      source: { itemSource: 'nypl' },
+    };
+
+    const item = definitionItem(value);
+
+    it('should be a div', () => {
+      expect(item.type).to.equal('div');
+    });
+
+    it('should default to index 0', () => {
+      expect(item.key).to.equal('0');
+    });
+
+    it('should have a link with correct information', () => {
+      const link = item.props.children[0];
+      expect(link.type).to.equal('a');
+      expect(link.props.href).to.equal('ItemContent');
+      expect(link.props.title).to.equal(JSON.stringify(value.source, null, 2));
+      expect(link.props.children).to.equal('ItemLabel');
+    });
+
+    it('should accept index param', () => {
+      expect(definitionItem(value, 1).key).to.equal('1');
+    });
+
+    it('should default to content if label is not present', () => {
+      const valueMissingLabel = {
+        content: 'ItemContent',
+        source: { itemSource: 'nypl' },
+      };
+
+      const itemMissingLabel = definitionItem(valueMissingLabel);
+
+      expect(itemMissingLabel.props.children[0]).to.equal('ItemContent');
+    });
+
+    it('should display parallels if available', () => {
+      const valueWithParallels = {
+        label: 'ItemLabel',
+        content: 'ItemContent',
+        source: { itemSource: 'nypl' },
+        parallels: 'Parallel',
+      };
+
+      const itemWithParallels = definitionItem(valueWithParallels);
+
+      expect(itemWithParallels.props.children[1]).to.equal('Parallel');
+    });
+  });
+
+  describe('annotatedMarcDetails', () => {
+    it('should map fields in annotated marc to term,definition pairs, where term points to field label and definition points to list of definition items populated from field values', () => {
+      const mockBib = {
+        annotatedMarc: {
+          bib: {
+            fields: [
+              {
+                label: 'Field1',
+                values: [
+                  {
+                    label: 'ItemLabel1',
+                    content: 'ItemContent1',
+                    source: { itemSource: 'nypl' },
+                  },
+                  {
+                    label: 'ItemLabel2',
+                    content: 'ItemContent2',
+                    source: { itemSource: 'nypl' },
+                  },
+                ],
+              },
+              {
+                label: 'Field2',
+                values: [
+                  {
+                    label: 'ItemLabel3',
+                    content: 'ItemContent3',
+                    source: { itemSource: 'nypl' },
+                  },
+                  {
+                    label: 'ItemLabel4',
+                    content: 'ItemContent4',
+                    source: { itemSource: 'nypl' },
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      };
+
+      const mockOutput = annotatedMarcDetails(mockBib);
+      expect(mockOutput.length).to.equal(2);
+      expect(mockOutput[0].term).to.equal('Field1');
+      expect(mockOutput[0].definition[0].props.children[0].props.children).to.equal('ItemLabel1');
+      expect(mockOutput[0].definition[1].props.children[0].props.children).to.equal('ItemLabel2');
+      expect(mockOutput[1].term).to.equal('Field2');
+      expect(mockOutput[1].definition[0].props.children[0].props.children).to.equal('ItemLabel3');
+      expect(mockOutput[1].definition[1].props.children[0].props.children).to.equal('ItemLabel4');
+    });
+  });
+
+  describe('combineBibDetailsData', () => {
+    it('should combine two lists, dropping items from second list whose term property already exists in first list', () => {
+      const list1 = [
+        { term: 'a', value: '1' },
+        { term: 'c', value: '4' },
+        { term: 'a', value: '2' },
+        { term: 'b', value: '3' },
+      ];
+
+      const list2 = [
+        { term: 'b', value: '7' },
+        { term: 'a', value: '5' },
+        { term: 'd', value: '9' },
+        { term: 'a', value: '6' },
+        { term: 'e', value: '10' },
+        { term: 'd', value: '8' },
+      ];
+
+      expect(JSON.stringify(combineBibDetailsData(list1, list2))).to.equal(
+        JSON.stringify(
+          [
+            { term: 'a', value: '1' },
+            { term: 'c', value: '4' },
+            { term: 'a', value: '2' },
+            { term: 'b', value: '3' },
+            { term: 'd', value: '9' },
+            { term: 'e', value: '10' },
+            { term: 'd', value: '8' },
+          ],
+        ),
+      );
+    });
+  });
+});

--- a/test/unit/bibDetailsUtils.test.js
+++ b/test/unit/bibDetailsUtils.test.js
@@ -10,7 +10,7 @@ import {
   combineBibDetailsData,
 } from '../../src/app/utils/bibDetailsUtils';
 
-describe.only('bibDetailsUtils', () => {
+describe('bibDetailsUtils', () => {
   describe('definitionItem', () => {
     const value = {
       label: 'ItemLabel',


### PR DESCRIPTION
**What's this do?**
- Removes tabs from the Bib page, and replaces with sequential sections
- Combines the two details tabs into one section

**Why are we doing this? (w/ JIRA link if applicable)**
This is scc-2813

**Do these changes have automated tests?**
Yes

**How should this be QAed?**
Viewing any bib page should show the new layout. Should look at:
- A serials page (to see holdings section)
- A non-serials page (no holdings section)
- A partner page (to check there are no errors in case of a missing details tab)

**Dependencies for merging? Releasing to production?**
No

**Has the application documentation been updated for these changes?**
NA

**Did someone actually run this code to verify it works?**
Yes.
