### PR TITLE
Identify Aeon links in 856 and don't show surrogates in bib details

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "dist": "cross-env NODE_ENV=production webpack --config webpack.config.js",
     "preinstall": "npm i webpack-cli",
     "postinstall": "npm run dist",
-    "test": ". ./test.env; node_modules/.bin/mocha test/helpers/browser.js test/unit/*.test.js",
+    "test": "mocha test/helpers/browser.js test/unit/*.test.js",
     "test-dev": "node_modules/.bin/mocha -w test/helpers/browser.js test/unit/*.test.js",
     "test-file": "node_modules/.bin/mocha -w test/helpers/browser.js",
     "coverage": "BABEL_ENV=test node_modules/.bin/nyc --require mocha npm test",

--- a/src/app/components/BibPage/BackToSearchResults.jsx
+++ b/src/app/components/BibPage/BackToSearchResults.jsx
@@ -1,0 +1,16 @@
+import { Link as DSLink } from '@nypl/design-system-react-components';
+import React from 'react';
+import { Link } from 'react-router';
+
+const BackToSearchResults = ({ result, bibId }) => {
+  return (
+    result.fromUrl &&
+    result.bibId === bibId && (
+      <DSLink>
+        <Link to={result.fromUrl}>Back to search results</Link>
+      </DSLink>
+    )
+  );
+};
+
+export default BackToSearchResults;

--- a/src/app/components/BibPage/BibDetails.jsx
+++ b/src/app/components/BibPage/BibDetails.jsx
@@ -1,20 +1,17 @@
-import React from 'react';
 import PropTypes from 'prop-types';
+import React from 'react';
 import { Link } from 'react-router';
 import {
   isArray as _isArray,
-  isObject as _isObject,
   isEmpty as _isEmpty,
+  isObject as _isObject,
 } from 'underscore';
-
-import {
-  trackDiscovery,
-} from '../../utils/utils';
-import DefinitionList from './DefinitionList';
 import appConfig from '../../data/appConfig';
+import { combineBibDetailsData } from '../../utils/bibDetailsUtils';
 import getOwner from '../../utils/getOwner';
 import LibraryItem from '../../utils/item';
