### PR TITLE
Remove Unnecessary Bib Checks && Simplify 404 Reroute

### DIFF
--- a/src/app/components/BibPage/BibNotFound404.jsx
+++ b/src/app/components/BibPage/BibNotFound404.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import NotFound404 from '../NotFound404/NotFound404';
+import Redirect404 from '../Redirect404/Redirect404';
+
+const BibNotFound404 = ({ context }) => {
+  const originalUrl =
+    context &&
+    context.router &&
+    context.router.location &&
+    context.router.location.query &&
+    context.router.location.query.originalUrl;
+
+  return originalUrl ? <Redirect404 /> : <NotFound404 />;
+};
+
+export default BibNotFound404;

--- a/src/app/pages/BibPage.jsx
+++ b/src/app/pages/BibPage.jsx
@@ -69,7 +69,7 @@ const checkForMoreItems = (bib, dispatch) => {
 };
 
 export const BibPage = (
-  { location, searchKeywords, dispatch, resultSelection },
+  { bib, location, searchKeywords, dispatch, resultSelection },
   context,
 ) => {
   if (!bib || parseInt(bib.status, 10) === 404) {

--- a/src/app/pages/BibPage.jsx
+++ b/src/app/pages/BibPage.jsx
@@ -75,14 +75,14 @@ export const BibPage = (
   if (!bib || parseInt(bib.status, 10) === 404) {
     return <BibNotFound404 context={context} />;
   }
-  const bib = props.bib ? props.bib : {};
+
   // check whether this is a server side or client side render
   // by whether 'window' is defined. After the first render on the client side
   // check for more items
   if (typeof window !== 'undefined') {
     checkForMoreItems(bib, dispatch);
   }
-  const bibId = bib && bib['@id'] ? bib['@id'].substring(4) : '';
+  const bibId = bib['@id'] ? bib['@id'].substring(4) : '';
   const items = (bib.checkInItems || []).concat(LibraryItem.getItems(bib));
   const isElectronicResources = _every(items, i => i.isElectronicResource);
   // Related to removing MarcRecord because the webpack MarcRecord is not working. Sep/28/2017

--- a/src/app/pages/BibPage.jsx
+++ b/src/app/pages/BibPage.jsx
@@ -15,11 +15,9 @@ import itemsContainerModule from '../components/Item/ItemsContainer';
 import BibDetails from '../components/BibPage/BibDetails';
 import LibraryItem from '../utils/item';
 import AdditionalDetailsViewer from '../components/BibPage/AdditionalDetailsViewer';
-import NotFound404 from '../components/NotFound404/NotFound404';
 import LibraryHoldings from '../components/BibPage/LibraryHoldings';
 import getOwner from '../utils/getOwner';
 import appConfig from '../data/appConfig';
-import Redirect404 from '../components/Redirect404/Redirect404';
 // Removed MarcRecord because the webpack MarcRecord is not working. Sep/28/2017
 // import MarcRecord from './MarcRecord';
 import { ajaxCall, isNyplBnumber } from '@utils';
@@ -70,22 +68,12 @@ const checkForMoreItems = (bib, dispatch) => {
   }
 };
 
-export const BibPage = (props, context) => {
-  const {
-    location,
-    searchKeywords,
-    dispatch,
-    resultSelection,
-  } = props;
-
-  if (!props.bib || parseInt(props.bib.status, 10) === 404) {
-    const originalUrl = context &&
-      context.router &&
-      context.router.location &&
-      context.router.location.query &&
-      context.router.location.query.originalUrl;
-
-    return originalUrl ? (<Redirect404 />) : (<NotFound404 />);
+export const BibPage = (
+  { location, searchKeywords, dispatch, resultSelection },
+  context,
+) => {
+  if (!bib || parseInt(bib.status, 10) === 404) {
+    return <BibNotFound404 context={context} />;
   }
   const bib = props.bib ? props.bib : {};
   // check whether this is a server side or client side render


### PR DESCRIPTION
This is a simple clean up on the main Bib Page (Dot jsx)

It removes the verbose context property drills and 404 redirect to another component in order to reduce the size of the page component. And moves the destructed function prop variable into the function's property body out from the first line of the function body.

Additionally, removed the need to check and set the bib property after the initial bib property check on line 72. If the bib prop didn't exist, the patron would have been redirected to a 404. There is no need to check if it exists again and to set it to an empty object.

