### PR TITLE
Fix bug handling drb result with empty items

### DIFF
--- a/src/app/components/Drbb/DrbbResult.jsx
+++ b/src/app/components/Drbb/DrbbResult.jsx
@@ -60,7 +60,7 @@ const DrbbResult = (props) => {
   };
 
   const selectEdition = () => (editions.find(edition => (
-    edition && edition.items && edition.items[0].links && edition.items[0].links.length
+    edition && edition.items && edition.items.length && edition.items[0].links && edition.items[0].links.length
   ))) || editions[0];
 
   const edition = selectEdition();

--- a/test/unit/DrbbResult.test.js
+++ b/test/unit/DrbbResult.test.js
@@ -45,6 +45,21 @@ describe('DrbbResult', () => {
       });
     });
 
+    describe('edition with empty items', () => {
+      let component;
+      before(() => {
+        const workWithItemsNull = workData.data;
+        let { editions } = workWithItemsNull;
+        editions = [editions[0]];
+        editions[0].items = [];
+
+        component = shallow(<DrbbResult work={workWithItemsNull} />);
+      });
+      it('should still render', () => {
+        expect(component.find('li')).to.have.length(1);
+      });
+    });
+
     describe('work with no authors', () => {
       let component;
       before(() => {


### PR DESCRIPTION
**What's this do?**
Fixes bug where a DRB result with an empty items array fails the whole
page render. At writing, this is an example:

/research/research-catalog/search?q=michael%20kennedy

This is due to this DRB record's first `edition` having an empty
`items`:
/work/ae7dde86-87c4-4fbd-94b2-4c3a8dcdf19b

**Why are we doing this? (w/ JIRA link if applicable)**
n/a

**Do these changes have automated tests?**
Yes

**How should this be QAed?**
Test above RC query in QA

**Dependencies for merging? Releasing to production?**
none

**Has the application documentation been updated for these changes?**
n/a

**Did someone actually run this code to verify it works?**
I did