### PR TITLE
Revert Required Webpack Dev Server

### DIFF
--- a/server.js
+++ b/server.js
@@ -7,7 +7,6 @@ import webpack from 'webpack';
 import cookieParser from 'cookie-parser';
 import bodyParser from 'body-parser';
 
-import WebpackDevServer from 'webpack-dev-server';
 import appConfig from './src/app/data/appConfig';
 import webpackConfig from './webpack.config';
 import apiRoutes from './src/server/ApiRoutes/ApiRoutes';
@@ -158,6 +157,8 @@ process.on('SIGINT', gracefulShutdown);
  * - Using Webpack Dev Server
  */
 if (!isProduction && !isTest) {
+  const WebpackDevServer = require('webpack-dev-server');
+
   new WebpackDevServer(webpack(webpackConfig), {
     publicPath: webpackConfig.output.publicPath,
     hot: true,


### PR DESCRIPTION
The original change was breaking the QA dev due to installing only production dependencies. Since wpds was inserted in the global scope of the server and could not be found the build was throwing a module resolution error. It has been reverted.
