### PR TITLE
Add Harvard to landing text

### DIFF
--- a/src/app/pages/Home.jsx
+++ b/src/app/pages/Home.jsx
@@ -36,10 +36,10 @@ const Home = (props, context) => (
     </Heading>
     <div className="nypl-column-full">
       <p className="nypl-lead">
-        Discover millions of items from The New York Public Library's Stephen A. Schwarzman Building, Schomburg Center for Research in Black Culture, and The New York Public Library for the Performing Arts. Plus, access materials from library collections at Columbia University and Princeton University. <Link href="https://www.nypl.org/research/collections/about/shared-collection-catalog">Learn more.</Link>
+        Discover millions of items from The New York Public Library's Stephen A. Schwarzman Building, Schomburg Center for Research in Black Culture, and The New York Public Library for the Performing Arts. Plus, access materials from library collections at Columbia University, Harvard University, and Princeton University. <Link href="https://www.nypl.org/research/collections/about/shared-collection-catalog">Learn more.</Link>
       </p>
       <p>
-        Please note that the Research Catalog does not include circulating materials. For books and more that you can check out to take home please visit our <Link href="https://browse.nypl.org">circulating branch catalog.</Link> The <Link href="https://legacycatalog.nypl.org/">legacy research catalog</Link> is still available, but does not include all of our Scan & Deliver options or the Columbia University and Princeton University material from the Shared Collection.
+        Please note that the Research Catalog does not include circulating materials. For books and more that you can check out to take home please visit our <Link href="https://browse.nypl.org">circulating branch catalog.</Link> The <Link href="https://legacycatalog.nypl.org/">legacy research catalog</Link> is still available, but does not include all of our Scan & Deliver options or the Columbia University, Harvard University, and Princeton University material from the Shared Collection.
       </p>
     </div>
     <div>


### PR DESCRIPTION
**What's this do?**
Adds Harvard University to landing text

**Why are we doing this? (w/ JIRA link if applicable)**
This is scc-2845

**Do these changes have automated tests?**
We need to add tests for the Home component, but it doesn't seem worth holding up this small change.

**How should this be QAed?**
Should be obvious on the landing page.

**Dependencies for merging? Releasing to production?**
No

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Yes
