### PR TITLE
Configure Tests For DotENV && Windows OS

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "dist": "cross-env NODE_ENV=production webpack --config webpack.config.js",
     "preinstall": "npm i webpack-cli",
     "postinstall": "npm run dist",
-    "test": ". ./test.env; node_modules/.bin/mocha test/helpers/browser.js test/unit/*.test.js",
+    "test": "mocha test/helpers/browser.js test/unit/*.test.js",
     "test-dev": "node_modules/.bin/mocha -w test/helpers/browser.js test/unit/*.test.js",
     "test-file": "node_modules/.bin/mocha -w test/helpers/browser.js",
     "coverage": "BABEL_ENV=test node_modules/.bin/nyc --require mocha npm test",

--- a/test.env
+++ b/test.env
@@ -1,13 +1,12 @@
-export SET NODE_ENV=test
-export SET HOLD_REQUEST_NOTIFICATION
-export SET CLOSED_LOCATIONS="[]"
-export SET FEATURES=aeon-links
-export SET DISPLAY_TITLE="Research Catalog"
-export SET LEGACY_BASE_URL=https://legacyBaseUrl.nypl.org
-export SET SEARCH_RESULTS_NOTIFICATION="Some info for our patrons"
-export SET HOLD_REQUEST_NOTIFICATION="Some info for our patrons"
-export SET WEBPAC_BASE_URL=http://webpac.nypl.org
-export SET KMS_ENV=unencrypted
-export SET BASE_URL=/research/research-catalog
-export SET DRB_API_BASE_URL=http://example.com/search/
-export SET SHEP_BIBS_LIMIT=10
+NODE_ENV=test
+CLOSED_LOCATIONS="[]"
+FEATURES=aeon-links
+DISPLAY_TITLE="Research Catalog"
+LEGACY_BASE_URL=https://legacyBaseUrl.nypl.org
+SEARCH_RESULTS_NOTIFICATION="Some info for our patrons"
+HOLD_REQUEST_NOTIFICATION="Some info for our patrons"
+WEBPAC_BASE_URL=http://webpac.nypl.org
+KMS_ENV=unencrypted
+BASE_URL=/research/research-catalog
+DRB_API_BASE_URL=http://example.com/search/
+SHEP_BIBS_LIMIT=10

--- a/test/helpers/browser.js
+++ b/test/helpers/browser.js
@@ -1,3 +1,7 @@
+// TODO: Remove and Set to a setup file
+// Since the purpose of this file is to set up the browser
+// Perhaps we can instead point mocah to run a setupfile
+// which then executes this file to set up the browser
 require('dotenv').config({ path: 'test.env' });
 const enzyme = require('enzyme');
 const Adapter = require('enzyme-adapter-react-16');

--- a/test/helpers/browser.js
+++ b/test/helpers/browser.js
@@ -1,3 +1,4 @@
+require('dotenv').config({ path: 'test.env' });
 const enzyme = require('enzyme');
 const Adapter = require('enzyme-adapter-react-16');
 
@@ -24,4 +25,4 @@ global.navigator = {
 };
 
 const noop = () => {};
-require.extensions[".png"] = noop;
+require.extensions['.png'] = noop;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,7 +6,11 @@ const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const sassPaths = require('@nypl/design-toolkit').includePaths;
 const globImporter = require('node-sass-glob-importer');
 const Visualizer = require('webpack-visualizer-plugin');
-
+// TODO: This would ideally not be set in this file
+// Add this to a ticket for future refactor
+// The purpose of this is to allow for a local run of npm run dist
+// In order to test a production build on a local machine.
+require('dotenv').config();
 // const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 
 // References the applications root path


### PR DESCRIPTION
In order to run local test on a Windows machine without Linux support three things were needed to change.

1. Update the Test cmd script to run for Windows OS
   - Remove the Source execution since Windows does not recognize this command.
2. Remove test.env `export` and `set` commands
3. Inject the test.env file inside the running test processes
    - This was achieved by initializing the environments within the browser helper file  