### PR TITLE
Set Node Version For Travis Builds To v14.18.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-- 10.17.0
+  - 14.18.2
 install: npm rebuild node-sass && npm install
 before_script: npm run dist
 script: npm test


### PR DESCRIPTION
NodeJS v14.18.2 is the LTS (Fermium) for Version 14. Released on 2021-11-30 with npm v6.14.15 and Node_Module_Verson of 83. 
Find the downloads @ https://nodejs.org/download/release/v14.18.2/

v14.18.2 has an LTS End Of Life scheduled on 2023-04-30. This means any application running this LTS version will have support for at least another year. 
