### PR TITLE
Add itemId when creating new hold

### DIFF
--- a/src/server/ApiRoutes/Bib.js
+++ b/src/server/ApiRoutes/Bib.js
@@ -151,7 +151,7 @@ function fetchBib(bibId, cb, errorcb, reqOptions, res) {
       return data;
     })
     .then((bib) => {
-      const status = (!bib || !bib.uri || bib.uri !== bibId) ? '404' : '200';
+      const status = (!bib || !bib.uri || !bibId.includes(bib.uri)) ? '404' : '200';
       if (status === '404') {
         return nyplApiClient()
           .then(client => client.get(`/bibs/sierra-nypl/${bibId.slice(1)}`))

--- a/src/server/ApiRoutes/Hold.js
+++ b/src/server/ApiRoutes/Hold.js
@@ -304,7 +304,7 @@ function newHoldRequest(req, res, resolve) {
   const { redirect } = requireUser;
   if (redirect) return resolve({ redirect });
 
-  const bibId = req.params.bibId || '';
+  const bibId = (req.params.bibId || '') + (req.params.itemId ? `-${req.params.itemId}` : '');
   const patronId = req.patronTokenResponse.decodedPatron ?
     req.patronTokenResponse.decodedPatron.sub : '';
   let barcode;


### PR DESCRIPTION
**What's this do?**
Adds the `itemId` parameter to the bib request when creating a new hold

**Why are we doing this? (w/ JIRA link if applicable)**
Currently, we cannot create holds for items past 100 because of limits on the items included in the discovery api response.

**How should this be QAed?**
b21088122-i32086897 is a bib-item pair for an item past 100. If you can place a hold on this item in QA, it worked.

**Dependencies for merging? Releasing to production?**
For merging to production, depends on the corresponding api changes being deployed

**Has the application documentation been updated for these changes?**
NA

**Did someone actually run this code to verify it works?**
Yes
