### PR TITLE
Add addition of word 'Note' to note fields

### DIFF
--- a/src/app/components/BibPage/BibDetails.jsx
+++ b/src/app/components/BibPage/BibDetails.jsx
@@ -258,7 +258,7 @@ class BibDetails extends React.Component {
 
   getNoteType(note) {
     const type = note.noteType || '';
-    return type.toLowerCase().includes('note') ? type : `${type} Note`;
+    return type.toLowerCase().includes('note') ? type : `${type} (note)`;
   }
 
   /**

--- a/src/app/components/BibPage/BibDetails.jsx
+++ b/src/app/components/BibPage/BibDetails.jsx
@@ -249,6 +249,19 @@ class BibDetails extends React.Component {
   }
 
   /**
+   * getNoteType(note)
+   * Construct label for a note by adding the word 'Note'
+   *
+   * @param {object} note
+   * @return {string}
+   */
+
+  getNoteType(note) {
+    const type = note.noteType || '';
+    return type.toLowerCase().includes('note') ? type : `${type} Note`;
+  }
+
+  /**
    * getDisplayFields(bib)
    * Get an array of definition term/values.
    *
@@ -330,8 +343,9 @@ class BibDetails extends React.Component {
             // Make sure all notes are blanknodes:
             .filter(n => (typeof n) === 'object')
             .reduce((groups, n) => {
-              if (!groups[n.noteType]) groups[n.noteType] = [];
-              groups[n.noteType].push(n);
+              const noteType = this.getNoteType(n);
+              if (!groups[noteType]) groups[noteType] = [];
+              groups[noteType].push(n);
               return groups;
             }, {});
 

--- a/test/unit/BibDetails.test.js
+++ b/test/unit/BibDetails.test.js
@@ -209,7 +209,7 @@ describe('BibDetails', () => {
       );
 
       expect(component.find('dt').length).to.equal(2);
-      expect(component.find('dt').at(0).text()).to.equal('Language Note');
+      expect(component.find('dt').at(0).text()).to.equal('Language (note)');
       expect(component.find('dt').at(1).text()).to.equal('Explanatory Note');
     });
   });

--- a/test/unit/BibDetails.test.js
+++ b/test/unit/BibDetails.test.js
@@ -189,4 +189,28 @@ describe('BibDetails', () => {
       });
     });
   });
+
+  describe('getDisplayFields', () => {
+    it('modifies note fields appropriately', () => {
+      const component = mount(
+        React.createElement(BibDetails,
+          {
+            bib: {
+              note: [
+                { noteType: 'Language', prefLabel: 'In Urdu' },
+                { noteType: 'Explanatory Note', prefLabel: 'These regulations are to make provision...' },
+              ],
+            },
+            fields: [{ label: 'Notes', value: 'React Component' }],
+            electronicResources: [],
+            additionalData: [],
+          },
+        ),
+      );
+
+      expect(component.find('dt').length).to.equal(2);
+      expect(component.find('dt').at(0).text()).to.equal('Language Note');
+      expect(component.find('dt').at(1).text()).to.equal('Explanatory Note');
+    });
+  });
 });

--- a/test/unit/BibDetails.test.js
+++ b/test/unit/BibDetails.test.js
@@ -198,7 +198,7 @@ describe('BibDetails', () => {
             bib: {
               note: [
                 { noteType: 'Language', prefLabel: 'In Urdu' },
-                { noteType: 'Explanatory Note', prefLabel: 'These regulations are to make provision...' },
+                { noteType: 'Explanatory Note', prefLabel: 'https://www.youtube.com/watch?v=Eikb2lX5xYE' },
               ],
             },
             fields: [{ label: 'Notes', value: 'React Component' }],


### PR DESCRIPTION
**What's this do?**
- Adds some processing of display fields in the `BibDetails` component to ensure that note fields include the word note
- Adds some tests

**Why are we doing this? (w/ JIRA link if applicable)**
This is scc-2818

**Do these changes have automated tests?**
Yes

**How should this be QAed?**
The ticket has a sample record that should say 'Language Note'

**Dependencies for merging? Releasing to production?**
No

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Yes.
