### PR TITLE
Scc 2842 2

### DIFF
--- a/src/app/utils/utils.js
+++ b/src/app/utils/utils.js
@@ -172,6 +172,11 @@ const getFieldParam = (field = '') => {
   return `&search_scope=${field}`;
 };
 
+const getIdentifierQuery = (identifierNumbers = {}) =>
+  Object.entries(identifierNumbers).map(
+    ([key, value]) => (value ? `&${key}=${value}` : ''),
+  ).join('');
+
 /**
  * Tracks Google Analytics (GA) events. `.trackEvent` returns a function with
  * 'Discovery' set as the GA Category. `trackDiscovery` will then log the defined
@@ -202,10 +207,13 @@ const basicQuery = (props = {}) => {
     selectedFilters,
     searchKeywords,
     page,
+    identifierNumbers,
   }) => {
     const sortQuery = getSortQuery(sortBy || props.sortBy);
     const fieldQuery = getFieldParam(field || props.field);
     const filterQuery = getFilterParam(selectedFilters || props.selectedFilters);
+    const identifierQuery = getIdentifierQuery(identifierNumbers || props.identifierNumbers);
+    console.log('identifierQuery: ', identifierQuery);
     // `searchKeywords` can be an empty string, so check if it's undefined instead.
     const query = searchKeywords !== undefined ? searchKeywords : props.searchKeywords;
     const searchKeywordsQuery = query ? `${encodeURIComponent(query)}` : '';
@@ -213,7 +221,7 @@ const basicQuery = (props = {}) => {
     pageQuery = page && page !== '1' ? `&page=${page}` : pageQuery;
     pageQuery = page === '1' ? '' : pageQuery;
 
-    const completeQuery = `${searchKeywordsQuery}${filterQuery}${sortQuery}${fieldQuery}${pageQuery}`;
+    const completeQuery = `${searchKeywordsQuery}${filterQuery}${sortQuery}${fieldQuery}${pageQuery}${identifierQuery}`;
 
     return completeQuery ? `q=${completeQuery}` : null;
   };
@@ -227,6 +235,7 @@ const basicQuery = (props = {}) => {
  * @param {object} query The request query object from Express.
  */
 function getReqParams(query = {}) {
+  console.log('query: ', query);
   const page = query.page || '1';
   const perPage = query.per_page || '50';
   const q = query.q || '';
@@ -235,8 +244,28 @@ function getReqParams(query = {}) {
   const sortQuery = query.sort_scope || '';
   const fieldQuery = query.search_scope || '';
   const filters = query.filters || {};
+  const {
+    issn,
+    isbn,
+    oclc,
+    lccn,
+    redirectOnMatch,
+  } = query;
 
-  return { page, perPage, q, sort, order, sortQuery, fieldQuery, filters };
+  return {
+    page,
+    perPage,
+    q,
+    sort,
+    order,
+    sortQuery,
+    fieldQuery,
+    filters,
+    issn,
+    isbn,
+    oclc,
+    lccn,
+    redirectOnMatch };
 }
 
 /*

--- a/src/app/utils/utils.js
+++ b/src/app/utils/utils.js
@@ -213,7 +213,6 @@ const basicQuery = (props = {}) => {
     const fieldQuery = getFieldParam(field || props.field);
     const filterQuery = getFilterParam(selectedFilters || props.selectedFilters);
     const identifierQuery = getIdentifierQuery(identifierNumbers || props.identifierNumbers);
-    console.log('identifierQuery: ', identifierQuery);
     // `searchKeywords` can be an empty string, so check if it's undefined instead.
     const query = searchKeywords !== undefined ? searchKeywords : props.searchKeywords;
     const searchKeywordsQuery = query ? `${encodeURIComponent(query)}` : '';
@@ -235,7 +234,6 @@ const basicQuery = (props = {}) => {
  * @param {object} query The request query object from Express.
  */
 function getReqParams(query = {}) {
-  console.log('query: ', query);
   const page = query.page || '1';
   const perPage = query.per_page || '50';
   const q = query.q || '';

--- a/src/app/utils/utils.js
+++ b/src/app/utils/utils.js
@@ -630,6 +630,7 @@ export {
   getFilterParam,
   destructureFilters,
   getDefaultFilters,
+  getIdentifierQuery,
   basicQuery,
   getReqParams,
   parseServerSelectedFilters,

--- a/src/server/ApiRoutes/Search.js
+++ b/src/server/ApiRoutes/Search.js
@@ -26,6 +26,7 @@ const createAPIQuery = basicQuery({
   sortBy: 'relevance',
   field: 'all',
   selectedFilters: {},
+  identifierNumbers: {},
 });
 
 const nyplApiClientCall = (query, urlEnabledFeatures = []) => {
@@ -37,14 +38,17 @@ const nyplApiClientCall = (query, urlEnabledFeatures = []) => {
     );
 };
 
-function fetchResults(searchKeywords = '', page, sortBy, order, field, filters, cb, errorcb, features) {
+function fetchResults(searchKeywords = '', page, sortBy, order, field, filters, identifierNumbers, expressRes, cb, errorcb, features) {
   const encodedResultsQueryString = createAPIQuery({
     searchKeywords,
     sortBy: sortBy ? `${sortBy}_${order}` : '',
     selectedFilters: filters,
     field,
     page,
+    identifierNumbers,
   });
+
+  console.log('encodedResultsQueryString: ', encodedResultsQueryString);
   const encodedAggregationsQueryString = createAPIQuery({
     searchKeywords,
     selectedFilters: filters,
@@ -88,6 +92,12 @@ function fetchResults(searchKeywords = '', page, sortBy, order, field, filters, 
   ])
     .then((response) => {
       const [results, aggregations, drbbResults] = response;
+      console.log('results: ', results);
+      if (identifierNumbers.redirectOnMatch && results.totalResults === 1) {
+        console.log('result: ', JSON.stringify(results.itemListElement[0].result, null, 2));
+        const bnumber = results.itemListElement[0].result.uri;
+        return expressRes.redirect(`${appConfig.baseUrl}/bib/${bnumber}`);
+      }
       const locationCodes = new Set();
       const { itemListElement } = results;
       if (!itemListElement) {
@@ -147,7 +157,25 @@ function fetchResults(searchKeywords = '', page, sortBy, order, field, filters, 
 }
 
 function search(req, res, resolve) {
-  const { page, q, sort, order, fieldQuery, filters } = getReqParams(req.query);
+
+  console.log('search:');
+  const {
+    page,
+    q,
+    sort,
+    order,
+    fieldQuery,
+    filters,
+    issn,
+    isbn,
+    oclc,
+    lccn,
+    redirectOnMatch,
+  } = getReqParams(req.query);
+
+  const identifierNumbers = { issn, isbn, oclc, lccn, redirectOnMatch };
+
+  console.log('identifierNumbers: ', identifierNumbers);
 
   const sortBy = sort.length ? [sort, order].filter(field => field.length).join('_') : 'relevance';
 
@@ -170,6 +198,8 @@ function search(req, res, resolve) {
     order,
     apiQueryField,
     apiQueryFilters,
+    identifierNumbers,
+    res,
     (apiFilters, searchResults, pageQuery, drbbResults) => resolve({
       filters: apiFilters,
       searchResults,
@@ -186,6 +216,7 @@ function search(req, res, resolve) {
 }
 
 function searchServerPost(req, res) {
+  console.log('search server post');
   const { fieldQuery, q, filters, sortQuery } = getReqParams(req.body);
   const { dateAfter, dateBefore } = req.body;
   // The filters from req.body may be an array of selected filters, or just an object

--- a/src/server/ApiRoutes/Search.js
+++ b/src/server/ApiRoutes/Search.js
@@ -48,7 +48,6 @@ function fetchResults(searchKeywords = '', page, sortBy, order, field, filters, 
     identifierNumbers,
   });
 
-  console.log('encodedResultsQueryString: ', encodedResultsQueryString);
   const encodedAggregationsQueryString = createAPIQuery({
     searchKeywords,
     selectedFilters: filters,
@@ -92,9 +91,7 @@ function fetchResults(searchKeywords = '', page, sortBy, order, field, filters, 
   ])
     .then((response) => {
       const [results, aggregations, drbbResults] = response;
-      console.log('results: ', results);
       if (identifierNumbers.redirectOnMatch && results.totalResults === 1) {
-        console.log('result: ', JSON.stringify(results.itemListElement[0].result, null, 2));
         const bnumber = results.itemListElement[0].result.uri;
         return expressRes.redirect(`${appConfig.baseUrl}/bib/${bnumber}`);
       }
@@ -157,8 +154,6 @@ function fetchResults(searchKeywords = '', page, sortBy, order, field, filters, 
 }
 
 function search(req, res, resolve) {
-
-  console.log('search:');
   const {
     page,
     q,
@@ -174,8 +169,6 @@ function search(req, res, resolve) {
   } = getReqParams(req.query);
 
   const identifierNumbers = { issn, isbn, oclc, lccn, redirectOnMatch };
-
-  console.log('identifierNumbers: ', identifierNumbers);
 
   const sortBy = sort.length ? [sort, order].filter(field => field.length).join('_') : 'relevance';
 
@@ -216,7 +209,6 @@ function search(req, res, resolve) {
 }
 
 function searchServerPost(req, res) {
-  console.log('search server post');
   const { fieldQuery, q, filters, sortQuery } = getReqParams(req.body);
   const { dateAfter, dateBefore } = req.body;
   // The filters from req.body may be an array of selected filters, or just an object

--- a/test.env
+++ b/test.env
@@ -10,3 +10,4 @@ export SET WEBPAC_BASE_URL=http://webpac.nypl.org
 export SET KMS_ENV=unencrypted
 export SET BASE_URL=/research/research-catalog
 export SET DRB_API_BASE_URL=http://example.com/search/
+export SET SHEP_BIBS_LIMIT=10

--- a/test/unit/BibsList.test.js
+++ b/test/unit/BibsList.test.js
@@ -173,7 +173,7 @@ describe('BibsList', () => {
             setTimeout(() => {
               component.setProps({});
               setImmediate(() => {
-                expect(uri).to.equal('/api/subjectHeading/abcdefg?&sort=date&sort_direction=desc&per_page=50&shep_bib_count=undefined&shep_uuid=undefined');
+                expect(uri).to.equal('/api/subjectHeading/abcdefg?&sort=date&sort_direction=desc&per_page=10&shep_bib_count=undefined&shep_uuid=undefined');
               });
               setImmediate(() => resolve());
             }, 100);

--- a/test/unit/CachedAxios.test.js
+++ b/test/unit/CachedAxios.test.js
@@ -5,7 +5,7 @@ import { expect } from 'chai';
 import appConfig from '../../src/app/data/appConfig';
 import CachedAxios from '../../src/app/utils/CachedAxios';
 
-describe.only('Cached Axios', () => {
+describe('Cached Axios', () => {
   let callCount = 0;
   let savedBaseUrl;
   const cachedAxios = new CachedAxios();

--- a/test/unit/utils.test.js
+++ b/test/unit/utils.test.js
@@ -499,6 +499,11 @@ describe('getReqParams', () => {
         fieldQuery: '',
         filters: {},
         perPage: '50',
+        issn: undefined,
+        isbn: undefined,
+        lccn: undefined,
+        oclc: undefined,
+        redirectOnMatch: undefined,
       });
     });
   });
@@ -515,6 +520,11 @@ describe('getReqParams', () => {
         fieldQuery: '',
         filters: {},
         perPage: '50',
+        issn: undefined,
+        isbn: undefined,
+        lccn: undefined,
+        oclc: undefined,
+        redirectOnMatch: undefined,
       });
     });
 
@@ -529,6 +539,11 @@ describe('getReqParams', () => {
         fieldQuery: '',
         filters: {},
         perPage: '50',
+        issn: undefined,
+        isbn: undefined,
+        lccn: undefined,
+        oclc: undefined,
+        redirectOnMatch: undefined,
       });
     });
 
@@ -543,6 +558,11 @@ describe('getReqParams', () => {
         fieldQuery: '',
         filters: {},
         perPage: '50',
+        issn: undefined,
+        isbn: undefined,
+        lccn: undefined,
+        oclc: undefined,
+        redirectOnMatch: undefined,
       });
     });
 
@@ -557,6 +577,11 @@ describe('getReqParams', () => {
         fieldQuery: 'author',
         filters: {},
         perPage: '50',
+        issn: undefined,
+        isbn: undefined,
+        lccn: undefined,
+        oclc: undefined,
+        redirectOnMatch: undefined,
       });
     });
 
@@ -571,6 +596,11 @@ describe('getReqParams', () => {
         fieldQuery: '',
         filters: {},
         perPage: '50',
+        issn: undefined,
+        isbn: undefined,
+        lccn: undefined,
+        oclc: undefined,
+        redirectOnMatch: undefined,
       });
     });
 
@@ -585,6 +615,11 @@ describe('getReqParams', () => {
         fieldQuery: '',
         filters: 'filters[owner]=orgs%3A1000',
         perPage: '50',
+        issn: undefined,
+        isbn: undefined,
+        lccn: undefined,
+        oclc: undefined,
+        redirectOnMatch: undefined,
       });
     });
   });

--- a/test/unit/utils.test.js
+++ b/test/unit/utils.test.js
@@ -11,6 +11,7 @@ import {
   createAppHistory,
   destructureFilters,
   getSortQuery,
+  getIdentifierQuery,
   getFilterParam,
   getFieldParam,
   basicQuery,
@@ -481,6 +482,17 @@ describe('basicQuery', () => {
         page: '5',
       })).to.equal('q=hamlet&sort=title&sort_direction=asc&search_scope=title&page=5');
     });
+
+    it('should update the identifier number query', () => {
+      expect(createAPIQuery({
+        identifierNumbers: {
+          issn: '1234',
+          isbn: '2345',
+          oclc: '3456',
+          lccn: '4567',
+        },
+      })).to.equal('q=&issn=1234&isbn=2345&oclc=3456&lccn=4567');
+    });
   });
 });
 
@@ -620,6 +632,25 @@ describe('getReqParams', () => {
         lccn: undefined,
         oclc: undefined,
         redirectOnMatch: undefined,
+      });
+    });
+
+    it('should pass identifier number related params', () => {
+      const queryFromUrl = { issn: '1234-5678', isbn: '0123456789', lccn: '12345678', oclc: '234567890', redirectOnMatch: 'true' };
+      expect(getReqParams(queryFromUrl)).to.eql({
+        page: '1',
+        q: '',
+        sort: '',
+        order: '',
+        sortQuery: '',
+        fieldQuery: '',
+        filters: {},
+        perPage: '50',
+        issn: '1234-5678',
+        isbn: '0123456789',
+        lccn: '12345678',
+        oclc: '234567890',
+        redirectOnMatch: 'true',
       });
     });
   });
