### PR TITLE
Add Git Credentials File To Git Ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@ selenium-debug.log
 nightwatch_reports
 log/*.log
 
+# Git files
+.gitCredentials
+
 # Local env:
 .env
 


### PR DESCRIPTION
This file is automated during git remote push/pull commands in order to sign commits. It does not need to be commited to the repo. It is only needed for local delpoyments. Omitting this file from the repo is highly suggested.

**What's this do?**
Prevent .gitCredentials from being committed to Base Repository

**Why are we doing this? (w/ JIRA link if applicable)**
The Git Credentials file is automatically generated when utilizing GPG to verify commits. It does not need to be stored on the base repository and is specific to a single development clone per developer.

**Do these changes have automated tests?**
No

**How should this be QAed?**
Does not need QA

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
No