### PR TITLE
Do Not Display Aeon Request Link In ER if Table Contains Aeon Request Buttons

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,9 +2,10 @@
   "plugins": ["react", "jsx-a11y", "prettier"],
   "extends": [
     "airbnb",
-    "plugin:jsx-a11y/recommended",
+    "prettier",
+    "prettier/react",
     "plugin:react/recommended",
-    "prettier"
+    "plugin:jsx-a11y/recommended"
   ],
   "rules": {
     "react/forbid-prop-types": 0,

--- a/src/app/components/Item/ItemsContainer.jsx
+++ b/src/app/components/Item/ItemsContainer.jsx
@@ -30,6 +30,7 @@ class ItemsContainer extends React.Component {
     this.hasFilter = Object.keys(this.query).some(param => (
       itemFilters.map(filter => filter.type).includes(param)));
 
+    // NOTE: filteredItems: Setting 1
     this.filteredItems = this.props.bib && this.props.bib.done ?
       (this.filterItems(this.props.items) || [])
       : (this.props.items || []);
@@ -158,6 +159,7 @@ class ItemsContainer extends React.Component {
   }
 
   render() {
+    // NOTE: filteredItems: Setting 2
     this.filteredItems = this.props.bib && this.props.bib.done ?
       (this.filterItems(this.props.items) || [])
       : (this.props.items || []);

--- a/src/app/pages/BibPage.jsx
+++ b/src/app/pages/BibPage.jsx
@@ -102,11 +102,8 @@ export const BibPage = (props, context) => {
   // const bNumber = bib && bib.idBnum ? bib.idBnum : '';
   const itemPage = location.search;
   const aggregatedElectronicResources = getAggregatedElectronicResources(items);
-  let shortenItems = true;
 
-  if (location.pathname.indexOf('all') === -1) {
-    shortenItems = false;
-  }
+  const shortenItems = location.pathname.indexOf('all') !== -1;
 
   // `linkable` means that those values are links inside the app.
   // `selfLinkable` means that those values are external links and should be self-linked,

--- a/src/app/pages/BibPage.jsx
+++ b/src/app/pages/BibPage.jsx
@@ -26,6 +26,7 @@ import { itemBatchSize } from '../data/constants';
 
 import {
   getAggregatedElectronicResources,
+  pluckAeonLinksFromResource,
 } from '../utils/utils';
 
 import {
@@ -221,7 +222,10 @@ export const BibPage = (
         bib={bib}
         fields={topFields}
         logging
-        electronicResources={aggregatedElectronicResources}
+        electronicResources={pluckAeonLinksFromResource(
+          aggregatedElectronicResources,
+          items,
+        )}
       />
       {
         contentAreas

--- a/src/app/utils/utils.js
+++ b/src/app/utils/utils.js
@@ -403,13 +403,6 @@ function featuredAeonList(items) {
   });
 }
 
-// DESIRED TEST CASES
-// b11922867 - Has No Aeon Links; Has 1 or More ERs; Has 1 or more Items
-// b12514536 - Has No Aeon Links; Has No Other ERs; Has 1 or more Items
-// b11781968 - Has 1 or more Aeon Links; Has No Other ERs; Has 1 or more Items
-// b20618002 - Has 1 or more Aeon Links; Has No Other ERs; Has 1 or more Items
-// b22030125 - Has No; Has No Other ERs; Has 1 or more Items
-// NEED - Has 1 or more Aeon Links; Has 1 or more Other ERs; Has 1 or more Items
 
 /**
  *

--- a/src/app/utils/utils.js
+++ b/src/app/utils/utils.js
@@ -370,6 +370,29 @@ function getAggregatedElectronicResources(items = []) {
   return _flatten(electronicResources);
 }
 
+// TODO: Define Resources
+
+// interface Resources {
+//   @type: string;
+//   label: string;
+//   url: string;
+// }
+
+// TODO: Define Items
+
+// This is incomplete
+// interface Items {
+//    id: string;
+//    status: {
+//      @id: string;
+//      prefLabel: string
+//    };
+//    availability: string;
+//    available: boolean;
+//    aeonUrl: string | string[];
+//    electronicResources?: never | string[]
+// }
+
 /**
  * Return a list of non Aeon Link Electronic Resouces from given list
  * @param {array} resources Resources[ ]

--- a/src/app/utils/utils.js
+++ b/src/app/utils/utils.js
@@ -426,7 +426,6 @@ function featuredAeonList(items) {
   });
 }
 
-
 /**
  *
  * Confirm the url is an Aeon Link
@@ -438,7 +437,7 @@ function featuredAeonList(items) {
  * - https://nypl-aeon-test.aeon.atlas-sys.com
  */
 function isAeonLink(url) {
-  if (!url) url = '';
+  if (!url) return false;
   const aeonLinks = [
     'https://specialcollections.nypl.org/aeon/Aeon.dll',
     'https://nypl-aeon-test.aeon.atlas-sys.com',

--- a/src/app/utils/utils.js
+++ b/src/app/utils/utils.js
@@ -20,6 +20,8 @@ import {
 import appConfig from '../data/appConfig';
 import { noticePreferenceMapping } from '../data/constants';
 
+const { features } = appConfig;
+
 /**
  * ajaxCall
  * Utility function to make ajax requests.
@@ -369,6 +371,67 @@ function getAggregatedElectronicResources(items = []) {
 }
 
 /**
+ * Return a list of non Aeon Link Electronic Resouces from given list
+ * @param {array} resources Resources[ ]
+ * @param {array} items Items[ ]
+ * @return {array}
+ */
+function pluckAeonLinksFromResource(resources = [], items = []) {
+  return (
+    (resources.length &&
+      featuredAeonList(items) && // Does items list contain an Aeon Request Button
+      resources.filter((resource) => {
+        // Remove all Aeon Links
+        return !isAeonLink(resource.url);
+      })) ||
+    resources
+  );
+}
+
+/**
+ * Check if the list contains aeon urls && is a valid feature
+ * @param {array} items Items[ ]
+ * @return {boolean}
+ */
+function featuredAeonList(items) {
+  const featured = features.includes('aeon-links');
+
+  // Does a single item in the list have an aeon url
+  return items.some((item) => {
+    // item.aeonUrl: String || String[]
+    return isAeonLink(item.aeonUrl) && featured;
+  });
+}
+
+// DESIRED TEST CASES
+// b11922867 - Has No Aeon Links; Has 1 or More ERs; Has 1 or more Items
+// b12514536 - Has No Aeon Links; Has No Other ERs; Has 1 or more Items
+// b11781968 - Has 1 or more Aeon Links; Has No Other ERs; Has 1 or more Items
+// b20618002 - Has 1 or more Aeon Links; Has No Other ERs; Has 1 or more Items
+// b22030125 - Has No; Has No Other ERs; Has 1 or more Items
+// NEED - Has 1 or more Aeon Links; Has 1 or more Other ERs; Has 1 or more Items
+
+/**
+ *
+ * Confirm the url is an Aeon Link
+ * @param url string | string[]
+ * @return A boolean indicating the passed url[s] are valid Aeon links
+ *
+ * Example URL:
+ * - https://specialcollections.nypl.org/aeon/Aeon.dll
+ * - https://nypl-aeon-test.aeon.atlas-sys.com
+ */
+function isAeonLink(url) {
+  if (!url) url = '';
+  const aeonLinks = [
+    'https://specialcollections.nypl.org/aeon/Aeon.dll',
+    'https://nypl-aeon-test.aeon.atlas-sys.com',
+  ];
+  const link = Array.isArray(url) ? url[0] : url;
+  return Boolean(aeonLinks.some((path) => link.startsWith(path)));
+}
+
+/**
  * getUpdatedFilterValues(props)
  * Get an array of filter values based on one filter. If any filters are selected, they'll
  * be `true` in their object property `selected`.
@@ -672,4 +735,6 @@ export {
   institutionNameByNyplSource,
   addSource,
   isNyplBnumber,
+  pluckAeonLinksFromResource,
+  isAeonLink,
 };

--- a/test/fixtures/bibs.js
+++ b/test/fixtures/bibs.js
@@ -279,6 +279,1077 @@ const bibs = [
     uri: 'b11417539',
     suppressed: false,
   },
+  {
+    status: '200',
+    '@type': ['nypl:Item', 'nypl:Resource'],
+    '@id': 'res:b22030125',
+    'carrierType': ['{@id: "carriertypes:nc", prefLabel: "volume"}'],
+    'contributorLiteral': [
+      'Heartman, Charles F. (Charles Frederick), 1883-1953,',
+    ],
+    'createdString': ['1916'],
+    'createdYear': 1916,
+    'creatorLiteral': ['Schomburg, Arthur Alfonso, 1874-1938.'],
+    'dateStartYear': 1916,
+    'dateString': ['1916'],
+    'dimensions': ['25 cm.'],
+    'donor': [
+      'Home to Harlem Project funded by the Andrew W. Mellon Foundation.',
+    ],
+    'extent': ['57 p. ;'],
+    'genreForm': ['Inscriptions (Provenance)'],
+    'idLccn': ['   17007194'],
+    'identifier': [
+      {
+        '@type': 'bf:ShelfMark',
+        '@value': 'Sc Rare 016.811-S (Schomburg, A. Bibliographical checklist)',
+      },
+      {
+        '@type': 'nypl:Bnumber',
+        '@value': '22030125',
+      },
+      {
+        '@type': 'bf:Lccn',
+        '@value': '   17007194',
+      },
+      {
+        '@type': 'bf:Identifier',
+        '@value': '(OCoLC)2430488',
+      },
+    ],
+    'issuance': ['{@id: "urn:biblevel:m", prefLabel: "monograph/item"}'],
+    'items': [
+      {
+        '@id': 'res:i12169730',
+        'accessMessage': [
+          {
+            '@id': 'accessMessage:4',
+            'prefLabel': 'Restricted use',
+          },
+        ],
+        'aeonUrl': [
+          'https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=A+bibliographical+checklist+of+American+Negro+poetry+/&Site=SCHRB&CallNumber=Sc+Rare+016.811-S+(Schomburg,+A.+Bibliographical+checklist)&Author=Schomburg,+Arthur+Alfonso,&ItemPlace=New+York+:&ItemPublisher=Charles+F.+Heartman,&Date=1916.&ItemInfo3=https://catalog.nypl.org/record=b22030125&ReferenceNumber=b220301256&Genre=Book-text&Location=Schomburg+Center',
+        ],
+        'catalogItemType': [
+          {
+            '@id': 'catalogItemType:2',
+            'prefLabel': 'book non-circ',
+          },
+        ],
+        'holdingLocation': [
+          {
+            '@id': 'loc:scdd2',
+            'prefLabel': 'Schomburg Center - Manuscripts & Archives',
+            'url':
+              'http://www.nypl.org/locations/divisions/manuscripts-archives-and-rare-books-division',
+          },
+        ],
+        'idBarcode': ['33433034100010'],
+        'identifier': [
+          {
+            '@type': 'bf:ShelfMark',
+            '@value':
+              'Sc Rare 016.811-S (Schomburg, A. Bibliographical checklist)',
+          },
+          {
+            '@type': 'bf:Barcode',
+            '@value': '33433034100010',
+          },
+        ],
+        'owner': [
+          {
+            '@id': 'orgs:1116',
+            'prefLabel':
+              'Schomburg Center for Research in Black Culture, Manuscripts, Archives and Rare Books Division',
+          },
+        ],
+        'physicalLocation': [
+          'Sc Rare 016.811-S (Schomburg, A. Bibliographical checklist)',
+        ],
+        'requestable': [false],
+        'shelfMark': [
+          'Sc Rare 016.811-S (Schomburg, A. Bibliographical checklist)',
+        ],
+        'status': [
+          {
+            '@id': 'status:k',
+            'prefLabel': 'Check with staff',
+          },
+        ],
+        'uri': 'i12169730',
+        'idNyplSourceId': {
+          '@type': 'SierraNypl',
+          '@value': '12169730',
+        },
+      },
+      {
+        '@id': 'res:i12169731',
+        'accessMessage': [
+          {
+            '@id': 'accessMessage:4',
+            'prefLabel': 'Restricted use',
+          },
+        ],
+        'aeonUrl': [
+          'https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=A+bibliographical+checklist+of+American+Negro+poetry+/&Site=SCHRB&CallNumber=Sc+Rare+016.811-S+(Schomburg,+A.+Bibliographical+checklist)&Author=Schomburg,+Arthur+Alfonso,&ItemPlace=New+York+:&ItemPublisher=Charles+F.+Heartman,&Date=1916.&ItemInfo3=https://catalog.nypl.org/record=b22030125&ReferenceNumber=b220301256&Genre=Book-text&Location=Schomburg+Center',
+        ],
+        'catalogItemType': [
+          {
+            '@id': 'catalogItemType:2',
+            'prefLabel': 'book non-circ',
+          },
+        ],
+        'holdingLocation': [
+          {
+            '@id': 'loc:scdd2',
+            'prefLabel': 'Schomburg Center - Manuscripts & Archives',
+            'url':
+              'http://www.nypl.org/locations/divisions/manuscripts-archives-and-rare-books-division',
+          },
+        ],
+        'idBarcode': ['33433034100028'],
+        'identifier': [
+          {
+            '@type': 'bf:ShelfMark',
+            '@value':
+              'Sc Rare 016.811-S (Schomburg, A. Bibliographical checklist)',
+          },
+          {
+            '@type': 'bf:Barcode',
+            '@value': '33433034100028',
+          },
+        ],
+        'owner': [
+          {
+            '@id': 'orgs:1116',
+            'prefLabel':
+              'Schomburg Center for Research in Black Culture, Manuscripts, Archives and Rare Books Division',
+          },
+        ],
+        'physicalLocation': [
+          'Sc Rare 016.811-S (Schomburg, A. Bibliographical checklist)',
+        ],
+        'requestable': [false],
+        'shelfMark': [
+          'Sc Rare 016.811-S (Schomburg, A. Bibliographical checklist)',
+        ],
+        'status': [
+          {
+            '@id': 'status:k',
+            'prefLabel': 'Check with staff',
+          },
+        ],
+        'uri': 'i12169731',
+        'idNyplSourceId': {
+          '@type': 'SierraNypl',
+          '@value': '12169731',
+        },
+      },
+      {
+        '@id': 'res:i12169734',
+        'accessMessage': [
+          {
+            '@id': 'accessMessage:4',
+            'prefLabel': 'Restricted use',
+          },
+        ],
+        'aeonUrl': [
+          'https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=A+bibliographical+checklist+of+American+Negro+poetry+/&Site=SCHRB&CallNumber=Sc+Rare+016.811-S+(Schomburg,+A.+Bibliographical+checklist)&Author=Schomburg,+Arthur+Alfonso,&ItemPlace=New+York+:&ItemPublisher=Charles+F.+Heartman,&Date=1916.&ItemInfo3=https://catalog.nypl.org/record=b22030125&ReferenceNumber=b220301256&Genre=Book-text&Location=Schomburg+Center',
+        ],
+        'catalogItemType': [
+          {
+            '@id': 'catalogItemType:2',
+            'prefLabel': 'book non-circ',
+          },
+        ],
+        'holdingLocation': [
+          {
+            '@id': 'loc:scdd2',
+            'prefLabel': 'Schomburg Center - Manuscripts & Archives',
+            'url':
+              'http://www.nypl.org/locations/divisions/manuscripts-archives-and-rare-books-division',
+          },
+        ],
+        'idBarcode': ['33433034100333'],
+        'identifier': [
+          {
+            '@type': 'bf:ShelfMark',
+            '@value':
+              'Sc Rare 016.811-S (Schomburg, A. Bibliographical checklist)',
+          },
+          {
+            '@type': 'bf:Barcode',
+            '@value': '33433034100333',
+          },
+        ],
+        'owner': [
+          {
+            '@id': 'orgs:1116',
+            'prefLabel':
+              'Schomburg Center for Research in Black Culture, Manuscripts, Archives and Rare Books Division',
+          },
+        ],
+        'physicalLocation': [
+          'Sc Rare 016.811-S (Schomburg, A. Bibliographical checklist)',
+        ],
+        'requestable': [false],
+        'shelfMark': [
+          'Sc Rare 016.811-S (Schomburg, A. Bibliographical checklist)',
+        ],
+        'status': [
+          {
+            '@id': 'status:k',
+            'prefLabel': 'Check with staff',
+          },
+        ],
+        'uri': 'i12169734',
+        'idNyplSourceId': {
+          '@type': 'SierraNypl',
+          '@value': '12169734',
+        },
+      },
+      {
+        '@id': 'res:i12169735',
+        'accessMessage': [
+          {
+            '@id': 'accessMessage:4',
+            'prefLabel': 'Restricted use',
+          },
+        ],
+        'aeonUrl': [
+          'https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=A+bibliographical+checklist+of+American+Negro+poetry+/&Site=SCHRB&CallNumber=Sc+Rare+016.811-S+(Schomburg,+A.+Bibliographical+checklist)&Author=Schomburg,+Arthur+Alfonso,&ItemPlace=New+York+:&ItemPublisher=Charles+F.+Heartman,&Date=1916.&ItemInfo3=https://catalog.nypl.org/record=b22030125&ReferenceNumber=b220301256&Genre=Book-text&Location=Schomburg+Center',
+        ],
+        'catalogItemType': [
+          {
+            '@id': 'catalogItemType:2',
+            'prefLabel': 'book non-circ',
+          },
+        ],
+        'holdingLocation': [
+          {
+            '@id': 'loc:scdd2',
+            'prefLabel': 'Schomburg Center - Manuscripts & Archives',
+            'url':
+              'http://www.nypl.org/locations/divisions/manuscripts-archives-and-rare-books-division',
+          },
+        ],
+        'idBarcode': ['33433034100002'],
+        'identifier': [
+          {
+            '@type': 'bf:ShelfMark',
+            '@value':
+              'Sc Rare 016.811-S (Schomburg, A. Bibliographical checklist)',
+          },
+          {
+            '@type': 'bf:Barcode',
+            '@value': '33433034100002',
+          },
+        ],
+        'owner': [
+          {
+            '@id': 'orgs:1116',
+            'prefLabel':
+              'Schomburg Center for Research in Black Culture, Manuscripts, Archives and Rare Books Division',
+          },
+        ],
+        'physicalLocation': [
+          'Sc Rare 016.811-S (Schomburg, A. Bibliographical checklist)',
+        ],
+        'requestable': [false],
+        'shelfMark': [
+          'Sc Rare 016.811-S (Schomburg, A. Bibliographical checklist)',
+        ],
+        'status': [
+          {
+            '@id': 'status:k',
+            'prefLabel': 'Check with staff',
+          },
+        ],
+        'uri': 'i12169735',
+        'idNyplSourceId': {
+          '@type': 'SierraNypl',
+          '@value': '12169735',
+        },
+      },
+      {
+        '@id': 'res:i12169732',
+        'accessMessage': [
+          {
+            '@id': 'accessMessage:4',
+            'prefLabel': 'Restricted use',
+          },
+        ],
+        'aeonUrl': [
+          'https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=A+bibliographical+checklist+of+American+Negro+poetry+/&Site=SCHRB&CallNumber=Sc+Rare+016.811-S+(Schomburg,+A.+Bibliographical+checklist)&Author=Schomburg,+Arthur+Alfonso,&ItemPlace=New+York+:&ItemPublisher=Charles+F.+Heartman,&Date=1916.&ItemInfo3=https://catalog.nypl.org/record=b22030125&ReferenceNumber=b220301256&Genre=Book-text&Location=Schomburg+Center',
+        ],
+        'catalogItemType': [
+          {
+            '@id': 'catalogItemType:2',
+            'prefLabel': 'book non-circ',
+          },
+        ],
+        'holdingLocation': [
+          {
+            '@id': 'loc:scdd2',
+            'prefLabel': 'Schomburg Center - Manuscripts & Archives',
+            'url':
+              'http://www.nypl.org/locations/divisions/manuscripts-archives-and-rare-books-division',
+          },
+        ],
+        'idBarcode': ['33433034100036'],
+        'identifier': [
+          {
+            '@type': 'bf:ShelfMark',
+            '@value':
+              'Sc Rare 016.811-S (Schomburg, A. Bibliographical checklist)',
+          },
+          {
+            '@type': 'bf:Barcode',
+            '@value': '33433034100036',
+          },
+        ],
+        'owner': [
+          {
+            '@id': 'orgs:1116',
+            'prefLabel':
+              'Schomburg Center for Research in Black Culture, Manuscripts, Archives and Rare Books Division',
+          },
+        ],
+        'physicalLocation': [
+          'Sc Rare 016.811-S (Schomburg, A. Bibliographical checklist)',
+        ],
+        'requestable': [false],
+        'shelfMark': [
+          'Sc Rare 016.811-S (Schomburg, A. Bibliographical checklist)',
+        ],
+        'status': [
+          {
+            '@id': 'status:k',
+            'prefLabel': 'Check with staff',
+          },
+        ],
+        'uri': 'i12169732',
+        'idNyplSourceId': {
+          '@type': 'SierraNypl',
+          '@value': '12169732',
+        },
+      },
+      {
+        '@id': 'res:i22030125-e',
+        'electronicLocator': [
+          {
+            '@type': 'nypl:ElectronicLocation',
+            'label': 'Full text available via HathiTrust',
+            'url': 'http://hdl.handle.net/2027/nyp.33433076020639',
+          },
+          {
+            '@type': 'nypl:ElectronicLocation',
+            'label': 'Request Access to Special Collections Material',
+            'url':
+              'https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=A+bibliographical+checklist+of+American+Negro+poetry+/&Site=SCHRB&CallNumber=Sc+Rare+016.811-S+(Schomburg,+A.+Bibliographical+checklist)&Author=Schomburg,+Arthur+Alfonso,&ItemPlace=New+York+:&ItemPublisher=Charles+F.+Heartman,&Date=1916.&ItemInfo3=https://catalog.nypl.org/record=b22030125&ReferenceNumber=b220301256&Genre=Book-text&Location=Schomburg+Center',
+          },
+        ],
+        'identifier': ['urn:SierraNypl:22030125-e'],
+        'uri': 'i22030125-e',
+        'idNyplSourceId': {
+          '@type': 'SierraNypl',
+          '@value': '22030125-e',
+        },
+      },
+    ],
+    'language': ['{@id: "lang:eng", prefLabel: "English"}'],
+    'lccClassification': ['Z1231.P7 S3'],
+    'materialType': ['{@id: "resourcetypes:txt", prefLabel: "Text"}'],
+    'mediaType': ['{@id: "mediatypes:n", prefLabel: "unmediated"}'],
+    'note': [
+      {
+        'noteType': 'Note',
+        '@type': 'bf:Note',
+        'prefLabel':
+          'All pages printed on the recto of the leaf only, except the series title page which is printed on the verso, pagination is continuous.',
+      },
+      {
+        'noteType': 'Note',
+        '@type': 'bf:Note',
+        'prefLabel':
+          '"Bibliographia Americana. A series of monographs edited by Charles F. Heartman ..."--series title page; facing title page.',
+      },
+      {
+        'noteType': 'Bibliography',
+        '@type': 'bf:Note',
+        'prefLabel':
+          "\"Bibliography of the poetical works of Phillis Wheatley (copyrighted by Charles F. Heartman) [reprinted from Heartman's 'Phillis Wheatley (Phillis Peters)']\"--p. 47-57.",
+      },
+      {
+        'noteType': 'Provenance',
+        '@type': 'bf:Note',
+        'prefLabel':
+          'inscribed: in ink on recto of endleaf preceding series title leaf  "A.A. Schomburg." ; This copy is part of the original collection purchased from Arthur A. Schomburg in 1926.',
+      },
+    ],
+    'numAvailable': 0,
+    'numItems': 6,
+    'nyplSource': ['sierra-nypl'],
+    'placeOfPublication': ['New York :'],
+    'publicationStatement': ['New York : Charles F. Heartman, 1916.'],
+    'publisherLiteral': ['Charles F. Heartman,'],
+    'seriesStatement': ['Bibliographica Americana ; v. 2'],
+    'shelfMark': [
+      'Sc Rare 016.811-S (Schomburg, A. Bibliographical checklist)',
+    ],
+    'subjectLiteral': [
+      'African American poets -- Bibliography.',
+      'American poetry -- African American authors -- Bibliography.',
+      'Wheatley, Phillis, 1753-1784 -- Bibliography.',
+    ],
+    'title': ['A bibliographical checklist of American Negro poetry'],
+    'titleDisplay': [
+      'A bibliographical checklist of American Negro poetry / compiled by Arthur A. Schomburg.',
+    ],
+    'type': ['nypl:Item'],
+    'uniformTitle': ['Bibliographica Americana ; v. 2.'],
+    'updatedAt': 1637605687189,
+    'uri': 'b22030125',
+    'suppressed': false,
+    'annotatedMarc': {
+      'bib': {
+        'id': '22030125',
+        'nyplSource': 'sierra-nypl',
+        'fields': [
+          {
+            'label': 'Author',
+            'values': [
+              {
+                'content': 'Schomburg, Arthur Alfonso, 1874-1938.',
+                'source': {
+                  'fieldTag': 'a',
+                  'marcTag': '100',
+                  'ind1': '1',
+                  'ind2': ' ',
+                  'content': null,
+                  'subfields': [
+                    {
+                      'tag': 'a',
+                      'content': 'Schomburg, Arthur Alfonso,',
+                    },
+                    {
+                      'tag': 'd',
+                      'content': '1874-1938.',
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+          {
+            'label': 'Title',
+            'values': [
+              {
+                'content':
+                  'A bibliographical checklist of American Negro poetry / compiled by Arthur A. Schomburg.',
+                'source': {
+                  'fieldTag': 't',
+                  'marcTag': '245',
+                  'ind1': '1',
+                  'ind2': '2',
+                  'content': null,
+                  'subfields': [
+                    {
+                      'tag': 'a',
+                      'content':
+                        'A bibliographical checklist of American Negro poetry /',
+                    },
+                    {
+                      'tag': 'c',
+                      'content': 'compiled by Arthur A. Schomburg.',
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+          {
+            'label': 'Imprint',
+            'values': [
+              {
+                'content': 'New York : Charles F. Heartman, 1916.',
+                'source': {
+                  'fieldTag': 'p',
+                  'marcTag': '260',
+                  'ind1': ' ',
+                  'ind2': ' ',
+                  'content': null,
+                  'subfields': [
+                    {
+                      'tag': 'a',
+                      'content': 'New York :',
+                    },
+                    {
+                      'tag': 'b',
+                      'content': 'Charles F. Heartman,',
+                    },
+                    {
+                      'tag': 'c',
+                      'content': '1916.',
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+          {
+            'label': 'Description',
+            'values': [
+              {
+                'content': '57 p. ; 25 cm.',
+                'source': {
+                  'fieldTag': 'r',
+                  'marcTag': '300',
+                  'ind1': ' ',
+                  'ind2': ' ',
+                  'content': null,
+                  'subfields': [
+                    {
+                      'tag': 'a',
+                      'content': '57 p. ;',
+                    },
+                    {
+                      'tag': 'c',
+                      'content': '25 cm.',
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+          {
+            'label': 'Series',
+            'values': [
+              {
+                'content': 'Bibliographica Americana ; v. 2',
+                'source': {
+                  'fieldTag': 's',
+                  'marcTag': '490',
+                  'ind1': '1',
+                  'ind2': ' ',
+                  'content': null,
+                  'subfields': [
+                    {
+                      'tag': 'a',
+                      'content': 'Bibliographica Americana ;',
+                    },
+                    {
+                      'tag': 'v',
+                      'content': 'v. 2',
+                    },
+                  ],
+                },
+              },
+              {
+                'content': 'Bibliographica Americana ; v. 2.',
+                'source': {
+                  'fieldTag': 's',
+                  'marcTag': '830',
+                  'ind1': ' ',
+                  'ind2': '0',
+                  'content': null,
+                  'subfields': [
+                    {
+                      'tag': 'a',
+                      'content': 'Bibliographica Americana ;',
+                    },
+                    {
+                      'tag': 'v',
+                      'content': 'v. 2.',
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+          {
+            'label': 'Note',
+            'values': [
+              {
+                'content':
+                  'All pages printed on the recto of the leaf only, except the series title page which is printed on the verso, pagination is continuous.',
+                'source': {
+                  'fieldTag': 'n',
+                  'marcTag': '500',
+                  'ind1': ' ',
+                  'ind2': ' ',
+                  'content': null,
+                  'subfields': [
+                    {
+                      'tag': 'a',
+                      'content':
+                        'All pages printed on the recto of the leaf only, except the series title page which is printed on the verso, pagination is continuous.',
+                    },
+                  ],
+                },
+              },
+              {
+                'content':
+                  '"Bibliographia Americana. A series of monographs edited by Charles F. Heartman ..."--series title page; facing title page.',
+                'source': {
+                  'fieldTag': 'n',
+                  'marcTag': '500',
+                  'ind1': ' ',
+                  'ind2': ' ',
+                  'content': null,
+                  'subfields': [
+                    {
+                      'tag': 'a',
+                      'content':
+                        '"Bibliographia Americana. A series of monographs edited by Charles F. Heartman ..."--series title page; facing title page.',
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+          {
+            'label': 'Bibliography',
+            'values': [
+              {
+                'content':
+                  "\"Bibliography of the poetical works of Phillis Wheatley (copyrighted by Charles F. Heartman) [reprinted from Heartman's 'Phillis Wheatley (Phillis Peters)']\"--p. 47-57.",
+                'source': {
+                  'fieldTag': 'n',
+                  'marcTag': '504',
+                  'ind1': ' ',
+                  'ind2': ' ',
+                  'content': null,
+                  'subfields': [
+                    {
+                      'tag': 'a',
+                      'content':
+                        "\"Bibliography of the poetical works of Phillis Wheatley (copyrighted by Charles F. Heartman) [reprinted from Heartman's 'Phillis Wheatley (Phillis Peters)']\"--p. 47-57.",
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+          {
+            'label': 'Provenance',
+            'values': [
+              {
+                'content':
+                  'Copy in Sc Rare 016.811-S (Copy 4) (accession no. B593799) inscribed: in ink on recto of endleaf preceding series title leaf  "A.A. Schomburg." ; This copy is part of the original collection purchased from Arthur A. Schomburg in 1926.',
+                'source': {
+                  'fieldTag': 'n',
+                  'marcTag': '561',
+                  'ind1': '1',
+                  'ind2': ' ',
+                  'content': null,
+                  'subfields': [
+                    {
+                      'tag': '3',
+                      'content':
+                        'Copy in Sc Rare 016.811-S (Copy 4) (accession no. B593799)',
+                    },
+                    {
+                      'tag': 'a',
+                      'content':
+                        'inscribed: in ink on recto of endleaf preceding series title leaf  "A.A. Schomburg." ; This copy is part of the original collection purchased from Arthur A. Schomburg in 1926.',
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+          {
+            'label': 'Local Note',
+            'values': [
+              {
+                'content':
+                  'Copy in Sc Rare 016.811-S (Copy 4) bound incorrectly; p. 49 leaf bound after p. 57 leaf.',
+                'source': {
+                  'fieldTag': 'n',
+                  'marcTag': '590',
+                  'ind1': '1',
+                  'ind2': ' ',
+                  'content': null,
+                  'subfields': [
+                    {
+                      'tag': '3',
+                      'content': 'Copy in Sc Rare 016.811-S (Copy 4)',
+                    },
+                    {
+                      'tag': 'a',
+                      'content':
+                        'bound incorrectly; p. 49 leaf bound after p. 57 leaf.',
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+          {
+            'label': 'Connect to:',
+            'values': [
+              {
+                'label': 'Request Access to Special Collections Material',
+                'content':
+                  'https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=A+bibliographical+checklist+of+American+Negro+poetry+/&Site=SCHRB&CallNumber=Sc+Rare+016.811-S+(Schomburg,+A.+Bibliographical+checklist)&Author=Schomburg,+Arthur+Alfonso,&ItemPlace=New+York+:&ItemPublisher=Charles+F.+Heartman,&Date=1916.&ItemInfo3=https://catalog.nypl.org/record=b22030125&ReferenceNumber=b220301256&Genre=Book-text&Location=Schomburg+Center',
+                'source': {
+                  'fieldTag': 'y',
+                  'marcTag': '856',
+                  'ind1': '4',
+                  'ind2': '0',
+                  'content': null,
+                  'subfields': [
+                    {
+                      'tag': 'u',
+                      'content':
+                        'https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=A+bibliographical+checklist+of+American+Negro+poetry+/&Site=SCHRB&CallNumber=Sc+Rare+016.811-S+(Schomburg,+A.+Bibliographical+checklist)&Author=Schomburg,+Arthur+Alfonso,&ItemPlace=New+York+:&ItemPublisher=Charles+F.+Heartman,&Date=1916.&ItemInfo3=https://catalog.nypl.org/record=b22030125&ReferenceNumber=b220301256&Genre=Book-text&Location=Schomburg+Center',
+                    },
+                    {
+                      'tag': 'z',
+                      'content': '[redacted]',
+                    },
+                  ],
+                },
+              },
+              {
+                'label': 'Full text available via HathiTrust',
+                'content': 'http://hdl.handle.net/2027/nyp.33433076020639',
+                'source': {
+                  'fieldTag': 'y',
+                  'marcTag': '856',
+                  'ind1': '4',
+                  'ind2': '0',
+                  'content': null,
+                  'subfields': [
+                    {
+                      'tag': 'u',
+                      'content':
+                        'http://hdl.handle.net/2027/nyp.33433076020639',
+                    },
+                    {
+                      'tag': 'z',
+                      'content': '[redacted]',
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+          {
+            'label': 'Subject',
+            'values': [
+              {
+                'content': 'Wheatley, Phillis, 1753-1784 -- Bibliography.',
+                'source': {
+                  'fieldTag': 'd',
+                  'marcTag': '600',
+                  'ind1': '1',
+                  'ind2': '0',
+                  'content': null,
+                  'subfields': [
+                    {
+                      'tag': 'a',
+                      'content': 'Wheatley, Phillis,',
+                    },
+                    {
+                      'tag': 'd',
+                      'content': '1753-1784',
+                    },
+                    {
+                      'tag': 'v',
+                      'content': 'Bibliography.',
+                    },
+                  ],
+                },
+              },
+              {
+                'content':
+                  'American poetry -- African American authors -- Bibliography.',
+                'source': {
+                  'fieldTag': 'd',
+                  'marcTag': '650',
+                  'ind1': ' ',
+                  'ind2': '0',
+                  'content': null,
+                  'subfields': [
+                    {
+                      'tag': 'a',
+                      'content': 'American poetry',
+                    },
+                    {
+                      'tag': 'x',
+                      'content': 'African American authors',
+                    },
+                    {
+                      'tag': 'v',
+                      'content': 'Bibliography.',
+                    },
+                  ],
+                },
+              },
+              {
+                'content': 'African American poets -- Bibliography.',
+                'source': {
+                  'fieldTag': 'd',
+                  'marcTag': '650',
+                  'ind1': ' ',
+                  'ind2': '0',
+                  'content': null,
+                  'subfields': [
+                    {
+                      'tag': 'a',
+                      'content': 'African American poets',
+                    },
+                    {
+                      'tag': 'v',
+                      'content': 'Bibliography.',
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+          {
+            'label': 'Genre/Form',
+            'values': [
+              {
+                'content': 'Inscriptions (Provenance)',
+                'source': {
+                  'fieldTag': 'd',
+                  'marcTag': '655',
+                  'ind1': ' ',
+                  'ind2': '7',
+                  'content': null,
+                  'subfields': [
+                    {
+                      'tag': 'a',
+                      'content': 'Inscriptions (Provenance)',
+                    },
+                    {
+                      'tag': '2',
+                      'content': '[redacted]',
+                    },
+                    {
+                      'tag': '5',
+                      'content': '[redacted]',
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+          {
+            'label': 'Local Subject',
+            'values': [
+              {
+                'content': 'Black author.',
+                'source': {
+                  'fieldTag': 'd',
+                  'marcTag': '690',
+                  'ind1': ' ',
+                  'ind2': ' ',
+                  'content': null,
+                  'subfields': [
+                    {
+                      'tag': 'a',
+                      'content': 'Black author.',
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+          {
+            'label': 'Added Author',
+            'values': [
+              {
+                'content':
+                  'Heartman, Charles F. (Charles Frederick), 1883-1953, publisher.',
+                'source': {
+                  'fieldTag': 'b',
+                  'marcTag': '700',
+                  'ind1': '1',
+                  'ind2': ' ',
+                  'content': null,
+                  'subfields': [
+                    {
+                      'tag': 'a',
+                      'content': 'Heartman, Charles F.',
+                    },
+                    {
+                      'tag': 'q',
+                      'content': '(Charles Frederick),',
+                    },
+                    {
+                      'tag': 'd',
+                      'content': '1883-1953,',
+                    },
+                    {
+                      'tag': 'e',
+                      'content': 'publisher.',
+                    },
+                  ],
+                },
+              },
+              {
+                'content':
+                  'Schomburg, Arthur Alfonso, 1874-1938, former owner, inscriber.',
+                'source': {
+                  'fieldTag': 'b',
+                  'marcTag': '796',
+                  'ind1': ' ',
+                  'ind2': ' ',
+                  'content': null,
+                  'subfields': [
+                    {
+                      'tag': 'a',
+                      'content': 'Schomburg, Arthur Alfonso,',
+                    },
+                    {
+                      'tag': 'd',
+                      'content': '1874-1938,',
+                    },
+                    {
+                      'tag': 'e',
+                      'content': 'former owner,',
+                    },
+                    {
+                      'tag': 'e',
+                      'content': 'inscriber.',
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+          {
+            'label': 'Added Title',
+            'values': [
+              {
+                'content':
+                  'Home to Harlem Project funded by the Andrew W. Mellon Foundation.',
+                'source': {
+                  'fieldTag': 'u',
+                  'marcTag': '799',
+                  'ind1': ' ',
+                  'ind2': ' ',
+                  'content': null,
+                  'subfields': [
+                    {
+                      'tag': 'a',
+                      'content':
+                        'Home to Harlem Project funded by the Andrew W. Mellon Foundation.',
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+          {
+            'label': 'LCCN',
+            'values': [
+              {
+                'content': '   17007194',
+                'source': {
+                  'fieldTag': 'l',
+                  'marcTag': '010',
+                  'ind1': ' ',
+                  'ind2': ' ',
+                  'content': null,
+                  'subfields': [
+                    {
+                      'tag': 'a',
+                      'content': '   17007194',
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+          {
+            'label': 'Research Call Number',
+            'values': [
+              {
+                'content':
+                  'Sc Rare 016.811-S (Schomburg, A. Bibliographical checklist)',
+                'source': {
+                  'fieldTag': 'q',
+                  'marcTag': '852',
+                  'ind1': '8',
+                  'ind2': ' ',
+                  'content': null,
+                  'subfields': [
+                    {
+                      'tag': 'h',
+                      'content':
+                        'Sc Rare 016.811-S (Schomburg, A. Bibliographical checklist)',
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        ],
+      },
+    },
+    'subjectHeadingData': [
+      {
+        'label': 'American poetry -- African American authors -- Bibliography',
+        'uuid': '4d5501c7-6d58-4ed0-b395-0d9cc6fc12df',
+        'bib_count': 9,
+        'desc_count': 0,
+        'parent': {
+          'label': 'American poetry -- African American authors',
+          'uuid': '8a93e23b-a4f5-4f14-b5cc-2baa45b9bd28',
+          'bib_count': 1718,
+          'desc_count': 62,
+          'parent': {
+            'label': 'American poetry',
+            'uuid': '29c958a0-a19e-4a21-b59d-55cc4452b613',
+            'bib_count': 23905,
+            'desc_count': 969,
+          },
+        },
+      },
+      {
+        'label': 'Inscriptions (Provenance)',
+        'uuid': 'f820910e-d10a-428c-84c2-3e2daf3093d4',
+        'bib_count': 621,
+        'desc_count': 6,
+      },
+      {
+        'label': 'African American poets -- Bibliography',
+        'uuid': 'db2c4a50-a86b-4626-a745-e411a6d9bf19',
+        'bib_count': 1,
+        'desc_count': 0,
+        'parent': {
+          'label': 'African American poets',
+          'uuid': 'fa6e5a43-4909-4cd6-a02e-5cf89926f110',
+          'bib_count': 417,
+          'desc_count': 62,
+        },
+      },
+      {
+        'label': 'Black author',
+        'uuid': '8575c60c-8168-4677-a043-ebca8f62e8d3',
+        'bib_count': 74857,
+        'desc_count': 0,
+      },
+      {
+        'label': 'Wheatley, Phillis, 1753-1784 -- Bibliography',
+        'uuid': 'c08c43f2-2720-4530-af07-6599227d2f4d',
+        'bib_count': 5,
+        'desc_count': 0,
+        'parent': {
+          'label': 'Wheatley, Phillis, 1753-1784',
+          'uuid': '89a59af2-fbd3-43f0-bc78-1989a7d5d45b',
+          'bib_count': 120,
+          'desc_count': 21,
+        },
+      },
+    ],
+  },
 ];
 
 export default bibs;

--- a/test/unit/BibPage.test.js
+++ b/test/unit/BibPage.test.js
@@ -50,7 +50,9 @@ describe('BibPage', () => {
         (node) =>
           node.type() === BibDetails && node.prop('additionalData').length,
       );
-
+      // The Bottom Bib Details Component has the original, Non altered, aggregated resources list.
+      // It can be checked to see if the bib details would have been passed a list with Aeon links.
+      
       expect(bttBibComp.type()).to.equal(BibDetails);
       expect(bttBibComp.prop('electronicResources')).to.have.lengthOf(2);
 


### PR DESCRIPTION
Remove all Aeon links from the Electronic Resources List passed to the TOP BibDetails Component if the table of items contains a valid Aeon Request Bttn.

The only addition to functional BibPage is the removal of the resources. No other functionalities were added.