### PR TITLE
Add Donor/Sponsor in detailsFields

### DIFF
--- a/src/app/pages/BibPage.jsx
+++ b/src/app/pages/BibPage.jsx
@@ -124,6 +124,7 @@ export const BibPage = (props, context) => {
     { label: 'Found In', value: 'partOf' },
     { label: 'Publication Date', value: 'serialPublicationDates' },
     { label: 'Description', value: 'extent' },
+    { label: 'Donor/Sponsor', value: 'donor' },
     { label: 'Series Statement', value: 'seriesStatement' },
     { label: 'Uniform Title', value: 'uniformTitle' },
     { label: 'Alternative Title', value: 'titleAlt' },


### PR DESCRIPTION
**What's this do?**
Adds a display field for Donor/Sponsor

**Why are we doing this? (w/ JIRA link if applicable)**
This is part of the Index Added Titles work, scc-2827

**Did someone actually run this code to verify it works?**
Yes
