### PR TITLE
Ignore VsCode Configuration Files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ log/*.log
 !.elasticbeanstalk/*.global.yml
 
 #Files with names of missing fields
+
+# VS code Configuration Files
+.vscode


### PR DESCRIPTION
Addition to Gits Ignore file

Prevent any .vscode directories and all sub files from being pushed to git. The .vscode directory is a non-project specific directory and does not need to be added to the repository.  