### PR TITLE
Add new link color for advanced search link

### DIFF
--- a/src/client/styles/components/AdvancedSearch.scss
+++ b/src/client/styles/components/AdvancedSearch.scss
@@ -1,3 +1,10 @@
+#advanced-search-link-container {
+  a {
+    color: #0271CC;
+  }
+}
+
+
 .advancedSearchContainer.content-primary {
     min-height: 650px;
 


### PR DESCRIPTION
**What's this do?**
Changes the Advanced Search link to a new color with better contrast

**Why are we doing this? (w/ JIRA link if applicable)**
We need better contrast to meet accessibility standards. This is scc-2807

**Did someone actually run this code to verify it works?**

Yes