@@ -855,5 +886,16 @@ describe('isNyplBnumber', () => {
     expect(isNyplBnumber('pb1234')).to.eq(false);
     expect(isNyplBnumber('hb1234')).to.eq(false);
     expect(isNyplBnumber('cb1234')).to.eq(false);
+  });
+});
+
+describe('getIdentifierQuery', () => {
+  it('should combine key-value pairs into a query', () => {
+    expect(getIdentifierQuery({
+      issn: '1234',
+      isbn: '23456',
+      oclc: '34567',
+      lccn: '45678',
+    })).to.equal('&issn=1234&isbn=23456&oclc=34567&lccn=45678');
   });
 });


### PR DESCRIPTION
**What's this do?**
- Passes identifier number params (`issn`, `isbn`, `lccn`, `oclc`) to `discovery-api` when searching
- In case `redirectOnMatch` is truthy and frontend receives a single item in response, redirect immediately to the relevant bib page
- Fix some broken tests

**Why are we doing this? (w/ JIRA link if applicable)**
This is scc-2842. We are trying to improve support for requests for pages by identifier number redirected from WorldCat

**Do these changes have automated tests?**
Yes

**How should this be QAed?**
- Add an identifier number as a param in search and you should get a list of bibs with that number
- in case only one result and `redirectOnMatch` is true, should redirect to the Bib page.

**Dependencies for merging? Releasing to production?**
Depends on corresponding changes to `discovery-api`

**Has the application documentation been updated for these changes?**
NA

**Did someone actually run this code to verify it works?**
Yes.