-import { combineBibDetailsData } from '../../utils/bibDetailsUtils';
+import { trackDiscovery } from '../../utils/utils';
+import DefinitionList from './DefinitionList';
 
 class BibDetails extends React.Component {
   constructor(props) {
@@ -51,7 +48,13 @@ class BibDetails extends React.Component {
    * @param {string} fieldLabel - offers the type of search keywords
    * @return {HTML element}
    */
-  getDefinitionObject(bibValues, fieldValue, fieldLinkable, fieldSelfLinkable, fieldLabel) {
+  getDefinitionObject(
+    bibValues,
+    fieldValue,
+    fieldLinkable,
+    fieldSelfLinkable,
+    fieldLabel,
+  ) {
     // If there's only one value, we just want that value and not a list.
     if (bibValues.length === 1) {
       const bibValue = bibValues[0];
@@ -60,7 +63,9 @@ class BibDetails extends React.Component {
       if (fieldLinkable) {
         return (
           <Link
-            onClick={e => this.newSearch(e, url, fieldValue, bibValue['@id'], fieldLabel)}
+            onClick={(e) =>
+              this.newSearch(e, url, fieldValue, bibValue['@id'], fieldLabel)
+            }
             to={`${appConfig.baseUrl}/search?${url}`}
           >
             {bibValue.prefLabel}
@@ -72,7 +77,12 @@ class BibDetails extends React.Component {
         return (
           <a
             href={bibValue['@id']}
-            onClick={() => trackDiscovery('Bib fields', `${fieldLabel} - ${bibValue.prefLabel}`)}
+            onClick={() =>
+              trackDiscovery(
+                'Bib fields',
+                `${fieldLabel} - ${bibValue.prefLabel}`,
+              )
+            }
           >
             {bibValue.prefLabel}
           </a>
@@ -84,33 +94,38 @@ class BibDetails extends React.Component {
 
     return (
       <ul className="additionalDetails">
-        {
-          bibValues.map((value) => {
-            const url = `filters[${fieldValue}]=${value['@id']}`;
-            let itemValue = fieldLinkable ?
-              (
-                <Link
-                  onClick={e => this.newSearch(e, url, fieldValue, value['@id'], fieldLabel)}
-                  to={`${appConfig.baseUrl}/search?${url}`}
-                >
-                  {value.prefLabel}
-                </Link>
-              )
-              : <span>{value.prefLabel}</span>;
-            if (fieldSelfLinkable) {
-              itemValue = (
-                <a
-                  href={value['@id']}
-                  onClick={() => trackDiscovery('Bib fields', `${fieldLabel} - ${value.prefLabel}`)}
-                >
-                  {value.prefLabel}
-                </a>
-              );
-            }
+        {bibValues.map((value) => {
+          const url = `filters[${fieldValue}]=${value['@id']}`;
+          let itemValue = fieldLinkable ? (
+            <Link
+              onClick={(e) =>
+                this.newSearch(e, url, fieldValue, value['@id'], fieldLabel)
+              }
+              to={`${appConfig.baseUrl}/search?${url}`}
+            >
+              {value.prefLabel}
+            </Link>
+          ) : (
+            <span>{value.prefLabel}</span>
+          );
+          if (fieldSelfLinkable) {
+            itemValue = (
+              <a
+                href={value['@id']}
+                onClick={() =>
+                  trackDiscovery(
+                    'Bib fields',
+                    `${fieldLabel} - ${value.prefLabel}`,
+                  )
+                }
+              >
+                {value.prefLabel}
+              </a>
+            );
+          }
 
-            return (<li key={value.prefLabel}>{itemValue}</li>);
-          })
-        }
+          return <li key={value.prefLabel}>{itemValue}</li>;
+        })}
       </ul>
     );
   }
@@ -123,18 +138,32 @@ class BibDetails extends React.Component {
    * @param {string} identifierType - The rdf:type to get (e.g. bf:Isbn)
    */
   getIdentifiers(bibValues, identifierType) {
-    const entities = LibraryItem.getIdentifierEntitiesByType(bibValues, identifierType);
+    const entities = LibraryItem.getIdentifierEntitiesByType(
+      bibValues,
+      identifierType,
+    );
     if (Array.isArray(entities) && entities.length > 0) {
-      const markup = entities
-        .map((ent) => {
-          const nodes = [(<span key={`${ent['@value']}`}>{ent['@value']}</span>)];
-          if (ent.identifierStatus) nodes.push(<span key={`${ent['@value']}`}> <em>({ent.identifierStatus})</em></span>);
-          return nodes;
-        });
+      const markup = entities.map((ent) => {
+        const nodes = [<span key={`${ent['@value']}`}>{ent['@value']}</span>];
+        if (ent.identifierStatus)
+          nodes.push(
+            <span key={`${ent['@value']}`}>
+              {' '}
+              <em>({ent.identifierStatus})</em>
+            </span>,
+          );
+        return nodes;
+      });
 
-      return markup.length === 1
-        ? markup.pop()
-        : (<ul>{markup.map(m => (<li key={m[0].key}>{m}</li>))}</ul>);
+      return markup.length === 1 ? (
+        markup.pop()
+      ) : (
+        <ul>
+          {markup.map((m) => (
+            <li key={m[0].key}>{m}</li>
+          ))}
+        </ul>
+      );
     }
     return null;
   }
@@ -153,8 +182,12 @@ class BibDetails extends React.Component {
    * @return {HTML element}
    */
   getDefinition(
-    bibValues, fieldValue, fieldLinkable, fieldIdentifier,
-    fieldSelfLinkable, fieldLabel,
+    bibValues,
+    fieldValue,
+    fieldLinkable,
+    fieldIdentifier,
+    fieldSelfLinkable,
+    fieldLabel,
   ) {
     if (fieldValue === 'identifier') {
       return this.getIdentifiers(bibValues, fieldIdentifier);
@@ -177,25 +210,27 @@ class BibDetails extends React.Component {
 
     return (
       <ul>
-        {
-          bibValues.map((value) => {
-            const url = `filters[${fieldValue}]=${value}`;
-            return (
-              <li key={`filter${fieldValue}${typeof value === 'string' ? value : value.label}`}>
-                {this.getDefinitionOneItem(
-                  value,
-                  url,
-                  bibValues,
-                  fieldValue,
-                  fieldLinkable,
-                  fieldIdentifier,
-                  fieldSelfLinkable,
-                  fieldLabel,
-                )}
-              </li>
-            );
-          })
-        }
+        {bibValues.map((value) => {
+          const url = `filters[${fieldValue}]=${value}`;
+          return (
+            <li
+              key={`filter${fieldValue}${
+                typeof value === 'string' ? value : value.label
+              }`}
+            >
+              {this.getDefinitionOneItem(
+                value,
+                url,
+                bibValues,
+                fieldValue,
+                fieldLinkable,
+                fieldIdentifier,
+                fieldSelfLinkable,
+                fieldLabel,
+              )}
+            </li>
+          );
+        })}
       </ul>
     );
   }
@@ -216,17 +251,30 @@ class BibDetails extends React.Component {
    * @return {HTML element}
    */
   getDefinitionOneItem(
-    bibValue, url, bibValues, fieldValue, fieldLinkable, fieldIdentifier,
-    fieldSelfLinkable, fieldLabel,
+    bibValue,
+    url,
+    bibValues,
+    fieldValue,
+    fieldLinkable,
+    fieldIdentifier,
+    fieldSelfLinkable,
+    fieldLabel,
   ) {
     if (fieldValue === 'subjectLiteral') {
-      return this.constructSubjectHeading(bibValue, url, fieldValue, fieldLabel);
+      return this.constructSubjectHeading(
+        bibValue,
+        url,
+        fieldValue,
+        fieldLabel,
+      );
     }
 
     if (fieldLinkable) {
       return (
         <Link
-          onClick={e => this.newSearch(e, url, fieldValue, bibValue, fieldLabel)}
+          onClick={(e) =>
+            this.newSearch(e, url, fieldValue, bibValue, fieldLabel)
+          }
           to={`${appConfig.baseUrl}/search?${url}`}
         >
           {bibValue}
@@ -238,7 +286,12 @@ class BibDetails extends React.Component {
       return (
         <a
           href={bibValue.url}
-          onClick={() => trackDiscovery('Bib fields', `${fieldLabel} - ${bibValue.prefLabel}`)}
+          onClick={() =>
+            trackDiscovery(
+              'Bib fields',
+              `${fieldLabel} - ${bibValue.prefLabel}`,
+            )
+          }
         >
           {bibValue.prefLabel || bibValue.label || bibValue.url}
         </a>
@@ -295,16 +348,22 @@ class BibDetails extends React.Component {
         if (firstFieldValue['@id']) {
           fieldsToRender.push({
             term: fieldLabel,
-            definition:
-              this.getDefinitionObject(
-                bibValues, fieldValue, fieldLinkable, fieldSelfLinkable,
-                fieldLabel,
-              ),
+            definition: this.getDefinitionObject(
+              bibValues,
+              fieldValue,
+              fieldLinkable,
+              fieldSelfLinkable,
+              fieldLabel,
+            ),
           });
         } else {
           const definition = this.getDefinition(
-            bibValues, fieldValue, fieldLinkable, fieldIdentifier,
-            fieldSelfLinkable, fieldLabel,
+            bibValues,
+            fieldValue,
+            fieldLinkable,
+            fieldIdentifier,
+            fieldSelfLinkable,
+            fieldLabel,
           );
           if (definition) {
             fieldsToRender.push({
@@ -341,7 +400,7 @@ class BibDetails extends React.Component {
           // Group notes by noteType:
           const notesGroupedByNoteType = note
             // Make sure all notes are blanknodes:
-            .filter(n => (typeof n) === 'object')
+            .filter((n) => typeof n === 'object')
             .reduce((groups, n) => {
               const noteType = this.getNoteType(n);
               if (!groups[noteType]) groups[noteType] = [];
@@ -353,11 +412,9 @@ class BibDetails extends React.Component {
           Object.keys(notesGroupedByNoteType).forEach((noteType) => {
             const notesList = (
               <ul>
-                {
-                  notesGroupedByNoteType[noteType].map((n, i) => (
-                    <li key={i.toString()}>{n.prefLabel}</li>
-                  ))
-                }
+                {notesGroupedByNoteType[noteType].map((n, i) => (
+                  <li key={i.toString()}>{n.prefLabel}</li>
+                ))}
               </ul>
             );
             fieldsToRender.push({
@@ -368,7 +425,10 @@ class BibDetails extends React.Component {
         }
       }
 
-      if ((fieldLabel === 'Electronic Resource') && this.props.electronicResources.length) {
+      if (
+        fieldLabel === 'Electronic Resource' &&
+        this.props.electronicResources.length
+      ) {
         const electronicResources = this.props.electronicResources;
         let electronicElem;
 
@@ -379,29 +439,34 @@ class BibDetails extends React.Component {
               href={electronicItem.url}
               target="_blank"
               onClick={() =>
-                trackDiscovery('Bib fields', `Electronic Resource - ${electronicItem.label} - ${electronicItem.url}`)
+                trackDiscovery(
+                  'Bib fields',
+                  `Electronic Resource - ${electronicItem.label} - ${electronicItem.url}`,
+                )
               }
             >
               {electronicItem.label || electronicItem.url}
-            </a>);
+            </a>
+          );
         } else {
           electronicElem = (
             <ul>
-              {
-                electronicResources.map(e => (
-                  <li key={e.label}>
-                    <a
-                      href={e.url}
-                      target="_blank"
-                      onClick={
-                        () => trackDiscovery('Bib fields', `Electronic Resource - ${e.label} - ${e.url}`)
-                      }
-                    >
-                      {e.label || e.url}
-                    </a>
-                  </li>
-                ))
-              }
+              {electronicResources.map((e) => (
+                <li key={e.label}>
+                  <a
+                    href={e.url}
+                    target="_blank"
+                    onClick={() =>
+                      trackDiscovery(
+                        'Bib fields',
+                        `Electronic Resource - ${e.label} - ${e.url}`,
+                      )
+                    }
+                  >
+                    {e.label || e.url}
+                  </a>
+                </li>
+              ))}
             </ul>
           );
         }
@@ -425,14 +490,13 @@ class BibDetails extends React.Component {
    */
   compressSubjectLiteral(subjectLiteralArray) {
     if (Array.isArray(subjectLiteralArray) && subjectLiteralArray.length) {
-      subjectLiteralArray = subjectLiteralArray.map(item =>
+      subjectLiteralArray = subjectLiteralArray.map((item) =>
         item.replace(/\.$/, '').replace(/--/g, '>'),
       );
     }
 
     return subjectLiteralArray;
   }
-
 
   /**
    * constructSubjectHeading(bibValue, url, fieldValue, fieldLabel)
@@ -450,9 +514,11 @@ class BibDetails extends React.Component {
     const singleSubjectHeadingArray = bibValue.split(' > ');
     const returnArray = [];
 
-    const urlArray = url.replace(filterQueryForSubjectHeading, '').split(' > ')
+    const urlArray = url
+      .replace(filterQueryForSubjectHeading, '')
+      .split(' > ')
       .map((urlString, index) => {
-        const dashDivided = (index !== 0) ? ' -- ' : '';
+        const dashDivided = index !== 0 ? ' -- ' : '';
         currentArrayString = `${currentArrayString}${dashDivided}${urlString}`;
 
         return currentArrayString;
@@ -463,8 +529,14 @@ class BibDetails extends React.Component {
 
       const subjectHeadingLink = (
         <Link
-          onClick={
-            e => this.newSearch(e, urlWithFilterQuery, fieldValue, urlArray[index], fieldLabel)
+          onClick={(e) =>
+            this.newSearch(
+              e,
+              urlWithFilterQuery,
+              fieldValue,
+              urlArray[index],
+              fieldLabel,
+            )
           }
           to={`${appConfig.baseUrl}/search?${urlWithFilterQuery}`}
           key={heading}
@@ -501,18 +573,12 @@ class BibDetails extends React.Component {
     } else {
       display = (
         <ul>
-          {
-            note.map((n, i) => (
-              <li key={i.toString()}>
-                <h4>
-                  {n.noteType}
-                </h4>
-                <p>
-                  {n.prefLabel}
-                </p>
-              </li>
-            ))
-          }
+          {note.map((n, i) => (
+            <li key={i.toString()}>
+              <h4>{n.noteType}</h4>
+              <p>{n.prefLabel}</p>
+            </li>
+          ))}
         </ul>
       );
     }
@@ -543,7 +609,11 @@ class BibDetails extends React.Component {
     //  1) nonempty
     //  2) an object
     //  3) not an array (which is also an object)
-    if (_isEmpty(this.props.bib) || !_isObject(this.props.bib) || _isArray(this.props.bib)) {
+    if (
+      _isEmpty(this.props.bib) ||
+      !_isObject(this.props.bib) ||
+      _isArray(this.props.bib)
+    ) {
       return null;
     }
     // Make sure fields is a nonempty array:
@@ -558,7 +628,8 @@ class BibDetails extends React.Component {
       <DefinitionList
         data={data}
         headings={this.props.bib.subjectHeadingData}
-      />);
+      />
+    );
   }
 }
 

--- a/src/app/components/BibPage/BibNotFound404.jsx
+++ b/src/app/components/BibPage/BibNotFound404.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import NotFound404 from '../NotFound404/NotFound404';
+import Redirect404 from '../Redirect404/Redirect404';
+
+const BibNotFound404 = ({ context }) => {
+  const originalUrl =
+    context &&
+    context.router &&
+    context.router.location &&
+    context.router.location.query &&
+    context.router.location.query.originalUrl;
+
+  return originalUrl ? <Redirect404 /> : <NotFound404 />;
+};
+
+export default BibNotFound404;

--- a/src/app/components/BibPage/BottomBibDetails.jsx
+++ b/src/app/components/BibPage/BottomBibDetails.jsx
@@ -1,0 +1,68 @@
+import { Heading } from '@nypl/design-system-react-components';
+import React from 'react';
+import { annotatedMarcDetails } from '../../utils/bibDetailsUtils';
+import { isNyplBnumber } from '../../utils/utils';
+import BibDetails from './BibDetails';
+
+// `linkable` means that those values are links inside the app.
+// `selfLinkable` means that those values are external links and should be self-linked,
+// e.g. the prefLabel is the label and the URL is the id.
+const detailsFields = [
+  {
+    label: 'Additional Authors',
+    value: 'contributorLiteral',
+    linkable: true,
+  },
+  { label: 'Found In', value: 'partOf' },
+  { label: 'Publication Date', value: 'serialPublicationDates' },
+  { label: 'Description', value: 'extent' },
+  { label: 'Donor/Sponsor', value: 'donor' },
+  { label: 'Series Statement', value: 'seriesStatement' },
+  { label: 'Uniform Title', value: 'uniformTitle' },
+  { label: 'Alternative Title', value: 'titleAlt' },
+  { label: 'Former Title', value: 'formerTitle' },
+  { label: 'Subject', value: 'subjectHeadingData' },
+  { label: 'Genre/Form', value: 'genreForm' },
+  { label: 'Notes', value: 'React Component' },
+  { label: 'Contents', value: 'tableOfContents' },
+  { label: 'Bibliography', value: '' },
+  { label: 'Call Number', value: 'identifier', identifier: 'bf:ShelfMark' },
+  { label: 'ISBN', value: 'identifier', identifier: 'bf:Isbn' },
+  { label: 'ISSN', value: 'identifier', identifier: 'bf:Issn' },
+  { label: 'LCCN', value: 'identifier', identifier: 'bf:Lccn' },
+  { label: 'OCLC', value: 'identifier', identifier: 'nypl:Oclc' },
+  { label: 'GPO', value: '' },
+  { label: 'Other Titles', value: '' },
+  { label: 'Owning Institutions', value: '' },
+];
+
+const BottomBibDetails = ({ bib, resources }) => {
+  // if the subject heading API call failed for some reason,
+  // we will use the subjectLiteral property from the
+  // Discovery API response instead
+  if (!bib.subjectHeadingData) {
+    detailsFields.push({
+      label: 'Subject',
+      value: 'subjectLiteral',
+      linkable: true,
+    });
+  }
+
+  return (
+    <section style={{ marginTop: '20px' }}>
+      <Heading level={3}>Details</Heading>
+      <BibDetails
+        bib={bib}
+        fields={detailsFields}
+        electronicResources={resources}
+        additionalData={
+          isNyplBnumber(bib.uri) && bib.annotatedMarc
+            ? annotatedMarcDetails(bib)
+            : []
+        }
+      />
+    </section>
+  );
+};
+
+export default BottomBibDetails;

--- a/src/app/components/BibPage/DefinitionList.jsx
+++ b/src/app/components/BibPage/DefinitionList.jsx
@@ -1,5 +1,5 @@
-import React from 'react';
 import PropTypes from 'prop-types';
+import React from 'react';
 import SubjectHeadings from './SubjectHeadings';
 
 /*
@@ -7,24 +7,28 @@ import SubjectHeadings from './SubjectHeadings';
  * Expects data in the form of [{ term: '', definition: '' }, {...}, ...].
  */
 const DefinitionList = ({ data, headings }) => {
-  const getDefinitions = definitions => definitions.map((item) => {
-    if (!item || (!item.term && !item.definition)) {
-      return null;
-    }
+  const getDefinitions = (definitions) =>
+    definitions.map((item) => {
+      if (!item || (!item.term && !item.definition)) {
+        return null;
+      }
 
-    if (item.term === 'Subject' && headings) return <SubjectHeadings key="subjects" headings={headings} />;
+      if (item.term === 'Subject' && headings)
+        return <SubjectHeadings key="subjects" headings={headings} />;
 
-    return ([
-      (<dt key={`term-${item.term}`}>{item.term}</dt>),
-      (<dd data={`definition-${item.term}`} key={`definition-${item.term}`}>{item.definition}</dd>),
-    ]);
-  });
+      return [
+        <dt key={`term-${item.term}`}>{item.term}</dt>,
+        <dd data={`definition-${item.term}`} key={`definition-${item.term}`}>
+          {item.definition}
+        </dd>,
+      ];
+    });
 
   if (!data || !data.length) {
     return null;
   }
 
-  return (<dl>{getDefinitions(data)}</dl>);
+  return <dl>{getDefinitions(data)}</dl>;
 };
 
 DefinitionList.propTypes = {

--- a/src/app/components/BibPage/LibraryHoldings.jsx
+++ b/src/app/components/BibPage/LibraryHoldings.jsx
@@ -1,9 +1,7 @@
-import React from 'react';
+import { Heading } from '@nypl/design-system-react-components';
 import PropTypes from 'prop-types';
+import React from 'react';
 import DefinitionList from './DefinitionList';
-import {
-  Heading,
-} from '@nypl/design-system-react-components';
 
 const LibraryHoldings = ({ holdings }) => {
   if (!holdings) {
@@ -15,46 +13,26 @@ const LibraryHoldings = ({ holdings }) => {
     if (!el.url) return <li>{el.label}</li>;
     return (
       <li>
-        <a href={el.url}>
-          { el.label }
-        </a>
+        <a href={el.url}>{el.label}</a>
       </li>
     );
   };
 
-  const htmlDefinitions = holding => holding
-    .holdingDefinition
-    .map(definition => (
-      {
-        term: definition.term,
-        definition: (
-          <ul>
-            {
-              definition.definition.map(el => liForEl(el))
-            }
-          </ul>
-        ),
-      }
-    ));
+  const htmlDefinitions = (holding) =>
+    holding.holdingDefinition.map((definition) => ({
+      term: definition.term,
+      definition: <ul>{definition.definition.map((el) => liForEl(el))}</ul>,
+    }));
 
   return (
     <React.Fragment>
-      <Heading
-        level={3}
-      >
-        Holdings
-      </Heading>
-      {
-        holdings
-        .map(holding =>
-          (
-            <DefinitionList
-              data={htmlDefinitions(holding)}
-              key={holding.holdingDefinition}
-            />
-          ),
-        )
-      }
+      <Heading level={3}>Holdings</Heading>
+      {holdings.map((holding) => (
+        <DefinitionList
+          data={htmlDefinitions(holding)}
+          key={holding.holdingDefinition}
+        />
+      ))}
     </React.Fragment>
   );
 };

--- a/src/app/components/BibPage/SubjectHeadings.jsx
+++ b/src/app/components/BibPage/SubjectHeadings.jsx
@@ -1,5 +1,5 @@
-import React from 'react';
 import PropTypes from 'prop-types';
+import React from 'react';
 import { Link } from 'react-router';
 import appConfig from '../../data/appConfig';
 
@@ -11,23 +11,27 @@ const constructSubjectHeading = (heading, i) => {
     return (
       <Link
         key={`${uuid} ${i}`}
-        to={`${appConfig.baseUrl}/subject_headings/${uuid}?label=${encodeURIComponent(label)}`}
+        to={`${
+          appConfig.baseUrl
+        }/subject_headings/${uuid}?label=${encodeURIComponent(label)}`}
       >
         {subjectComponent}
       </Link>
     );
   }
 
-  return ([
+  return [
     constructSubjectHeading(parent),
     <span key={`${uuid} ${i}`}> {'>'} </span>,
     <Link
       key={uuid}
-      to={`${appConfig.baseUrl}/subject_headings/${uuid}?label=${encodeURIComponent(label)}`}
+      to={`${
+        appConfig.baseUrl
+      }/subject_headings/${uuid}?label=${encodeURIComponent(label)}`}
     >
       {subjectComponent}
     </Link>,
-  ]);
+  ];
 };
 
 const generateHeadingLi = (heading, i) => (
@@ -43,9 +47,7 @@ const SubjectHeadings = (props) => {
     <div>
       <dt key={`term-${i}`}>{headings.length > 1 ? 'Subjects' : 'Subject'}</dt>
       <dd data={`definition-${i}`} key={`definition-${i}`}>
-        <ul>
-          {headings.map(generateHeadingLi)}
-        </ul>
+        <ul>{headings.map(generateHeadingLi)}</ul>
       </dd>
     </div>
   );

--- a/src/app/components/BibPage/TopBibDetails.jsx
+++ b/src/app/components/BibPage/TopBibDetails.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import BibDetails from './BibDetails';
+
+// `linkable` means that those values are links inside the app.
+// `selfLinkable` means that those values are external links and should be self-linked,
+// e.g. the prefLabel is the label and the URL is the id.
+const topFields = [
+  { label: 'Title', value: 'titleDisplay' },
+  { label: 'Author', value: 'creatorLiteral', linkable: true },
+  { label: 'Publication', value: 'publicationStatement' },
+  { label: 'Electronic Resource', value: 'React Component' },
+  {
+    label: 'Supplementary Content',
+    value: 'supplementaryContent',
+    selfLinkable: true,
+  },
+];
+
+const TopBibDetails = ({ bib, resources }) => {
+  return (
+    <section style={{ marginTop: '20px' }}>
+      <BibDetails
+        logging
+        bib={bib}
+        fields={topFields}
+        electronicResources={resources}
+      />
+    </section>
+  );
+};
+
+export default TopBibDetails;

--- a/src/app/components/Item/ItemFilters.jsx
+++ b/src/app/components/Item/ItemFilters.jsx
@@ -1,16 +1,16 @@
-import React, { useState, Fragment } from 'react';
-import PropTypes from 'prop-types';
-
 import { Button } from '@nypl/design-system-react-components';
+import PropTypes from 'prop-types';
+import React, { Fragment, useState } from 'react';
+import { itemFilters } from '../../data/constants';
+import { trackDiscovery } from '../../utils/utils';
+import { MediaContext } from '../Application/Application';
 import ItemFilter from './ItemFilter';
 import ItemFiltersMobile from './ItemFiltersMobile';
-import { trackDiscovery } from '../../utils/utils';
-import { itemFilters } from '../../data/constants';
 
-import { MediaContext } from '../Application/Application';
-
-
-const ItemFilters = ({ items, hasFilterApplied, numOfFilteredItems }, { router }) => {
+const ItemFilters = (
+  { items, hasFilterApplied, numOfFilteredItems },
+  { router },
+) => {
   if (!items || !items.length) return null;
   const [openFilter, setOpenFilter] = useState('none');
   const { createHref } = router;
@@ -30,7 +30,8 @@ const ItemFilters = ({ items, hasFilterApplied, numOfFilteredItems }, { router }
       trackDiscovery('Search Filters', `Close Filter - ${filterType}`);
       setOpenFilter('none');
     } else {
-      if (filterType === 'none') trackDiscovery('Search Filters', `Close Filter - ${openFilter}`);
+      if (filterType === 'none')
+        trackDiscovery('Search Filters', `Close Filter - ${openFilter}`);
       else {
         trackDiscovery('Search Filters', `Open Filter - ${openFilter}`);
       }
@@ -42,7 +43,8 @@ const ItemFilters = ({ items, hasFilterApplied, numOfFilteredItems }, { router }
   const mapFilterIdsToLabel = {};
   itemFilters.forEach((filter) => {
     const optionsObjEntry = options[filter.type];
-    const filterOptions = optionsObjEntry || items.map(item => filter.retrieveOption(item));
+    const filterOptions =
+      optionsObjEntry || items.map((item) => filter.retrieveOption(item));
     if (!optionsObjEntry) options[filter.type] = filterOptions;
     filterOptions.forEach((option) => {
       mapFilterIdsToLabel[option.id] = option.label;
@@ -50,20 +52,23 @@ const ItemFilters = ({ items, hasFilterApplied, numOfFilteredItems }, { router }
   });
 
   // join filter selections and add single quotes
-  const parsedFilterSelections = () => itemFilters
-    .map((filter) => {
-      const filters = initialFilters[filter.type];
-      if (filters.length) {
-        let filtersString;
-        if (Array.isArray(filters)) {
-          filtersString = filters.join("', '");
-        } else {
-          filtersString = filters;
+  const parsedFilterSelections = () =>
+    itemFilters
+      .map((filter) => {
+        const filters = initialFilters[filter.type];
+        if (filters.length) {
+          let filtersString;
+          if (Array.isArray(filters)) {
+            filtersString = filters.join("', '");
+          } else {
+            filtersString = filters;
+          }
+          return `${filter.type}: '${filtersString}'`;
         }
-        return `${filter.type}: '${filtersString}'`;
-      }
-      return null;
-    }).filter(selected => selected).join(', ');
+        return null;
+      })
+      .filter((selected) => selected)
+      .join(', ');
 
   const resetFilters = () => {
     const href = router.createHref({
@@ -82,7 +87,10 @@ const ItemFilters = ({ items, hasFilterApplied, numOfFilteredItems }, { router }
         search: '',
       },
     });
-    trackDiscovery('Search Filters', `Apply Filter - ${JSON.stringify(filters)}`);
+    trackDiscovery(
+      'Search Filters',
+      `Apply Filter - ${JSON.stringify(filters)}`,
+    );
     router.push(href);
   };
 
@@ -97,49 +105,43 @@ const ItemFilters = ({ items, hasFilterApplied, numOfFilteredItems }, { router }
   return (
     <Fragment>
       <MediaContext.Consumer>
-        {
-          media =>
-          (
-            <Fragment>
-              {
-              ['mobile', 'tabletPortrait'].includes(media) ?
-              (<ItemFiltersMobile
+        {(media) => (
+          <Fragment>
+            {['mobile', 'tabletPortrait'].includes(media) ? (
+              <ItemFiltersMobile
                 options={options}
                 {...itemFilterComponentProps}
-              />) :
-              (
-                <div id="item-filters" className="item-table-filters">
-                  {
-                    itemFilters.map(filter => (
-                      <ItemFilter
-                        filter={filter.type}
-                        key={filter.type}
-                        options={options[filter.type]}
-                        isOpen={openFilter === filter.type}
-                        {...itemFilterComponentProps}
-                      />
-                    ))
-                  }
-                </div>
-              )
-            }
-            </Fragment>
-          )
-        }
+              />
+            ) : (
+              <div id="item-filters" className="item-table-filters">
+                {itemFilters.map((filter) => (
+                  <ItemFilter
+                    filter={filter.type}
+                    key={filter.type}
+                    options={options[filter.type]}
+                    isOpen={openFilter === filter.type}
+                    {...itemFilterComponentProps}
+                  />
+                ))}
+              </div>
+            )}
+          </Fragment>
+        )}
       </MediaContext.Consumer>
       <div className="item-filter-info">
-        <h3>{numOfFilteredItems > 0 ? numOfFilteredItems : 'No'} Result{numOfFilteredItems !== 1 ? 's' : null} Found</h3>
-        {hasFilterApplied ? <span>Filtered by {parsedFilterSelections()}</span> : null}
+        <h3>
+          {numOfFilteredItems > 0 ? numOfFilteredItems : 'No'} Result
+          {numOfFilteredItems !== 1 ? 's' : null} Found
+        </h3>
+        {hasFilterApplied ? (
+          <span>Filtered by {parsedFilterSelections()}</span>
+        ) : null}
         &nbsp;
-        {
-          hasFilterApplied ? (
-            <Button
-              buttonType="link"
-              onClick={() => resetFilters()}
-            >Clear all filters
-            </Button>
-          ) : null
-        }
+        {hasFilterApplied ? (
+          <Button buttonType="link" onClick={() => resetFilters()}>
+            Clear all filters
+          </Button>
+        ) : null}
       </div>
     </Fragment>
   );

--- a/src/app/components/Item/ItemsContainer.jsx
+++ b/src/app/components/Item/ItemsContainer.jsx
@@ -1,19 +1,18 @@
-import React from 'react';
+import { Heading } from '@nypl/design-system-react-components';
 import PropTypes from 'prop-types';
+import React from 'react';
+import { connect } from 'react-redux';
 import { Link } from 'react-router';
 import { isArray as _isArray } from 'underscore';
-import { connect } from 'react-redux';
-
-import {
-  Heading,
-} from '@nypl/design-system-react-components';
-
-import Pagination from '../Pagination/Pagination';
-import ItemTable from './ItemTable';
-import ItemFilters from './ItemFilters';
 import appConfig from '../../data/appConfig';
-import { trackDiscovery, isOptionSelected } from '../../utils/utils';
-import { itemFilters, bibPageItemsListLimit as itemsListPageLimit } from '../../data/constants';
+import {
+  bibPageItemsListLimit as itemsListPageLimit,
+  itemFilters,
+} from '../../data/constants';
+import { isOptionSelected, trackDiscovery } from '../../utils/utils';
+import Pagination from '../Pagination/Pagination';
+import ItemFilters from './ItemFilters';
+import ItemTable from './ItemTable';
 
 class ItemsContainer extends React.Component {
   constructor(props, context) {
@@ -27,13 +26,15 @@ class ItemsContainer extends React.Component {
     };
 
     this.query = context.router.location.query;
-    this.hasFilter = Object.keys(this.query).some(param => (
-      itemFilters.map(filter => filter.type).includes(param)));
+    this.hasFilter = Object.keys(this.query).some((param) =>
+      itemFilters.map((filter) => filter.type).includes(param),
+    );
 
     // NOTE: filteredItems: Setting 1
-    this.filteredItems = this.props.bib && this.props.bib.done ?
-      (this.filterItems(this.props.items) || [])
-      : (this.props.items || []);
+    this.filteredItems =
+      this.props.bib && this.props.bib.done
+        ? this.filterItems(this.props.items) || []
+        : this.props.items || [];
 
     this.updatePage = this.updatePage.bind(this);
     this.chunk = this.chunk.bind(this);
@@ -76,21 +77,24 @@ class ItemsContainer extends React.Component {
      * If there are more items than the page limit AND
      * we need to shorten it to the page limit AND
      * not show all
-    */
-    const itemsToDisplay = items && shortenItems && !showAll ?
-      items.slice(0, itemsListPageLimit) : items;
+     */
+    const itemsToDisplay =
+      items && shortenItems && !showAll
+        ? items.slice(0, itemsListPageLimit)
+        : items;
     const bibId = this.props.bibId;
 
-    return (
-      (itemsToDisplay && _isArray(itemsToDisplay) && itemsToDisplay.length) ?
-        <ItemTable
-          items={itemsToDisplay}
-          bibId={bibId}
-          id="bib-item-table"
-          searchKeywords={this.props.searchKeywords}
-          holdings={this.props.holdings}
-        /> : null
-    );
+    return itemsToDisplay &&
+      _isArray(itemsToDisplay) &&
+      itemsToDisplay.length ? (
+      <ItemTable
+        items={itemsToDisplay}
+        bibId={bibId}
+        id="bib-item-table"
+        searchKeywords={this.props.searchKeywords}
+        holdings={this.props.holdings}
+      />
+    ) : null;
   }
 
   filterItems(items) {
@@ -104,11 +108,14 @@ class ItemsContainer extends React.Component {
         const filterType = filter.type;
         const filterValue = query[filterType];
         if (!filterValue) return true;
-        const selections = typeof filterValue === 'string' ? [filterValue] : filterValue;
+        const selections =
+          typeof filterValue === 'string' ? [filterValue] : filterValue;
         return selections.some((selection) => {
-          const isRequestable = filterType === 'status' && selection === 'requestable';
+          const isRequestable =
+            filterType === 'status' && selection === 'requestable';
           if (isRequestable) return item.requestable;
-          const isOffsite = filterType === 'location' && selection === 'offsite';
+          const isOffsite =
+            filterType === 'location' && selection === 'offsite';
           if (isOffsite) return item.isOffsite;
           const itemProperty = filter.retrieveOption(item).label;
           return isOptionSelected(selection, itemProperty, true);
@@ -160,9 +167,10 @@ class ItemsContainer extends React.Component {
 
   render() {
     // NOTE: filteredItems: Setting 2
-    this.filteredItems = this.props.bib && this.props.bib.done ?
-      (this.filterItems(this.props.items) || [])
-      : (this.props.items || []);
+    this.filteredItems =
+      this.props.bib && this.props.bib.done
+        ? this.filterItems(this.props.items) || []
+        : this.props.items || [];
     const bibId = this.props.bibId;
     const bibDone = this.props.bib && this.props.bib.done;
     const { items } = this.props;
@@ -171,7 +179,12 @@ class ItemsContainer extends React.Component {
     let pagination = null;
 
     let itemsToDisplay = this.filteredItems;
-    if (this.state.js && itemsToDisplay && itemsToDisplay.length > itemsListPageLimit && !this.state.showAll) {
+    if (
+      this.state.js &&
+      itemsToDisplay &&
+      itemsToDisplay.length > itemsListPageLimit &&
+      !this.state.showAll
+    ) {
       pagination = (
         <Pagination
           total={itemsToDisplay.length}
@@ -186,13 +199,19 @@ class ItemsContainer extends React.Component {
       itemsToDisplay = this.state.chunkedItems[this.state.page - 1];
     }
 
-    const itemTable = this.getTable(itemsToDisplay, shortenItems, this.state.showAll);
-    const numItemsEstimate = this.props.bib.numItems + (this.props.bib.checkInItems || []).length;
+    const itemTable = this.getTable(
+      itemsToDisplay,
+      shortenItems,
+      this.state.showAll,
+    );
+    const numItemsEstimate =
+      this.props.bib.numItems + (this.props.bib.checkInItems || []).length;
     const itemLoadingMessage = (
       <div className="item-filter-info">
         <h3>
           <br />
-          About {`${numItemsEstimate}`} Item{numItemsEstimate !== 1 ? 's. ' : '. ' }
+          About {`${numItemsEstimate}`} Item
+          {numItemsEstimate !== 1 ? 's. ' : '. '}
           <div className="items-loading">
             Still Loading More items
             <span className="dot1">.</span>
@@ -205,44 +224,42 @@ class ItemsContainer extends React.Component {
 
     return (
       <>
-        <Heading
-          level={3}
-        >
-          Items in the Library & Offsite
-        </Heading>
+        <Heading level={3}>Items in the Library & Offsite</Heading>
         <div className="nypl-results-item">
-          {
-            bibDone ?
-              <ItemFilters
-                items={items}
-                hasFilterApplied={this.hasFilter}
-                query={this.query}
-                numOfFilteredItems={this.filteredItems.length}
-              />
-              :
-              itemLoadingMessage
-          }
+          {bibDone ? (
+            <ItemFilters
+              items={items}
+              hasFilterApplied={this.hasFilter}
+              query={this.query}
+              numOfFilteredItems={this.filteredItems.length}
+            />
+          ) : (
+            itemLoadingMessage
+          )}
           {itemTable}
-          {
-            !!(shortenItems && this.filteredItems.length > itemsListPageLimit && !this.state.showAll) &&
-              (
-                <div className="view-all-items-container">
-                  {
-                    this.state.js ?
-                      (<a href="#" onClick={this.showAll}>View All Items</a>) :
-                      (
-                        <Link
-                          to={`${appConfig.baseUrl}/bib/${bibId}/all`}
-                          className="view-all-items"
-                          onClick={() => trackDiscovery('View All Items', `Click - ${bibId}`)}
-                        >
-                          View All Items
-                        </Link>
-                      )
+          {!!(
+            shortenItems &&
+            this.filteredItems.length > itemsListPageLimit &&
+            !this.state.showAll
+          ) && (
+            <div className="view-all-items-container">
+              {this.state.js ? (
+                <a href="#" onClick={this.showAll}>
+                  View All Items
+                </a>
+              ) : (
+                <Link
+                  to={`${appConfig.baseUrl}/bib/${bibId}/all`}
+                  className="view-all-items"
+                  onClick={() =>
+                    trackDiscovery('View All Items', `Click - ${bibId}`)
                   }
-                </div>
-              )
-          }
+                >
+                  View All Items
+                </Link>
+              )}
+            </div>
+          )}
           {pagination}
         </div>
       </>
@@ -269,7 +286,7 @@ ItemsContainer.contextTypes = {
   router: PropTypes.object,
 };
 
-const mapStateToProps = state => ({
+const mapStateToProps = (state) => ({
   bib: state.bib,
 });
 

--- a/src/app/components/Item/ItemsContainer.jsx
+++ b/src/app/components/Item/ItemsContainer.jsx
@@ -30,6 +30,7 @@ class ItemsContainer extends React.Component {
     this.hasFilter = Object.keys(this.query).some(param => (
       itemFilters.map(filter => filter.type).includes(param)));
 
+    // NOTE: filteredItems: Setting 1
     this.filteredItems = this.props.bib && this.props.bib.done ?
       (this.filterItems(this.props.items) || [])
       : (this.props.items || []);
@@ -158,6 +159,7 @@ class ItemsContainer extends React.Component {
   }
 
   render() {
+    // NOTE: filteredItems: Setting 2
     this.filteredItems = this.props.bib && this.props.bib.done ?
       (this.filterItems(this.props.items) || [])
       : (this.props.items || []);

--- a/src/app/components/LegacyCatalog/LegacyCatalogLink.jsx
+++ b/src/app/components/LegacyCatalog/LegacyCatalogLink.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import appConfig from '../../data/appConfig';
+
+const LegacyCatalogLink = ({ recordNumber, display }) => {
+  return (
+    (display && (
+      <a
+        href={`${appConfig.legacyBaseUrl}/record=${recordNumber}~S1`}
+        id="legacy-catalog-link"
+      >
+        View in Legacy Catalog
+      </a>
+    )) ||
+    null
+  );
+};
+
+export default LegacyCatalogLink;

--- a/src/app/components/SccContainer/SccContainer.jsx
+++ b/src/app/components/SccContainer/SccContainer.jsx
@@ -1,21 +1,14 @@
-import React from 'react';
+import { Breadcrumbs, Heading } from '@nypl/design-system-react-components';
 import PropTypes from 'prop-types';
-import { useSelector } from 'react-redux';
+import React from 'react';
 import DocumentTitle from 'react-document-title';
-
-import {
-  Breadcrumbs,
-  Heading,
-} from '@nypl/design-system-react-components';
-
+import { useSelector } from 'react-redux';
+import appConfig from '../../data/appConfig';
 import LoadingLayer from '../LoadingLayer/LoadingLayer';
 import SubNav from '../SubNav/SubNav';
-import appConfig from '../../data/appConfig';
 
 const SccContainer = (props) => {
-  const {
-    loading,
-  } = useSelector(state => ({
+  const { loading } = useSelector((state) => ({
     loading: state.loading,
   }));
   const {
@@ -28,18 +21,14 @@ const SccContainer = (props) => {
     contentPrimaryStyle,
   } = props;
 
-  const documentTitle = `${pageTitle ? `${pageTitle} | ` : ''}${appConfig.displayTitle} | NYPL`;
+  const documentTitle = `${pageTitle ? `${pageTitle} | ` : ''}${
+    appConfig.displayTitle
+  } | NYPL`;
 
   return (
     <DocumentTitle title={documentTitle}>
       <div className="nypl-ds nypl--research layout-container">
-        {
-          useLoadingLayer ? (
-            <LoadingLayer
-              loading={loading}
-            />
-          ) : null
-        }
+        {useLoadingLayer ? <LoadingLayer loading={loading} /> : null}
         <main className="main main-page">
           <div className="content-header catalog__header">
             <Breadcrumbs
@@ -51,17 +40,17 @@ const SccContainer = (props) => {
               className="breadcrumbs"
             />
             <div className="catalog__heading">
-              <Heading
-                level={1}
-                id="1"
-                blockName="hero"
-              >
+              <Heading level={1} id="1" blockName="hero">
                 {appConfig.displayTitle}
               </Heading>
             </div>
             <SubNav activeSection={activeSection} />
           </div>
-          <div className={`content-primary ${className || ''}`} id={primaryId} style={contentPrimaryStyle}>
+          <div
+            className={`content-primary ${className || ''}`}
+            id={primaryId}
+            style={contentPrimaryStyle}
+          >
             {children}
           </div>
         </main>

--- a/src/app/data/appConfig.js
+++ b/src/app/data/appConfig.js
@@ -5,7 +5,8 @@ const appConfig = {
   appTitle: 'NYPL | Discovery',
   appName: 'discovery',
   displayTitle: process.env.DISPLAY_TITLE || 'Shared Collection Catalog',
-  baseUrl: process.env.BASE_URL || '/research/collections/shared-collection-catalog',
+  baseUrl:
+    process.env.BASE_URL || '/research/collections/shared-collection-catalog',
   redirectFromBaseUrl: process.env.REDIRECT_FROM_BASE_URL,
   legacyBaseUrl: process.env.LEGACY_BASE_URL,
   favIconPath: 'https://ux-static.nypl.org/images/favicon.ico',
@@ -14,12 +15,19 @@ const appConfig = {
   environment: process.env.APP_ENV || 'production',
   api: {
     discovery: {
-      development: process.env.PLATFORM_API_BASE_URL || 'https://qa-platform.nypl.org/api/v0.1',
-      production: process.env.PLATFORM_API_BASE_URL || 'https://platform.nypl.org/api/v0.1',
+      development:
+        process.env.PLATFORM_API_BASE_URL ||
+        'https://qa-platform.nypl.org/api/v0.1',
+      production:
+        process.env.PLATFORM_API_BASE_URL ||
+        'https://platform.nypl.org/api/v0.1',
     },
     drbb: {
-      development: process.env.DRB_API_BASE_URL || 'http://drb-api-qa.nypl.org/search/',
-      production: process.env.DRB_API_BASE_URL || 'https://digital-research-books-api.nypl.org/v3/sfr/search',
+      development:
+        process.env.DRB_API_BASE_URL || 'http://drb-api-qa.nypl.org/search/',
+      production:
+        process.env.DRB_API_BASE_URL ||
+        'https://digital-research-books-api.nypl.org/v3/sfr/search',
     },
   },
   circulatingCatalog: process.env.CIRCULATING_CATALOG,
@@ -48,11 +56,14 @@ const appConfig = {
   closedLocations: mapLocations(process.env.CLOSED_LOCATIONS),
   recapClosedLocations: mapLocations(process.env.RECAP_CLOSED_LOCATIONS),
   nonRecapClosedLocations: mapLocations(process.env.NON_RECAP_CLOSED_LOCATIONS),
-  openLocations: process.env.OPEN_LOCATIONS ? process.env.OPEN_LOCATIONS.split(',') : null,
+  openLocations: process.env.OPEN_LOCATIONS
+    ? process.env.OPEN_LOCATIONS.split(',')
+    : null,
   holdRequestNotification: process.env.HOLD_REQUEST_NOTIFICATION,
   searchResultsNotification: process.env.SEARCH_RESULTS_NOTIFICATION,
   drbbFrontEnd: {
-    development: 'http://sfr-front-end-development.us-east-1.elasticbeanstalk.com',
+    development:
+      'http://sfr-front-end-development.us-east-1.elasticbeanstalk.com',
     production: 'https://digital-research-books-beta.nypl.org',
   },
   drbbEreader: {

--- a/src/app/pages/BibPage.jsx
+++ b/src/app/pages/BibPage.jsx
@@ -26,6 +26,7 @@ import { itemBatchSize } from '../data/constants';
 
 import {
   getAggregatedElectronicResources,
+  pluckAeonLinksFromResource,
 } from '../utils/utils';
 
 import {
@@ -90,11 +91,8 @@ export const BibPage = (
   // const bNumber = bib && bib.idBnum ? bib.idBnum : '';
   const itemPage = location.search;
   const aggregatedElectronicResources = getAggregatedElectronicResources(items);
-  let shortenItems = true;
 
-  if (location.pathname.indexOf('all') === -1) {
-    shortenItems = false;
-  }
+  const shortenItems = location.pathname.indexOf('all') !== -1;
 
   // `linkable` means that those values are links inside the app.
   // `selfLinkable` means that those values are external links and should be self-linked,
@@ -224,7 +222,10 @@ export const BibPage = (
         bib={bib}
         fields={topFields}
         logging
-        electronicResources={aggregatedElectronicResources}
+        electronicResources={pluckAeonLinksFromResource(
+          aggregatedElectronicResources,
+          items,
+        )}
       />
       {
         contentAreas

--- a/src/app/pages/BibPage.jsx
+++ b/src/app/pages/BibPage.jsx
@@ -69,7 +69,7 @@ const checkForMoreItems = (bib, dispatch) => {
 };
 
 export const BibPage = (
-  { location, searchKeywords, dispatch, resultSelection },
+  { bib, location, searchKeywords, dispatch, resultSelection },
   context,
 ) => {
   if (!bib || parseInt(bib.status, 10) === 404) {

--- a/src/app/pages/BibPage.jsx
+++ b/src/app/pages/BibPage.jsx
@@ -75,14 +75,14 @@ export const BibPage = (
   if (!bib || parseInt(bib.status, 10) === 404) {
     return <BibNotFound404 context={context} />;
   }
-  const bib = props.bib ? props.bib : {};
+
   // check whether this is a server side or client side render
   // by whether 'window' is defined. After the first render on the client side
   // check for more items
   if (typeof window !== 'undefined') {
     checkForMoreItems(bib, dispatch);
   }
-  const bibId = bib && bib['@id'] ? bib['@id'].substring(4) : '';
+  const bibId = bib['@id'] ? bib['@id'].substring(4) : '';
   const items = (bib.checkInItems || []).concat(LibraryItem.getItems(bib));
   const isElectronicResources = _every(items, i => i.isElectronicResource);
   // Related to removing MarcRecord because the webpack MarcRecord is not working. Sep/28/2017

--- a/src/app/pages/BibPage.jsx
+++ b/src/app/pages/BibPage.jsx
@@ -15,11 +15,9 @@ import itemsContainerModule from '../components/Item/ItemsContainer';
 import BibDetails from '../components/BibPage/BibDetails';
 import LibraryItem from '../utils/item';
 import AdditionalDetailsViewer from '../components/BibPage/AdditionalDetailsViewer';
-import NotFound404 from '../components/NotFound404/NotFound404';
 import LibraryHoldings from '../components/BibPage/LibraryHoldings';
 import getOwner from '../utils/getOwner';
 import appConfig from '../data/appConfig';
-import Redirect404 from '../components/Redirect404/Redirect404';
 // Removed MarcRecord because the webpack MarcRecord is not working. Sep/28/2017
 // import MarcRecord from './MarcRecord';
 import { ajaxCall, isNyplBnumber } from '@utils';
@@ -70,22 +68,12 @@ const checkForMoreItems = (bib, dispatch) => {
   }
 };
 
-export const BibPage = (props, context) => {
-  const {
-    location,
-    searchKeywords,
-    dispatch,
-    resultSelection,
-  } = props;
-
-  if (!props.bib || parseInt(props.bib.status, 10) === 404) {
-    const originalUrl = context &&
-      context.router &&
-      context.router.location &&
-      context.router.location.query &&
-      context.router.location.query.originalUrl;
-
-    return originalUrl ? (<Redirect404 />) : (<NotFound404 />);
+export const BibPage = (
+  { location, searchKeywords, dispatch, resultSelection },
+  context,
+) => {
+  if (!bib || parseInt(bib.status, 10) === 404) {
+    return <BibNotFound404 context={context} />;
   }
   const bib = props.bib ? props.bib : {};
   // check whether this is a server side or client side render

--- a/src/app/pages/BibPage.jsx
+++ b/src/app/pages/BibPage.jsx
@@ -1,37 +1,25 @@
 /* global window */
-import React from 'react';
-import PropTypes from 'prop-types';
-import { every as _every } from 'underscore';
-import { connect } from 'react-redux';
-import { withRouter, Link } from 'react-router';
-
-import {
-  Heading,
-  Link as DSLink,
-} from '@nypl/design-system-react-components';
-
-import SccContainer from '../components/SccContainer/SccContainer';
-import itemsContainerModule from '../components/Item/ItemsContainer';
-import BibDetails from '../components/BibPage/BibDetails';
-import LibraryItem from '../utils/item';
-import AdditionalDetailsViewer from '../components/BibPage/AdditionalDetailsViewer';
-import LibraryHoldings from '../components/BibPage/LibraryHoldings';
-import getOwner from '../utils/getOwner';
-import appConfig from '../data/appConfig';
-// Removed MarcRecord because the webpack MarcRecord is not working. Sep/28/2017
-// import MarcRecord from './MarcRecord';
-import { ajaxCall, isNyplBnumber } from '@utils';
 import { updateBibPage } from '@Actions';
+import { Heading } from '@nypl/design-system-react-components';
+import { ajaxCall } from '@utils';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { connect } from 'react-redux';
+import { withRouter } from 'react-router';
+import BackToSearchResults from '../components/BibPage/BackToSearchResults';
+import BottomBibDetails from '../components/BibPage/BottomBibDetails';
+import LibraryHoldings from '../components/BibPage/LibraryHoldings';
+import TopBibDetails from '../components/BibPage/TopBibDetails';
+import itemsContainerModule from '../components/Item/ItemsContainer';
+import LegacyCatalogLink from '../components/LegacyCatalog/LegacyCatalogLink';
+import SccContainer from '../components/SccContainer/SccContainer';
+import appConfig from '../data/appConfig';
 import { itemBatchSize } from '../data/constants';
-
+import LibraryItem from '../utils/item';
 import {
   getAggregatedElectronicResources,
   pluckAeonLinksFromResource,
 } from '../utils/utils';
-
-import {
-  annotatedMarcDetails,
-} from '../utils/bibDetailsUtils';
 
 const ItemsContainer = itemsContainerModule.ItemsContainer;
 
@@ -45,26 +33,30 @@ const checkForMoreItems = (bib, dispatch) => {
     // need to fetch more items
     const baseUrl = appConfig.baseUrl;
     const itemFrom = bib.itemFrom || itemBatchSize;
-    const bibApi = `${window.location.pathname.replace(baseUrl, `${baseUrl}/api`)}?itemFrom=${itemFrom}`;
+    const bibApi = `${window.location.pathname.replace(
+      baseUrl,
+      `${baseUrl}/api`,
+    )}?itemFrom=${itemFrom}`;
     ajaxCall(
       bibApi,
       (resp) => {
         // put items in
         const bibResp = resp.data.bib;
-        const done = !bibResp || !bibResp.items || bibResp.items.length < itemBatchSize;
-        dispatch(updateBibPage({
-          bib:
-            Object.assign(
-              {},
-              bib,
-              { items: bib.items.concat((bibResp && bibResp.items) || []),
-                done,
-                itemFrom: parseInt(itemFrom, 10) + parseInt(itemBatchSize, 10),
-              },
-            ),
-        }));
+        const done =
+          !bibResp || !bibResp.items || bibResp.items.length < itemBatchSize;
+        dispatch(
+          updateBibPage({
+            bib: Object.assign({}, bib, {
+              items: bib.items.concat((bibResp && bibResp.items) || []),
+              done,
+              itemFrom: parseInt(itemFrom, 10) + parseInt(itemBatchSize, 10),
+            }),
+          }),
+        );
       },
-      (error) => { console.error(error); },
+      (error) => {
+        console.error(error);
+      },
     );
   }
 };
@@ -77,122 +69,23 @@ export const BibPage = (
     return <BibNotFound404 context={context} />;
   }
 
-  // check whether this is a server side or client side render
-  // by whether 'window' is defined. After the first render on the client side
-  // check for more items
   if (typeof window !== 'undefined') {
+    // check whether this is a server side or client side render
+    // by whether 'window' is defined. After the first render on the client side
+    // check for more items
     checkForMoreItems(bib, dispatch);
+    // NOTE: I'm not entirely sure what this is doing yet, but I believe it should be
+    // done in an effect.
   }
+
   const bibId = bib['@id'] ? bib['@id'].substring(4) : '';
   const items = (bib.checkInItems || []).concat(LibraryItem.getItems(bib));
-  const isElectronicResources = _every(items, i => i.isElectronicResource);
+  const isElectronicResources = items.every((i) => i.isElectronicResource);
+  const aggregatedElectronicResources = getAggregatedElectronicResources(items);
+
   // Related to removing MarcRecord because the webpack MarcRecord is not working. Sep/28/2017
   // const isNYPLReCAP = LibraryItem.isNYPLReCAP(bib['@id']);
   // const bNumber = bib && bib.idBnum ? bib.idBnum : '';
-  const itemPage = location.search;
-  const aggregatedElectronicResources = getAggregatedElectronicResources(items);
-
-  const shortenItems = location.pathname.indexOf('all') !== -1;
-
-  // `linkable` means that those values are links inside the app.
-  // `selfLinkable` means that those values are external links and should be self-linked,
-  // e.g. the prefLabel is the label and the URL is the id.
-  const topFields = [
-    { label: 'Title', value: 'titleDisplay' },
-    { label: 'Author', value: 'creatorLiteral', linkable: true },
-    { label: 'Publication', value: 'publicationStatement' },
-    { label: 'Electronic Resource', value: 'React Component' },
-    { label: 'Supplementary Content', value: 'supplementaryContent', selfLinkable: true },
-  ];
-
-  const detailsFields = [
-    { label: 'Additional Authors', value: 'contributorLiteral', linkable: true },
-    { label: 'Found In', value: 'partOf' },
-    { label: 'Publication Date', value: 'serialPublicationDates' },
-    { label: 'Description', value: 'extent' },
-    { label: 'Donor/Sponsor', value: 'donor' },
-    { label: 'Series Statement', value: 'seriesStatement' },
-    { label: 'Uniform Title', value: 'uniformTitle' },
-    { label: 'Alternative Title', value: 'titleAlt' },
-    { label: 'Former Title', value: 'formerTitle' },
-    { label: 'Subject', value: 'subjectHeadingData' },
-    { label: 'Genre/Form', value: 'genreForm' },
-    { label: 'Notes', value: 'React Component' },
-    { label: 'Contents', value: 'tableOfContents' },
-    { label: 'Bibliography', value: '' },
-    { label: 'Call Number', value: 'identifier', identifier: 'bf:ShelfMark' },
-    { label: 'ISBN', value: 'identifier', identifier: 'bf:Isbn' },
-    { label: 'ISSN', value: 'identifier', identifier: 'bf:Issn' },
-    { label: 'LCCN', value: 'identifier', identifier: 'bf:Lccn' },
-    { label: 'OCLC', value: 'identifier', identifier: 'nypl:Oclc' },
-    { label: 'GPO', value: '' },
-    { label: 'Other Titles', value: '' },
-    { label: 'Owning Institutions', value: '' },
-  ];
-
-  // if the subject heading API call failed for some reason,
-  // we will use the subjectLiteral property from the
-  // Discovery API response instead
-  if (!bib.subjectHeadingData) {
-    detailsFields.push({
-      label: 'Subject', value: 'subjectLiteral', linkable: true,
-    });
-  }
-
-  const itemsContainer = items.length && !isElectronicResources ? (
-    <ItemsContainer
-      key={bibId}
-      shortenItems={shortenItems}
-      items={items}
-      bibId={bibId}
-      itemPage={itemPage}
-      searchKeywords={searchKeywords}
-      holdings={bib.holdings}
-    />
-  ) : null;
-
-  const isNYPL = isNyplBnumber(bib.uri);
-
-  const details = (
-    <React.Fragment>
-      <Heading
-        level={3}
-      >
-        Details
-      </Heading>
-      <BibDetails
-        bib={bib}
-        fields={detailsFields}
-        electronicResources={aggregatedElectronicResources}
-        additionalData={isNYPL && bib.annotatedMarc ? annotatedMarcDetails(bib) : []}
-      />
-    </React.Fragment>
-  );
-
-  const contentAreas = [
-    itemsContainer ? {
-      title: 'Availability',
-      content: itemsContainer,
-    } : null,
-    bib.holdings ? {
-      title: 'Library Holdings',
-      content: <LibraryHoldings holdings={bib.holdings} />,
-    } : null,
-    {
-      title: 'Details',
-      content: details,
-    },
-  ].filter(area => area)
-    .map(area => <React.Fragment><br /> { area.content }</React.Fragment>);
-
-  const classicLink = (
-    bibId.startsWith('b') ?
-      <a href={`${appConfig.legacyBaseUrl}/record=${bibId}~S1`} id="legacy-catalog-link">View in Legacy Catalog</a>
-      :
-      null
-  );
-
-  const title = bib.title && bib.title.length ? bib.title[0] : ' ';
 
   return (
     <SccContainer
@@ -200,37 +93,44 @@ export const BibPage = (
       className="nypl-item-details"
       pageTitle="Item Details"
     >
-      <div
-        className="nypl-item-details__heading"
-      >
-        <Heading
-          level={2}
-        >
-          {title}
+      <section className="nypl-item-details__heading">
+        <Heading level={2}>
+          {bib.title && bib.title.length ? bib.title[0] : ' '}
         </Heading>
-        {resultSelection.fromUrl && resultSelection.bibId === bibId && (
-          <DSLink>
-            <Link
-              to={resultSelection.fromUrl}
-            >
-              Back to search results
-            </Link>
-          </DSLink>
-        )}
-      </div>
-      <BibDetails
+        <BackToSearchResults result={resultSelection} bibId={bibId} />
+      </section>
+
+      <TopBibDetails
         bib={bib}
-        fields={topFields}
-        logging
-        electronicResources={pluckAeonLinksFromResource(
+        resources={pluckAeonLinksFromResource(
           aggregatedElectronicResources,
           items,
         )}
       />
-      {
-        contentAreas
-      }
-      {classicLink}
+
+      {items.length && !isElectronicResources && (
+        <section style={{ marginTop: '20px' }}>
+          <ItemsContainer
+            key={bibId}
+            shortenItems={location.pathname.indexOf('all') !== -1}
+            items={items}
+            bibId={bibId}
+            itemPage={location.search}
+            searchKeywords={searchKeywords}
+            holdings={bib.holdings}
+          />
+        </section>
+      )}
+
+      {bib.holdings && (
+        <section style={{ marginTop: '20px' }}>
+          <LibraryHoldings holdings={bib.holdings} />
+        </section>
+      )}
+
+      <BottomBibDetails bib={bib} resources={aggregatedElectronicResources} />
+
+      <LegacyCatalogLink recordNumber={bibId} display={bibId.startsWith('b')} />
     </SccContainer>
   );
 };

--- a/src/app/utils/bibDetailsUtils.jsx
+++ b/src/app/utils/bibDetailsUtils.jsx
@@ -9,28 +9,24 @@ const definitionItem = (value, index = 0) => {
 
   return (
     <div key={index}>
-      { value.label ? link : value.content }
-      { value.parallels ? value.parallels : null }
+      {value.label ? link : value.content}
+      {value.parallels ? value.parallels : null}
     </div>
   );
 };
 
-const annotatedMarcDetails = bib =>
-  bib.annotatedMarc.bib.fields.map(field => (
-    {
-      term: field.label,
-      definition: field.values.map(definitionItem),
-    }
-  ));
+const annotatedMarcDetails = (bib) =>
+  bib.annotatedMarc.bib.fields.map((field) => ({
+    term: field.label,
+    definition: field.values.map(definitionItem),
+  }));
 
 const combineBibDetailsData = (bibDetails, additionalData) => {
-  const bibDetailsTerms = new Set(bibDetails.map(item => item.term));
-  const filteredAdditionalData = additionalData.filter(item => !bibDetailsTerms.has(item.term));
+  const bibDetailsTerms = new Set(bibDetails.map((item) => item.term));
+  const filteredAdditionalData = additionalData.filter(
+    (item) => !bibDetailsTerms.has(item.term),
+  );
   return bibDetails.concat(filteredAdditionalData);
 };
 
-export {
-  definitionItem,
-  annotatedMarcDetails,
-  combineBibDetailsData,
-};
+export { definitionItem, annotatedMarcDetails, combineBibDetailsData };

--- a/src/app/utils/getOwner.js
+++ b/src/app/utils/getOwner.js
@@ -1,23 +1,30 @@
-import {
-  every as _every,
-} from 'underscore';
 /*
-* getOwner(bib)
-* This is currently only for non-NYPL partner items. If it's NYPL, it should return undefined.
-* @param {object} bib
-* @return {string}
-*/
-
-
+ * getOwner(bib)
+ * This is currently only for non-NYPL partner items. If it's NYPL, it should return undefined.
+ * @param {object} bib
+ * @return {string}
+ */
 export default function getOwner(bib) {
   if (!bib || !bib.items) return null;
 
-  return bib.items
-    // Only consider items with a Recap source id
-    .filter((item) => item.idNyplSourceId && item.idNyplSourceId['@type'] && /^Recap/.test(item.idNyplSourceId['@type']))
-    // Only consider items with an `owner` (should be all, in practice)
-    .filter((item) => item.owner && item.owner.length && item.owner[0] && item.owner[0].prefLabel)
-    // Map to owner `prefLabel`
-    .map((item) => item.owner[0].prefLabel)
-    [0];
+  return (
+    bib.items
+      // Only consider items with a Recap source id
+      .filter(
+        (item) =>
+          item.idNyplSourceId &&
+          item.idNyplSourceId['@type'] &&
+          /^Recap/.test(item.idNyplSourceId['@type']),
+      )
+      // Only consider items with an `owner` (should be all, in practice)
+      .filter(
+        (item) =>
+          item.owner &&
+          item.owner.length &&
+          item.owner[0] &&
+          item.owner[0].prefLabel,
+      )
+      // Map to owner `prefLabel`
+      .map((item) => item.owner[0].prefLabel)[0]
+  );
 }

--- a/src/app/utils/item.js
+++ b/src/app/utils/item.js
@@ -1,7 +1,4 @@
-import {
-  findWhere as _findWhere,
-  isEmpty as _isEmpty,
-} from 'underscore';
+import { findWhere as _findWhere, isEmpty as _isEmpty } from 'underscore';
 import LocationCodes from '../data/locationCodes';
 import { camelToShishKabobCase } from './utils';
 
@@ -73,7 +70,8 @@ function LibraryItem() {
     },
     {
       '@id': 'loc:mai',
-      prefLabel: 'Stephen A. Schwarzman Building - Milstein Microform Reading Room 119',
+      prefLabel:
+        'Stephen A. Schwarzman Building - Milstein Microform Reading Room 119',
       customerCode: 'NF',
     },
     {
@@ -82,7 +80,6 @@ function LibraryItem() {
       customerCode: 'NP',
     },
   ];
-
 
   /**
    * Given an identifier value, returns same identifier transformed to entity
@@ -95,13 +92,19 @@ function LibraryItem() {
     if (typeof identifier === 'string') {
       // Convert them to entitys:
       return Object.keys(itemIdentifierTypeMappings)
-        .filter(name => identifier.indexOf(itemIdentifierTypeMappings[name].legacyUrnPrefix) === 0)
-        .map(name => (
-          {
-            '@type': itemIdentifierTypeMappings[name].type,
-            '@value': identifier.replace(itemIdentifierTypeMappings[name].legacyUrnPrefix, ''),
-          }
-        ))
+        .filter(
+          (name) =>
+            identifier.indexOf(
+              itemIdentifierTypeMappings[name].legacyUrnPrefix,
+            ) === 0,
+        )
+        .map((name) => ({
+          '@type': itemIdentifierTypeMappings[name].type,
+          '@value': identifier.replace(
+            itemIdentifierTypeMappings[name].legacyUrnPrefix,
+            '',
+          ),
+        }))
         .pop();
     }
 
@@ -125,7 +128,7 @@ function LibraryItem() {
   this.getIdentifierEntitiesByType = (identifiersArray, type) => {
     return identifiersArray
       .map(this.ensureLegacyIdentifierIsEntity)
-      .filter(identifier => identifier && identifier['@type'] === type);
+      .filter((identifier) => identifier && identifier['@type'] === type);
   };
 
   /**
@@ -147,8 +150,14 @@ function LibraryItem() {
   this.getIdentifiers = (identifiersArray, neededTagsArray) => {
     if (!Array.isArray(identifiersArray)) return {};
     return neededTagsArray.reduce((identifierMap, neededTag) => {
-      const matches = this.getIdentifierEntitiesByType(identifiersArray, neededTag.value);
-      if (matches && matches.length > 0) return Object.assign(identifierMap, { [neededTag.name]: matches[0]['@value'] });
+      const matches = this.getIdentifierEntitiesByType(
+        identifiersArray,
+        neededTag.value,
+      );
+      if (matches && matches.length > 0)
+        return Object.assign(identifierMap, {
+          [neededTag.name]: matches[0]['@value'],
+        });
       return identifierMap;
     }, {});
   };
@@ -176,44 +185,72 @@ function LibraryItem() {
     const id = item && item['@id'] ? item['@id'].substring(4) : '';
     const itemSource = item.idNyplSourceId ? item.idNyplSourceId['@type'] : '';
     // Taking the first object in the accessMessage array.
-    const accessMessage = item.accessMessage && item.accessMessage.length ?
-      item.accessMessage[0] : {};
+    const accessMessage =
+      item.accessMessage && item.accessMessage.length
+        ? item.accessMessage[0]
+        : {};
     // Taking first callNumber.
-    const callNumber = item.shelfMark && item.shelfMark.length ? item.shelfMark[0] : '';
+    const callNumber =
+      item.shelfMark && item.shelfMark.length ? item.shelfMark[0] : '';
     // Taking the first value in the array.
-    const requestable = item.requestable && item.requestable.length ? item.requestable[0] : false;
+    const requestable =
+      item.requestable && item.requestable.length ? item.requestable[0] : false;
     // Taking the first value in the array;
-    const suppressed = item.suppressed && item.suppressed.length ? item.suppressed[0] : false;
+    const suppressed =
+      item.suppressed && item.suppressed.length ? item.suppressed[0] : false;
     const isElectronicResource = this.isElectronicResource(item);
-    const electronicResources = isElectronicResource ? this.getElectronicResources(item) : null;
+    const electronicResources = isElectronicResource
+      ? this.getElectronicResources(item)
+      : null;
     // Taking the first status object in the array.
     const status = item.status && item.status.length ? item.status[0] : {};
-    const volume = item.enumerationChronology && item.enumerationChronology.length ?
-      item.enumerationChronology[0] : '';
-    const availability = !_isEmpty(status) && status.prefLabel ?
-      status.prefLabel.replace(/\W/g, '').toLowerCase() : '';
+    const volume =
+      item.enumerationChronology && item.enumerationChronology.length
+        ? item.enumerationChronology[0]
+        : '';
+    const availability =
+      !_isEmpty(status) && status.prefLabel
+        ? status.prefLabel.replace(/\W/g, '').toLowerCase()
+        : '';
     const available = ['available', 'useinlibrary'].includes(availability);
     // non-NYPL ReCAP
     const nonNyplRecap = itemSource.indexOf('Recap') !== -1;
     const holdingLocation = this.getHoldingLocation(item, nonNyplRecap);
     // nypl-owned ReCAP
-    const nyplRecap = !!((holdingLocation && !_isEmpty(holdingLocation) &&
-      holdingLocation['@id'].substring(4, 6) === 'rc') && (itemSource === 'SierraNypl'));
-    const nonRecapNYPL = !!((holdingLocation && !_isEmpty(holdingLocation) &&
-      holdingLocation['@id'].substring(4, 6) !== 'rc') && (itemSource === 'SierraNypl'));
+    const nyplRecap = !!(
+      holdingLocation &&
+      !_isEmpty(holdingLocation) &&
+      holdingLocation['@id'].substring(4, 6) === 'rc' &&
+      itemSource === 'SierraNypl'
+    );
+    const nonRecapNYPL = !!(
+      holdingLocation &&
+      !_isEmpty(holdingLocation) &&
+      holdingLocation['@id'].substring(4, 6) !== 'rc' &&
+      itemSource === 'SierraNypl'
+    );
     const isRecap = nonNyplRecap || nyplRecap;
     // The identifier we need for an item now
     const identifiersArray = [{ name: 'barcode', value: 'bf:Barcode' }];
-    const bibIdentifiers = this.getIdentifiers(item.identifier, identifiersArray);
+    const bibIdentifiers = this.getIdentifiers(
+      item.identifier,
+      identifiersArray,
+    );
     const barcode = bibIdentifiers.barcode || '';
     const mappedItemSource = camelToShishKabobCase(itemSource);
     const isOffsite = this.isOffsite(holdingLocation.prefLabel.toLowerCase());
     let url = null;
-    const isSerial = !!(bib && bib.issuance && bib.issuance[0]['@id'] === 'urn:biblevel:s');
-    const materialType = bib && bib.materialType && bib.materialType[0] ?
-      bib.materialType[0] : {};
-    const format = bib && bib.holdings && bib.holdings.format ?
-      bib.holdings.format : materialType.prefLabel;
+    const isSerial = !!(
+      bib &&
+      bib.issuance &&
+      bib.issuance[0]['@id'] === 'urn:biblevel:s'
+    );
+    const materialType =
+      bib && bib.materialType && bib.materialType[0] ? bib.materialType[0] : {};
+    const format =
+      bib && bib.holdings && bib.holdings.format
+        ? bib.holdings.format
+        : materialType.prefLabel;
 
     if (availability === 'available') {
       // For all items that we want to send to the Hold Request Form.
@@ -256,7 +293,7 @@ function LibraryItem() {
    * @return {array}
    */
   this.getItem = (bib, itemId) => {
-    const items = (bib && bib.items) ? bib.items : [];
+    const items = bib && bib.items ? bib.items : [];
 
     if (itemId && items.length) {
       // Will return undefined if not found.
@@ -278,7 +315,7 @@ function LibraryItem() {
   this.getItems = (bib) => {
     // filter out anything without a status or location
     const bibItems = bib && bib.items && bib.items.length ? bib.items : [];
-    const finalItems = bibItems.map(item => this.mapItem(item, bib));
+    const finalItems = bibItems.map((item) => this.mapItem(item, bib));
 
     return finalItems;
   };
@@ -290,7 +327,8 @@ function LibraryItem() {
    * @return {string}
    */
   this.getLocationHoldUrl = (location) => {
-    const holdingLocationId = location && location['@id'] ? location['@id'].substring(4) : '';
+    const holdingLocationId =
+      location && location['@id'] ? location['@id'].substring(4) : '';
     let url = '';
     let shortLocation = 'schwarzman';
 
@@ -300,23 +338,28 @@ function LibraryItem() {
 
     switch (shortLocation) {
       case 'schwarzman':
-        url = 'http://www.questionpoint.org/crs/servlet/org.oclc.admin.BuildForm?&institution=' +
+        url =
+          'http://www.questionpoint.org/crs/servlet/org.oclc.admin.BuildForm?&institution=' +
           '13777&type=1&language=1';
         break;
       case 'lpa':
-        url = 'http://www.questionpoint.org/crs/servlet/org.oclc.admin.BuildForm?&institution=' +
+        url =
+          'http://www.questionpoint.org/crs/servlet/org.oclc.admin.BuildForm?&institution=' +
           '13252&type=1&language=1';
         break;
       case 'schomburg':
-        url = 'http://www.questionpoint.org/crs/servlet/org.oclc.admin.BuildForm?&institution=' +
+        url =
+          'http://www.questionpoint.org/crs/servlet/org.oclc.admin.BuildForm?&institution=' +
           '13810&type=1&language=1';
         break;
       case 'sibl':
-        url = 'http://www.questionpoint.org/crs/servlet/org.oclc.admin.BuildForm?&institution=' +
+        url =
+          'http://www.questionpoint.org/crs/servlet/org.oclc.admin.BuildForm?&institution=' +
           '13809&type=1&language=1';
         break;
       default:
-        url = 'http://www.questionpoint.org/crs/servlet/org.oclc.admin.BuildForm?&institution=' +
+        url =
+          'http://www.questionpoint.org/crs/servlet/org.oclc.admin.BuildForm?&institution=' +
           '13777&type=1&language=1';
         break;
     }
@@ -352,7 +395,8 @@ function LibraryItem() {
    * @param {object} item
    * @return {boolean}
    */
-  this.isElectronicResource = item => !!(item.electronicLocator && item.electronicLocator.length);
+  this.isElectronicResource = (item) =>
+    !!(item.electronicLocator && item.electronicLocator.length);
 
   /**
    * isOffsite(prefLabel)
@@ -369,7 +413,8 @@ function LibraryItem() {
    * @param {string} bibId
    * @return {boolean}
    */
-  this.isNYPLReCAP = (bibId = '') => (bibId.indexOf('pb') === -1) && (bibId.indexOf('cb') === -1);
+  this.isNYPLReCAP = (bibId = '') =>
+    bibId.indexOf('pb') === -1 && bibId.indexOf('cb') === -1;
 }
 
-export default new LibraryItem;
+export default new LibraryItem();

--- a/src/app/utils/utils.js
+++ b/src/app/utils/utils.js
@@ -390,16 +390,14 @@ function getAggregatedElectronicResources(items = []) {
   return _flatten(electronicResources);
 }
 
-// TODO: Define Resources
-
+// TODO: [SCC-2996] Define Resources
 // interface Resources {
 //   @type: string;
 //   label: string;
 //   url: string;
 // }
 
-// TODO: Define Items
-
+// TODO: [SCC-2997] Define Items
 // This is incomplete
 // interface Items {
 //    id: string;

--- a/src/app/utils/utils.js
+++ b/src/app/utils/utils.js
@@ -1,22 +1,17 @@
-import { gaUtils } from 'dgx-react-ga';
 import axios from 'axios';
+import { gaUtils } from 'dgx-react-ga';
+import { createHistory, createMemoryHistory, useQueries } from 'history';
 import {
-  createHistory,
-  useQueries,
-  createMemoryHistory,
-} from 'history';
-import {
-  mapObject as _mapObject,
-  findWhere as _findWhere,
-  forEach as _forEach,
-  isEmpty as _isEmpty,
-  isArray as _isArray,
-  extend as _extend,
   chain as _chain,
+  extend as _extend,
+  findWhere as _findWhere,
   flatten as _flatten,
+  forEach as _forEach,
+  isArray as _isArray,
+  isEmpty as _isEmpty,
+  mapObject as _mapObject,
   sortBy as _sortBy,
 } from 'underscore';
-
 import appConfig from '../data/appConfig';
 import { noticePreferenceMapping } from '../data/constants';
 
@@ -32,14 +27,11 @@ const { features } = appConfig;
 const ajaxCall = (
   endpoint,
   cb = () => {},
-  errorcb = error => console.error('Error making ajaxCall', error),
+  errorcb = (error) => console.error('Error making ajaxCall', error),
 ) => {
   if (!endpoint) return null;
 
-  return axios
-    .get(endpoint)
-    .then(cb)
-    .catch(errorcb);
+  return axios.get(endpoint).then(cb).catch(errorcb);
 };
 
 /**
@@ -70,13 +62,18 @@ const createAppHistory = () => {
 function destructureFilters(filters, apiFilters) {
   const selectedFilters = {};
   const filterArrayfromAPI =
-    apiFilters && apiFilters.itemListElement && apiFilters.itemListElement.length ?
-      apiFilters.itemListElement : [];
+    apiFilters &&
+    apiFilters.itemListElement &&
+    apiFilters.itemListElement.length
+      ? apiFilters.itemListElement
+      : [];
 
   _forEach(filters, (value, key) => {
-    const id = key.indexOf('date') !== -1 ?
-      // Because filters are in the form of `filters[language][0]`;
-      key.substring(8, key.length - 1) : key.substring(8, key.length - 4);
+    const id =
+      key.indexOf('date') !== -1
+        ? // Because filters are in the form of `filters[language][0]`;
+          key.substring(8, key.length - 1)
+        : key.substring(8, key.length - 4);
 
     if (id === 'dateAfter' || id === 'dateBefore') {
       selectedFilters[id] = value;
@@ -86,8 +83,14 @@ function destructureFilters(filters, apiFilters) {
       }
       _forEach(value, (filterValue) => {
         const filterObjFromApi = _findWhere(filterArrayfromAPI, { id });
-        if (filterObjFromApi && filterObjFromApi.values && filterObjFromApi.values.length) {
-          const filter = _findWhere(filterObjFromApi.values, { value: filterValue });
+        if (
+          filterObjFromApi &&
+          filterObjFromApi.values &&
+          filterObjFromApi.values.length
+        ) {
+          const filter = _findWhere(filterObjFromApi.values, {
+            value: filterValue,
+          });
           if (filter) {
             selectedFilters[id].push({
               value: filter.value,
@@ -98,7 +101,11 @@ function destructureFilters(filters, apiFilters) {
       });
     } else if (typeof value === 'string') {
       const filterObjFromApi = _findWhere(filterArrayfromAPI, { id });
-      if (filterObjFromApi && filterObjFromApi.values && filterObjFromApi.values.length) {
+      if (
+        filterObjFromApi &&
+        filterObjFromApi.values &&
+        filterObjFromApi.values.length
+      ) {
         const filter = _findWhere(filterObjFromApi.values, { value });
         if (filter) {
           if (!selectedFilters[id]) {
@@ -146,9 +153,13 @@ const getFilterParam = (filters) => {
       if (val && val.length && _isArray(val)) {
         _forEach(val, (filter, index) => {
           if (filter.value && filter.value !== '') {
-            strSearch += `&filters[${key}][${index}]=${encodeURIComponent(filter.value)}`;
+            strSearch += `&filters[${key}][${index}]=${encodeURIComponent(
+              filter.value,
+            )}`;
           } else if (typeof filter === 'string') {
-            strSearch += `&filters[${key}][${index}]=${encodeURIComponent(filter)}`;
+            strSearch += `&filters[${key}][${index}]=${encodeURIComponent(
+              filter,
+            )}`;
           }
         });
       } else if (val && val.value && val.value !== '') {
@@ -175,9 +186,9 @@ const getFieldParam = (field = '') => {
 };
 
 const getIdentifierQuery = (identifierNumbers = {}) =>
-  Object.entries(identifierNumbers).map(
-    ([key, value]) => (value ? `&${key}=${value}` : ''),
-  ).join('');
+  Object.entries(identifierNumbers)
+    .map(([key, value]) => (value ? `&${key}=${value}` : ''))
+    .join('');
 
 /**
  * Tracks Google Analytics (GA) events. `.trackEvent` returns a function with
@@ -219,17 +230,32 @@ const basicQuery = (props = {}) => {
   }) => {
     const sortQuery = getSortQuery(sortBy || props.sortBy);
     const fieldQuery = getFieldParam(field || props.field);
-    const filterQuery = getFilterParam(selectedFilters || props.selectedFilters);
-    const identifierQuery = getIdentifierQuery(identifierNumbers || props.identifierNumbers);
+    const filterQuery = getFilterParam(
+      selectedFilters || props.selectedFilters,
+    );
+    const identifierQuery = getIdentifierQuery(
+      identifierNumbers || props.identifierNumbers,
+    );
     // `searchKeywords` can be an empty string, so check if it's undefined instead.
-    const query = searchKeywords !== undefined ? searchKeywords : props.searchKeywords;
+    const query =
+      searchKeywords !== undefined ? searchKeywords : props.searchKeywords;
     const searchKeywordsQuery = query ? `${encodeURIComponent(query)}` : '';
-    let pageQuery = props.page && props.page !== '1' ? `&page=${props.page}` : '';
+    let pageQuery =
+      props.page && props.page !== '1' ? `&page=${props.page}` : '';
     pageQuery = page && page !== '1' ? `&page=${page}` : pageQuery;
     pageQuery = page === '1' ? '' : pageQuery;
-    const contributorQuery = (contributor || props.contributor) && !clearContributor ? `&contributor=${contributor || props.contributor}` : '';
-    const titleQuery = (title || props.title) && !clearTitle ? `&title=${title || props.title}` : '';
-    const subjectQuery = (subject || props.subject) && !clearSubject ? `&subject=${subject || props.subject}` : '';
+    const contributorQuery =
+      (contributor || props.contributor) && !clearContributor
+        ? `&contributor=${contributor || props.contributor}`
+        : '';
+    const titleQuery =
+      (title || props.title) && !clearTitle
+        ? `&title=${title || props.title}`
+        : '';
+    const subjectQuery =
+      (subject || props.subject) && !clearSubject
+        ? `&subject=${subject || props.subject}`
+        : '';
     const advancedQuery = `${contributorQuery}${titleQuery}${subjectQuery}`;
 
     const completeQuery = `${searchKeywordsQuery}${advancedQuery}${filterQuery}${sortQuery}${fieldQuery}${pageQuery}${identifierQuery}`;
@@ -258,13 +284,7 @@ function getReqParams(query = {}) {
   const title = query.title;
   const subject = query.subject;
 
-  const {
-    issn,
-    isbn,
-    oclc,
-    lccn,
-    redirectOnMatch,
-  } = query;
+  const { issn, isbn, oclc, lccn, redirectOnMatch } = query;
 
   return {
     contributor,
@@ -282,7 +302,8 @@ function getReqParams(query = {}) {
     isbn,
     oclc,
     lccn,
-    redirectOnMatch };
+    redirectOnMatch,
+  };
 }
 
 /*
@@ -320,19 +341,18 @@ function parseServerSelectedFilters(filters, dateAfter, dateBefore) {
   if (_isArray(filters) && filters.length && !_isEmpty(filters[0])) {
     _chain(filters)
       // Each incoming filter is in JSON string format so it needs to be parsed first.
-      .map(filter => JSON.parse(filter))
+      .map((filter) => JSON.parse(filter))
       // Group selected filters into arrays according to their field.
       .groupBy('field')
       // Created the needed data structure.
       .mapObject((filterArray, key) => {
         if (key) {
-          selectedFilters[key] =
-            filterArray.map(filter => ({
-              value: filter.value,
-              label: filter.label,
-              count: filter.count,
-              selected: true,
-            }));
+          selectedFilters[key] = filterArray.map((filter) => ({
+            value: filter.value,
+            label: filter.label,
+            count: filter.count,
+            selected: true,
+          }));
         }
       });
   }
@@ -454,13 +474,13 @@ function isAeonLink(url) {
  * @return {array}
  */
 const getUpdatedFilterValues = (props) => {
-  const {
-    filter,
-    selectedFilters,
-  } = props;
-  const filterValues = filter && filter.values && filter.values.length ? filter.values : [];
+  const { filter, selectedFilters } = props;
+  const filterValues =
+    filter && filter.values && filter.values.length ? filter.values : [];
   // Just want to add the `selected` property here.
-  const defaultFilterValues = filterValues.map(value => _extend({ selected: false }, value));
+  const defaultFilterValues = filterValues.map((value) =>
+    _extend({ selected: false }, value),
+  );
   let updatedFilterValues = defaultFilterValues;
 
   // If there are selected filters, then we want to update the filter values with those
@@ -478,22 +498,30 @@ const getUpdatedFilterValues = (props) => {
     });
   }
 
-  updatedFilterValues = _sortBy(updatedFilterValues, f => f.label);
+  updatedFilterValues = _sortBy(updatedFilterValues, (f) => f.label);
 
   return updatedFilterValues;
 };
 
 // This function is used in `ResultsCount`, primarily.
 /*
-   * displayContext({ searchKeywords, selectedFilters, field, count })
-   * @param {object} takes keys `searchKeywords` {string}, `selectedFilters` {object}, `field` {string}, `count` {integer}.
-   * Displays where the results are coming from. This currently only allows for one
-   * option at a time due to constraints on the front end not allowing for multiple
-   * selections to occur.
-   *
-   * @returns {string} A phrase like "for (keyword|title|author) TERM"
-   */
-function displayContext({ searchKeywords, contributor, title, subject, selectedFilters, field, count }) {
+ * displayContext({ searchKeywords, selectedFilters, field, count })
+ * @param {object} takes keys `searchKeywords` {string}, `selectedFilters` {object}, `field` {string}, `count` {integer}.
+ * Displays where the results are coming from. This currently only allows for one
+ * option at a time due to constraints on the front end not allowing for multiple
+ * selections to occur.
+ *
+ * @returns {string} A phrase like "for (keyword|title|author) TERM"
+ */
+function displayContext({
+  searchKeywords,
+  contributor,
+  title,
+  subject,
+  selectedFilters,
+  field,
+  count,
+}) {
   const keyMapping = {
     // Currently from links on the bib page:
     creatorLiteral: 'author',
@@ -510,19 +538,17 @@ function displayContext({ searchKeywords, contributor, title, subject, selectedF
   const clauses = [];
 
   // Build a hash of active, non-empty filters:
-  const activeFilters = Object.keys((selectedFilters || {}))
-    .reduce((map, key) => {
+  const activeFilters = Object.keys(selectedFilters || {}).reduce(
+    (map, key) => {
       const label = keyMapping[key];
       const filter = selectedFilters[key];
-      if (label
-        && Array.isArray(filter)
-        && filter[0]
-        && filter[0].value
-      ) {
+      if (label && Array.isArray(filter) && filter[0] && filter[0].value) {
         return Object.assign({ [label]: selectedFilters[key][0].value }, map);
       }
       return map;
-    }, {});
+    },
+    {},
+  );
 
   // Are there any filters at work?
   const hasActiveFilters = Object.keys(activeFilters).length > 0;
@@ -531,7 +557,7 @@ function displayContext({ searchKeywords, contributor, title, subject, selectedF
   if (hasActiveFilters) {
     clauses.push(
       Object.keys(activeFilters)
-        .map(label => `${label} "${activeFilters[label]}"`)
+        .map((label) => `${label} "${activeFilters[label]}"`)
         .join(', '),
     );
   }
@@ -582,10 +608,14 @@ function displayContext({ searchKeywords, contributor, title, subject, selectedF
  * @param {int} maxLength - The maximum length of the returned string to be applied
  */
 const truncateStringOnWhitespace = (str, maxLength) => {
-  if (str.length < maxLength) { return str; }
+  if (str.length < maxLength) {
+    return str;
+  }
   const truncStr = str.substr(0, maxLength - 3);
   const truncArray = truncStr.split(/\s+/).slice(0, -1);
-  if (truncArray.length === 0) { return `${truncStr}...`; }
+  if (truncArray.length === 0) {
+    return `${truncStr}...`;
+  }
   return `${truncArray.join(' ')}...`;
 };
 
@@ -598,7 +628,7 @@ const truncateStringOnWhitespace = (str, maxLength) => {
 const isOptionSelected = (filterValue, itemValue) => {
   const itemValues = Array.isArray(itemValue) ? itemValue : [itemValue];
   const filterValues = Array.isArray(filterValue) ? filterValue : [filterValue];
-  return filterValues.some(filter => itemValues.includes(filter));
+  return filterValues.some((filter) => itemValues.includes(filter));
 };
 
 /**
@@ -645,9 +675,10 @@ const isOptionSelected = (filterValue, itemValue) => {
  * @return {boolean}
  */
 const hasValidFilters = (selectedFilters) => {
-  return Object.values(selectedFilters || {}).some((v) => Array.isArray(v) ? v.length > 0 : v );
+  return Object.values(selectedFilters || {}).some((v) =>
+    Array.isArray(v) ? v.length > 0 : v,
+  );
 };
-
 
 /**
  * encodeHTML(str, maxLength)
@@ -655,7 +686,10 @@ const hasValidFilters = (selectedFilters) => {
  * @param {string} str - The string to be sanitized
  */
 function encodeHTML(str) {
-  return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/"/g, '&quot;');
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/"/g, '&quot;');
 }
 
 /**
@@ -679,13 +713,14 @@ function extractNoticePreference(fixedFields) {
  *        => "first-char-can-be-lower-case"
  */
 function camelToShishKabobCase(s) {
-  return s
-    // Change capital letters into "-{lowercase letter}"
-    .replace(/([A-Z])/g, (c, p1, i) => {
-      // If capital letter is not first character, precede with '-':
-      return (i > 0 ? '-' : '')
-        + c.toLowerCase();
-    })
+  return (
+    s
+      // Change capital letters into "-{lowercase letter}"
+      .replace(/([A-Z])/g, (c, p1, i) => {
+        // If capital letter is not first character, precede with '-':
+        return (i > 0 ? '-' : '') + c.toLowerCase();
+      })
+  );
 }
 
 /**
@@ -697,7 +732,7 @@ function institutionNameByNyplSource(nyplSource) {
     'recap-pul': 'Princeton',
     'recap-cul': 'Columbia',
     'recap-hl': 'Harvard',
-    'sierra-nypl': 'NYPL'
+    'sierra-nypl': 'NYPL',
   }[nyplSource];
 }
 

--- a/src/app/utils/utils.js
+++ b/src/app/utils/utils.js
@@ -20,6 +20,8 @@ import {
 import appConfig from '../data/appConfig';
 import { noticePreferenceMapping } from '../data/constants';
 
+const { features } = appConfig;
+
 /**
  * ajaxCall
  * Utility function to make ajax requests.
@@ -368,6 +370,82 @@ function getAggregatedElectronicResources(items = []) {
   return _flatten(electronicResources);
 }
 
+// TODO: Define Resources
+
+// interface Resources {
+//   @type: string;
+//   label: string;
+//   url: string;
+// }
+
+// TODO: Define Items
+
+// This is incomplete
+// interface Items {
+//    id: string;
+//    status: {
+//      @id: string;
+//      prefLabel: string
+//    };
+//    availability: string;
+//    available: boolean;
+//    aeonUrl: string | string[];
+//    electronicResources?: never | string[]
+// }
+
+/**
+ * Return a list of non Aeon Link Electronic Resouces from given list
+ * @param {array} resources Resources[ ]
+ * @param {array} items Items[ ]
+ * @return {array}
+ */
+function pluckAeonLinksFromResource(resources = [], items = []) {
+  return (
+    (resources.length &&
+      featuredAeonList(items) && // Does items list contain an Aeon Request Button
+      resources.filter((resource) => {
+        // Remove all Aeon Links
+        return !isAeonLink(resource.url);
+      })) ||
+    resources
+  );
+}
+
+/**
+ * Check if the list contains aeon urls && is a valid feature
+ * @param {array} items Items[ ]
+ * @return {boolean}
+ */
+function featuredAeonList(items) {
+  const featured = features.includes('aeon-links');
+
+  // Does a single item in the list have an aeon url
+  return items.some((item) => {
+    // item.aeonUrl: String || String[]
+    return isAeonLink(item.aeonUrl) && featured;
+  });
+}
+
+/**
+ *
+ * Confirm the url is an Aeon Link
+ * @param url string | string[]
+ * @return A boolean indicating the passed url[s] are valid Aeon links
+ *
+ * Example URL:
+ * - https://specialcollections.nypl.org/aeon/Aeon.dll
+ * - https://nypl-aeon-test.aeon.atlas-sys.com
+ */
+function isAeonLink(url) {
+  if (!url) return false;
+  const aeonLinks = [
+    'https://specialcollections.nypl.org/aeon/Aeon.dll',
+    'https://nypl-aeon-test.aeon.atlas-sys.com',
+  ];
+  const link = Array.isArray(url) ? url[0] : url;
+  return Boolean(aeonLinks.some((path) => link.startsWith(path)));
+}
+
 /**
  * getUpdatedFilterValues(props)
  * Get an array of filter values based on one filter. If any filters are selected, they'll
@@ -672,4 +750,6 @@ export {
   institutionNameByNyplSource,
   addSource,
   isNyplBnumber,
+  pluckAeonLinksFromResource,
+  isAeonLink,
 };

--- a/test.env
+++ b/test.env
@@ -1,13 +1,12 @@
-export SET NODE_ENV=test
-export SET HOLD_REQUEST_NOTIFICATION
-export SET CLOSED_LOCATIONS="[]"
-export SET FEATURES=aeon-links
-export SET DISPLAY_TITLE="Research Catalog"
-export SET LEGACY_BASE_URL=https://legacyBaseUrl.nypl.org
-export SET SEARCH_RESULTS_NOTIFICATION="Some info for our patrons"
-export SET HOLD_REQUEST_NOTIFICATION="Some info for our patrons"
-export SET WEBPAC_BASE_URL=http://webpac.nypl.org
-export SET KMS_ENV=unencrypted
-export SET BASE_URL=/research/research-catalog
-export SET DRB_API_BASE_URL=http://example.com/search/
-export SET SHEP_BIBS_LIMIT=10
+NODE_ENV=test
+CLOSED_LOCATIONS="[]"
+FEATURES=aeon-links
+DISPLAY_TITLE="Research Catalog"
+LEGACY_BASE_URL=https://legacyBaseUrl.nypl.org
+SEARCH_RESULTS_NOTIFICATION="Some info for our patrons"
+HOLD_REQUEST_NOTIFICATION="Some info for our patrons"
+WEBPAC_BASE_URL=http://webpac.nypl.org
+KMS_ENV=unencrypted
+BASE_URL=/research/research-catalog
+DRB_API_BASE_URL=http://example.com/search/
+SHEP_BIBS_LIMIT=10

--- a/test/fixtures/bibs.js
+++ b/test/fixtures/bibs.js
@@ -279,6 +279,1077 @@ const bibs = [
     uri: 'b11417539',
     suppressed: false,
   },
+  {
+    status: '200',
+    '@type': ['nypl:Item', 'nypl:Resource'],
+    '@id': 'res:b22030125',
+    'carrierType': ['{@id: "carriertypes:nc", prefLabel: "volume"}'],
+    'contributorLiteral': [
+      'Heartman, Charles F. (Charles Frederick), 1883-1953,',
+    ],
+    'createdString': ['1916'],
+    'createdYear': 1916,
+    'creatorLiteral': ['Schomburg, Arthur Alfonso, 1874-1938.'],
+    'dateStartYear': 1916,
+    'dateString': ['1916'],
+    'dimensions': ['25 cm.'],
+    'donor': [
+      'Home to Harlem Project funded by the Andrew W. Mellon Foundation.',
+    ],
+    'extent': ['57 p. ;'],
+    'genreForm': ['Inscriptions (Provenance)'],
+    'idLccn': ['   17007194'],
+    'identifier': [
+      {
+        '@type': 'bf:ShelfMark',
+        '@value': 'Sc Rare 016.811-S (Schomburg, A. Bibliographical checklist)',
+      },
+      {
+        '@type': 'nypl:Bnumber',
+        '@value': '22030125',
+      },
+      {
+        '@type': 'bf:Lccn',
+        '@value': '   17007194',
+      },
+      {
+        '@type': 'bf:Identifier',
+        '@value': '(OCoLC)2430488',
+      },
+    ],
+    'issuance': ['{@id: "urn:biblevel:m", prefLabel: "monograph/item"}'],
+    'items': [
+      {
+        '@id': 'res:i12169730',
+        'accessMessage': [
+          {
+            '@id': 'accessMessage:4',
+            'prefLabel': 'Restricted use',
+          },
+        ],
+        'aeonUrl': [
+          'https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=A+bibliographical+checklist+of+American+Negro+poetry+/&Site=SCHRB&CallNumber=Sc+Rare+016.811-S+(Schomburg,+A.+Bibliographical+checklist)&Author=Schomburg,+Arthur+Alfonso,&ItemPlace=New+York+:&ItemPublisher=Charles+F.+Heartman,&Date=1916.&ItemInfo3=https://catalog.nypl.org/record=b22030125&ReferenceNumber=b220301256&Genre=Book-text&Location=Schomburg+Center',
+        ],
+        'catalogItemType': [
+          {
+            '@id': 'catalogItemType:2',
+            'prefLabel': 'book non-circ',
+          },
+        ],
+        'holdingLocation': [
+          {
+            '@id': 'loc:scdd2',
+            'prefLabel': 'Schomburg Center - Manuscripts & Archives',
+            'url':
+              'http://www.nypl.org/locations/divisions/manuscripts-archives-and-rare-books-division',
+          },
+        ],
+        'idBarcode': ['33433034100010'],
+        'identifier': [
+          {
+            '@type': 'bf:ShelfMark',
+            '@value':
+              'Sc Rare 016.811-S (Schomburg, A. Bibliographical checklist)',
+          },
+          {
+            '@type': 'bf:Barcode',
+            '@value': '33433034100010',
+          },
+        ],
+        'owner': [
+          {
+            '@id': 'orgs:1116',
+            'prefLabel':
+              'Schomburg Center for Research in Black Culture, Manuscripts, Archives and Rare Books Division',
+          },
+        ],
+        'physicalLocation': [
+          'Sc Rare 016.811-S (Schomburg, A. Bibliographical checklist)',
+        ],
+        'requestable': [false],
+        'shelfMark': [
+          'Sc Rare 016.811-S (Schomburg, A. Bibliographical checklist)',
+        ],
+        'status': [
+          {
+            '@id': 'status:k',
+            'prefLabel': 'Check with staff',
+          },
+        ],
+        'uri': 'i12169730',
+        'idNyplSourceId': {
+          '@type': 'SierraNypl',
+          '@value': '12169730',
+        },
+      },
+      {
+        '@id': 'res:i12169731',
+        'accessMessage': [
+          {
+            '@id': 'accessMessage:4',
+            'prefLabel': 'Restricted use',
+          },
+        ],
+        'aeonUrl': [
+          'https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=A+bibliographical+checklist+of+American+Negro+poetry+/&Site=SCHRB&CallNumber=Sc+Rare+016.811-S+(Schomburg,+A.+Bibliographical+checklist)&Author=Schomburg,+Arthur+Alfonso,&ItemPlace=New+York+:&ItemPublisher=Charles+F.+Heartman,&Date=1916.&ItemInfo3=https://catalog.nypl.org/record=b22030125&ReferenceNumber=b220301256&Genre=Book-text&Location=Schomburg+Center',
+        ],
+        'catalogItemType': [
+          {
+            '@id': 'catalogItemType:2',
+            'prefLabel': 'book non-circ',
+          },
+        ],
+        'holdingLocation': [
+          {
+            '@id': 'loc:scdd2',
+            'prefLabel': 'Schomburg Center - Manuscripts & Archives',
+            'url':
+              'http://www.nypl.org/locations/divisions/manuscripts-archives-and-rare-books-division',
+          },
+        ],
+        'idBarcode': ['33433034100028'],
+        'identifier': [
+          {
+            '@type': 'bf:ShelfMark',
+            '@value':
+              'Sc Rare 016.811-S (Schomburg, A. Bibliographical checklist)',
+          },
+          {
+            '@type': 'bf:Barcode',
+            '@value': '33433034100028',
+          },
+        ],
+        'owner': [
+          {
+            '@id': 'orgs:1116',
+            'prefLabel':
+              'Schomburg Center for Research in Black Culture, Manuscripts, Archives and Rare Books Division',
+          },
+        ],
+        'physicalLocation': [
+          'Sc Rare 016.811-S (Schomburg, A. Bibliographical checklist)',
+        ],
+        'requestable': [false],
+        'shelfMark': [
+          'Sc Rare 016.811-S (Schomburg, A. Bibliographical checklist)',
+        ],
+        'status': [
+          {
+            '@id': 'status:k',
+            'prefLabel': 'Check with staff',
+          },
+        ],
+        'uri': 'i12169731',
+        'idNyplSourceId': {
+          '@type': 'SierraNypl',
+          '@value': '12169731',
+        },
+      },
+      {
+        '@id': 'res:i12169734',
+        'accessMessage': [
+          {
+            '@id': 'accessMessage:4',
+            'prefLabel': 'Restricted use',
+          },
+        ],
+        'aeonUrl': [
+          'https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=A+bibliographical+checklist+of+American+Negro+poetry+/&Site=SCHRB&CallNumber=Sc+Rare+016.811-S+(Schomburg,+A.+Bibliographical+checklist)&Author=Schomburg,+Arthur+Alfonso,&ItemPlace=New+York+:&ItemPublisher=Charles+F.+Heartman,&Date=1916.&ItemInfo3=https://catalog.nypl.org/record=b22030125&ReferenceNumber=b220301256&Genre=Book-text&Location=Schomburg+Center',
+        ],
+        'catalogItemType': [
+          {
+            '@id': 'catalogItemType:2',
+            'prefLabel': 'book non-circ',
+          },
+        ],
+        'holdingLocation': [
+          {
+            '@id': 'loc:scdd2',
+            'prefLabel': 'Schomburg Center - Manuscripts & Archives',
+            'url':
+              'http://www.nypl.org/locations/divisions/manuscripts-archives-and-rare-books-division',
+          },
+        ],
+        'idBarcode': ['33433034100333'],
+        'identifier': [
+          {
+            '@type': 'bf:ShelfMark',
+            '@value':
+              'Sc Rare 016.811-S (Schomburg, A. Bibliographical checklist)',
+          },
+          {
+            '@type': 'bf:Barcode',
+            '@value': '33433034100333',
+          },
+        ],
+        'owner': [
+          {
+            '@id': 'orgs:1116',
+            'prefLabel':
+              'Schomburg Center for Research in Black Culture, Manuscripts, Archives and Rare Books Division',
+          },
+        ],
+        'physicalLocation': [
+          'Sc Rare 016.811-S (Schomburg, A. Bibliographical checklist)',
+        ],
+        'requestable': [false],
+        'shelfMark': [
+          'Sc Rare 016.811-S (Schomburg, A. Bibliographical checklist)',
+        ],
+        'status': [
+          {
+            '@id': 'status:k',
+            'prefLabel': 'Check with staff',
+          },
+        ],
+        'uri': 'i12169734',
+        'idNyplSourceId': {
+          '@type': 'SierraNypl',
+          '@value': '12169734',
+        },
+      },
+      {
+        '@id': 'res:i12169735',
+        'accessMessage': [
+          {
+            '@id': 'accessMessage:4',
+            'prefLabel': 'Restricted use',
+          },
+        ],
+        'aeonUrl': [
+          'https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=A+bibliographical+checklist+of+American+Negro+poetry+/&Site=SCHRB&CallNumber=Sc+Rare+016.811-S+(Schomburg,+A.+Bibliographical+checklist)&Author=Schomburg,+Arthur+Alfonso,&ItemPlace=New+York+:&ItemPublisher=Charles+F.+Heartman,&Date=1916.&ItemInfo3=https://catalog.nypl.org/record=b22030125&ReferenceNumber=b220301256&Genre=Book-text&Location=Schomburg+Center',
+        ],
+        'catalogItemType': [
+          {
+            '@id': 'catalogItemType:2',
+            'prefLabel': 'book non-circ',
+          },
+        ],
+        'holdingLocation': [
+          {
+            '@id': 'loc:scdd2',
+            'prefLabel': 'Schomburg Center - Manuscripts & Archives',
+            'url':
+              'http://www.nypl.org/locations/divisions/manuscripts-archives-and-rare-books-division',
+          },
+        ],
+        'idBarcode': ['33433034100002'],
+        'identifier': [
+          {
+            '@type': 'bf:ShelfMark',
+            '@value':
+              'Sc Rare 016.811-S (Schomburg, A. Bibliographical checklist)',
+          },
+          {
+            '@type': 'bf:Barcode',
+            '@value': '33433034100002',
+          },
+        ],
+        'owner': [
+          {
+            '@id': 'orgs:1116',
+            'prefLabel':
+              'Schomburg Center for Research in Black Culture, Manuscripts, Archives and Rare Books Division',
+          },
+        ],
+        'physicalLocation': [
+          'Sc Rare 016.811-S (Schomburg, A. Bibliographical checklist)',
+        ],
+        'requestable': [false],
+        'shelfMark': [
+          'Sc Rare 016.811-S (Schomburg, A. Bibliographical checklist)',
+        ],
+        'status': [
+          {
+            '@id': 'status:k',
+            'prefLabel': 'Check with staff',
+          },
+        ],
+        'uri': 'i12169735',
+        'idNyplSourceId': {
+          '@type': 'SierraNypl',
+          '@value': '12169735',
+        },
+      },
+      {
+        '@id': 'res:i12169732',
+        'accessMessage': [
+          {
+            '@id': 'accessMessage:4',
+            'prefLabel': 'Restricted use',
+          },
+        ],
+        'aeonUrl': [
+          'https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=A+bibliographical+checklist+of+American+Negro+poetry+/&Site=SCHRB&CallNumber=Sc+Rare+016.811-S+(Schomburg,+A.+Bibliographical+checklist)&Author=Schomburg,+Arthur+Alfonso,&ItemPlace=New+York+:&ItemPublisher=Charles+F.+Heartman,&Date=1916.&ItemInfo3=https://catalog.nypl.org/record=b22030125&ReferenceNumber=b220301256&Genre=Book-text&Location=Schomburg+Center',
+        ],
+        'catalogItemType': [
+          {
+            '@id': 'catalogItemType:2',
+            'prefLabel': 'book non-circ',
+          },
+        ],
+        'holdingLocation': [
+          {
+            '@id': 'loc:scdd2',
+            'prefLabel': 'Schomburg Center - Manuscripts & Archives',
+            'url':
+              'http://www.nypl.org/locations/divisions/manuscripts-archives-and-rare-books-division',
+          },
+        ],
+        'idBarcode': ['33433034100036'],
+        'identifier': [
+          {
+            '@type': 'bf:ShelfMark',
+            '@value':
+              'Sc Rare 016.811-S (Schomburg, A. Bibliographical checklist)',
+          },
+          {
+            '@type': 'bf:Barcode',
+            '@value': '33433034100036',
+          },
+        ],
+        'owner': [
+          {
+            '@id': 'orgs:1116',
+            'prefLabel':
+              'Schomburg Center for Research in Black Culture, Manuscripts, Archives and Rare Books Division',
+          },
+        ],
+        'physicalLocation': [
+          'Sc Rare 016.811-S (Schomburg, A. Bibliographical checklist)',
+        ],
+        'requestable': [false],
+        'shelfMark': [
+          'Sc Rare 016.811-S (Schomburg, A. Bibliographical checklist)',
+        ],
+        'status': [
+          {
+            '@id': 'status:k',
+            'prefLabel': 'Check with staff',
+          },
+        ],
+        'uri': 'i12169732',
+        'idNyplSourceId': {
+          '@type': 'SierraNypl',
+          '@value': '12169732',
+        },
+      },
+      {
+        '@id': 'res:i22030125-e',
+        'electronicLocator': [
+          {
+            '@type': 'nypl:ElectronicLocation',
+            'label': 'Full text available via HathiTrust',
+            'url': 'http://hdl.handle.net/2027/nyp.33433076020639',
+          },
+          {
+            '@type': 'nypl:ElectronicLocation',
+            'label': 'Request Access to Special Collections Material',
+            'url':
+              'https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=A+bibliographical+checklist+of+American+Negro+poetry+/&Site=SCHRB&CallNumber=Sc+Rare+016.811-S+(Schomburg,+A.+Bibliographical+checklist)&Author=Schomburg,+Arthur+Alfonso,&ItemPlace=New+York+:&ItemPublisher=Charles+F.+Heartman,&Date=1916.&ItemInfo3=https://catalog.nypl.org/record=b22030125&ReferenceNumber=b220301256&Genre=Book-text&Location=Schomburg+Center',
+          },
+        ],
+        'identifier': ['urn:SierraNypl:22030125-e'],
+        'uri': 'i22030125-e',
+        'idNyplSourceId': {
+          '@type': 'SierraNypl',
+          '@value': '22030125-e',
+        },
+      },
+    ],
+    'language': ['{@id: "lang:eng", prefLabel: "English"}'],
+    'lccClassification': ['Z1231.P7 S3'],
+    'materialType': ['{@id: "resourcetypes:txt", prefLabel: "Text"}'],
+    'mediaType': ['{@id: "mediatypes:n", prefLabel: "unmediated"}'],
+    'note': [
+      {
+        'noteType': 'Note',
+        '@type': 'bf:Note',
+        'prefLabel':
+          'All pages printed on the recto of the leaf only, except the series title page which is printed on the verso, pagination is continuous.',
+      },
+      {
+        'noteType': 'Note',
+        '@type': 'bf:Note',
+        'prefLabel':
+          '"Bibliographia Americana. A series of monographs edited by Charles F. Heartman ..."--series title page; facing title page.',
+      },
+      {
+        'noteType': 'Bibliography',
+        '@type': 'bf:Note',
+        'prefLabel':
+          "\"Bibliography of the poetical works of Phillis Wheatley (copyrighted by Charles F. Heartman) [reprinted from Heartman's 'Phillis Wheatley (Phillis Peters)']\"--p. 47-57.",
+      },
+      {
+        'noteType': 'Provenance',
+        '@type': 'bf:Note',
+        'prefLabel':
+          'inscribed: in ink on recto of endleaf preceding series title leaf  "A.A. Schomburg." ; This copy is part of the original collection purchased from Arthur A. Schomburg in 1926.',
+      },
+    ],
+    'numAvailable': 0,
+    'numItems': 6,
+    'nyplSource': ['sierra-nypl'],
+    'placeOfPublication': ['New York :'],
+    'publicationStatement': ['New York : Charles F. Heartman, 1916.'],
+    'publisherLiteral': ['Charles F. Heartman,'],
+    'seriesStatement': ['Bibliographica Americana ; v. 2'],
+    'shelfMark': [
+      'Sc Rare 016.811-S (Schomburg, A. Bibliographical checklist)',
+    ],
+    'subjectLiteral': [
+      'African American poets -- Bibliography.',
+      'American poetry -- African American authors -- Bibliography.',
+      'Wheatley, Phillis, 1753-1784 -- Bibliography.',
+    ],
+    'title': ['A bibliographical checklist of American Negro poetry'],
+    'titleDisplay': [
+      'A bibliographical checklist of American Negro poetry / compiled by Arthur A. Schomburg.',
+    ],
+    'type': ['nypl:Item'],
+    'uniformTitle': ['Bibliographica Americana ; v. 2.'],
+    'updatedAt': 1637605687189,
+    'uri': 'b22030125',
+    'suppressed': false,
+    'annotatedMarc': {
+      'bib': {
+        'id': '22030125',
+        'nyplSource': 'sierra-nypl',
+        'fields': [
+          {
+            'label': 'Author',
+            'values': [
+              {
+                'content': 'Schomburg, Arthur Alfonso, 1874-1938.',
+                'source': {
+                  'fieldTag': 'a',
+                  'marcTag': '100',
+                  'ind1': '1',
+                  'ind2': ' ',
+                  'content': null,
+                  'subfields': [
+                    {
+                      'tag': 'a',
+                      'content': 'Schomburg, Arthur Alfonso,',
+                    },
+                    {
+                      'tag': 'd',
+                      'content': '1874-1938.',
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+          {
+            'label': 'Title',
+            'values': [
+              {
+                'content':
+                  'A bibliographical checklist of American Negro poetry / compiled by Arthur A. Schomburg.',
+                'source': {
+                  'fieldTag': 't',
+                  'marcTag': '245',
+                  'ind1': '1',
+                  'ind2': '2',
+                  'content': null,
+                  'subfields': [
+                    {
+                      'tag': 'a',
+                      'content':
+                        'A bibliographical checklist of American Negro poetry /',
+                    },
+                    {
+                      'tag': 'c',
+                      'content': 'compiled by Arthur A. Schomburg.',
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+          {
+            'label': 'Imprint',
+            'values': [
+              {
+                'content': 'New York : Charles F. Heartman, 1916.',
+                'source': {
+                  'fieldTag': 'p',
+                  'marcTag': '260',
+                  'ind1': ' ',
+                  'ind2': ' ',
+                  'content': null,
+                  'subfields': [
+                    {
+                      'tag': 'a',
+                      'content': 'New York :',
+                    },
+                    {
+                      'tag': 'b',
+                      'content': 'Charles F. Heartman,',
+                    },
+                    {
+                      'tag': 'c',
+                      'content': '1916.',
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+          {
+            'label': 'Description',
+            'values': [
+              {
+                'content': '57 p. ; 25 cm.',
+                'source': {
+                  'fieldTag': 'r',
+                  'marcTag': '300',
+                  'ind1': ' ',
+                  'ind2': ' ',
+                  'content': null,
+                  'subfields': [
+                    {
+                      'tag': 'a',
+                      'content': '57 p. ;',
+                    },
+                    {
+                      'tag': 'c',
+                      'content': '25 cm.',
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+          {
+            'label': 'Series',
+            'values': [
+              {
+                'content': 'Bibliographica Americana ; v. 2',
+                'source': {
+                  'fieldTag': 's',
+                  'marcTag': '490',
+                  'ind1': '1',
+                  'ind2': ' ',
+                  'content': null,
+                  'subfields': [
+                    {
+                      'tag': 'a',
+                      'content': 'Bibliographica Americana ;',
+                    },
+                    {
+                      'tag': 'v',
+                      'content': 'v. 2',
+                    },
+                  ],
+                },
+              },
+              {
+                'content': 'Bibliographica Americana ; v. 2.',
+                'source': {
+                  'fieldTag': 's',
+                  'marcTag': '830',
+                  'ind1': ' ',
+                  'ind2': '0',
+                  'content': null,
+                  'subfields': [
+                    {
+                      'tag': 'a',
+                      'content': 'Bibliographica Americana ;',
+                    },
+                    {
+                      'tag': 'v',
+                      'content': 'v. 2.',
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+          {
+            'label': 'Note',
+            'values': [
+              {
+                'content':
+                  'All pages printed on the recto of the leaf only, except the series title page which is printed on the verso, pagination is continuous.',
+                'source': {
+                  'fieldTag': 'n',
+                  'marcTag': '500',
+                  'ind1': ' ',
+                  'ind2': ' ',
+                  'content': null,
+                  'subfields': [
+                    {
+                      'tag': 'a',
+                      'content':
+                        'All pages printed on the recto of the leaf only, except the series title page which is printed on the verso, pagination is continuous.',
+                    },
+                  ],
+                },
+              },
+              {
+                'content':
+                  '"Bibliographia Americana. A series of monographs edited by Charles F. Heartman ..."--series title page; facing title page.',
+                'source': {
+                  'fieldTag': 'n',
+                  'marcTag': '500',
+                  'ind1': ' ',
+                  'ind2': ' ',
+                  'content': null,
+                  'subfields': [
+                    {
+                      'tag': 'a',
+                      'content':
+                        '"Bibliographia Americana. A series of monographs edited by Charles F. Heartman ..."--series title page; facing title page.',
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+          {
+            'label': 'Bibliography',
+            'values': [
+              {
+                'content':
+                  "\"Bibliography of the poetical works of Phillis Wheatley (copyrighted by Charles F. Heartman) [reprinted from Heartman's 'Phillis Wheatley (Phillis Peters)']\"--p. 47-57.",
+                'source': {
+                  'fieldTag': 'n',
+                  'marcTag': '504',
+                  'ind1': ' ',
+                  'ind2': ' ',
+                  'content': null,
+                  'subfields': [
+                    {
+                      'tag': 'a',
+                      'content':
+                        "\"Bibliography of the poetical works of Phillis Wheatley (copyrighted by Charles F. Heartman) [reprinted from Heartman's 'Phillis Wheatley (Phillis Peters)']\"--p. 47-57.",
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+          {
+            'label': 'Provenance',
+            'values': [
+              {
+                'content':
+                  'Copy in Sc Rare 016.811-S (Copy 4) (accession no. B593799) inscribed: in ink on recto of endleaf preceding series title leaf  "A.A. Schomburg." ; This copy is part of the original collection purchased from Arthur A. Schomburg in 1926.',
+                'source': {
+                  'fieldTag': 'n',
+                  'marcTag': '561',
+                  'ind1': '1',
+                  'ind2': ' ',
+                  'content': null,
+                  'subfields': [
+                    {
+                      'tag': '3',
+                      'content':
+                        'Copy in Sc Rare 016.811-S (Copy 4) (accession no. B593799)',
+                    },
+                    {
+                      'tag': 'a',
+                      'content':
+                        'inscribed: in ink on recto of endleaf preceding series title leaf  "A.A. Schomburg." ; This copy is part of the original collection purchased from Arthur A. Schomburg in 1926.',
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+          {
+            'label': 'Local Note',
+            'values': [
+              {
+                'content':
+                  'Copy in Sc Rare 016.811-S (Copy 4) bound incorrectly; p. 49 leaf bound after p. 57 leaf.',
+                'source': {
+                  'fieldTag': 'n',
+                  'marcTag': '590',
+                  'ind1': '1',
+                  'ind2': ' ',
+                  'content': null,
+                  'subfields': [
+                    {
+                      'tag': '3',
+                      'content': 'Copy in Sc Rare 016.811-S (Copy 4)',
+                    },
+                    {
+                      'tag': 'a',
+                      'content':
+                        'bound incorrectly; p. 49 leaf bound after p. 57 leaf.',
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+          {
+            'label': 'Connect to:',
+            'values': [
+              {
+                'label': 'Request Access to Special Collections Material',
+                'content':
+                  'https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=A+bibliographical+checklist+of+American+Negro+poetry+/&Site=SCHRB&CallNumber=Sc+Rare+016.811-S+(Schomburg,+A.+Bibliographical+checklist)&Author=Schomburg,+Arthur+Alfonso,&ItemPlace=New+York+:&ItemPublisher=Charles+F.+Heartman,&Date=1916.&ItemInfo3=https://catalog.nypl.org/record=b22030125&ReferenceNumber=b220301256&Genre=Book-text&Location=Schomburg+Center',
+                'source': {
+                  'fieldTag': 'y',
+                  'marcTag': '856',
+                  'ind1': '4',
+                  'ind2': '0',
+                  'content': null,
+                  'subfields': [
+                    {
+                      'tag': 'u',
+                      'content':
+                        'https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=A+bibliographical+checklist+of+American+Negro+poetry+/&Site=SCHRB&CallNumber=Sc+Rare+016.811-S+(Schomburg,+A.+Bibliographical+checklist)&Author=Schomburg,+Arthur+Alfonso,&ItemPlace=New+York+:&ItemPublisher=Charles+F.+Heartman,&Date=1916.&ItemInfo3=https://catalog.nypl.org/record=b22030125&ReferenceNumber=b220301256&Genre=Book-text&Location=Schomburg+Center',
+                    },
+                    {
+                      'tag': 'z',
+                      'content': '[redacted]',
+                    },
+                  ],
+                },
+              },
+              {
+                'label': 'Full text available via HathiTrust',
+                'content': 'http://hdl.handle.net/2027/nyp.33433076020639',
+                'source': {
+                  'fieldTag': 'y',
+                  'marcTag': '856',
+                  'ind1': '4',
+                  'ind2': '0',
+                  'content': null,
+                  'subfields': [
+                    {
+                      'tag': 'u',
+                      'content':
+                        'http://hdl.handle.net/2027/nyp.33433076020639',
+                    },
+                    {
+                      'tag': 'z',
+                      'content': '[redacted]',
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+          {
+            'label': 'Subject',
+            'values': [
+              {
+                'content': 'Wheatley, Phillis, 1753-1784 -- Bibliography.',
+                'source': {
+                  'fieldTag': 'd',
+                  'marcTag': '600',
+                  'ind1': '1',
+                  'ind2': '0',
+                  'content': null,
+                  'subfields': [
+                    {
+                      'tag': 'a',
+                      'content': 'Wheatley, Phillis,',
+                    },
+                    {
+                      'tag': 'd',
+                      'content': '1753-1784',
+                    },
+                    {
+                      'tag': 'v',
+                      'content': 'Bibliography.',
+                    },
+                  ],
+                },
+              },
+              {
+                'content':
+                  'American poetry -- African American authors -- Bibliography.',
+                'source': {
+                  'fieldTag': 'd',
+                  'marcTag': '650',
+                  'ind1': ' ',
+                  'ind2': '0',
+                  'content': null,
+                  'subfields': [
+                    {
+                      'tag': 'a',
+                      'content': 'American poetry',
+                    },
+                    {
+                      'tag': 'x',
+                      'content': 'African American authors',
+                    },
+                    {
+                      'tag': 'v',
+                      'content': 'Bibliography.',
+                    },
+                  ],
+                },
+              },
+              {
+                'content': 'African American poets -- Bibliography.',
+                'source': {
+                  'fieldTag': 'd',
+                  'marcTag': '650',
+                  'ind1': ' ',
+                  'ind2': '0',
+                  'content': null,
+                  'subfields': [
+                    {
+                      'tag': 'a',
+                      'content': 'African American poets',
+                    },
+                    {
+                      'tag': 'v',
+                      'content': 'Bibliography.',
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+          {
+            'label': 'Genre/Form',
+            'values': [
+              {
+                'content': 'Inscriptions (Provenance)',
+                'source': {
+                  'fieldTag': 'd',
+                  'marcTag': '655',
+                  'ind1': ' ',
+                  'ind2': '7',
+                  'content': null,
+                  'subfields': [
+                    {
+                      'tag': 'a',
+                      'content': 'Inscriptions (Provenance)',
+                    },
+                    {
+                      'tag': '2',
+                      'content': '[redacted]',
+                    },
+                    {
+                      'tag': '5',
+                      'content': '[redacted]',
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+          {
+            'label': 'Local Subject',
+            'values': [
+              {
+                'content': 'Black author.',
+                'source': {
+                  'fieldTag': 'd',
+                  'marcTag': '690',
+                  'ind1': ' ',
+                  'ind2': ' ',
+                  'content': null,
+                  'subfields': [
+                    {
+                      'tag': 'a',
+                      'content': 'Black author.',
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+          {
+            'label': 'Added Author',
+            'values': [
+              {
+                'content':
+                  'Heartman, Charles F. (Charles Frederick), 1883-1953, publisher.',
+                'source': {
+                  'fieldTag': 'b',
+                  'marcTag': '700',
+                  'ind1': '1',
+                  'ind2': ' ',
+                  'content': null,
+                  'subfields': [
+                    {
+                      'tag': 'a',
+                      'content': 'Heartman, Charles F.',
+                    },
+                    {
+                      'tag': 'q',
+                      'content': '(Charles Frederick),',
+                    },
+                    {
+                      'tag': 'd',
+                      'content': '1883-1953,',
+                    },
+                    {
+                      'tag': 'e',
+                      'content': 'publisher.',
+                    },
+                  ],
+                },
+              },
+              {
+                'content':
+                  'Schomburg, Arthur Alfonso, 1874-1938, former owner, inscriber.',
+                'source': {
+                  'fieldTag': 'b',
+                  'marcTag': '796',
+                  'ind1': ' ',
+                  'ind2': ' ',
+                  'content': null,
+                  'subfields': [
+                    {
+                      'tag': 'a',
+                      'content': 'Schomburg, Arthur Alfonso,',
+                    },
+                    {
+                      'tag': 'd',
+                      'content': '1874-1938,',
+                    },
+                    {
+                      'tag': 'e',
+                      'content': 'former owner,',
+                    },
+                    {
+                      'tag': 'e',
+                      'content': 'inscriber.',
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+          {
+            'label': 'Added Title',
+            'values': [
+              {
+                'content':
+                  'Home to Harlem Project funded by the Andrew W. Mellon Foundation.',
+                'source': {
+                  'fieldTag': 'u',
+                  'marcTag': '799',
+                  'ind1': ' ',
+                  'ind2': ' ',
+                  'content': null,
+                  'subfields': [
+                    {
+                      'tag': 'a',
+                      'content':
+                        'Home to Harlem Project funded by the Andrew W. Mellon Foundation.',
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+          {
+            'label': 'LCCN',
+            'values': [
+              {
+                'content': '   17007194',
+                'source': {
+                  'fieldTag': 'l',
+                  'marcTag': '010',
+                  'ind1': ' ',
+                  'ind2': ' ',
+                  'content': null,
+                  'subfields': [
+                    {
+                      'tag': 'a',
+                      'content': '   17007194',
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+          {
+            'label': 'Research Call Number',
+            'values': [
+              {
+                'content':
+                  'Sc Rare 016.811-S (Schomburg, A. Bibliographical checklist)',
+                'source': {
+                  'fieldTag': 'q',
+                  'marcTag': '852',
+                  'ind1': '8',
+                  'ind2': ' ',
+                  'content': null,
+                  'subfields': [
+                    {
+                      'tag': 'h',
+                      'content':
+                        'Sc Rare 016.811-S (Schomburg, A. Bibliographical checklist)',
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        ],
+      },
+    },
+    'subjectHeadingData': [
+      {
+        'label': 'American poetry -- African American authors -- Bibliography',
+        'uuid': '4d5501c7-6d58-4ed0-b395-0d9cc6fc12df',
+        'bib_count': 9,
+        'desc_count': 0,
+        'parent': {
+          'label': 'American poetry -- African American authors',
+          'uuid': '8a93e23b-a4f5-4f14-b5cc-2baa45b9bd28',
+          'bib_count': 1718,
+          'desc_count': 62,
+          'parent': {
+            'label': 'American poetry',
+            'uuid': '29c958a0-a19e-4a21-b59d-55cc4452b613',
+            'bib_count': 23905,
+            'desc_count': 969,
+          },
+        },
+      },
+      {
+        'label': 'Inscriptions (Provenance)',
+        'uuid': 'f820910e-d10a-428c-84c2-3e2daf3093d4',
+        'bib_count': 621,
+        'desc_count': 6,
+      },
+      {
+        'label': 'African American poets -- Bibliography',
+        'uuid': 'db2c4a50-a86b-4626-a745-e411a6d9bf19',
+        'bib_count': 1,
+        'desc_count': 0,
+        'parent': {
+          'label': 'African American poets',
+          'uuid': 'fa6e5a43-4909-4cd6-a02e-5cf89926f110',
+          'bib_count': 417,
+          'desc_count': 62,
+        },
+      },
+      {
+        'label': 'Black author',
+        'uuid': '8575c60c-8168-4677-a043-ebca8f62e8d3',
+        'bib_count': 74857,
+        'desc_count': 0,
+      },
+      {
+        'label': 'Wheatley, Phillis, 1753-1784 -- Bibliography',
+        'uuid': 'c08c43f2-2720-4530-af07-6599227d2f4d',
+        'bib_count': 5,
+        'desc_count': 0,
+        'parent': {
+          'label': 'Wheatley, Phillis, 1753-1784',
+          'uuid': '89a59af2-fbd3-43f0-bc78-1989a7d5d45b',
+          'bib_count': 120,
+          'desc_count': 21,
+        },
+      },
+    ],
+  },
 ];
 
 export default bibs;

--- a/test/helpers/browser.js
+++ b/test/helpers/browser.js
@@ -1,3 +1,8 @@
+// TODO: Remove and Set to a setup file
+// Since the purpose of this file is to set up the browser
+// Perhaps we can instead point mocah to run a setupfile
+// which then executes this file to set up the browser
+require('dotenv').config({ path: 'test.env' });
 const enzyme = require('enzyme');
 const Adapter = require('enzyme-adapter-react-16');
 
@@ -24,4 +29,4 @@ global.navigator = {
 };
 
 const noop = () => {};
-require.extensions[".png"] = noop;
+require.extensions['.png'] = noop;

--- a/test/unit/BibPage.test.js
+++ b/test/unit/BibPage.test.js
@@ -16,6 +16,8 @@ import annotatedMarc from '../fixtures/annotatedMarc.json';
 import mockBibWithHolding from '../fixtures/mockBibWithHolding.json';
 import { makeTestStore } from '../helpers/store';
 import { mockRouterContext } from '../helpers/routing';
+import BackToSearchResults from '../../src/app/components/BibPage/BackToSearchResults';
+import { Link } from 'react-router';
 import BibDetails from '../../src/app/components/BibPage/BibDetails';
 import { isAeonLink } from '../../src/app/utils/utils';
 
@@ -181,8 +183,9 @@ describe('BibPage', () => {
     });
   });
 
-  describe('"Back to search results" link', () => {
+  describe('Back to search results Text', () => {
     const bib = { ...mockBibWithHolding, ...annotatedMarc };
+
     it('displays if `resultSelection.bibId` matches ID of bib for page', () => {
       const component = shallow(
         <BibPage
@@ -193,8 +196,14 @@ describe('BibPage', () => {
             fromUrl: 'resultsurl.com',
             bibId: bib['@id'].substring(4),
           }}
-        />, { context });
-      expect(component.find('Link').first().render().text()).to.equal('Back to search results');
+        />,
+        { context },
+      );
+
+      expect(component.find(BackToSearchResults)).to.have.lengthOf(1);
+      expect(
+        component.find(BackToSearchResults).first().render().text(),
+      ).to.equal('Back to search results');
     });
 
     it('does not display if `resultSelection.bibId` does not match ID of bib for page', () => {
@@ -207,9 +216,14 @@ describe('BibPage', () => {
             fromUrl: 'resultsurl.com',
             bibId: 'wrongbib',
           }}
-        />, { context });
+        />,
+        { context },
+      );
 
-      expect(component.find('Link').length).to.equal(0);
+      expect(component.find(BackToSearchResults)).to.have.lengthOf(1);
+      expect(
+        component.find(BackToSearchResults).first().render().find(Link).length,
+      ).to.equal(0);
     });
   });
 });

--- a/test/unit/BibPage.test.js
+++ b/test/unit/BibPage.test.js
@@ -16,9 +16,69 @@ import annotatedMarc from '../fixtures/annotatedMarc.json';
 import mockBibWithHolding from '../fixtures/mockBibWithHolding.json';
 import { makeTestStore } from '../helpers/store';
 import { mockRouterContext } from '../helpers/routing';
+import BibDetails from '../../src/app/components/BibPage/BibDetails';
+import { isAeonLink } from '../../src/app/utils/utils';
 
 describe('BibPage', () => {
   const context = mockRouterContext();
+  describe('Electronic Resources List', () => {
+    const testStore = makeTestStore({
+      bib: {
+        done: true,
+        numItems: 0,
+      },
+    });
+
+    const bib = { ...bibs[2] };
+    const page = mount(
+      <Provider store={testStore}>
+        <BibPage
+          location={{ search: 'search', pathname: '' }}
+          bib={bib}
+          dispatch={() => {}}
+          resultSelection={{
+            fromUrl: '',
+            bibId: '',
+          }}
+        />
+      </Provider>,
+      { context, childContextTypes: { router: PropTypes.object } },
+    );
+
+    it('should have an Aeon link available', () => {
+      const bttBibComp = page.findWhere(
+        (node) =>
+          node.type() === BibDetails && node.prop('additionalData').length,
+      );
+      // The Bottom Bib Details Component has the original, Non altered, aggregated resources list.
+      // It can be checked to see if the bib details would have been passed a list with Aeon links.
+      
+      expect(bttBibComp.type()).to.equal(BibDetails);
+      expect(bttBibComp.prop('electronicResources')).to.have.lengthOf(2);
+
+      const [resource] = bttBibComp
+        .prop('electronicResources')
+        .filter(
+          (er) => er.label === 'Request Access to Special Collections Material',
+        );
+      expect(isAeonLink(resource.url)).to.be.true;
+    });
+
+    it('should not include an Aeon link in top BibDetails', () => {
+      const topBibComp = page.findWhere(
+        (node) =>
+          node.type() === BibDetails && !node.prop('additionalData').length,
+      );
+      expect(topBibComp.type()).to.equal(BibDetails);
+      expect(
+        topBibComp.findWhere(
+          (el) => el.type() === 'dt' && el.text() === 'Electronic Resource',
+        ).length,
+      ).to.equal(1);
+      expect(topBibComp.prop('electronicResources')).to.have.lengthOf(1);
+    });
+  });
+
   describe('Non-serial bib', () => {
     const testStore = makeTestStore({
       bib: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,7 +6,11 @@ const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const sassPaths = require('@nypl/design-toolkit').includePaths;
 const globImporter = require('node-sass-glob-importer');
 const Visualizer = require('webpack-visualizer-plugin');
-
+// TODO: This would ideally not be set in this file
+// Add this to a ticket for future refactor
+// The purpose of this is to allow for a local run of npm run dist
+// In order to test a production build on a local machine.
+require('dotenv').config();
 // const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 
 // References the applications root path


### PR DESCRIPTION
**What's this do?**
Display/don't display Aeon link if the Items table contains a special collections request btn.

**Why are we doing this? (w/ JIRA link if applicable)**
There appeared to be duplicate abilities to request electronic resources in the item detail

**Do these changes have automated tests?**
Test Added to check that Top Bib Details does/not show given provided schema

**How should this be QAed?**
Unknown

**Dependencies for merging? Releasing to production?**
Some changes to Environments may affect testing

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Yes
