### PR TITLE
Remove Design Toolkit Import and Set Sass Files to Src Styles Dir

### DIFF
--- a/src/client/styles/components/BibPage.scss
+++ b/src/client/styles/components/BibPage.scss
@@ -1,4 +1,4 @@
-@import 'toolkit';
+@import '../sass/**/*.scss';
 
 .view-all-items-container {
   margin-top: 1.5rem;

--- a/src/client/styles/components/SubjectHeadings.scss
+++ b/src/client/styles/components/SubjectHeadings.scss
@@ -1,4 +1,4 @@
-@import "utils/colors.scss";
+@import '../utils/colors.scss';
 
 $subject-heading-table-header: rgb(224, 219, 214);
 

--- a/src/client/styles/components/SubjectHeadings/NestedTableHeader.scss
+++ b/src/client/styles/components/SubjectHeadings/NestedTableHeader.scss
@@ -1,4 +1,4 @@
-@import "utils/colors.scss";
+@import '../../utils/colors.scss';
 
 .nestedTableHeader {
   border-bottom: $table-row-border;

--- a/src/client/styles/components/SubjectHeadings/SubjectHeading.scss
+++ b/src/client/styles/components/SubjectHeadings/SubjectHeading.scss
@@ -1,4 +1,4 @@
-@import "utils/colors.scss";
+@import '../../utils/colors.scss';
 
 #subject-heading-content-primary {
   min-height: 600px;

--- a/src/client/styles/main.scss
+++ b/src/client/styles/main.scss
@@ -1,34 +1,34 @@
 /*
 Import style rules from NYPL Design Toolkit
 */
-@import "nypl-normalize";
-@import "toolkit";
+@import 'sass/nypl-normalize';
+@import 'sass/**/*.scss';
 
 /*
 Import style rules from NYPL Design System
 */
-@import '~@nypl/design-system-react-components/dist/styles.css';
-@import '~@nypl/design-system-react-components/dist/resources.scss';
+@import '@nypl/design-system-react-components/dist/styles';
+@import '@nypl/design-system-react-components/dist/resources';
 
 /*
 App-specific utilities and defaults
 */
-@import "utils/mixins.scss";
-@import "utils/utils.scss";
+@import 'utils/mixins.scss';
+@import 'utils/utils.scss';
 // @import "utils/fonts.scss";
-@import "utils/variables.scss";
-@import "utils/base.scss";
-@import "utils/colors.scss";
+@import 'utils/variables.scss';
+@import 'utils/base.scss';
+@import 'utils/colors.scss';
 
 /*
 Import style rules from NYPL React module components
 */
-@import "~@nypl/dgx-header-component/dist/styles/main";
-@import "~@nypl/dgx-react-footer/dist/styles/styles";
+@import '@nypl/dgx-header-component/dist/styles/main';
+@import '@nypl/dgx-react-footer/dist/styles/styles';
 
-@import "components/**/*.scss";
+@import 'components/**/*.scss';
 
-@import "style-v2.scss";
+@import 'style-v2.scss';
 
 html {
   @include font-settings;

--- a/src/client/styles/sass/_buttons.scss
+++ b/src/client/styles/sass/_buttons.scss
@@ -1,0 +1,426 @@
+// buttons
+
+@import "css3";
+@import "measurements";
+@import "colors";
+// Buttons stylings
+//TODO: move button style in _forms.scss to this partial
+//      add in styles for request button
+
+//@warn "use 'default' in default names (from colors.scss i suppose)";
+//@warn "some magic numbers";
+
+@mixin link-button {
+  background: none;
+  border: 0;
+  color: $link-color;
+  cursor: pointer;
+  font: inherit;
+  padding: 0;
+  text-decoration: underline;
+
+  &:hover {
+    text-decoration: none;
+  }
+}
+
+@mixin basic-button (
+  $background-color: $nypl-dark-gray,
+  $border-color: $nypl-dark-gray,
+  $border-radius: ($general-border-radius / 3),
+  $border-width: ($general-border-width / 3),
+  $button-icon: false,
+  $collapsible: false,
+  $disabled-color: $nypl-light-gray,
+  $font-size: 1rem,
+  $font-weight: normal,
+  $hover-text-color: $nypl-dark-gray,
+  $hover-background-color: $button-text-color,
+  $height: auto,
+  $letter-spacing: normal,
+  $padding-horizontal: 0.75rem,
+  $padding-vertical: 0.2rem,
+  $text-color: $button-text-color,
+  $text-transform: none) {
+  background-color: $background-color;
+  border: $border-width solid $border-color;
+  border-radius: $border-radius;
+  color: $text-color;
+  cursor: pointer;
+  display: inline-block;
+  font-size: $font-size;
+  font-weight: $font-weight;
+  height: $height;
+  letter-spacing: $letter-spacing;
+  padding: $padding-vertical $padding-horizontal;
+  text-decoration: none;
+  text-transform: $text-transform;
+  white-space: normal;
+  -webkit-appearance: none;
+  @content;
+
+  @include transition(all, $hover-time, ease-in);
+
+  @if ($collapsible == true) {
+    // has nypl-icon with down arrow
+    position: relative;
+    padding-right: 1.5rem;
+    text-align: left;
+
+    .nypl-icon {
+      @include transition(all, $hover-time, ease-in);
+      @include nypl-icon(
+        $fill: $text-color,
+        $background-color: $background-color);
+      height: 1rem;
+      position: absolute;
+      right: 0.25rem;
+      $top: 0.2rem;
+      @if ($padding-vertical != 0) {
+        $top: ($top + $padding-vertical);
+      }
+
+      top: $top;
+      width: 1rem;
+    }
+  } // /collapsible
+
+  // Button w/ Icon...
+  // TODO: Refactor $collapsible & $button-icon to be DRYer...
+  @if ($button-icon == true) {
+
+    .nypl-icon {
+      @include nypl-icon(
+      $fill: $text-color,
+      $background-color: $background-color);
+      @include transition(all, $hover-time, ease-in);
+    }
+  } // /button-icon
+
+  &:link,
+  &:visited {
+    color: $text-color;
+  }
+
+  $the-text-color: "";
+  $the-background-color: "";
+
+  @if $hover-background-color != $text-color {
+    // there's custom hover color
+    $the-background-color: $hover-background-color;
+  } @else {
+    $the-background-color: $text-color;
+  }
+
+  @if $hover-text-color != $background-color {
+    // there's custom hover color
+    $the-text-color: $hover-text-color;
+  } @else {
+    $the-text-color: $background-color;
+  }
+
+  &:hover,
+  &:hover:visited,
+  &.active,
+  &:focus {
+    border-color: $the-text-color;
+    background-color: $the-background-color;
+    color: $the-text-color;
+
+    @if $collapsible == true {
+      // has nypl-icon with down arrow
+      .nypl-icon {
+        @include nypl-icon(
+        $fill: $the-text-color,
+        $background-color: $the-background-color);
+      }
+    }
+
+    // button has an icon to the left or right:
+    @if $button-icon == true {
+      $custom-icon-height: "";
+      $custom-icon-width: "";
+
+      .nypl-icon {
+        @include nypl-icon(
+        $fill: $the-text-color,
+        $background-color: $the-background-color,
+        $height: $custom-icon-height,
+        $width: $custom-icon-width);
+      }
+    }
+
+    &:focus {
+      box-shadow: 1px 1px 1px 1px darken($focus-color, 10%);
+      border-radius: 0;
+    }
+  }
+
+  &.active {
+    @if $collapsible == true {
+      .nypl-icon {
+        transform: rotate(180deg);
+      }
+    }
+  }
+
+  &.disabled,
+  &[disabled="disabled"],
+  &[disabled="true"],
+  &[disabled],
+  &[disabled=true] {
+
+    //@warn "set universal disabled style";
+    background-color: $disabled-color;
+    border-color: $the-background-color;
+    cursor: default;
+
+    &:hover {
+      background-color: $disabled-color;
+      border-color: $the-background-color;
+      color: $text-color;
+    }
+  }
+} // /"basic" button
+
+@mixin primary-button {
+  @include basic-button (
+  $text-color: $nypl-white,
+  $border-color: $nypl-blue,
+  $background-color: $nypl-blue,
+  $border-radius: 0.25rem);
+
+  &:hover,
+  &:focus {
+    background: $nypl-white;
+    border-color: $nypl-blue;
+    color: $nypl-blue;
+  }
+
+  &:focus {
+    box-shadow: 0 0 1px 1px darken($focus-color, 10%);
+  }
+}
+
+//
+// Mixin for the requesting pattern
+//
+@mixin request-button {
+  @include basic-button (
+  $text-color: $nypl-white,
+  $border-color: $nypl-red,
+  $background-color: $nypl-red,
+  $border-radius: 0.25rem
+  );
+
+  &:hover,
+  &:focus {
+    background: $nypl-white;
+    border-color: $nypl-red;
+    color: $nypl-red;
+  }
+
+  &:focus {
+    box-shadow: 1px 1px 2px 2px darken($focus-color, 10%);
+  }
+}
+
+
+@mixin results-button {
+  @include basic-button (
+    $text-color: $nypl-blue,
+    $border-color: $nypl-blue,
+    $background-color: $nypl-white,
+    $hover-text-color: $nypl-white,
+    $hover-background-color: $nypl-blue,
+    $border-radius: 0.25rem);
+  margin: 0.5rem 0;
+
+  span {
+    display: block;
+    font-size: 2rem;
+    line-height: 1;
+    margin-right: 0.25rem;
+  }
+}
+
+@mixin service-button(
+  $collapsible: false,
+  $text-color: $nypl-white,
+  $background-color: $nypl-red) {
+
+  @include basic-button(
+    $font-size: 0.8rem,
+    $text-color: $text-color,
+    $background-color:
+    $background-color,
+    $collapsible: $collapsible,
+    $border-width: 0,
+    $padding-vertical: 0,
+    $padding-horizontal: 0.5rem);
+  border-radius: 0;
+  display: block;
+  font-weight: bold;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+@mixin login-button($collapsible: false) {
+  @include basic-button(
+    $font-size: 0.7rem,
+    $text-color: $nypl-white,
+    $background-color: $nypl-gray,
+    $padding-vertical: 0,
+    $padding-horizontal: 0.5rem,
+    $collapsible: $collapsible,
+    $border-width: 0);
+  border-radius: 0;
+  display: block;
+  font-weight: bold;
+  text-transform: uppercase;
+}
+
+@mixin menu-button(
+    $attachment: "left",
+    $text-color: $button-text-color,
+    $background-color: $nypl-search-color-dark) {
+  display: inline-block;
+  position: relative;
+
+  .nypl-menu-button_button {
+    @include basic-button($collapsible: true);
+  }
+
+  .nypl-menu-button_menu {
+    background-color: $background-color;
+    border-radius: $general-border-radius;
+    color: $text-color;
+    min-width: 10rem;
+    padding: 1rem;
+    position: absolute;
+    z-index: 1;
+
+    @if ($attachment == "left") {
+      left: 0;
+    } @else {
+      right: 0;
+    }
+  }
+}
+
+@mixin navigation-button(
+  $text-color: $button-text-color,
+  $background-color: $nypl-search-color-dark) {
+  display: inline-block;
+  position: relative;
+
+  .nypl-navigation-button_button {
+    @include basic-button($collapsible: true);
+  }
+
+  .nypl-navigation-button_list {
+    background-color: $background-color;
+    border-radius: $general-border-radius;
+    color: $text-color;
+    left: 0;
+    list-style: none;
+    padding: 0;
+    position: absolute;
+    top: 0;
+    z-index: 1;
+
+    li {
+      margin: 0;
+      padding: 0;
+    }
+
+    a {
+      color: $text-color;
+      display: block;
+      min-width: 10rem;
+      padding: 0.5rem 1rem;
+    }
+  }
+}
+
+
+
+
+///
+/// TODO: A better method for combining buttons & icons needs to be developed.
+///       Probably undo this mixin mess and make button, buttons with text & icons and buttons with icons only...
+///
+@mixin basic-button-icon($button-icon: true) {
+  @include basic-button(
+  $background-color: $nypl-red,
+  $border-color: $nypl-red,
+  $border-radius: 0.25rem,
+  $button-icon: true,
+  $hover-text-color: $nypl-red,
+  $hover-background-color: $nypl-white,
+  $text-color: $nypl-white
+  );
+  // We set the icon's position here and not on the general mixin since we are using a specific icon [x]
+  .nypl-icon {
+    height: 1rem;
+    position: relative;
+    top: 0.15rem;
+    width: 1rem;
+  }
+} // /basic-button-icon
+
+
+
+///
+/// TODO: Hovering w/ different icons needs sorting out.
+///
+@mixin close-button($button-icon: true) {
+  @include basic-button(
+  $background-color: $nypl-white,
+  $border-width: 0,
+  $button-icon: true,
+  $hover-text-color: $nypl-red,
+  $text-color: $nypl-red
+  );
+
+  .nypl-icon {
+    width: 1.75rem;
+    height: 1.75rem;
+    position: relative;
+    top: 0.5rem;
+  }
+} // /close-button
+
+///
+/// A special case where we need to change dimensions of the button:
+/// A use case its the "Filter Results"
+@mixin short-button(
+  // hacky
+  $short-button-height: 2.1rem
+  ) {
+  @include basic-button(
+    $background-color: $nypl-white,
+    $border-color: $nypl-dark-gray,
+    $border-radius: 0.25rem,
+    $button-icon: true,
+    $font-size: 0.85rem,
+    $height: null,
+    $hover-text-color: $nypl-white,
+    $hover-background-color: $nypl-dark-gray,
+    $padding-vertical: 0,
+    $padding-horizontal: 1.5rem,
+    $text-color: $nypl-dark-gray) {
+    height: $short-button-height;
+    padding-right: 0.5rem;
+    -webkit-appearance: none !important;
+  }
+
+  .nypl-icon {
+    height: 1rem;
+    margin-left: 1.75rem;
+    position: relative;
+    top: 0.1rem;
+    width: 1rem;
+  }
+}

--- a/src/client/styles/sass/_colors.scss
+++ b/src/client/styles/sass/_colors.scss
@@ -1,0 +1,91 @@
+//@warn "_colors.scss now using set from Marketing. Probably do some magic for eaching to prefix nypl automatically to each variable...";
+// nypl _colors.scss
+
+// NYPL Reds
+$nypl-red: #d0343a;
+$nypl-red-dark: #97272c;
+
+// NYPL Blues
+$nypl-blue: #1b7fa7;
+$nypl-blue-dark: #135772;
+$nypl-light-blue: lighten($nypl-blue, 30%);
+
+
+// NYPL Monochromatic
+$nypl-gray-cool: #76777b;
+$nypl-gray: #776e64;
+$nypl-gray-brown: #54514a;
+$nypl-dark-gray: darken($nypl-gray, 40%);
+$nypl-light-gray: lighten($nypl-gray, 40%);
+$nypl-white: #fff;
+$nypl-black: #111;
+
+
+// NYPL Yellows for Alerts & Focus halos etc.
+$nypl-yellow: #fee24a;
+$nypl-orange: #ffb81d;
+$nypl-orange-desaturated: desaturate($nypl-orange, 40%);
+
+// NYPL Greens ~ Used in Learn
+$nypl-green: #799a05;
+$nypl-green-dark: #497629;
+$nypl-green-bright: #008918;
+
+// NYPL Purple ~ Attend Colors
+$nypl-purple: #72256d;
+$nypl-purple-dark: #52174f;
+$nypl-purple-tint: lighten($nypl-purple, 60%);
+
+
+// NYPL Teal ~ Research colors
+$nypl-teal: #07818d;
+$nypl-teal-dark: #047074;
+$nypl-teal-tint: lighten($nypl-teal, 60%);
+
+// Semantic colors
+$nypl-search-color: $nypl-light-gray;
+$nypl-search-color-dark: $nypl-gray;//darken($nypl-search-color, 10%);
+$nypl-search-color-light: lighten($nypl-search-color, 10%);
+
+// Accessible, high contrast orange yellow for focus rings
+$focus-color: darken($nypl-blue-dark, 5%);
+
+
+// General Page Styles
+$page-color: $nypl-dark-gray;
+$page-text-color: $nypl-dark-gray;
+$page-color-light: $nypl-light-gray;
+$nypl-bar-color: rgba(0, 0, 0, 0.1);
+
+// General page background
+$page-background-color: $nypl-white;
+
+// Global Footer background
+$nypl-footer-color: $nypl-gray-brown;
+
+// Alerting and Highlights
+$highlight-color: $nypl-red;
+$success-color: $nypl-green-bright;
+$alert-color: $nypl-yellow;
+
+// Hyper-link colors
+$link-color: $nypl-blue;
+$link-visited-color: darken($link-color, 15%);
+$link-hover-color: darken($link-color, 5%);
+$inverted-link-color: $nypl-white;
+$inverted-link-visited-color: darken($inverted-link-color, 10%);
+
+// button colors not already defined above.
+$button-text-color: $nypl-white;
+
+$button-border-color: $nypl-dark-gray;
+
+$button-background-color: $nypl-white;
+//
+
+// field error bg
+$nypl-red-tint: tint($nypl-red, 30%);
+$nypl-red-error: tint($nypl-red, 80%);
+$nypl-blue-tint: tint($nypl-blue, 80%);
+$nypl-yellow-tint: tint($nypl-yellow, 50%);
+$nypl-green-tint: #f3f7e6;

--- a/src/client/styles/sass/_css3.scss
+++ b/src/client/styles/sass/_css3.scss
@@ -1,0 +1,109 @@
+// CSS 3 mixins taken from https://github.com/alphagov/govuk_frontend_toolkit
+
+// This file includes mixins for CSS properties that require vendor prefixes.
+
+// Please add more mixins here as you need them, rather than adding them to
+// your application - this lets us manage them in one place.
+
+// You can use the @warn directive to deprecate a mixin where the property
+// no longer needs prefixes.
+
+// This style of indentation is preferred as it is easier to scan
+// Allow more than two spaces per indentation level and don't require a space after a colon
+// scss-lint:disable Indentation SpaceAfterPropertyColon
+
+@mixin border-radius($radius) {
+  -webkit-border-radius: $radius; // Chrome 4.0, Safari 3.1 to 4.0, Mobile Safari 3.2, Android Browser 2.1
+     -moz-border-radius: $radius; // Firefox 2.0 to 3.6
+          border-radius: $radius;
+}
+
+@mixin box-shadow($shadow) {
+  -webkit-box-shadow: $shadow; // Chrome 4.0 to 9.0, Safari 3.1 to 5.0, Mobile Safari 3.2 to 4.3, Android Browser 2.1 to 3.0
+     -moz-box-shadow: $shadow; // Firefox 3.5 to 3.6
+          box-shadow: $shadow;
+}
+
+@mixin scale($x, $y, $transform-origin: 50% 50% 0) {
+  // $x and $y should be numeric values without units
+  -webkit-transform: scale($x, $y); // Still in use now, started at: Chrome 4.0, Safari 3.1, Mobile Safari 3.2, Android 2.1
+     -moz-transform: scale($x, $y); // Firefox 3.5 to 15.0
+      -ms-transform: scale($x, $y); // IE9 only
+          transform: scale($x, $y);
+
+  -webkit-transform-origin: $transform-origin; // Chrome, Safari 3.1
+     -moz-transform-origin: $transform-origin; // Firefox 10 to 15.0
+      -ms-transform-origin: $transform-origin; // IE9
+          transform-origin: $transform-origin;
+}
+
+@mixin translate($x, $y) {
+  -webkit-transform: translate($x, $y); // Still in use now, started at: Chrome 4.0, Safari 3.1, Mobile Safari 3.2, Android 2.1
+     -moz-transform: translate($x, $y); // Firefox 3.5 to 15.0
+      -ms-transform: translate($x, $y); // IE9 only
+       -o-transform: translate($x, $y); // Opera 10.5 to 12.0
+          transform: translate($x, $y);
+}
+
+@mixin rotate($degrees) {
+  -webkit-transform: rotate($degrees);
+     -moz-transform: rotate($degrees);
+      -ms-transform: rotate($degrees);
+          transform: rotate($degrees);
+}
+
+@mixin gradient($from, $to) {
+  // Creates a vertical gradient where $from is the colour at the top of the element
+  // and $to is the colour at the bottom. The top colour is used as a background-color
+  // for browsers that don't support gradients.
+  background-color: $from;
+  background-image: -webkit-gradient(linear, 0% 0%, 0% 100%, from($from), to($to)); // Safari 4.0 to 5.1, Chrome 1.0 to 10.0, old deprecated syntax
+  background-image: -webkit-linear-gradient($from, $to); // Chrome 10.0 to 25.0, Safari 5.1 to 6.0, Mobile Safari 5.0 to 6.1, Android Browser 4.0 to 4.3
+  background-image:    -moz-linear-gradient($from, $to); // Firefox 3.6 to 15.0
+  background-image:      -o-linear-gradient($from, $to); // Opera 11.1 to 12.0
+  background-image:         linear-gradient($from, $to);
+  filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#{$from}', endColorstr='#{$to}',GradientType=0 ); // IE6 to IE9
+}
+
+@mixin transition($property, $duration, $function, $delay: 0s) {
+  -webkit-transition: ($property $duration $function $delay); // Chrome 4.0 to 25.0, Safari 3.1 to 6.0, Mobile Safari 3.2 to 6.1, Android Browser 2.1 to 4.3
+     -moz-transition: ($property $duration $function $delay); // Firefox 4.0 to 15.0
+       -o-transition: ($property $duration $function $delay); // Opera 10.5 to 12.0
+          transition: ($property $duration $function $delay);
+}
+
+@mixin box-sizing($type) {
+  // http://www.w3.org/TR/css3-ui/#box-sizing
+  // $type can be one of: content-box | padding-box | border-box | inherit
+  -webkit-box-sizing: $type; // Chrome 4.0 to 9.0, Safari 3.1 to 5.0, Mobile Safari 3.2 to 4.3, Android Browser 2.1 to 3.0
+     -moz-box-sizing: $type; // Firefox 2.0 to 28.0, Firefox for Android 26.0 onwards
+          box-sizing: $type;
+}
+
+@mixin appearance($appearance) {
+  -webkit-appearance: $appearance;
+     -moz-appearance: $appearance;
+}
+
+@mixin calc($property, $calc) {
+  #{$property}: -webkit-calc(#{$calc}); // Chrome 19.0 to 25.0, Safari 6.0, Mobile Safari 6.0 to 6.1
+  #{$property}:         calc(#{$calc});
+}
+
+@mixin opacity($trans) {
+  zoom: 1;
+  filter: unquote('alpha(opacity=' + ($trans * 100) + ')'); // IE6 to IE8
+  opacity: $trans;
+}
+
+//
+// Create generic Columns for a layout
+//
+@mixin generic-columns(
+  $column-count: null,
+  $column-width: null
+) {
+  -webkit-column-count: $column-count $column-width;
+  -moz-column-count: $column-count $column-width;
+  column-count: $column-count $column-width;
+}

--- a/src/client/styles/sass/_footer.scss
+++ b/src/client/styles/sass/_footer.scss
@@ -1,0 +1,53 @@
+
+@import "measurements";
+@import "general-mixins";
+@import "microformats";
+@import "media-queries";
+
+//@warn "do footer";
+
+@mixin footer {
+  background-color: $nypl-footer-color;
+  color: $nypl-white;
+  font-size: 0.9rem;
+  margin-top: 5rem;
+  // font-weight: bold;
+  // @include Kievit-Bold;
+
+  ul {
+    list-style: none;
+    margin: 1rem 0;
+    padding: 0;
+    @include clearfix;
+  }
+
+  .copyright {
+    margin-top: 2rem;
+    margin-bottom: 5rem;
+
+    p {
+      padding-top: 1rem;
+    }
+  }
+
+  .footerLinks {
+
+    li {
+      margin-left: 0;
+    }
+
+    > li {
+      float: left;
+      width: 25%;
+
+      @include media($mobile-breakpoint) {
+        float: none;
+        width: auto;
+      }
+
+      a:focus {
+        background-color: transparent;
+      }
+    }
+  }
+}

--- a/src/client/styles/sass/_forms.scss
+++ b/src/client/styles/sass/_forms.scss
@@ -1,0 +1,1047 @@
+///
+/// Forms 
+///
+
+
+@import "buttons";
+/// @warn "omnisearch mixin is a the bottom of this file";
+/// overriding focus borders to make them stand out
+/// @warn "lots of magic numbers here";
+
+*::-moz-focus-inner {
+  border: 0;
+}
+
+
+$form-padding: 0.5rem;
+
+@each $tag in a, input, select, button, textarea {
+  #{$tag} {
+    border-radius: 0;
+  }
+
+  #{$tag}:focus {
+    box-shadow: 1px 1px 1px 1px darken($focus-color, 10%);
+    outline-color: $focus-color;
+    outline-style: solid;
+    outline-width: $focus-width;
+  }
+}
+
+footer a:focus {
+  $background-color: $nypl-footer-color;
+}
+
+@mixin label(
+  $display: block,
+  $font-weight: 400,
+  $margin-bottom: ($form-padding / 2)
+) {
+  color: $page-text-color;
+  display: $display;
+  font-weight: $font-weight;
+  margin-bottom: $margin-bottom;
+}
+
+
+
+///
+/// A basic Fieldset mixin
+///  Lots of arguments can be set to modify the end result based on it context
+///
+
+@mixin fieldset(
+    $border-width: 0,
+    $border-color: null,
+    $border-style: null,
+    $display: block,
+    $padding: 0) {
+  background-color: $page-background-color;
+  border: $border-width $border-color $border-style;
+  border-radius: $general-border-radius;
+  box-shadow: none;
+  display: $display;
+  margin: $general-padding 0;
+  padding: $padding;
+  position: relative;
+
+  fieldset {
+    border: $border-width $border-color $border-style;
+    box-shadow: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  label,
+  legend {
+    @include label;
+  }
+  /// Special Case where we have <h3-4> in a legend
+  legend h3 {
+    margin: 0;
+  }
+}
+
+
+
+//
+// Base input field
+// from which all others are constructed
+//
+
+@mixin input(
+    $background-color: $page-background-color,
+    $border-radius: ($general-border-radius * 1.25),
+    $font-size: 1rem,
+    $padding: 0) {
+  background-color: $background-color;
+  border: 0;
+  border-radius: $border-radius;
+  font-size: $font-size;
+  padding: $padding;
+}
+
+
+
+///
+/// Text styling for inputs
+///
+
+@mixin text {
+  @include input;
+  @include box-shadow(inset 0 0 0 1px $nypl-dark-gray);
+  height: 1.5rem;
+  padding: 0.5rem 0;
+  text-indent: $form-padding;
+  transition: all 0.2s ease-out;
+  width: 100%;
+  -webkit-appearance: none;
+
+  &.active {
+    width: 16rem;
+  }
+
+  &:focus {
+    @include box-shadow(inset 0 0 0 $focus-width $focus-color);
+    background-color: darken($page-background-color, 5%);
+    color: $page-color;
+    outline: none;
+  }
+}
+
+
+
+///
+/// Basic Text Area
+///
+
+@mixin text-area(
+  $border-radius: ($general-border-radius * 1.25),
+  $width: 100%,
+  $height: 12rem) {
+
+  textarea {
+    @include box-shadow(inset 0 0 0 1px $nypl-dark-gray);
+    border: 0;
+    border-radius: $border-radius;
+    box-sizing: border-box;
+    font-family: $sans-serif-stack;
+    height: $height;
+    padding: $general-padding;
+    width: $width;
+
+    &:focus {
+      background-color: darken($page-background-color, 5%);
+      border-radius: 0;
+      }
+    }
+  }
+
+
+
+///
+/// Text Fields with labels
+///
+
+@mixin text-field-with-label {
+  label {
+    background-color: transparent;
+    color: $page-text-color;
+    display: inline-block;
+    font-weight: 400;
+  }
+
+  input {
+    &[type=text],
+    &[type=email],
+    &[type=date],
+    &[type=number] {
+      @include text;
+    }
+  }
+
+  .nypl-field-status {
+    background-color: $page-background-color;
+    color: $nypl-gray;
+    display: block;
+    font-size: 0.9rem;
+    line-height: 1.5;
+    padding-top: $form-padding;
+  }
+}
+
+
+
+///
+/// Error states for input fields
+///
+
+@mixin field-error {
+  background: $page-background-color;
+
+  input[type=text],
+  textarea {
+    background-color: $nypl-red-error;
+    border: ($general-border-width / 2) $nypl-red-dark solid;
+    box-shadow: none;
+
+    &:focus {
+      background-color: lighten($nypl-red-error, 5%);
+      outline-color: $nypl-red-dark;;
+    }
+  }
+
+  .nypl-field-status {
+    background: $page-background-color;
+    color: $nypl-red;
+  }
+}
+
+
+
+///
+/// Success states for fields
+///
+
+@mixin field-success {
+  background: $page-background-color;
+
+  input[type=text],
+  textarea {
+    background-color: $nypl-green-tint;
+    border: ($general-border-width / 2) $nypl-green-bright solid;
+    box-shadow: none;
+
+    &:focus {
+      background-color: lighten($nypl-green-tint, 5%);
+      outline-color: $nypl-green-bright;
+    }
+  }
+}
+
+
+
+///
+/// Text Field
+///
+
+@mixin text-field {
+  @include fieldset;
+  @include text-field-with-label;
+}
+
+@mixin year-field {
+  @include fieldset;
+  @include text-field-with-label;
+}
+
+
+
+///
+/// Name Field(s)
+///
+
+@mixin name-field {
+  @include clearfix;
+  @include fieldset;
+  @include text-field-with-label;
+  background-color: $page-background-color;
+
+  > div {
+    display: block;
+    float: left;
+    margin-right: 0.125rem;
+    width: calc(50% - 0.125rem);
+
+    &:last-child {
+      margin-right: 0;
+    }
+
+    @include media($mobile-breakpoint) {
+      float: none;
+      margin-bottom: 1rem;
+      margin-right: 0;
+      width: auto;
+
+      &:last-child {
+        margin-bottom: 0;
+      }
+    }
+  }
+}
+
+
+
+///
+/// Basic Text Area Label & help / status text
+///
+
+@mixin text-area-with-label {
+  @include text-field-with-label;
+  @include text-area;
+}
+
+
+
+///
+/// Address Field
+///
+
+@mixin address-fieldset {
+  @include fieldset;
+  @include text-field-with-label;
+  background-color: $page-background-color;
+
+  div {
+    @include clearfix;
+    margin-bottom: $general-padding;
+  }
+
+  .nypl-simple-radiobutton {
+    background-color: $nypl-search-color-light;
+
+    label {
+      position: relative;
+    }
+  }
+}
+
+
+
+///
+/// Date Field(s)
+///
+
+@mixin date-field {
+  @include fieldset;
+  @include text-field-with-label;
+  min-width: 12rem;
+
+  input[type=date] {
+    -webkit-appearance: none; // to prevent iOS override
+  }
+}
+
+
+
+///
+/// Required Fields
+///
+
+@mixin required-field {
+  color: darken($highlight-color, 10%);
+  font-size: 0.9rem;
+  font-weight: 400;
+}
+
+
+
+///
+/// Select (Dropdowns)
+/// TODO: remove data svg and replace w/ inline
+///
+
+@mixin select (
+  $background-color: $nypl-white,
+  $height: 2em,
+  $padding-left: $form-padding,
+  $padding-right: 7%,
+  $width: 100%
+) {
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  appearance: none;
+  background: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4NCjxzdmcgdmVyc2lvbj0iMS4xIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB3aWR0aD0iMzAuNSIgaGVpZ2h0PSIxOC40Mjc3NCIgdmlld0JveD0iMCAwIDMwLjUgMTguNDI3NzQiIGFyaWEtaGlkZGVuPSJ0cnVlIiBwcmVzZXJ2ZUFzcGVjdFJhdGlvPSJ4TWlkWU1pZCBtZWV0Ij4NCjxzdHlsZSB0eXBlPSJ0ZXh0L2NzcyI+DQogIHBhdGggeyBmaWxsOiAjMTExMTExOyB9DQo8L3N0eWxlPg0KICA8dGl0bGU+ZG93biB3ZWRnZTwvdGl0bGU+DQogIDxwYXRoIGQ9Ik0yNi44MTguNjc5LDE1LjI4OCwxMi4yMjMxNSwzLjU5MTUzLjU5NTkyQTIuMDc0OCwyLjA3NDgsMCwwLDAsLjY5MDg0LjU4NjM2aDBhMi4yNzc1MywyLjI3NzUzLDAsMCwwLS4wMjYsMy4yNDIxMUwxNS4yMjQwNywxOC40Mjc3NCwyOS44NywzLjczNDMxQTIuMTU5MywyLjE1OTMsMCwwLDAsMjkuODU0MzYuNjdoMEEyLjE1OTMsMi4xNTkzLDAsMCwwLDI2LjgxOC42NzlaIi8+DQo8L3N2Zz4=) no-repeat 99% $background-color;
+  background-size: 1rem;
+  border: 0;
+  border-radius: $general-border-radius;
+  height: $height;
+  padding-right: $padding-right;
+  padding-left: $padding-left;
+  width: $width;
+}
+
+
+
+///
+/// Select Field
+///
+
+@mixin select-field {
+
+  @include fieldset;
+
+  label { // now has arguments to be applied
+    @include label;
+    position: relative;
+  }
+
+  select {
+    @include select;
+    @include box-shadow(inset 0 0 0 1px $nypl-dark-gray);
+    height: 3em;
+  }
+}
+
+
+
+///
+/// Select Field results
+/// Drop down w/ option for sorting...
+/// ex: /discovery-search.html
+///
+
+@mixin select-field-results {
+
+  form {
+    display: inline-block;
+    font-size: 0.85rem;
+    padding: 0.4rem 0;
+  }
+
+  @include fieldset;
+
+  label { // now has arguments to be applied
+    @include label(
+    $display: inline-block);
+    font-size: 1rem;
+    margin: 0 0.25rem 0 0;
+  }
+
+  select {
+    @include select(
+      $background-color: $nypl-white,
+      $height: 3em,
+      $width: inherit);
+    background-position-x: 92%;
+    border: ($general-border-width * 0.5) solid $nypl-dark-gray;
+    display: inline-block;
+    padding: 0 ($general-padding * 1.25) 0 ($general-padding * 0.75);
+  }
+
+  margin-top: 0;
+}
+
+@mixin form-error {
+  border-left: 1rem solid $highlight-color;
+  color: $highlight-color;
+  padding-left: 1rem;
+}
+
+
+
+///
+/// Sorting row pattern
+///
+
+@mixin sorter-row {
+  border-bottom: $general-border-width / 1.5 solid $nypl-dark-gray;
+  border-top: $general-border-width / 1.5 solid $nypl-dark-gray;
+
+  //
+  // Special case where we need to remove the padding on this module
+  //
+  .nypl-full-width-wrapper {
+    padding-bottom: 0;
+    padding-top: 0;
+
+    .nypl-column-full {
+      @include media($xtrasmall-breakpoint) {
+        display: block;
+      }
+
+      align-items: center;
+      display: flex;
+      margin-bottom: 0;
+    } // /.nypl-column-full
+  }
+}
+
+
+
+///
+/// replaces the error message / status w/ a generic mixin that can be styled for errors, success and inline alert state.
+///
+@mixin form-message(
+  $color: null) {
+  border-left: 1rem solid $color;
+  color: $color;
+  padding-left: 1rem;
+}
+
+
+
+///
+/// Simple Radiobutton
+/// Though, not so Simple
+///
+
+@mixin simple-radiobutton(
+    $background-color: $nypl-white,
+    $border-radius: 0,
+    $border-width: 0,
+    $border-color: $nypl-dark-gray,
+    $height: 4rem,
+    $margins: auto) {
+  border-radius: $border-radius;
+  @content;
+
+  span.nypl-label {
+    @include label;
+  }
+
+  label {
+    background-color: $background-color;
+    border-radius: 0;
+    font-weight: 400;
+    padding: 1rem 1rem 2rem 4rem;
+  }
+
+  input[type=radio],
+  input[type=checkbox] {
+    height: initial;
+    margin: 0 0.5rem;
+  }
+}
+
+
+
+///
+/// Special case to extend the default to the Item Holds screen
+///
+
+@mixin item-holds-radiobutton-field {
+  @include fieldset;
+  @include simple-radiobutton(
+    $background-color: $nypl-white,
+    $margins: 0) {
+
+    label {
+      border: $nypl-light-gray solid ($general-border-width / 2);
+      border-bottom: 0;
+      margin: 0;
+      padding: 1rem 1rem 2rem 4rem;
+
+      &:last-child {
+        border-bottom: $nypl-light-gray solid ($general-border-width / 2);
+      }
+
+      &.electronic-delivery {
+        border-bottom: $nypl-light-gray solid ($general-border-width / 2);
+        margin-bottom: 1rem;
+      }
+
+      input[type=radio] {
+        display: block;
+        position: relative;
+        top: 1.25rem;
+        left: -2.75rem;
+      }
+    } // /label
+  } // /simple-radiobutton
+} // /item-holds-radiobutton-field
+
+
+
+///
+/// radiobutton-field in action
+///
+@mixin radiobutton-field {
+  @include fieldset;
+  @include simple-radiobutton;
+
+  label {
+    border: ($general-border-width / 3) solid $nypl-light-gray;
+  }
+
+  input[type=radio] {
+    display: block;
+    position: relative;
+    top: 1.15rem;
+    left: -2.75rem;
+  }
+} // /radiobutton-field
+
+
+
+///
+/// Not So Generic Checkbox Style
+///
+
+@mixin generic-checkbox {
+
+  // If the the checkboxes are in <ul> remove the list stylings
+  // TODO: find a better ,more generic mixin argumenty way of doing this...
+  > li {
+    list-style: none;
+    margin: 0 0 0.35rem -1rem;
+    padding: 0.25rem 0;
+  }
+
+  input[type="checkbox"] {
+    opacity: 0;
+  }
+
+  label {
+    display: inline-block;
+    line-height: 1.2;
+    position: relative;
+    padding-left: 0.25rem;
+    padding-top: 0.27rem;
+    //width: 60%;
+  }
+
+  label::after,
+  label::before {
+    content: "";
+    display: inline-block;
+    position: absolute;
+  }
+
+  label::before {
+    border: $general-border-width solid;
+    height: 1rem;
+    left: -1.2em;
+    width: 1em;
+    top: 0.25rem;
+  }
+
+  label::after {
+    height: 0.375rem;
+    width: 0.5625rem;
+    border-left: $general-border-width solid;
+    border-bottom: $general-border-width solid;
+    transform: rotate(-45deg);
+    left: -0.90em;
+    top: 0.5em;
+  }
+// Hide the checkmark by default
+  input[type="checkbox"] + label::after {
+    content: none;
+  }
+
+  input[type="checkbox"]:checked + label::before {
+    background-color: lighten($nypl-green-tint, 35%);
+    border-width: $general-border-width;
+  }
+
+  input[type="checkbox"]:checked + label,
+  input[type="checkbox"]:checked + label::before {
+    border-color: darken($nypl-green-bright, 8%);
+    color: darken($nypl-green-bright, 8%);
+  }
+
+  input[type="checkbox"]:checked + label::after {
+    border-color: darken($nypl-green-bright, 8%);
+    color: darken($nypl-green-bright, 8%);
+    content: "";
+  }
+
+  // Adding focus styles on the outer-box of the fake checkbox
+  input[type="checkbox"]:focus + label::before {
+    outline: $focus-color auto 0.125rem;
+  }
+} // /generic-checkbox
+
+
+///
+/// The other Generic Checkbox pattern
+/// TODO: convert this checkbox to the pattern used above
+///
+
+@mixin terms-checkbox {
+  border-left: 0.5rem solid $nypl-gray;
+  margin-bottom: 1rem;
+  padding-left: 0.5rem;
+
+  label {
+    font-weight: 400;
+    padding: 0.1875rem 0;
+  }
+
+  input[type=checkbox] {
+    height: initial;
+    margin: 0 0.25rem 0 0;
+  }
+
+  &.checked {
+    border-left-color: $nypl-green-bright;
+  }
+} // /terms-checkbox
+
+
+
+///
+/// Facet toggling
+///
+
+@mixin facet-toggle {
+  background-color: $nypl-white;
+  border: 0;
+  color: $page-background-color;
+  cursor: pointer;
+  display: block;
+  font-weight: bold;
+  position: relative;
+  padding-bottom: 0.25rem;
+  padding-left: $form-padding;
+  padding-right: 1.5rem;
+  padding-top: 0.25rem;
+  text-align: left;
+  width: 100%;
+
+  h3 {
+    color: $page-text-color;
+    font-size: inherit;
+    margin: 0;
+    padding: 0;
+    pointer-events: none;
+  }
+
+  .nypl-icon {
+    @include nypl-icon(
+      $fill: $page-text-color,
+      $height: 0.75rem,
+      $background-color: $page-background-color,
+      $width: 0.75rem);
+    @include transition(all, $hover-time, ease-in);
+    position: absolute;
+    right: 0.5rem;
+    top: 0.65rem;
+    transform: rotate(-90deg);
+  }
+} // /facet-toggle
+
+
+
+///
+/// Collapsible fields
+///
+
+@mixin collapsible-field($is-searchable: false) {
+  @include fieldset;
+  border: $nypl-light-gray solid ($general-border-width / 2);
+  padding-bottom: $form-padding;
+  padding-top: $form-padding;
+
+  @if ($is-searchable == false) {
+    .nypl-collapsible {
+      background-color: $nypl-white;
+      padding-left: $form-padding;
+      padding-right: $form-padding;
+    }
+  }
+
+  &.collapsed {
+    .nypl-facet-toggle .nypl-icon {
+      transform: rotate(90deg);
+    }
+  }
+}
+
+
+
+///
+/// Searchable Field Module
+///
+
+@mixin searchable-field {
+  @include collapsible-field($is-searchable: true);
+  @include simple-radiobutton;
+
+  .nypl-facet-search {
+    @include text-field-with-label;
+    position: relative;
+
+    label {
+      font-weight: normal;
+    }
+  }
+
+  .nypl-facet-list {
+    width: 100%;
+
+    label {
+      @include clearfix;
+      border-radius: 0;
+      display: block;
+      font-size: 0.85rem;
+      margin-top: 0.2rem;
+    }
+
+    input[type="radio"],
+    input[type="checkbox"] {
+      box-sizing: border-box;
+      display: inline-block;
+    }
+
+    .nypl-facet-count {
+      color: $nypl-gray;
+      display: inline-block;
+      float: right;
+      margin: 0 0.25rem 0 1rem;
+      text-align: right;
+    }
+  }
+
+  .nypl-link-button {
+    margin: $form-padding $form-padding 0;
+  }
+
+  &.nosearch {
+    // when there are too few items to make search worthwhile
+
+    .nypl-facet-search {
+      display: none;
+    }
+
+  }
+}
+
+
+
+///
+/// Filter by Alpha
+///
+
+@mixin alphabetical-filter {
+  @include fieldset;
+
+  button {
+    @include basic-button(
+      $background-color: $nypl-search-color-light,
+      $text-color:$page-color,
+      $border-width: 0);
+    display: inline-block;
+    font-weight: normal;
+    margin: 0 0 0.5rem 0.5rem;
+    padding: 0.2rem 0.25rem;
+    width: 2rem;
+
+    &.nypl-long {
+      // because “any” has different lengths in different langs
+      min-width: 4.75rem;
+    }
+  }
+}
+
+
+
+///
+/// Mobile refine
+///
+
+@mixin mobile-refine {
+  display: none;
+
+  @include media($mobile-breakpoint) {
+    display: block;
+
+    &.hidden {
+      display: none;
+    }
+  }
+}
+
+
+
+///
+/// Left hand Search field.
+///
+
+@mixin search-form() {
+  // used for left-column searches
+  margin: 0 0 1rem;
+
+  @include media($mobile-breakpoint) {
+    display: none;
+
+    &.active {
+      display: block;
+    }
+  }
+}
+
+
+///
+/// Request form(s)
+/// Mixins for Discovery requests pages
+///
+
+@mixin request-item-summary {
+  background: $nypl-white;
+
+  h2 {
+    font-weight: 400;
+  }
+
+  .call-number {
+    margin: $general-padding 0;
+    font-size: 1rem;
+    font-weight: 400;
+  }
+}
+
+
+
+///
+/// Electronic Delivery
+///
+
+@mixin electronic-delivery-form {
+  fieldset {
+    border: 0;
+  }
+}
+
+
+
+///
+/// The Request page header
+///
+
+@mixin request-page-header {
+  @include page-header(
+  $background-color: lighten($nypl-light-gray, 15%),
+  $font-weight: 100,
+  $type-color: $nypl-red);
+  border-bottom: $general-border-width / 1.5 solid darken($nypl-light-gray, 15%);
+  margin-bottom: 0;
+
+  h2 {
+    margin-bottom: 0;
+  } // /h2
+
+  .search-control {
+    margin-top: 0;
+  } // /.search-control
+
+  .nypl-column-three-quarters {
+    margin-bottom: 0;
+  } // /.nypl-column-three-quarters
+} // /request-page-header
+
+
+
+// Need a title styling for forms so this might expand in the future
+// In this case the class is being used by an h2, but there is probably a
+// more Toolkity way of doing things:
+@mixin request-form-title(
+  $font-weight: 400,
+  $font-family: $sans-serif-stack) {
+  font-family: $font-family;
+  font-weight: $font-weight;
+}
+
+
+
+///
+/// Filtering Styles for Modals w/ complex filtering controls
+///
+
+@mixin modal-filter-form {
+
+  .inner {
+    border-bottom: $general-border-width solid $nypl-light-gray;
+    padding: 0 ($general-padding * 3.125);
+
+    &:nth-child(4),
+    &:nth-child(5) {
+      border-bottom: 0;
+    }
+
+    @include media($xtrasmall-breakpoint) {
+      padding-left: $general-padding;
+    }
+
+    legend {
+      font-size: 1.125rem;
+      margin-top: 0.75rem;
+    }
+
+    .nypl-filter-date-field {
+
+      > label {
+
+        @include media($xtrasmall-breakpoint) {
+          display: block;
+          max-width: 100%;
+          width: 100%;
+        }
+
+        display: inline-block;
+        max-width: calc(50% - 5.125rem);
+      }
+
+      > .nypl-icon {
+
+        @include media($xtrasmall-breakpoint) {
+          display: none;
+          height: 0;
+          opacity: 0;
+          visibility: hidden;
+          width: 0;
+        }
+
+        height: 2rem;
+        position: relative;
+        top: ($general-margin / 2);
+        width: 2rem;
+
+      }
+    }
+
+    .nypl-generic-columns {
+      @include generic-columns(3);
+      max-width: 100%;
+
+      @include media($mobile-breakpoint) {
+        @include generic-columns(2);
+      }
+
+      @include media($xtrasmall-breakpoint) {
+        @include generic-columns(1);
+       } // /$xtrasmall-breakpoint
+      } // /.nypl-generic-columns
+    } // /.inner
+
+
+  .nypl-filter-button {
+    @include basic-button-icon;
+    @include media($xtrasmall-breakpoint) {
+      @include clearfix;
+      clear: both;
+    }
+
+    margin-right: $general-margin;
+    margin-top: $general-margin;
+  }
+}
+
+
+
+///
+/// TODO: Move this to a more sensible location. Preferably at the top
+/// Could use a major refactor in general...
+///
+@import "omni-search";

--- a/src/client/styles/sass/_general-mixins.scss
+++ b/src/client/styles/sass/_general-mixins.scss
@@ -1,0 +1,137 @@
+@mixin clearfix() {
+  &::before,
+  &::after {
+    content: "";
+    display: table;
+  }
+
+  &::after {
+    clear: both;
+  }
+}
+
+$bullet-size: 0.5rem;
+
+@mixin custom-list-bullet(
+    $color: $nypl-light-gray,
+    $hides-on-mobile: true) {
+  list-style-type: none;
+  position: relative;
+
+  @if ($hides-on-mobile == true) {
+    @include media($mobile-breakpoint) {
+      margin-left: 0;
+    }
+  }
+}
+
+@mixin custom-list(
+    $color: $nypl-light-gray,
+    $hides-on-mobile: true) {
+  li {
+    @include custom-list-bullet(
+      $color: $nypl-light-gray,
+      $hides-on-mobile: true);
+  }
+}
+
+@mixin collapsible {
+  $collapsing-time: 0.5s;
+  $max-height: 40rem; // 640
+
+  @include transition(all, $collapsing-time, ease-out);
+
+  max-height: $max-height;
+  overflow: hidden;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+
+  &.collapsed {
+    max-height: 0;
+    visibility: hidden;
+  }
+}
+
+@mixin spinner-element {
+  $bar-color: transparentize($nypl-light-gray, 0.5);
+  $spinner-time: 1.5s;
+
+  @keyframes spinner-right {
+    0% {
+      right: -5rem;
+    }
+
+    100% {
+      right: -1rem;
+    }
+  }
+
+  overflow: hidden;
+  position: relative;
+
+  &.spinning {
+    &::after {
+      animation: spinner-right $spinner-time linear infinite;
+      background: -moz-repeating-linear-gradient(to right, $bar-color, $bar-color 1rem, transparent 1.1rem, transparent 2rem, $bar-color 2.1rem);
+      background: repeating-linear-gradient(to right, $bar-color, $bar-color 1rem, transparent 1.1rem, transparent 2rem, $bar-color 2.1rem);
+      content: "";
+      display: block;
+      height: 100%;
+      margin-top: 0;
+      position: absolute;
+      right: -50%;
+      top: 0;
+      transform: skewX(-30deg);
+      width: 200%;
+    }
+  }
+}
+
+@mixin screenreader-only {
+  // to hide something from view but make it visible to screen readers
+  // used on some table headers
+  // based on last.fm tables
+  position: absolute;
+  width: 0.1rem;
+  height: 0.1rem;
+  margin: -0.1rem;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+$white: #fff; // for tint lint pass
+$black: #000; // for shade lint pass
+
+/// Slightly lighten a color
+/// @access public
+/// @param {Color} $color - color to tint
+/// @param {Number} $percentage - percentage of `$color` in returned color
+/// @return {Color}
+
+@function tint($color, $percentage) {
+  @return mix($white, $color, $percentage);
+}
+
+/// Slightly darken a color
+/// @access public
+/// @param {Color} $color - color to shade
+/// @param {Number} $percentage - percentage of `$color` in returned color
+/// @return {Color}
+
+@function shade($color, $percentage) {
+  @return mix($black, $color, $percentage);
+}
+
+
+//
+// Focus rings...
+//
+
+@mixin basic-focus {
+  @include box-shadow(inset 0 0 0 0.15rem $focus-color);
+  border-style: solid;
+  outline: none;
+  padding: $focus-padding 0;
+}

--- a/src/client/styles/sass/_grid-ie.scss
+++ b/src/client/styles/sass/_grid-ie.scss
@@ -1,0 +1,5 @@
+@import "grid";
+
+// there should be a call to the grid system with is-ie set to true
+
+$is-ie: true;

--- a/src/client/styles/sass/_grid.scss
+++ b/src/client/styles/sass/_grid.scss
@@ -1,0 +1,246 @@
+@import "measurements";
+@import "css3";
+@import "general-mixins";
+@import "microformats";
+@import "media-queries";
+
+//@warn "remove magic numbers";
+
+///
+/// Basic Page header:
+/// based on: https://drive.google.com/drive/folders/0B2LQIUUuUDJdUk00VFFLaWJJLU0
+/// specifically: Discovery_home_v4a.psd
+///
+
+@mixin page-header(
+  $background-color: lighten($page-color-light, 10%),
+  $font-family: 'Milo-Light',
+  $font-weight: 400,
+  $type-color: $nypl-dark-gray) {
+  background-color: $background-color;
+  @content;
+
+  h1,
+  h2 {
+    font-family: $font-family;
+    font-size: 2rem;
+    margin: 0;
+  }
+
+  h1 {
+    font-weight: $font-weight;
+    margin: 1rem 0 1.5rem;
+  }
+
+  ///
+  /// TODO: clean this up so its not dependent upon a specific heading level
+  /// Though its pretty clear at first glance at what its doing...
+  h1.item-title,
+  h2.item-title {
+    font-family: $sans-serif-stack;
+    font-weight: 400;
+  }
+
+  h2 { // when it's a secondary title (real title is inside content below)
+    line-height: 1;
+  }
+
+  h2 {
+    font-family: $sans-serif-stack;
+    font-weight: 400;
+    margin: 1rem 0 1.5rem;
+
+    @include media($mobile-breakpoint) {
+      margin-top: 0.5rem;
+    }
+  }
+}
+
+
+
+///
+/// Home Page Hero
+///
+
+@mixin homepage-hero(
+    $background-color: lighten($page-color-light, 10%),
+    $font-family: $sans-serif-stack,
+    $font-weight: 400,
+    $type-color: $nypl-red) {
+  background-color: $background-color;
+
+  h1 {
+    color: $type-color;
+    font-family: 'Milo-Light', $font-family;
+    font-size: 3rem;
+    font-weight: $font-weight;
+    margin: 3rem 0 1.5rem;
+
+    @include media($mobile-breakpoint) {
+      font-size: 2rem;
+      margin-top: 0.5rem;
+      margin-bottom: 0.25rem;
+    }
+
+    @include media($xtrasmall-breakpoint) {
+      margin: 0.5rem 0 0.75rem;
+    }
+  } // /h1
+
+  p {
+    font-weight: 200;
+    max-width: none;
+
+    @include media($mobile-breakpoint) {
+      line-height: 2;
+    }
+  }
+} // /homepage-hero
+
+
+
+///
+/// Breadcrumbs
+///
+
+@mixin breadcrumbs {
+  list-style-type: none;
+  margin: 0 0 0 -0.5rem;
+  padding-left: 0;
+
+  li {
+    display: inline-block;
+    margin-left: 0;
+    //overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+
+    a {
+      border-radius: $general-border-radius;
+      color: $nypl-dark-gray;
+      padding: 0.25rem 0.45rem;
+
+      &:hover {
+        background: $nypl-light-gray;
+      }
+
+      &:visited {
+        color: lighten($nypl-dark-gray, 20%);
+      }
+    }
+
+
+
+    @include media($mobile-breakpoint) {
+      max-width: 90vw;
+    }
+
+    &::before {
+      content: " > ";
+    }
+
+    &:first-child::before {
+      content: "";
+    }
+  }
+}
+
+
+
+///
+/// Full Width Wrapper(s) Mixin
+///
+/// TODO: Find a better way to abstract all this nasty math away from the below calculations...
+
+@mixin full-width-wrapper($in-header: false) {
+  @if $in-header == false {
+    max-width: calc(#{$final-max-width} - #{$final-logo-offset * 2});
+    padding: $general-padding $final-logo-offset $general-padding $final-logo-offset;
+  } @else {
+    max-width: calc(#{$max-width} - #{$general-padding * 2});
+    padding: 0 $general-padding;
+  }
+
+  position: relative;
+  margin: 0 auto;
+  @include clearfix;
+
+  @include media($mobile-breakpoint) {
+    @if $in-header == false {
+      padding-left: ($general-padding * 2);
+      padding-right: ($general-padding * 2);
+    } @else {
+      margin: 0;
+      padding: 0 #{$general-padding * 0.5};
+    }
+  }
+}
+
+
+
+///
+/// Row Mixin
+///
+@mixin row {
+  margin: 0 -0.5rem;
+  min-height: 1rem;
+  @include clearfix;
+}
+
+@mixin column-type(
+    $border: 0,
+    $float: left,
+    $margin-bottom: 1rem,
+    $width: auto) {
+  //border: 1px solid $nypl-red;
+  border: $border;
+  float: $float;
+  margin-bottom: $margin-bottom;
+  min-height: 1rem;
+  padding: 0 0.5rem;
+  width: $width;
+  @include clearfix;
+  @include box-sizing(border-box);
+
+  @include media($mobile-breakpoint) {
+    float: none;
+    padding: 0;
+    width: auto;
+  }
+}
+
+@mixin column-full {
+  @include column-type($float: none);
+}
+
+@mixin column-half {
+  @include column-type($width: $half);
+}
+
+@mixin column-one-quarter {
+  @include column-type($width: $one-quarter);
+}
+
+@mixin column-one-third {
+  @include column-type($width: $one-third);
+}
+
+@mixin column-two-thirds {
+  @include column-type($width: $two-thirds);
+}
+
+@mixin column-three-quarters {
+  @include column-type($width: $three-quarters);
+}
+
+@mixin column-offset($column-count) {
+  margin-left: percentage($column-count / 4);
+
+  @include media($mobile-breakpoint) {
+    margin-left: 0;
+  }
+}
+
+// @mixin inner-block {
+//   @warn "deprecated. use row-column pattern instead.";
+// }

--- a/src/client/styles/sass/_header.scss
+++ b/src/client/styles/sass/_header.scss
@@ -1,0 +1,521 @@
+@import "grid";
+@import "buttons";
+
+//@warn "lots of refactoring to do here";
+
+@mixin header {
+  .horizontal {
+    display: table-cell;
+    float: right;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    position: relative;
+    @include clearfix;
+
+    @include media($mobile-breakpoint) {
+      float: none;
+    }
+
+    li {
+      display: inline-block;
+      margin-left: 0;
+      margin-right: 0.35rem;
+      vertical-align: bottom;
+
+      &:last-child {
+        margin-right: 0;
+      }
+    }
+  }
+
+  .collapsed-menu-toggle,
+  .main-menu-toggle {
+    display: none;
+  }
+
+  .main-menu-toggle {
+    @include media($mobile-breakpoint) {
+      background-color: $nypl-red;
+      color: $nypl-white !important;
+      display: block;
+      font-size: 1.1rem;
+      height: 2rem;
+      margin: 0 -1rem;
+      padding: 0 1rem 0.65rem 0;
+      text-align: right;
+      text-decoration: none;
+
+      .nypl-icon {
+        @include nypl-icon($nypl-white, $nypl-red, $width: 1.5em, $height: 1.5em);
+        position: relative;
+        top: 0.4375rem;
+      }
+    }
+  }
+
+  .logo {
+    position: absolute;
+    z-index: 1;
+    @include clearfix;
+
+    @include media($mobile-breakpoint) {
+      float: none;
+      margin: 1rem 0.5rem 1.5rem 0;
+      position: relative;
+      width: $logo-height;
+    }
+  }
+
+  .nypl-logo {
+    border: 0;
+    display: block;
+    font-size: 0;
+    height: $logo-height;
+    margin-top: 1rem;
+    margin-bottom: 0.1rem;
+    width: $logo-width;
+
+    svg {
+      height: $logo-height;
+      width: $logo-width;
+    }
+
+    @include media($mobile-breakpoint) {
+      margin: 0;
+      margin-right: 0.5rem;
+      overflow: hidden;
+      width: $logo-height;
+
+      .wordmark {
+        display: none;
+      }
+    }
+  }
+
+  .content {
+    position: relative;
+    @include clearfix;
+
+    @include media($mobile-breakpoint) {
+      width: 100%;
+    }
+  }
+
+  .service {
+    background-color: $nypl-red;
+    margin-bottom: 1rem;
+
+    @include media($mobile-breakpoint) {
+      display: table-footer-group;
+    }
+  }
+
+  @include media($mobile-breakpoint) {
+    display: table;
+    width: 100%;
+  }
+
+  .nypl-full-width-wrapper {
+    @include full-width-wrapper($in-header: true);
+  }
+
+  &.collapsed {
+    border-bottom: 2px solid $nypl-light-gray; // absolute px because no control over page rem
+    position: relative;
+
+    &.collapsed .login-toggle {
+      right: 110px; // absolute px because no control over page rem
+      top: 9px; // absolute px because no control over page rem
+
+      @include media($mobile-breakpoint) {
+        font-size: 12px; // absolute px because no control over page rem
+        top: -19px;
+
+        div {
+          right: -100%;
+        }
+      }
+    }
+
+    .main-menu-toggle {
+      display: none;
+    }
+
+    .collapsed-menu-toggle {
+      bottom: 0;
+      color: $page-text-color;
+      display: block;
+      font-size: 12px; // absolute px because no control over page rem
+      font-weight: bold;
+      position: absolute;
+      right: 1rem;
+    }
+
+    .logo {
+      height: $collapsed-nav-height;
+      overflow: hidden;
+    }
+
+    .nypl-logo {
+      // background: url("../img/lion.svg") no-repeat scroll 0 0/#{$logo-height} auto $nypl-white;
+      // background-position-y: -4px;
+      margin: 0;
+    }
+
+    .service-buttons {
+      min-height: $collapsed-service-height;
+
+      li {
+        display: none;
+      }
+    }
+
+    .nav-buttons {
+      font-size: 0;
+      font-weight: bold;
+      height: $collapsed-nav-height;
+      margin-top: 0;
+
+      li {
+        box-shadow: none;
+      }
+
+      a {
+        padding: 0.1rem 0.4rem;
+      }
+
+      .nypl-search {
+        display: none;
+      }
+    }
+  }
+
+
+  .service-buttons {
+    font-size: 0.8rem;
+    padding: 0;
+
+    @include media($mobile-breakpoint) {
+      display: none;
+      padding-top: 0.33rem;
+      width: 100%;
+
+      li {
+        border-bottom: 1px solid $nypl-white;
+        float: left;
+        line-height: 2;
+        margin: 0 0 0.33rem;
+        width: 50%;
+      }
+    }
+
+    li > a {
+      @include service-button;
+
+      &.donate {
+        @include service-button($text-color: $nypl-red, $background-color: $nypl-white);
+      }
+    }
+
+    button.collapsible {
+      @include service-button($collapsible: true);
+    }
+  }
+
+  .email-toggle {
+    position: relative;
+
+    button,
+    svg {
+      transition: all $hover-time;
+    }
+
+    button.active svg {
+      transform: rotate(180deg);
+    }
+
+    .subscribe-button {
+      @include basic-button($border-width: 0.0625rem, $border-color: $nypl-white);
+    }
+
+    form {
+      background-color: $nypl-search-color-dark;
+      color: $nypl-white;
+      font-size: 1rem;
+      min-width: 17rem;
+      position: absolute;
+      padding: 1rem;
+      right: 0;
+      text-transform: none;
+      z-index: 1;
+
+      @include media($mobile-breakpoint) {
+        left: 0;
+        right: auto;
+      }
+    }
+
+    .email-toggle-title {
+      font-size: 1.2rem;
+      font-weight: bold;
+      line-height: 1.5;
+      margin: 0;
+    }
+
+    .links {
+      margin: 1rem 0 0;
+    }
+  }
+
+  .login-toggle { // should be renamed
+    position: absolute;
+    right: 0;
+    top: 1.5rem;
+
+    button {
+
+      &.collapsible {
+        @include login-button($collapsible: true);
+      }
+    }
+
+    div {
+      background-color: $nypl-search-color-dark;
+      color: $nypl-white;
+      font-size: 1rem;
+      padding: 1rem;
+      padding-bottom: 0;
+      position: absolute;
+      right: 0;
+      text-transform: none;
+      z-index: 1;
+    }
+
+    > a {
+      @include login-button;
+    }
+
+    a.inverted {
+      display: block;
+      margin-bottom: 1rem;
+      white-space: nowrap;
+    }
+
+    .welcome-message {
+      display: inline-block;
+      margin-right: 1rem;
+      text-transform: none;
+    }
+
+    > a,
+    button.collapsible {
+      display: inline-block;
+
+      &:link {
+        text-decoration: none;
+      }
+    }
+
+    @include media($mobile-breakpoint) {
+      top: -3.3rem;
+
+      .welcome-message {
+        display: none;
+      }
+    }
+  }
+
+  .nav-buttons {
+    font-size: 1.1rem;
+    line-height: 1.7;
+    margin-top: calc(#{$logo-height} + 2rem);
+    @include clearfix;
+
+    @include media($intermediate-breakpoint) {
+      font-size: 0.9rem;
+    }
+
+    @include media($mobile-breakpoint) {
+      display: none;
+      font-size: 1.2rem;
+      margin-top: 1rem;
+
+      li {
+        border-bottom: 1px solid $nypl-light-gray;
+        float: left;
+        height: auto;
+        line-height: 2;
+        margin: 0 0 0.33rem;
+        width: 50%;
+
+        a {
+          line-height: inherit;
+        }
+      }
+
+      li.nypl-search {
+        border: 0;
+        font-size: 1rem;
+        position: relative;
+        right: initial;
+        top: initial;
+        width: 100%;
+      }
+    }
+
+    a {
+      border: 0;
+      color: $page-color;
+      display: block;
+      line-height: 2.3;
+      overflow: hidden;
+      padding: 0.2rem 0.4rem;
+      text-decoration: none;
+      text-overflow: ellipsis;
+      transition: all $hover-time;
+      white-space: nowrap;
+
+      &:hover {
+        color: $nypl-red;
+      }
+
+    }
+
+    li {
+      box-shadow: inset 0 0 0 $nypl-red;
+      transition: box-shadow 0.2s;
+    }
+
+    li:hover,
+    li.active {
+      box-shadow: inset 0 -4px 0 $nypl-red;
+    }
+
+  }
+
+
+  li.nypl-search {
+    @include media($intermediate-breakpoint) {
+      // float: none;
+      // position: absolute;
+      // right: 0;
+      // top: -3rem;
+    }
+
+    .nypl-search_main {
+      background-color: $nypl-search-color;
+      border-radius: ($general-border-radius * 2) ($general-border-radius * 2) 0 0;
+      margin: 0;
+      position: relative;
+      @include transition(all, $hover-time, ease-out);
+
+      .nypl-search_button {
+        @include basic-button($font-size: inherit, $border-width: 0, $background-color: $link-color, $hover-background-color: $nypl-search-color-light, $height: 2rem, $padding-vertical: 0);
+        margin-right: $form-padding;
+      }
+
+      &.display {
+        display: block;
+      }
+
+      &.active {
+        background-color: $nypl-search-color-dark;
+      }
+
+      .nypl-search_query-content {
+        padding: $form-padding;
+        position: relative;
+      }
+
+      .nypl-search_select {
+        background-color: $nypl-search-color-dark;
+        border-radius: 0 0 ($general-border-radius * 2) ($general-border-radius * 2);
+        font-size: 0.9rem;
+        right: 0;
+        padding: 0 $form-padding $form-padding;
+        position: absolute;
+        top: 3rem; // because ¯\_(ツ)_/¯
+        white-space: nowrap;
+        z-index: 1;
+      }
+
+      .nypl-search_radio-label {
+        @include simple-radiobutton;
+        color: $nypl-search-color-light;
+        display: inline-block;
+        height: 2rem;
+        line-height: 2;
+        padding: 0.25rem 0.75rem 0 0.5rem;
+        @include transition(all, $hover-time, ease-out);
+
+        &.selected {
+          background-color: $nypl-search-color-light;
+          color: $page-text-color;
+        }
+
+        &.focus {
+          box-shadow: inset 0 0 0 3px $focus-color;
+        }
+
+        input:focus {
+          box-shadow: 0 0 0 3px $focus-color;
+        }
+
+      }
+
+      input:focus {
+        outline: none;
+      }
+
+      .nypl-form-text {
+        @include input;
+        // box-shadow: inset 0 0 0 2px $nypl-search-color-dark;
+        border-radius: $general-border-radius;
+        height: 2rem;
+        margin-right: 0;
+        padding: 0;
+        text-indent: 0.5rem;
+        transition: all $hover-time ease-out;
+        width: 10rem;
+
+        &.active {
+          width: 16rem;
+        }
+
+        &:focus {
+          background-color: $nypl-white;
+          box-shadow: inset 0 0 0 0.25rem $focus-color;
+          color: $nypl-search-color-dark;
+          outline: none;
+        }
+      }
+
+      @include media($mobile-breakpoint) {
+        .nypl-form-text,
+        .nypl-search_button,
+        .nypl-search_radio-label {
+          height: 2.5rem;
+          line-height: 2.5;
+        }
+
+        .nypl-form-text,
+        .nypl-form-text.active {
+          margin: 0;
+          width: 70%;
+        }
+
+        .nypl-search_button {
+          margin: 0;
+          width: 30%;
+        }
+
+        .nypl-search_select {
+          top: 3.5rem;
+        }
+      }
+
+    }
+
+  }
+}

--- a/src/client/styles/sass/_holds-table.scss
+++ b/src/client/styles/sass/_holds-table.scss
@@ -1,0 +1,137 @@
+@mixin holds-table {
+  @include basic-table;
+  border-top: 0.25rem solid $page-color;
+  margin-bottom: 2rem;
+  margin-top: 1rem;
+  padding-top: 1rem;
+
+  // make sure we use the right cursors on hover.
+  // TODO: investigate a more elegant way to accomplish this:
+  thead tr th {
+    &[class^=sorting] { // using this attr. selector lets us get
+                        // get at DataTable's injected classes sorting,sort
+      cursor: pointer;
+    }
+
+    &[class=sorting_disabled] {
+      cursor: default;
+    }
+  }
+
+  td {
+    padding-top: 0.75rem;
+
+    @include item-definition-list($dt-width: 10%, $dd-width: 90%);
+    dl {
+      padding-left: #{$general-border-width * 5};
+
+      dt.item-title { // style first item in the Holds table context
+        font-weight: 700;
+        width: 100%;
+      }
+    }
+
+    &.recap dl {
+      border-left-color: $nypl-light-blue;
+      border-left-style: solid;
+      border-left-width: #{$general-border-width * 2.5};
+    }
+
+    .item {
+      font-weight: 700;
+    }
+  }
+
+  td span {
+    border-left-color: $page-background-color;
+    border-left-style: solid;
+    border-left-width: #{$general-border-width * 2.5};
+    display: block;
+    padding: 1rem 0 1rem 0.5rem;
+
+    &.available {
+      border-left-color: $nypl-green;
+      color: $nypl-green;
+    }
+
+    &.in-transit {
+      border-left-color: $nypl-yellow;
+    }
+
+    &.ill {
+      // &::before {
+      //   content: "ill?";
+      // }
+    }
+
+    &.recap {
+      background-color: lighten($nypl-light-blue, 15%);
+    }
+  }
+
+  @include media($mobile-breakpoint) {
+    thead {
+      border: 0;
+    }
+
+    thead tr {
+      @include screenreader-only;
+    }
+
+    tr {
+      border-top: #{$general-border-width * 2.5} solid $nypl-dark-gray;
+
+      &:nth-of-type(1) {
+        border: 0;
+      }
+    }
+
+    td {
+      border: 0;
+      display: block;
+      position: relative;
+      width: 100%;
+
+      &::before {
+        display: block;
+        float: left;
+        font-weight: bold;
+        padding-left: #{$general-border-width * 6};
+        width: 100%;
+      }
+
+      a {
+        display: block;
+        padding-left: #{$general-border-width * 6};
+      }
+
+      dt a {
+        padding-left: 0;
+      }
+
+      .item {
+        font-size: 1.2rem;
+        padding: 1rem 0;
+      }
+
+      &:nth-of-type(1)::before {
+        content: "Item";
+        display: none;
+      }
+
+      &:nth-of-type(2)::before {
+        content: "Status";
+        margin-bottom: 0;
+      }
+
+      &:nth-of-type(3)::before {
+        content: "Location";
+      }
+
+      &:nth-of-type(4)::before {
+        content: "Options";
+      }
+
+    }
+  }
+}

--- a/src/client/styles/sass/_icons.scss
+++ b/src/client/styles/sass/_icons.scss
@@ -1,0 +1,21 @@
+@mixin nypl-icon(
+  $background-color: $nypl-white,
+  $border-radius: 0,
+  $fill: $page-text-color,
+  $height: null,
+  $inverted-color: $inverted-link-color,
+  $width: null
+  ) {
+  background-color: $background-color;
+  border-radius: $border-radius;
+  display: inline-block;
+  fill: $fill;
+  height: $height;
+  speak: none;
+  width: $width;
+
+  &.reversed {
+    background-color: inherit;
+    fill: $inverted-color;
+  }
+}

--- a/src/client/styles/sass/_measurements.scss
+++ b/src/client/styles/sass/_measurements.scss
@@ -1,0 +1,104 @@
+/// Measurements
+
+///
+/// font base values
+///
+
+$basefontraw: 16;
+
+$basefont: $basefontraw * 1px;
+
+$small-type: ($basefont * 0.9);
+
+///
+/// page measures
+///
+
+$max-width-raw: 1315;
+$max-width: ($max-width-raw / $basefontraw) * 1rem; // in rems
+
+///
+/// Breakpoints
+///
+
+$intermediate-breakpoint: 1120px;
+$mobile-breakpoint: 965px;
+$xtrasmall-breakpoint: 483px;
+
+
+
+///
+/// Borders
+///
+
+$focus-width: (2 / $basefontraw) * 1rem;
+$related-links-border-width: 0.25rem;
+$simple-border: (1 / $basefontraw) * 1rem;
+
+
+
+///
+/// Grid Measures
+///
+
+$full-width: 100%;
+$one-quarter: $full-width / 4;
+$one-third: $full-width / 3;
+$half: $full-width / 2;
+$two-thirds: ($full-width) - ($one-third);
+$three-quarters: ($full-width) - ($one-quarter);
+$gutter: 0.5rem;
+$general-padding: 1rem;
+$general-margin: $general-padding;
+$general-border-radius: 0.2rem;
+$general-border-width: ($simple-border * 2);
+$focus-padding: ($general-padding / 2);
+
+
+
+
+///
+/// Animation timing
+///
+
+$hover-time: 0.1s;
+
+
+
+///
+/// Header numbers
+///
+/// Be advised that much of the DTK's calculations are based on the Header defined herein, NOT the Global Header React Appliction that is in production
+///
+
+$logo-ratio: 144 / 257;
+$logo-width-raw: 16;
+$logo-width: $logo-width-raw * 1rem;
+$logo-height-raw: $logo-width-raw * $logo-ratio;
+$logo-height: $logo-height-raw * 1rem;
+$collapsed-service-height: 10px;
+$collapsed-nav-height: 30px;
+
+///
+/// These values are based on the current implementation of the logo in the React App header.
+
+/// Convert the width of each logo element into rems:
+$logo-type-width-raw: 112.53 / $basefontraw;
+$logo-type-width: $logo-type-width-raw * 1rem;
+$logo-mark-width-raw: 96.37 / $basefontraw;
+$logo-mark-width: $logo-mark-width-raw * 1rem;
+
+/// the gap between the logomark and logotype
+$logo-gap-between: $logo-type-width - $logo-mark-width;
+
+/// More than likely this is the kludgiest way to
+/// do the math that sets up the padding & spacing necessary for nice layout that our grid will consume:
+/// the first value that sets the max-width of the container:
+$final-max-width: $max-width - $general-padding;
+
+/// this gets the width of the logotype and subracts the width of the gap between the mark and the type:
+$logo-offset: $logo-mark-width + $logo-gap-between;
+
+$final-logo-offset: $logo-width - ($logo-offset + 0.5);
+
+$final-offset: $logo-offset + $general-padding;

--- a/src/client/styles/sass/_media-queries.scss
+++ b/src/client/styles/sass/_media-queries.scss
@@ -1,0 +1,60 @@
+$is-ie: false !default;
+// $mobile-ie6: true !default;
+
+@mixin media(
+  $max-width,
+  $min-width: false,
+  $ignore-for-ie: false) {
+  @media (max-width: $max-width) {
+    @content;
+  }
+  // @if $is-ie and ($ignore-for-ie == false) {
+  //   @if $size != mobile {
+  //     @if ($ie-version == 6 and $mobile-ie6 == false) or $ie-version > 6 {
+  //       @content;
+  //     }
+  //   }
+  // } @else {
+  //   @if $size == desktop {
+  //     @media (min-width: 769px){
+  //       @content;
+  //     }
+  //   } @else if $size == tablet {
+  //     @media (min-width: 641px){
+  //       @content;
+  //     }
+  //   } @else if $size == mobile {
+  //     @media (max-width: 640px){
+  //       @content;
+  //     }
+  //   } @else if $max-width != false {
+  //     @media (max-width: $max-width){
+  //       @content;
+  //     }
+  //   } @else if $min-width != false {
+  //     @media (min-width: $min-width){
+  //       @content;
+  //     }
+  //   } @else {
+  //     @media (min-width: $size){
+  //       @content
+  //     }
+  //   }
+  // }
+}
+
+@mixin ie-lte($version) {
+  @if $is-ie {
+    @if $ie-version <= $version {
+      @content;
+    }
+  }
+}
+
+// @mixin ie($version) {
+//   @if $is-ie {
+//     @if $ie-version == $version {
+//       @content;
+//     }
+//   }
+// }

--- a/src/client/styles/sass/_microformats.scss
+++ b/src/client/styles/sass/_microformats.scss
@@ -1,0 +1,244 @@
+//@warn "remove magic numbers";
+
+@mixin banner-alert() {
+  background-color: $alert-color;
+  padding: 0.8rem 0;
+}
+
+@mixin bar($percent: 100) {
+  background: linear-gradient(to right, transparent 0%, transparent ((100 - $percent) * 1%), $nypl-bar-color ((100 - $percent) * 1%), $nypl-bar-color) 100%;
+}
+
+@mixin lead {
+  font-size: 1.6rem;
+
+  @include media($mobile-breakpoint) {
+    font-size: 1.2rem;
+  }
+}
+
+@mixin basic-list {
+  list-style-type: none;
+
+  li {
+    margin-bottom: 0.5rem;
+    margin-left: 0;
+  }
+}
+
+@mixin bar-list {
+  @include basic-list;
+
+  h2 {
+    font-size: 1.4rem;
+  }
+
+  li {
+    span.count {
+      color: $nypl-gray;
+      display: inline-block;
+      float: right;
+      margin-right: 0.2rem;
+    }
+  }
+}
+
+@mixin secondary-title {
+  font-size: 1.2rem;
+  font-weight: bold;
+  line-height: 1.5;
+  margin: 0;
+}
+
+@mixin a11y-note {
+  border-left: 1rem solid $alert-color;
+  padding-left: 1rem;
+}
+
+@mixin general-note {
+  border-left: 1rem solid $nypl-gray;
+  padding-left: 1rem;
+}
+
+@mixin progress-indicator {
+  color: $nypl-gray;
+  margin: 0;
+  padding: 0;
+}
+
+@mixin location-info {
+  border-left: 1rem solid $nypl-light-gray;
+  margin-bottom: 2rem;
+  padding-left: 1rem;
+
+  p {
+    margin: 0;
+    margin-bottom: 0.5rem;
+  }
+
+  .nypl-room {
+    font-weight: bold;
+  }
+
+  .nypl-access {
+    color: $highlight-color;
+    font-weight: bold;
+  }
+}
+
+@mixin location-hours {
+  @include basic-table;
+
+  margin-bottom: 2rem;
+
+  .nypl-current {
+    background-color: $nypl-yellow-tint;
+  }
+
+  @include media($mobile-breakpoint) {
+    thead tr {
+      @include screenreader-only;
+    }
+
+    tr {
+      border: 0;
+    }
+
+
+    td {
+      display: block;
+      position: relative;
+      width: 100%;
+
+      &::before {
+        display: block;
+        float: left;
+        font-weight: bold;
+        margin-bottom: 2rem;
+        width: 40%;
+      }
+
+      &:nth-of-type(1)::before {
+        content: "Monday";
+      }
+
+      &:nth-of-type(2)::before {
+        content: "Tuesday";
+      }
+
+      &:nth-of-type(3)::before {
+        content: "Wednesday";
+      }
+
+      &:nth-of-type(4)::before {
+        content: "Thursday";
+      }
+
+      &:nth-of-type(5)::before {
+        content: "Friday";
+      }
+
+      &:nth-of-type(6)::before {
+        content: "Saturday";
+      }
+
+      &:nth-of-type(7)::before {
+        content: "Sunday";
+      }
+    }
+
+  }
+} // /@location-hours
+
+
+
+//@warn "Move these mixins out of the microformats partial since they effect the entire style guide...";
+
+@mixin related-links {
+  border-top: $related-links-border-width solid $nypl-gray;
+  padding-top: 2rem;
+}
+
+@mixin toolkit-example {
+  border: $simple-border solid $nypl-light-gray;
+  padding: ($general-padding * 3) $general-padding ($general-padding * 0.5);
+  position: relative;
+
+  .nypl-example-text {
+    border: $simple-border solid $nypl-light-gray;
+    border-left: 0;
+    border-top: 0;
+    color: $nypl-gray;
+    display: inline-block;
+    font-size: 1rem;
+    font-weight: normal;
+    left: 0;
+    padding: 0.3rem $general-padding;
+    position: absolute;
+    top: 0;
+  }
+}
+
+@mixin toolkit-example-dark {
+  background: $nypl-footer-color;
+
+  &::before {
+    background-color: $inverted-link-color;
+  }
+}
+
+
+//
+// Discovery HP Image, H4 & copy section below the Hero
+// TODO: Make a proper toolkit patter for this
+// TODO: This is a bit hacky to override the toolkit's established grid styles, but in this case for medium sized viewports we need an breakpoint to hanle this layout:
+//@warn "many magic numbers & work arounds here";
+
+// Special case where there is an h3 that has special styling. here it is:
+
+@mixin special-title(
+    $color: $nypl-red,
+    $font-size: 2rem,
+    $font-weight: 200) {
+  color: $color;
+  font-size: $font-size;
+  font-weight: $font-weight;
+
+  @include media($mobile-breakpoint) {
+    font-size: 1.75rem;
+    margin: 0.85rem 0;
+  }
+}
+
+@mixin quarter-image {
+  width: 100%;
+
+  .image-column-one-quarter {
+
+    @include media($mobile-breakpoint) {
+      float: left;
+      margin-bottom: 1rem;
+      padding-right: 0.5rem;
+      width: 25%;
+    }
+
+    @include media($xtrasmall-breakpoint) {
+      width: 100%;
+    }
+  }
+
+  .image-column-three-quarters {
+
+    @include media($mobile-breakpoint) {
+      float: left;
+      margin-bottom: 1rem;
+      padding: 0 0.5rem;
+      width: 75%;
+    }
+
+    @include media($xtrasmall-breakpoint) {
+      width: 100%;
+      float: none;
+    }
+  }
+}

--- a/src/client/styles/sass/_modal-container.scss
+++ b/src/client/styles/sass/_modal-container.scss
@@ -1,0 +1,105 @@
+//
+// Very basic modal container
+//
+// Import this as:
+// .nypl-basic-modal-container {
+//    @include basic-modal;
+//    }
+
+#closeModal {
+  display: none;
+}
+
+#filterButton {
+  display: none;
+}
+
+#cancelFiltering {
+  display: none;
+}
+
+#popup-no-js:target {
+  display: block;
+  opacity: 1;
+  visibility: visible;
+}
+
+@mixin basic-modal {
+
+  &.inactive {
+    display: none;
+    opacity: 0;
+    visibility: hidden;
+  }
+
+  &.no-js {
+    display: none;
+    opacity: 0;
+    visibility: hidden;
+  }
+
+  &.no-js:target,
+  &.active {
+    display: block;
+    opacity: 1;
+    visibility: visible;
+
+    .nypl-modal-underlay {
+      background: transparentize($nypl-white, 0.2);
+      bottom: 0;
+      left: 0;
+      position: fixed;
+      right: 0;
+      top: 0;
+      z-index: 1000;
+    }
+
+
+    $shadow: 0 0.125rem 0.5rem 0.25rem transparentize($nypl-gray-brown, 0.75);
+
+    .nypl-modal-content {
+      @include box-shadow($shadow);
+      background: darken($nypl-white, 0.2);
+      bottom: 0;
+      display: block;
+      left: 0;
+      height: 100%;
+      overflow: scroll;
+      position: fixed;
+      right: 0;
+      top: 0;
+      width: 100%;
+      z-index: 1001;
+      -webkit-overflow-scrolling: none;
+
+      h3 {
+        margin-bottom: 0;
+        margin-left: ($general-margin * 3.125);
+
+        @include media($xtrasmall-breakpoint) {
+          margin-left: $general-margin;
+        }
+      }
+    } // /.nypl-modal-content
+
+    .nypl-x-close-button {
+      display: block;
+      right: 3%;
+      height: 3rem;
+      padding: 0;
+      position: absolute;
+      top: ($general-margin * 0.75);
+      width: 5rem;
+      z-index: 2001;
+
+      @include media($xtrasmall-breakpoint) {
+        right: 5%;
+        width: 1.75rem;
+
+        span {
+          @include screenreader-only;
+        }
+      }
+    }
+  } // /.active
+} // /.basic-modal

--- a/src/client/styles/sass/_modal.scss
+++ b/src/client/styles/sass/_modal.scss
@@ -1,0 +1,220 @@
+//
+// NYPL Search Results Filter Modal
+// TODO: Too much quick and dirty in here... needs clean up / refactoring
+// TODO: Separate the Modality of this from the specific useage of this particular filtering
+
+@mixin popup {
+
+  &.inactive {
+    display: none;
+  }
+
+  &.no-js-active,
+  &.active {
+    background: transparentize($nypl-white, 0.2);
+    display: block;
+    height: 100%;
+    overflow: auto;
+    position: fixed;
+    top: 0;
+    width: 100%;
+    z-index: 2101;
+
+    .nypl-popup-filter-menu {
+      $shadow: 0 0.125rem 0.5rem 0.25rem transparentize($nypl-gray-brown, 0.75);
+      @include box-shadow($shadow);
+      background: $nypl-white;
+      border-bottom: $general-border-width solid $nypl-light-gray;
+      left: 0;
+      //position: absolute;
+      top: 0;
+      width: 100%;
+
+
+      @include media($xtrasmall-breakpoint) {
+        padding-top: ($general-padding * 1.5);
+      }
+
+      .nypl-parent-fieldset {
+        border: 0;
+        margin: 0;
+        padding-left: 0;
+        padding-right: 0;
+
+        // TODO: Explore a more elegant way of handling this:
+        > legend:first-child {
+          display: block;
+          margin-left: ($general-margin * 3.125);
+          width: 100%;
+
+          @include media($xtrasmall-breakpoint) {
+            margin-left: ($general-margin * 1.25);
+          }
+
+          h3 {
+            margin-bottom: 0;
+            // padding-left: ($general-padding * 2);
+            // padding-top: $general-padding;
+
+            @include media($xtrasmall-breakpoint) {
+              padding-left: 0;
+            }
+
+            &:focus {
+              outline-color: $focus-color;
+              outline-style: solid;
+              outline-width: $focus-width;
+              padding: ($general-padding / 2) 0;
+          } // /.:focus
+        } // /h3
+      } // / > legend:first-child
+
+        .nypl-inner-fieldset:nth-child(4) {
+          border: 0;
+        }
+      }
+
+
+//
+// Here we have rules to layout the inner fieldsets...
+// TODO: build a better mixin to handle these kinds of nested fielsets w/ easier ease.
+//
+      .nypl-inner-fieldset {
+        border: 0;
+        border-bottom: ($general-border-width * 0.25) solid lighten($nypl-gray-cool, 15%);
+        padding: 0 $general-padding 0 ($general-padding * 3.125);
+
+        @include media($xtrasmall-breakpoint) {
+          padding-left: ($general-padding * 1.25);
+        }
+
+        legend {
+          font-size: 1.125rem;
+          margin-top: 0.75rem;
+        }
+
+        // where we have columns needed:
+        .nypl-generic-checkbox.nypl-generic-columns {
+
+          @include generic-columns(3);
+          max-width: 45rem;
+
+          @include media($xtrasmall-breakpoint) {
+            @include generic-columns(2);
+
+          }
+        }
+      } // /.nypl-inner-fieldset
+
+//
+// This handles just the date fiels set since it needs special attention
+//
+      .nypl-inner-fieldset-date {
+        padding-bottom: ($general-padding * 1.125);
+      }
+
+//
+// Here we abuse the nicely crafted name field...
+//
+      .nypl-name-field {
+        margin: 0;
+
+        div {
+          float: left;
+          margin-right: ($general-padding * 1.125);
+          width: 25%;
+
+          @include media($xtrasmall-breakpoint) {
+            width: 85%;
+          }
+        }
+      }  // /.nypl-name-field
+
+
+//
+// Buttons for this context need all kinds of overriding and such...
+// TODO: do a better job of this too...
+//
+      .nypl-filter-button-container {
+        //background: $nypl-light-gray;
+        border-top: ($general-border-width * 0.25) solid lighten($nypl-gray-cool, 15%);
+        height: 3.5rem;
+        padding: $general-padding 0 0 ($general-padding * 2);
+
+        @include media($xtrasmall-breakpoint) {
+          height: 6.5rem;
+          padding-left: ($general-padding * 1.125);
+        }
+      } // /.nypl-filter-button-container
+
+      .nypl-control-buttons {
+        @include media($mobile-breakpoint) {
+          height: 2.5rem;
+          width: 20.5rem;
+        }
+
+        @include media($xtrasmall-breakpoint) {
+          height: 5.5rem;
+          width: 9.5rem;
+        }
+      }
+
+      .nypl-filter-button {
+        @include basic-button-icon(
+        // $background-color: $nypl-red,
+        // $border-color: $nypl-red,
+        // $text-color: $nypl-white
+        );
+        @include media($xtrasmall-breakpoint) {
+          display: block;
+          float: left;
+          margin: 0 ($general-margin * 0.5) $general-margin;
+          position: relative;
+
+          &:nth-child(2) {
+            margin-right: 0;
+          }
+        }
+        // .nypl-icon {
+        //   background: $nypl-red;
+        //   fill: $nypl-white;
+        //   position: relative;
+        //   top: 0.125rem;
+        // }
+      } // /.nypl-filter-button
+
+      .nypl-x-close-button {
+        display: block;
+        // float: right;
+        position: relative;
+        margin-left: calc(93% - 5rem);
+        // margin-right: $general-margin;
+        // bottom: 43rem;
+        top: -43rem;
+
+        // @include media($mobile-breakpoint) {
+        //   bottom: 43.5rem;
+        // }
+
+        @include media($xtrasmall-breakpoint) {
+          // bottom: 51.75rem;
+          // right: 1.25rem;
+
+          span {
+            @include screenreader-only;
+          }
+        }
+      } // /.nypl-x-close-button
+    }
+
+    // .nypl-popup-filter-overlay {
+    //   //background: transparentize($nypl-white, 0);
+    //   bottom: 0;
+    //   left: 0;
+    //   position: fixed;
+    //   right: 0;
+    //   top: 0;
+    //   z-index: 2100;
+    // }
+  } // /.active
+} // /@mixin popup

--- a/src/client/styles/sass/_normalize.scss
+++ b/src/client/styles/sass/_normalize.scss
@@ -1,0 +1,422 @@
+/*! normalize.css v4.1.1 | MIT License | github.com/necolas/normalize.css */
+
+/**
+ * 1. Change the default font family in all browsers (opinionated).
+ * 2. Correct the line height in all browsers.
+ * 3. Prevent adjustments of font size after orientation changes in IE and iOS.
+ */
+
+html {
+  font-family: sans-serif; /* 1 */
+  line-height: 1.15; /* 2 */
+  -ms-text-size-adjust: 100%; /* 3 */
+  -webkit-text-size-adjust: 100%; /* 3 */
+}
+
+/**
+ * Remove the margin in all browsers (opinionated).
+ */
+
+body {
+  margin: 0;
+}
+
+/* HTML5 display definitions
+   ========================================================================== */
+
+/**
+ * Add the correct display in IE 9-.
+ * 1. Add the correct display in Edge, IE, and Firefox.
+ * 2. Add the correct display in IE.
+ */
+
+article,
+aside,
+details, /* 1 */
+figcaption,
+figure,
+footer,
+header,
+main, /* 2 */
+menu,
+nav,
+section,
+summary { /* 1 */
+  display: block;
+}
+
+/**
+ * Add the correct display in IE 9-.
+ */
+
+audio,
+canvas,
+progress,
+video {
+  display: inline-block;
+}
+
+/**
+ * Add the correct display in iOS 4-7.
+ */
+
+audio:not([controls]) {
+  display: none;
+  height: 0;
+}
+
+/**
+ * Add the correct vertical alignment in Chrome, Firefox, and Opera.
+ */
+
+progress {
+  vertical-align: baseline;
+}
+
+/**
+ * Add the correct display in IE 10-.
+ * 1. Add the correct display in IE.
+ */
+
+template, /* 1 */
+[hidden] {
+  display: none;
+}
+
+/* Links
+   ========================================================================== */
+
+/**
+ * 1. Remove the gray background on active links in IE 10.
+ * 2. Remove gaps in links underline in iOS 8+ and Safari 8+.
+ */
+
+a {
+  background-color: transparent; /* 1 */
+  -webkit-text-decoration-skip: objects; /* 2 */
+}
+
+/**
+ * Remove the outline on focused links when they are also active or hovered
+ * in all browsers (opinionated).
+ */
+
+a:active,
+a:hover {
+  outline-width: 0;
+}
+
+/* Text-level semantics
+   ========================================================================== */
+
+/**
+ * 1. Remove the bottom border in Firefox 39-.
+ * 2. Add the correct text decoration in Chrome, Edge, IE, Opera, and Safari.
+ */
+
+abbr[title] {
+  border-bottom: none; /* 1 */
+  text-decoration: underline; /* 2 */
+  text-decoration: underline dotted; /* 2 */
+}
+
+/**
+ * Prevent the duplicate application of `bolder` by the next rule in Safari 6.
+ */
+
+b,
+strong {
+  font-weight: inherit;
+}
+
+/**
+ * Add the correct font weight in Chrome, Edge, and Safari.
+ */
+
+b,
+strong {
+  font-weight: bolder;
+}
+
+/**
+ * Add the correct font style in Android 4.3-.
+ */
+
+dfn {
+  font-style: italic;
+}
+
+/**
+ * Correct the font size and margin on `h1` elements within `section` and
+ * `article` contexts in Chrome, Firefox, and Safari.
+ */
+
+h1 {
+  font-size: 2em;
+  margin: 0.67em 0;
+}
+
+/**
+ * Add the correct background and color in IE 9-.
+ */
+
+mark {
+  background-color: #ff0;
+  color: #000;
+}
+
+/**
+ * Add the correct font size in all browsers.
+ */
+
+small {
+  font-size: 80%;
+}
+
+/**
+ * Prevent `sub` and `sup` elements from affecting the line height in
+ * all browsers.
+ */
+
+sub,
+sup {
+  font-size: 75%;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline;
+}
+
+sub {
+  bottom: -0.25em;
+}
+
+sup {
+  top: -0.5em;
+}
+
+/* Embedded content
+   ========================================================================== */
+
+/**
+ * Remove the border on images inside links in IE 10-.
+ */
+
+img {
+  border-style: none;
+}
+
+/**
+ * Hide the overflow in IE.
+ */
+
+svg:not(:root) {
+  overflow: hidden;
+}
+
+/* Grouping content
+   ========================================================================== */
+
+/**
+ * 1. Correct the inheritance and scaling of font size in all browsers.
+ * 2. Correct the odd `em` font sizing in all browsers.
+ */
+
+code,
+kbd,
+pre,
+samp {
+  font-family: monospace, monospace; /* 1 */
+  font-size: 1em; /* 2 */
+}
+
+/**
+ * Add the correct margin in IE 8.
+ */
+
+figure {
+  margin: 1em 40px;
+}
+
+/**
+ * 1. Add the correct box sizing in Firefox.
+ * 2. Show the overflow in Edge and IE.
+ */
+
+hr {
+  box-sizing: content-box; /* 1 */
+  height: 0; /* 1 */
+  overflow: visible; /* 2 */
+}
+
+/* Forms
+   ========================================================================== */
+
+/**
+ * 1. Change font properties to `inherit` in all browsers (opinionated).
+ * 2. Remove the margin in Firefox and Safari.
+ */
+
+button,
+input,
+optgroup,
+select,
+textarea {
+  font: inherit; /* 1 */
+  margin: 0; /* 2 */
+}
+
+/**
+ * Restore the font weight unset by the previous rule.
+ */
+
+optgroup {
+  font-weight: bold;
+}
+
+/**
+ * Show the overflow in IE.
+ * 1. Show the overflow in Edge.
+ */
+
+button,
+input { /* 1 */
+  overflow: visible;
+}
+
+/**
+ * Remove the inheritance of text transform in Edge, Firefox, and IE.
+ * 1. Remove the inheritance of text transform in Firefox.
+ */
+
+button,
+select { /* 1 */
+  text-transform: none;
+}
+
+/**
+ * 1. Prevent a WebKit bug where (2) destroys native `audio` and `video`
+ *    controls in Android 4.
+ * 2. Correct the inability to style clickable types in iOS and Safari.
+ */
+
+button,
+html [type="button"], /* 1 */
+[type="reset"],
+[type="submit"] {
+  -webkit-appearance: button; /* 2 */
+}
+
+/**
+ * Remove the inner border and padding in Firefox.
+ */
+
+button::-moz-focus-inner,
+[type="button"]::-moz-focus-inner,
+[type="reset"]::-moz-focus-inner,
+[type="submit"]::-moz-focus-inner {
+  border-style: none;
+  padding: 0;
+}
+
+/**
+ * Restore the focus styles unset by the previous rule.
+ */
+
+button:-moz-focusring,
+[type="button"]:-moz-focusring,
+[type="reset"]:-moz-focusring,
+[type="submit"]:-moz-focusring {
+  outline: 1px dotted ButtonText;
+}
+
+/**
+ * Change the border, margin, and padding in all browsers (opinionated).
+ */
+
+fieldset {
+  border: 1px solid #c0c0c0;
+  margin: 0;
+  padding: 0.35em 0.625em 0.75em;
+}
+
+/**
+ * 1. Correct the text wrapping in Edge and IE.
+ * 2. Correct the color inheritance from `fieldset` elements in IE.
+ * 3. Remove the padding so developers are not caught out when they zero out
+ *    `fieldset` elements in all browsers.
+ */
+
+legend {
+  box-sizing: border-box; /* 1 */
+  color: inherit; /* 2 */
+  display: table; /* 1 */
+  max-width: 100%; /* 1 */
+  padding: 0; /* 3 */
+  white-space: normal; /* 1 */
+}
+
+/**
+ * Remove the default vertical scrollbar in IE.
+ */
+
+textarea {
+  overflow: auto;
+}
+
+/**
+ * 1. Add the correct box sizing in IE 10-.
+ * 2. Remove the padding in IE 10-.
+ */
+
+[type="checkbox"],
+[type="radio"] {
+  box-sizing: border-box; /* 1 */
+  padding: 0; /* 2 */
+}
+
+/**
+ * Correct the cursor style of increment and decrement buttons in Chrome.
+ */
+
+[type="number"]::-webkit-inner-spin-button,
+[type="number"]::-webkit-outer-spin-button {
+  height: auto;
+}
+
+/**
+ * 1. Correct the odd appearance in Chrome and Safari.
+ * 2. Correct the outline style in Safari.
+ */
+
+[type="search"] {
+  -webkit-appearance: textfield; /* 1 */
+  outline-offset: -2px; /* 2 */
+}
+
+/**
+ * Remove the inner padding and cancel buttons in Chrome and Safari on OS X.
+ */
+
+[type="search"]::-webkit-search-cancel-button,
+[type="search"]::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+/**
+ * Correct the text style of placeholders in Chrome, Edge, and Safari.
+ */
+
+::-webkit-input-placeholder {
+  color: inherit;
+  opacity: 0.54;
+}
+
+/**
+ * 1. Correct the inability to style clickable types in iOS and Safari.
+ * 2. Change font properties to `inherit` in Safari.
+ */
+
+::-webkit-file-upload-button {
+  -webkit-appearance: button; /* 1 */
+  font: inherit; /* 2 */
+}

--- a/src/client/styles/sass/_nypl-normalize.scss
+++ b/src/client/styles/sass/_nypl-normalize.scss
@@ -1,0 +1,151 @@
+@import "normalize";
+@import "css3";
+@import "measurements";
+@import "colors";
+@import "typography";
+@import "icons";
+@import "forms";
+@import "buttons";
+
+//@warn "remove magic numbers and convert to mixins?";
+
+body {
+  color: $page-text-color;
+
+}
+
+::selection {
+  background: $page-text-color;
+  color: $page-background-color;
+}
+
+::-moz-selection {
+  background: $page-text-color;
+  color: $page-background-color;
+}
+
+html {
+  @include font-settings;
+  background-color: $page-background-color;
+
+  //@warn "hard-coded filter to make page grayscale. make mixin?";
+  -webkit-filter: grayscale(1);
+  filter: grayscale(1);
+  -webkit-filter: none;
+  filter: none;
+}
+
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p {
+  margin-top: 1.5rem;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p,
+li {
+  max-width: 35rem;
+  word-wrap: break-word;
+}
+
+h1 {
+  font-size: 2.5rem;
+  line-height: 1;
+}
+
+h2 {
+  font-size: 1.6rem;
+  line-height: 1.1;
+}
+
+h3 {
+  font-size: 1.4rem;
+  font-weight: 400;
+}
+
+p {
+  margin-top: 0;
+  margin-bottom: 1rem;
+}
+
+h4 {
+  font-size: 1.2rem;
+  font-weight: 400;
+  line-height: 1.5;
+  margin: 0;
+}
+
+ul,
+ol {
+  margin-top: 0;
+  padding: 0;
+}
+
+li {
+  margin-left: 0.5rem;
+}
+
+code,
+pre {
+  background-color: $nypl-light-gray;
+  font-family: $monospace-stack;
+  font-size: 0.9rem;
+}
+
+code {
+  padding-left: 0.25rem;
+  padding-right: 0.25rem;
+}
+
+strong {
+  font-weight: bold;
+}
+
+legend {
+  display: table;
+}
+
+a {
+  display: inline-flex;
+  padding: 0 1px;
+  text-decoration: underline;
+
+  &:link {
+    color: $link-color;
+  }
+
+  &:visited {
+    color: $link-visited-color;
+  }
+
+  &:hover,
+  &:visited:hover {
+    color: $link-hover-color;
+    text-decoration: none;
+  }
+
+  &.inverted {
+    &:link {
+      color: $inverted-link-color;
+    }
+
+    &:visited {
+      color: $inverted-link-visited-color;
+    }
+
+    &:hover,
+    &:visited:hover {
+      color: $inverted-link-color;
+    }
+  }
+}

--- a/src/client/styles/sass/_omni-search.scss
+++ b/src/client/styles/sass/_omni-search.scss
@@ -1,0 +1,184 @@
+@import "general-mixins";
+@import "media-queries";
+$form-padding: 0.5rem;
+
+@mixin basic-omnisearch (
+  $background-color: $nypl-white,
+  $border: 0,
+  $border-radius: ($general-border-radius * 2),
+  $padding: $form-padding) {
+  background-color: $background-color;
+  border: $border;
+  border-radius: $border-radius;
+  padding: $padding;
+  }
+
+@mixin nypl-omnisearch {
+  @include basic-omnisearch(
+    $background-color: $nypl-white,
+    $border: solid 0.0625rem $nypl-dark-gray,
+    $border-radius: $general-border-radius,
+    $padding: 0);
+  font-weight: 400;
+  height: 3rem;
+
+  @include media($mobile-breakpoint) {
+    width: 97%;
+  }
+
+  button,
+  input,
+  .nypl-omni-fields {
+    display: block;
+    float: left;
+    height: 2rem;
+  }
+
+  ::placeholder {
+    color: $nypl-dark-gray;
+    opacity: 1;
+  }
+
+  legend {
+    display: none;
+    height: 0;
+    width: 0;
+  }
+
+  .nypl-omni-fields {
+    background-color: $nypl-white;
+    border-right: $general-border-width / 1.5 solid $nypl-dark-gray;
+    margin-left: 0.25rem;
+    padding-right: 0.25rem;
+    position: relative;
+    top: 0.475rem;
+    width: 28%;
+
+    @include media($mobile-breakpoint) {
+      font-size: 0.9rem;
+      margin-left: 0.25rem;
+      padding-right: 0.25rem;
+      width: 28%;
+    } // /mobile-breakpoint
+
+    label {
+      @include screenreader-only;
+    }
+
+    select {
+      @include select;
+      border-radius: 0;
+      border-right: $general-border-width / 1.5;
+      background: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI3LjY5OTA1IiBoZWlnaHQ9IjMuOTg3MTMiIHZpZXdCb3g9IjAgMCA3LjY5OTA1IDMuOTg3MTMiPgogIDx0aXRsZT5kb3duLjIud2VkZ2U8L3RpdGxlPgogIDxwb2x5bGluZSBwb2ludHM9IjcuMzk1IDAuMzYgMy44NSAzLjM3IDAuMzA0IDAuMzU4IiBmaWxsPSIjZmZmIiBzdHJva2U9IiMyMzFmMjAiIHN0cm9rZS1taXRlcmxpbWl0PSIxMCIgc3Ryb2tlLXdpZHRoPSIwLjk0MDUiLz4KPC9zdmc+) no-repeat 95% $nypl-white;
+      background-color: $nypl-white;
+      text-overflow: ellipsis;
+  }
+} // /.nypl-omni-fields
+
+  input[type=text],
+  input[type=email],
+  input[type=number] {
+    @include input;
+    margin: 0 1%;
+    text-indent: $form-padding;
+}
+
+  input[type=text] {
+    background: $nypl-white;
+    position: relative;
+    width: 50%;
+    top: 0.475rem;
+
+    @include media($mobile-breakpoint) {
+      width: 45%;
+    }
+  }
+
+  input[type=submit] {
+    background: $nypl-blue;
+    border: 0;
+    border-radius: 0.0625rem;
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+    color: $nypl-white;
+    float: right;
+    height: 3rem;
+    position: relative;
+    width: 15%;
+
+    @include media($mobile-breakpoint) {
+      font-size: $small-type;
+      width: 20%;
+    }
+
+    &:hover,
+    &:focus {
+      background-color: $nypl-white;
+      border: solid 0.0625rem $nypl-blue;
+      color: $nypl-blue;
+    }
+  }
+
+  svg {
+    display: inline-block;
+    fill: $nypl-dark-gray;
+    height: 1.3125rem;
+    margin-left: 93.5%;
+    position: relative;
+    top: -1.9rem;
+    width: 0.9375rem;
+  }
+}
+
+//
+// needs a better name, this widget is the remains of the breadcrumbs & save record button below the search field...
+// Possibly make this its own mixin?
+//
+.search-control {
+  color: $nypl-dark-gray;
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.04rem;
+  margin-top: 1.75rem;
+
+  @include media($mobile-breakpoint) {
+    margin-top: 0.5rem;
+  }
+//
+// Back to results link
+// svg back arrow
+//
+  svg {
+    fill: $nypl-gray-cool;
+    height: 2rem;
+    position: relative;
+    width: 0.5625rem;
+    top: 0.7rem;
+  }
+
+  a {
+    color: $nypl-dark-gray;
+    margin-left: 0.5rem;
+    text-decoration: none;
+  }
+
+  a:hover {
+    text-decoration: underline;
+  }
+} // /nypl-omnisearch
+
+
+
+// Override for the omnisearch div to work as a fieldset and
+// allow focus on the search button.
+// TODO: Integrate this a little better
+div.nypl-omnisearch {
+
+  &.nypl-spinner-field {
+    overflow: inherit;
+  }
+
+  &.spinning {
+    overflow: hidden;
+  }
+}

--- a/src/client/styles/sass/_pager.scss
+++ b/src/client/styles/sass/_pager.scss
@@ -1,0 +1,75 @@
+// Tradional numbered pager
+@mixin pager-item(
+  $width: ($general-padding * 2)) {
+  li {
+    border: 1px dotted $nypl-red;
+    display: inline-block;
+    text-align: center;
+    width: $width;
+
+    @include media($mobile-breakpoint) {
+      margin-left: 0;
+    }
+
+    a {
+      float: none;
+    }
+  }
+}
+
+@mixin pager-items(
+  $border: ($general-border-width / 1.5) solid $nypl-gray,
+  $font-size: 1rem) {
+  ul {
+    //display: inline-block;
+    font-size: $font-size;
+    list-style: none;
+    margin: auto;
+    overflow: hidden;
+    padding: $general-padding;
+    position: relative;
+    width: auto;
+
+    @include media($mobile-breakpoint) {
+      font-size: ($font-size * 0.85);
+      padding-left: 0;
+      padding-right: 0;
+    }
+
+    .pager-previous {
+      border-right: $border;
+      width: 12%;
+
+      @include media($mobile-breakpoint) {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+    }
+
+    .pager-next {
+      border-left: $border;
+      width: 12%;
+
+      @include media($mobile-breakpoint) {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+    }
+  }
+
+  @include pager-item;
+} // /pager-items
+
+@mixin numbered-pager(
+  $border-color: $nypl-light-gray,
+  $border-width: ($general-border-width / 1.5),
+  $border-radius: $general-border-radius) {
+  // container
+  border: $border-color solid $border-width;
+  border-radius: $border-radius;
+  // numbers
+  // forward-backward arrows
+  @include pager-items;
+}

--- a/src/client/styles/sass/_tables-results.scss
+++ b/src/client/styles/sass/_tables-results.scss
@@ -1,0 +1,839 @@
+@import "measurements";
+@import "icons";
+@import "general-mixins";
+@import "microformats";
+@import "media-queries";
+
+//@warn "refactor mixins and remove magic numbers";
+
+$results-item-border-width: 0.0625rem;
+
+@mixin basic-table {
+  border-collapse: collapse;
+  display: table;
+  position: relative;
+  width: 100%;
+
+  tr {
+    border-bottom: 0.0625rem solid $nypl-light-gray;
+    display: table-row;
+  }
+
+  thead,
+  th {
+    border-bottom: 0.0625rem solid $page-color;
+    font-weight: bold;
+    text-align: left;
+  }
+
+  th,
+  td {
+    display: table-cell;
+    overflow: hidden;
+    padding: 0.125rem 0.25rem;
+    text-overflow: ellipsis;
+  }
+
+  td {
+    border-bottom: 1px solid $nypl-light-gray;
+    padding-bottom: 0.5rem;
+    vertical-align: top;
+  }
+}
+
+///
+/// Search Results have a summary this is it.
+///
+
+@mixin results-summary {
+  @include clearfix;
+  @include media($xtrasmall-breakpoint) {
+    float: none;
+    max-width: 100%;
+  }
+
+  display: inline-block;
+  flex-grow: 2;
+  //max-width: 65%;
+
+  h2 {
+    @include media($xtrasmall-breakpoint) {
+      margin-top: 1em;
+    }
+
+    font-size: 1rem;
+    font-weight: normal;
+    margin-bottom: 0;
+    margin-top: 0;
+    max-width: none;
+    min-height: 1rem;
+  }
+
+  .nypl-results-count {
+    //float: left;
+    font-size: 1rem;
+    font-weight: 400;
+    line-height: 1;
+    // margin-bottom: 0.25rem;
+    // margin-right: 0.5rem;
+    margin-top: 0.25em;
+  }
+
+  .nypl-facet {
+    background-color: $nypl-light-gray;
+    border-radius: $general-border-radius 2rem 2rem $general-border-radius;
+    display: inline-block;
+    margin-bottom: 0.25rem;
+    margin-left: 0.25rem;
+    padding: 0 0.25rem;
+
+    strong {
+      display: inline-block;
+      max-width: 15rem;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      vertical-align: bottom;
+      white-space: nowrap;
+
+      @include media($mobile-breakpoint) {
+        max-width: 7rem;
+      }
+    }
+
+    button {
+      // the button inside a facet
+      @include basic-button(
+      $background-color: none,
+      $border-radius: 2rem,
+      $padding-vertical: 0,
+      $padding-horizontal: 0,
+      $border-width: 0);
+      margin: 0.25rem 0 0.25rem 0.25rem;
+      vertical-align: bottom;
+
+      span {
+        @include screenreader-only;
+      }
+
+      .nypl-icon {
+        @include nypl-icon(
+        $fill: $nypl-search-color-dark,
+        $background-color: $nypl-light-gray,
+        $border-radius: 1rem,
+        $height: 1rem,
+        $width: 1rem);
+        display: block;
+        margin: 0;
+      }
+    }
+  } // /.facet
+
+  .nypl-clear-results {
+    clear: both;
+  }
+} // /results-summary
+
+
+
+///
+/// Basic Left / Right Arrowed Pagination
+///
+
+@mixin results-pagination {
+  font-size: 1.1rem;
+  margin-top: 1.5rem;
+  margin-bottom: 3rem;
+  @include clearfix;
+
+  .page-count,
+  a {
+    display: block;
+    float: left;
+    text-decoration: none;
+    width: 15%;
+    @include clearfix;
+  }
+
+  .page-count.first {
+    margin-left: 15%;
+
+    &:focus {
+      -moz-focusring: none;
+      outline: none;
+    }
+  }
+
+  .page-count {
+    padding: ($general-padding * 0.75);
+    text-align: center;
+    width: 20%;
+
+    @include media($mobile-breakpoint) {
+      font-size: 1rem;
+      padding: 0 0.2rem;
+      padding-top: ($general-padding * 0.25);
+      width: 35%;
+    }
+  }
+
+  a:last-child {
+    text-align: center;
+  }
+
+  a:first-child svg {
+    float: left;
+  }
+
+  a {
+    border: ($general-border-width / 1.5) solid $nypl-light-gray;
+    border-radius: $general-border-radius;
+    font-weight: 500;
+    padding: ($general-padding * 0.75);
+    text-align: center;
+
+    svg {
+      @include nypl-icon(
+        $height: 1rem,
+        $width: 1rem);
+      display: block;
+      fill: $link-color;
+      float: right;
+      margin-top: 0.4rem;
+    } // /svg
+
+    @include media($mobile-breakpoint) {
+      font-size: 0.9rem;
+      padding: ($general-padding * 0.2);
+      width: 5rem;
+
+      &:first-child svg {
+        display: none;
+      }
+
+      &:last-child svg {
+        display: none;
+      }
+    } // /$mobile-breakpoint a
+  } // /a
+} // /results-pagination
+
+
+
+
+///
+/// Sorting controls
+///
+
+@mixin results-sorting-controls(
+  $background-color: $nypl-white,
+  $border: ($general-border-width * 2) solid $page-color,
+  $margin: 1rem) {
+
+  @include clearfix;
+  @include media($mobile-breakpoint) {
+    min-width: 13.75em;
+  }
+  @include media($xtrasmall-breakpoint) {
+    float: none;
+    width: 100%;
+  }
+
+  border: 0;
+  display: inline-block;
+  flex-grow: 1;
+  margin: $margin 0 0;
+}
+
+
+
+/// Do something less magic with this:
+$sorter-width: 11em;
+
+// In some cases we need to expose things to screen readers only:
+// TODO: Move this to the general mixins...
+
+@mixin submission($visibility) {
+  @if $visibility == visible {
+    @content; // put the visible stuff here:
+  } @else if $visibility == visually-hidden {
+    @content; // put the screenreader-only stuff here...
+  }
+}
+
+
+///
+///
+///
+
+@mixin results-sorter {
+  @include submission(visually-hidden) {
+    button.nypl-screenreader-only {
+      @include screenreader-only;
+    }
+  } // /submssion ~ visually-hidden
+  @include media($mobile-breakpoint) {}
+  @include media($xtrasmall-breakpoint) {
+    float: none;
+    width: 100%;
+  }
+
+  @include submission(visible) {
+    button {
+      @include basic-button(
+        $background-color: $nypl-white,
+        $border-color: lighten($nypl-gray-cool, 15%),
+        $border-width: ($general-border-width / 2),
+        $collapsible: true,
+        $font-size: 0.85rem,
+        $hover-background-color: $nypl-white,
+        $padding-vertical: ($general-padding * 0.4),
+        $text-color: $nypl-dark-gray);
+      padding-right: 1.75rem;
+
+      .nypl-icon {
+        right: 0.5rem;
+        transform: rotate(90deg)
+      }
+
+      &.active .nypl-icon {
+        transform: rotate(270deg)
+      }
+    } // /button
+  } // /submssion ~ visible
+
+  display: inline-block;
+  float: right;
+  position: relative;
+
+  ul {
+    background-color: $nypl-white;
+    border: ($general-border-width / 1.5) solid;
+    border-radius: 0;
+    box-shadow: 10px 5px 11px -8px rgba(0, 0, 0, 0.3);
+    list-style: none;
+    min-width: $sorter-width;
+    position: absolute;
+    left: 0;
+    width: 14rem;
+    z-index: 1;
+  }
+
+  li {
+    margin-left: 0;
+  }
+
+  a {
+    color: $page-color;
+    display: block;
+    padding: 0.25rem 0.5rem 0.25rem 1rem;
+    text-decoration: none;
+
+    &.active,
+    &:hover,
+    &:focus {
+      color: $page-color;
+      font-weight: bold;
+    }
+  }
+} // /resuts-sorter
+
+
+
+///
+/// Filter Button
+/// Activates the filter modal
+/// TODO: Remove the modal pattern all together
+///
+
+@mixin filter-button {
+  float: left;
+  position: relative;
+
+  @include media($xtrasmall-breakpoint) {
+    @include clearfix;
+  }
+}
+
+@mixin item-definition-list(
+  $item-margin-bottom: 0,
+  $dt-width: 7.6rem,
+  $dd-width: auto) {
+  dl {
+    @include clearfix;
+    margin-bottom: 0;
+    margin-top: 0;
+
+    ul {
+      margin-bottom: 0;
+    }
+
+    li {
+      list-style-type: none;
+      margin-bottom: 0;
+      margin-left: 0;
+    }
+  }
+
+  dt,
+  dd {
+    float: left;
+    line-height: 1.5;
+    margin: 0;
+    width: $dd-width;
+  }
+
+  dt {
+    clear: left;
+    color: $nypl-gray;
+    width: $dt-width;
+
+    @include media($mobile-breakpoint) {
+      width: 45%;
+    }
+  }
+
+  dd {
+    margin: 0;
+
+    @include media($mobile-breakpoint) {
+      width: 55%;
+    }
+  }
+}
+
+
+
+///
+/// Bib Results Lists
+///
+
+@mixin results-item(
+  $border-width: $results-item-border-width,
+  $border-color: $nypl-light-gray,
+  $margin-bottom: 0,
+  $padding-bottom: '') {
+  border-bottom: $border-width solid $border-color;
+  list-style-type: none;
+  margin-bottom: $margin-bottom;
+  margin-left: 0;
+  max-width: none;
+  padding-bottom: $padding-bottom;
+
+  h2,
+  h3 {
+    font-size: 1.2rem;
+    font-weight: normal;
+    margin-bottom: 0.5rem;
+    max-width: none;
+  }
+
+  @include item-definition-list($item-margin-bottom: 0);
+
+
+  p {
+    margin-bottom: 0;
+    max-width: none;
+  }
+
+  .view-all-items-container {
+    margin-top: 1.5rem;
+  }
+}
+
+@mixin results-unavailable {
+  border-left: 0.5rem solid $highlight-color;
+  color: $highlight-color;
+  margin: 0.5rem 0;
+  padding-left: 0.5rem;
+}
+
+@mixin results-item-description($item-margin-bottom: 0) {
+  margin-bottom: $item-margin-bottom;
+}
+
+@mixin results-info($margin: 1rem) {
+  display: inline-block;
+  margin-right: $margin;
+}
+
+@mixin results-media(
+$color: $nypl-gray,
+$font-size: "",
+$font-weight: 400) {
+  @include results-info;
+  color: $color;
+  font-size: $font-size;
+  font-weight: $font-weight;
+}
+
+@mixin results-use {
+  color: $nypl-gray;
+  display: block;
+  font-size: 0.9rem;
+  font-style: italic;
+}
+
+@mixin item-info (
+  $border-width: 0.5rem,
+  $border-type: solid,
+  $border-color: $nypl-gray) {
+  border-left: $border-width $border-type $border-color;
+  padding-left: 0.5rem;
+  margin-bottom: 0;
+  max-width: none;
+
+  p {
+    margin: 0;
+    max-width: none;
+  }
+}
+
+@mixin item-media {
+  color: $nypl-gray;
+  font-weight: bold;
+}
+
+@mixin item-holdings {
+  $holdings-height: 40rem;
+
+  h2 {
+    font-size: 1rem;
+    line-height: 1.5;
+    margin: 0;
+  }
+
+  ul {
+    background: linear-gradient(to bottom, transparent 0, transparent ($holdings-height - 3), lighten($nypl-light-gray, 20%) ($holdings-height - 1), $nypl-light-gray $holdings-height);
+    max-height: 40rem;
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
+
+    @include media($mobile-breakpoint) {
+      background: transparent;
+      max-height: unset;
+      overflow-y: inherit;
+    }
+  }
+
+  li {
+    @include clearfix;
+    border-bottom: ($general-border-width * 0.5) solid $nypl-light-gray;
+    line-height: 1.5;
+    list-style-type: none;
+    margin: 1rem 0;
+
+    @include media($mobile-breakpoint) {
+      clear: left;
+      margin-left: 0;
+    }
+  }
+
+  a,
+  .nypl-item-unavailable {
+    display: block;
+    float: right;
+    margin: 0 0 1rem 1rem;
+    width: 7rem;
+  }
+
+  .nypl-item-unavailable {
+    color: $highlight-color;
+  }
+}
+
+@mixin item-details {
+  @include item-definition-list($item-margin-bottom: 0);
+
+  h2 {
+    font-size: 1.6rem;
+    font-weight: normal;
+  }
+
+  dl {
+    border-left: 0.25rem solid $nypl-dark-gray;
+    padding: 0 0.75rem;
+  }
+}
+
+@mixin item-external-links {
+  @include item-definition-list($item-margin-bottom: 0);
+
+
+  li {
+    margin-bottom: 0;
+  }
+}
+
+@mixin views-table {
+  //@warn "this mixin is not used";
+
+  display: table;
+  border-collapse: collapse;
+
+  tr,
+  .views-table-row {
+    border-bottom: 1px solid $nypl-light-gray;
+    display: table-row;
+  }
+
+  .views-table-row .views-table-header,
+  thead,
+  th {
+    border-bottom: 1px solid $page-color;
+    text-align: left;
+  }
+
+  td,
+  th,
+  .views-table-header,
+  .views-table-cell {
+    display: table-cell;
+  }
+
+  th,
+  .views-table-header {
+    font-weight: bold;
+  }
+
+  .views-table-header.event-time {
+    width: 20%;
+  }
+
+  .views-table-header.event-title {
+    width: 40%;
+  }
+
+  .views-table-header.event-location {
+    width: 20%;
+  }
+
+  .views-table-header.event-audience {
+    width: 20%;
+  }
+
+  .views-table-header.resource-availability {
+    width: 25%;
+  }
+
+  .views-table-header.resouce-description {
+    width: 65%;
+  }
+
+  td,
+  .views-table-cell {
+    border-bottom: 1px solid $nypl-light-gray;
+    padding: 0.5rem 0.5rem 3rem 0;
+    vertical-align: top;
+  }
+
+  .channel-title {
+    color: $highlight-color;
+  }
+
+  .signup-method {
+    color: $highlight-color;
+  }
+
+  .resource-title {
+    font-weight: bold;
+  }
+
+  &.collapses {
+    @include media($mobile-breakpoint) {
+      thead,
+      th,
+      .views-table-header,
+      .views-table-row:first-child {
+        display: none;
+      }
+
+      td,
+      .views-table-cell {
+        display: block;
+        float: left;
+        margin: 0;
+        padding: 1rem 0;
+      }
+
+      tr:first-child,
+      .views-table-row:first-child {
+        border-top: 1px solid $nypl-light-gray;
+      }
+
+      .event-time,
+      .event-audience,
+      .event-title {
+        border: 0;
+        display: block;
+      }
+
+      .event-time {
+        width: 20%;
+      }
+
+      .event-title,
+      .event-location,
+      .event-audience {
+        width: 30%;
+      }
+
+      .event-title {
+        margin-right: 5%;
+        width: 45%;
+        max-height: 12rem;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+
+      .event-location {
+        border-bottom: 0;
+        font-weight: bold;
+      }
+
+      .event-audience::before {
+        content: "For: ";
+      }
+
+      .resource-availability {
+        width: 25%;
+      }
+
+      .resouce-description {
+        width: 65%;
+      }
+    }
+  }
+
+}
+
+////
+// Styles for docs/discovery-search.html
+////
+.nypl-results-list {
+
+  // override the default spacing between items here:
+  .nypl-results-item-description {
+    @include results-item-description($item-margin-bottom: 0.25rem);
+  }
+
+  .nypl-results-item {
+    @include results-item(
+      $margin-bottom: 2em,
+      $padding-bottom: 2em);
+    //border-bottom: ($general-border-width / 1.25) solid lighten($nypl-light-gray, 15%);
+
+    h2,
+    h3 {
+      margin-bottom: 0;
+
+      a:link {
+        text-decoration: none;
+      }
+    }
+
+    // If there is a request table inline in the results, add the class
+    &.has-request {
+      margin-bottom: 3.25rem;
+    }
+
+    .nypl-results-media {
+      @include results-media(
+        $color: $nypl-dark-gray,
+        //$font-size: 0.85rem,
+        $font-weight: 400);
+
+        // &::before {
+        //   content: 'Format: ';
+        // }
+    } // /.nypl-results-media
+
+    //
+    // TODO: find a more elegant way of writing this:
+    // Posibly a for/in thing...
+
+    .nypl-results-room,
+    .nypl-results-place,
+    .nypl-results-publisher,
+    .nypl-results-date,
+    .nypl-results-info {
+      //font-size: 0.85rem;
+    } // /.nypl-results-room
+
+    // Special case where we need the the publisher & published date closer to one another:
+    .nypl-results-publisher {
+      margin-right: 0.25rem;
+    }
+  } // /.nypl-results-item
+}
+
+
+
+// This block styles the table set in the <dl>
+//
+// TODO: Combine this layout w/ the one above
+// TODO: refactor code below to address nested style depth being too deep.
+// TODO: refactor so the table is not dependent on being embedded in the <dl>
+
+dl dd.multi-item-list,
+.nypl-results-item {
+
+  .nypl-basic-table {
+    display: table;
+    width: 100%;
+
+   @include media($mobile-breakpoint) {
+     overflow: auto;
+     overflow-y: hidden;
+     overflow-x: auto;
+     display: block;
+   }
+
+    thead {
+      border: 0;
+    } // /thead
+
+    th {
+      border: 0;
+      font-size: 0.85rem;
+      padding-bottom: 0.5em;
+      width: 25%;
+    }
+
+    td {
+      border: 0;
+      padding-top: 0.25em;
+    }
+
+    tr {
+      border-bottom: 0;
+    }
+
+    tbody tr:first-child {
+      line-height: 1.2;
+    }
+
+    tbody tr:last-child {
+      border-bottom: 0;
+    }
+
+    button {
+      @include basic-button(
+        $text-color: $nypl-red,
+        $background-color: $nypl-white,
+        $border-color: $nypl-red,
+        $border-radius: ($general-border-radius / 1.5),
+        $border-width: ($general-border-width / 1.5),
+        $font-size: 0.8rem,
+        $height: 2.5rem,
+        $hover-text-color: $nypl-white,
+        $hover-background-color: $nypl-red,
+        $letter-spacing: 0.06rem);
+      margin-top: 0;
+      width: 8rem;
+
+      @include media($mobile-breakpoint) {
+        display: inline-block;
+      } // /$mobile-breakpoint
+    } // /button
+  } // /.nypl-basic-table
+}

--- a/src/client/styles/sass/_toolkit.scss
+++ b/src/client/styles/sass/_toolkit.scss
@@ -1,0 +1,539 @@
+// NYPL Design Toolkit 0.1.3
+// https://nypl.github.io/design-toolkit/
+// MIT License
+
+@import "css3";
+@import "measurements";
+@import "media-queries";
+@import "general-mixins";
+@import "microformats";
+@import "colors";
+@import "typography";
+@import "icons";
+@import "forms";
+@import "grid";
+@import "tables-results";
+@import "holds-table";
+@import "buttons";
+@import "pager";
+@import "modal-container";
+
+.hidden { // hacky
+  display: none;
+}
+
+.centered { // also hacky
+  text-align: center;
+}
+
+
+
+///
+/// SVG Iconography
+///
+
+.nypl-icon {
+  @include nypl-icon;
+}
+
+.nypl-logo {
+  @include nypl-icon(
+    $height: 13em,
+    $width: 20em);
+}
+
+.nypl-logo-rev {
+  @include nypl-icon(
+    $height: $logo-height,
+    $width: $logo-width,
+    $background-color: transparent);
+}
+
+
+.nypl-arrow-icon {
+  @include rotate(90deg);
+}
+
+
+
+///
+/// Loaders
+///
+
+@for $percent from 1 through 100 {
+  .nypl-bar_#{$percent} {
+    @include bar($percent);
+  }
+}
+
+.nypl-lead {
+  @include lead;
+}
+
+.nypl-basic-list {
+  @include basic-list;
+}
+
+.nypl-bar-list {
+  @include bar-list;
+}
+
+.nypl-custom-list {
+  @include custom-list;
+}
+
+.nypl-collapsible {
+  @include collapsible;
+}
+
+
+
+//
+// Buttons
+//
+
+.nypl-link-button {
+  @include link-button;
+}
+
+.nypl-unset-filter {
+  @include basic-button-icon;
+}
+
+.nypl-short-button {
+  @include short-button;
+}
+
+.nypl-x-close-button {
+  @include close-button;
+}
+
+.nypl-basic-button {
+  @include basic-button;
+}
+
+.nypl-results-button {
+  @include results-button;
+}
+
+ // for background compatibility support
+.nypl-primary-button {
+  @include primary-button;
+}
+
+// item requests
+.nypl-request-button {
+  @include request-button;
+}
+
+.nypl-request-item-summary {
+  @include request-item-summary;
+}
+
+.nypl-electronic-delivery-form {
+  @include electronic-delivery-form;
+}
+
+.nypl-service-button {
+  @include service-button;
+}
+
+.nypl-login-button {
+  @include login-button;
+}
+
+@each $side in left, right {
+  .nypl-menu-button_#{$side} {
+    @include menu-button($attachment: $side);
+  }
+}
+
+.nypl-navigation-button {
+  @include navigation-button;
+}
+
+.nypl-spinner-button,
+.nypl-spinner-field {
+  @include spinner-element;
+}
+
+
+.nypl-progress-indicator {
+  @include progress-indicator;
+}
+
+///
+/// Forms & Fields ~ User Inputs
+///
+
+.nypl-label {
+  @include label;
+}
+
+.nypl-fieldset {
+  @include fieldset;
+}
+
+.nypl-input {
+  @include input;
+}
+
+.nypl-text-field {
+  @include text-field;
+}
+
+.nypl-year-field {
+  @include year-field;
+}
+
+.nypl-text-field-with-label {
+  @include text-field-with-label;
+}
+
+.nypl-name-field {
+  @include name-field;
+}
+
+.nypl-address-fieldset {
+  @include address-fieldset;
+}
+
+.nypl-date-field {
+  @include date-field;
+}
+
+.nypl-required-field {
+  @include required-field;
+}
+
+.nypl-text-area-with-label {
+  @include text-area-with-label;
+}
+
+.nypl-field-error {
+  @include field-error;
+}
+
+.nypl-field-success {
+  @include field-success;
+}
+
+.nypl-select {
+  @include select;
+}
+
+.nypl-select-field {
+  @include select-field;
+}
+
+.nypl-form-error {
+  @include form-message($color: $highlight-color);
+}
+
+.nypl-form-success {
+  @include form-message($color: $success-color);
+}
+
+.nypl-simple-radiobutton {
+  @include simple-radiobutton;
+}
+
+.nypl-generic-checkbox {
+  @include generic-checkbox;
+}
+
+.nypl-terms-checkbox {
+  @include terms-checkbox;
+}
+
+.nypl-request-radiobutton-field {
+  @include item-holds-radiobutton-field;
+}
+
+.nypl-request-form-title {
+  @include request-form-title;
+}
+
+.nypl-radiobutton-field,
+.nypl-checkbox-field {
+  @include radiobutton-field;
+}
+
+.nypl-omnisearch {
+  @include nypl-omnisearch;
+}
+
+.nypl-mobile-refine {
+  @include mobile-refine;
+}
+
+.nypl-facet-toggle {
+  @include facet-toggle;
+}
+
+.nypl-collapsible-field {
+  @include collapsible-field;
+}
+
+.nypl-searchable-field {
+  @include searchable-field;
+}
+
+.nypl-alphabetical-filter {
+  @include alphabetical-filter;
+}
+
+.nypl-search-form {
+  @include search-form;
+}
+
+.nypl-sorter-row {
+  @include sorter-row;
+}
+
+
+///
+/// Screen readers only
+///
+
+.nypl-screenreader-only {
+  @include screenreader-only;
+}
+///
+/// Page Layout
+///
+
+.nypl-homepage-hero {
+  @include homepage-hero;
+}
+
+.nypl-quarter-image {
+  @include quarter-image;
+}
+
+.nypl-special-title {
+  @include special-title;
+}
+
+.nypl-page-header {
+  @include page-header;
+}
+
+.nypl-request-page-header {
+  @include request-page-header;
+}
+
+.nypl-breadcrumbs {
+  @include breadcrumbs;
+}
+
+.nypl-full-width-wrapper {
+  @include full-width-wrapper;
+}
+
+.nypl-row {
+  @include row;
+}
+
+.nypl-column-type {
+  @include column-type;
+}
+
+.nypl-column-full,
+.nypl-column-four-quarters {
+  @include column-full;
+}
+
+.nypl-column-half,
+.nypl-column-two-quarters {
+  @include column-half;
+}
+
+.nypl-column-one-quarter {
+  @include column-one-quarter;
+}
+
+.nypl-column-one-third {
+  @include column-one-third;
+}
+
+.nypl-column-two-thirds {
+  @include column-two-thirds;
+}
+
+.nypl-column-three-quarters {
+  @include column-three-quarters;
+}
+
+.nypl-column-offset-one {
+  @include column-offset(1);
+}
+
+.nypl-column-offset-two {
+  @include column-offset(2);
+}
+
+.nypl-column-offset-three {
+  @include column-offset(3);
+}
+
+///
+/// Titles, Text & Icons
+///
+
+.nypl-nypl-icon {
+  @include nypl-icon;
+}
+
+.nypl-banner-alert {
+  @include banner-alert;
+}
+
+.nypl-secondary-title {
+  @include secondary-title;
+}
+
+.nypl-location-info {
+  @include location-info;
+}
+
+.nypl-location-hours {
+  @include location-hours;
+}
+
+.nypl-related-links {
+  @include related-links;
+}
+
+///
+/// Toolkit Styles
+/// TODO: Break this out into a separate style sheet that
+/// doesnt get compiled along w/ the rest of the DTK
+.nypl-general-note {
+  @include general-note;
+}
+
+.nypl-a11y-note {
+  @include a11y-note;
+}
+
+.nypl-toolkit-example {
+  @include toolkit-example;
+}
+
+.nypl-toolkit-example-dark {
+  @include toolkit-example;
+  @include toolkit-example-dark;
+}
+
+///
+/// Tables
+///
+
+.nypl-basic-table {
+  @include basic-table;
+}
+
+.nypl-holds-table {
+  @include holds-table;
+}
+
+.nypl-results-summary {
+  @include results-summary;
+}
+
+.nypl-results-pagination {
+  @include results-pagination;
+}
+
+.nypl-results-sorting-controls {
+  @include results-sorting-controls;
+}
+
+.nypl-results-sorter {
+  @include results-sorter;
+}
+
+.nypl-filter-button {
+  @include filter-button;
+}
+
+.nypl-select-field-results {
+  @include select-field-results;
+}
+
+.nypl-results-item {
+  @include results-item;
+}
+
+.nypl-results-unavailable {
+  @include results-unavailable;
+}
+
+.nypl-results-item-description {
+  @include results-item-description;
+}
+
+.nypl-results-info,
+.nypl-results-place,
+.nypl-results-publisher,
+.nypl-results-date {
+  @include results-info;
+}
+
+.nypl-results-media {
+  @include results-media;
+}
+
+.nypl-results-use {
+  @include results-use;
+}
+
+.nypl-item-info {
+  @include item-info;
+}
+
+.nypl-item-media {
+  @include item-media;
+}
+
+.nypl-item-use {
+  @include results-use;
+}
+
+.nypl-item-holdings {
+  @include item-holdings;
+}
+
+.nypl-item-details {
+  @include item-details;
+}
+
+.nypl-item-external-links {
+  @include item-external-links;
+}
+
+.nypl-views-table {
+  @include views-table;
+}
+
+
+// Modals & Overlays
+// .nypl-popup-container {
+//   @include popup;
+// }
+
+.nypl-basic-modal-container {
+  @include basic-modal;
+}
+//
+// Filtering context
+//
+.nypl-modal-filter-form {
+  @include modal-filter-form;
+}
+
+// Text Columns
+.nypl-generic-columns {
+  @include generic-columns;
+}

--- a/src/client/styles/sass/_typography.scss
+++ b/src/client/styles/sass/_typography.scss
@@ -1,0 +1,13 @@
+@import "measurements";
+
+$sans-serif-stack: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+
+$serif-stack: Cambria, "Hoefler Text", Utopia, "Liberation Serif", "Nimbus Roman No9 L Regular", Times, "Times New Roman", serif;
+
+$monospace-stack: "SFMono-Regular", Consolas, "Andale Mono WT", "Andale Mono", "Lucida Console", "Lucida Sans Typewriter", "DejaVu Sans Mono", "Bitstream Vera Sans Mono", "Liberation Mono", "Nimbus Mono L", Monaco, "Courier New", Courier, monospace;
+
+@mixin font-settings {
+  font-family: $sans-serif-stack;
+  font-size: $basefont;
+  line-height: 1.65;
+}

--- a/src/client/styles/sass/docs.scss
+++ b/src/client/styles/sass/docs.scss
@@ -1,0 +1,253 @@
+@import "typography";
+@import "grid";
+@import "general-mixins";
+@import "measurements";
+@import "colors";
+@import "icons";
+
+
+.hljs-selector-class {
+  color: $highlight-color; // overriding highlightjs which has low contrast in css class highlighting
+}
+
+#skip a {
+  background-color: $nypl-white;
+  border: 0;
+  color: $link-color;
+  display: block;
+  font-size: 13px;
+  height: 1px;
+  left: -10000px;
+  line-height: 2;
+  overflow: hidden;
+  padding: 5px 10px 3px;
+  position: absolute;
+  top: 7px;
+  width: 1px;
+  z-index: 1000;
+
+  &:focus {
+    border: 5px solid $focus-color;
+    height: auto;
+    left: 7px;
+    outline: 0;
+    overflow: visible;
+    padding: ($general-padding / 2) 0;
+    width: auto;
+  }
+}
+
+.hidden {
+  display: none;
+}
+
+.centered {
+  text-align: center;
+}
+
+$blue: #00f;
+$gray: #ccc;
+
+code {
+  border-radius: $general-border-radius;
+  padding: 0;
+
+  &::before,
+  &::after {
+    letter-spacing: -0.2em;
+    content: "\00a0";
+  }
+}
+
+pre {
+  border: $simple-border solid $nypl-light-gray;
+}
+
+h1 {
+  margin-top: 0;
+}
+
+.toolkit-svg-icon {
+  border: 1px dotted $nypl-light-gray;
+  margin-right: 1rem;
+}
+
+.clickable-header {
+  cursor: pointer;
+}
+
+.clickable-header:hover {
+  text-decoration: underline;
+}
+
+.top-level-header {
+  display: inline-block;
+}
+
+.back-to-top {
+  cursor: pointer;
+  font-style: normal;
+  margin-left: 0.5rem;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
+// Style the Color swatches in color.html
+
+// Create the color swatch classes used in sections/color.html
+@mixin swatch-box ($color-name: $nypl-light-gray) {
+  background-color: $color-name;
+  @content;
+  }
+
+$colors: (
+ nypl-red: $nypl-red,
+ nypl-red-dark: $nypl-red-dark,
+ nypl-red-tint: $nypl-red-tint,
+ nypl-blue: $nypl-blue,
+ nypl-blue-dark: $nypl-blue-dark,
+ nypl-light-blue: $nypl-light-blue,
+ nypl-blue-tint: $nypl-blue-tint,
+ nypl-gray-cool: $nypl-gray-cool,
+ nypl-gray: $nypl-gray,
+ nypl-gray-brown: $nypl-gray-brown,
+ nypl-dark-gray: $nypl-dark-gray,
+ nypl-light-gray: $nypl-light-gray,
+ nypl-white: $nypl-white,
+ nypl-black: $nypl-black,
+ nypl-yellow: $nypl-yellow,
+ nypl-yellow-tint: $nypl-yellow-tint,
+ nypl-orange: $nypl-orange,
+ nypl-orange-desaturated: $nypl-orange-desaturated,
+ nypl-green: $nypl-green,
+ nypl-green-dark: $nypl-green-dark,
+ nypl-green-tint: $nypl-green-tint,
+ nypl-purple: $nypl-purple,
+ nypl-purple-dark: $nypl-purple-dark,
+ nypl-purple-tint: $nypl-purple-tint,
+ nypl-teal: $nypl-teal,
+ nypl-teal-dark: $nypl-teal-dark,
+ nypl-teal-tint: $nypl-teal-tint
+);
+
+@each $nypl-colors, $color-name in $colors {
+  .#{$nypl-colors}-swatch {
+    @include swatch-box ($color-name);
+ }
+}
+
+
+.swatches {
+  box-sizing: border-box;
+
+  .reverse {
+    color: $nypl-black;
+  }
+}
+
+.color-box {
+  list-style: none;
+  padding: 0.25rem;
+  margin-left: 0;
+
+  > .main {
+    height: 8rem;
+    padding-top: 3rem;
+  }
+
+  > div {
+    color: $nypl-white;
+    min-height: 4rem;
+    margin: 0;
+    padding: 1rem 0 1rem 1rem;
+    text-align: left;
+  }
+}
+
+// Customize the A11y Table here: /sections/color-a11y.html
+.nypl-ally-table {
+  th {
+    text-align: left;
+  }
+}
+
+
+// Creating Some Styles for the TK Docs themselves
+// adding a toolkit class to the body tag
+// Some of this stuff is purely cosmetic. deal with it.
+.toolkit {
+  .nypl-toolkit-header {
+    @include page-header;
+    background-color: lighten($nypl-light-blue, 20%);
+    border-bottom: solid ($general-border-width * 2) $nypl-blue-dark;
+
+    h2 {
+      color: $nypl-blue-dark;
+      margin-bottom: 0.25rem;
+      //text-shadow: 1px 1px 0 darken($nypl-blue, 0.1);
+
+      + span {
+        color: $nypl-blue-dark;
+        font-style: italic;
+      }
+    } // h2 block thing...
+  } // /.nypl-page-header
+
+  .main-page {
+    h3.top-level-header {
+      &::before {
+        background: $nypl-blue-dark;
+        content: "";
+        display: block;
+        height: ($general-border-width * 2);
+        margin-bottom: 0.5rem;
+        width: 5rem;
+      }
+    }
+  }
+
+//
+// Modal Documentation Example:
+//
+  .nypl-toolkit-example {
+
+    .nypl-basic-modal-container {
+
+      .nypl-modal-content {
+        margin: $general-margin;
+        padding: ($general-margin * 2.5);
+        width: 90%;
+      }
+
+      .nypl-modal-underlay {
+        background: transparentize($nypl-white, 0.2);
+      }
+    }
+  }
+
+  footer {
+    background-color: lighten($nypl-light-blue, 20%);
+    color: $nypl-blue-dark;
+    height: 6rem;
+  }
+} // /.toolkit
+
+// SVG Section Specific Styles
+// Fix the way the logo is displayed in the toolkit's svg page.
+textarea {
+  color: $nypl-black;
+  font-family: monospace;
+  font-size: 0.85rem;
+  padding: 1rem;
+  width: 96.2%;
+}
+
+.nypl-toolkit-example {
+
+  .nypl-logo {
+    height: 13em;
+    width: 20em;
+  }
+}

--- a/src/client/styles/sass/example-search-styles.scss
+++ b/src/client/styles/sass/example-search-styles.scss
@@ -1,0 +1,38 @@
+@import "nypl-normalize";
+@import "toolkit";
+@import "header";
+@import "footer";
+
+.nypl-header {
+  @include header;
+}
+
+.nypl-footer {
+  @include footer;
+}
+
+#skip a {
+  background-color: $nypl-white;
+  border: 0;
+  color: $link-color;
+  display: block;
+  font-size: 13px;
+  height: 1px;
+  left: -10000px;
+  line-height: 2;
+  overflow: hidden;
+  padding: 5px 10px 3px;
+  position: absolute;
+  top: 7px;
+  width: 1px;
+  z-index: 1000;
+
+  &:focus {
+    border: 5px solid $link-color;
+    height: auto;
+    left: 7px;
+    outline: 0;
+    overflow: visible;
+    width: auto;
+  }
+}

--- a/src/client/styles/sass/example-search-styles.v2.scss
+++ b/src/client/styles/sass/example-search-styles.v2.scss
@@ -1,0 +1,230 @@
+@import "nypl-normalize";
+@import "toolkit";
+@import "header";
+@import "footer";
+
+.nypl-header {
+  @include header;
+}
+
+.nypl-footer {
+  @include footer;
+}
+
+#skip a {
+  background-color: $nypl-white;
+  border: 0;
+  color: $link-color;
+  display: block;
+  font-size: 13px;
+  height: 1px;
+  left: -10000px;
+  line-height: 2;
+  overflow: hidden;
+  padding: 5px 10px 3px;
+  position: absolute;
+  top: 7px;
+  width: 1px;
+  z-index: 1000;
+
+  &:focus {
+    border: 5px solid $link-color;
+    height: auto;
+    left: 7px;
+    outline: 0;
+    overflow: visible;
+    width: auto;
+  }
+}
+
+
+
+///
+/// Customized page header
+/// TODO: Make this a proper design pattern and create a set of mixins that make it easier to implement
+/// TODO: Get this out of the example SCSS
+///
+
+.nypl-page-header {
+  @include page-header(
+  $background-color: lighten($nypl-light-gray, 15%),
+  $font-weight: 100,
+  $type-color: $nypl-red);
+  border-bottom: $general-border-width / 1.5 solid darken($nypl-light-gray, 15%);
+  margin-bottom: 0;
+
+  .nypl-column-three-quarters {
+    margin-bottom: 0;
+  }
+}
+
+///
+/// item info / the full item record
+///
+
+.nypl-item-details {
+
+  h1 {
+    margin-bottom: 3rem;
+    line-height: 1.5625;
+  }
+
+  .nypl-item-info {
+    @include item-info ($border-width: 0);
+    padding-left: 0;
+  }
+
+  dl {
+    border-left: 0;
+    font-size: 0.95rem;
+    padding-left: 0;
+
+    dt {
+      color: $nypl-dark-gray;
+      font-size: 0.85rem;
+      font-weight: 700;
+      letter-spacing: 0.04rem;
+      margin: 0 0.5rem 0 0;
+      width: 20%;
+
+      @include media($mobile-breakpoint) {
+        float: none;
+        margin-bottom: 0;
+        width: 100%;
+      }
+    }
+
+    dd {
+      //font-size: 0.95rem;
+      margin-bottom: 0;
+      width: 70%;
+
+      @include media($mobile-breakpoint) {
+        margin-bottom: 1.25rem;
+        width: 100%;
+      }
+
+      &.subject-listing a {
+        display: block;
+      }
+      /// all kinds of kludge... there needs to be cleaner and more global way of handling lists and nested lists...
+      li {
+        margin-bottom: 0;
+      }
+    }
+  }
+
+} // /.nypl-item-details
+
+dl dt.list-multi-control {
+  width: 100%;
+
+  h3 {
+    font-weight: 400;
+    margin: 0 0 1rem;
+    text-transform: none;
+    width: 100%;
+  }
+}
+
+//
+// numbered pager -approach 1:
+//
+.nypl-numbered-pager {
+  @include numbered-pager;
+} // .nypl-results-pagination
+
+//
+// numbered pager -approach 2:
+//
+.nypl-numbered-pager-2 {
+  @include numbered-pager;
+  position: relative;
+
+  @include media($mobile-breakpoint) {
+    padding: 0 0 3rem;
+  }
+
+  .pager {
+
+    .pages {
+      @include clearfix;
+      @include media($mobile-breakpoint) {
+        border-bottom: ($general-border-width / 1.5) solid $nypl-light-gray;
+        float: none;
+        padding: 2% 0;
+        width: 100%;
+      }
+
+      float: left;
+      padding: 0.5rem 0;
+      text-align: center;
+      width: 62%;
+
+      .pager-item {
+        @include media($mobile-breakpoint) {
+          margin-right: 5.5%;
+        }
+
+        margin-right: 6.5%;
+        padding: 0.25em 1.66667%;
+        text-align: center;
+        width: 10%;
+
+        &:last-child {
+          margin-right: 0;
+        }
+
+      } // /.pager-item
+
+      .current {
+        background-color: $nypl-blue-dark;
+        color: $nypl-white;
+        border-radius: $general-border-radius;
+      }
+  }
+
+    .previous,
+    .next {
+
+      @include media($mobile-breakpoint) {
+        float: none;
+        padding: 4% 2rem;
+        position: absolute;
+        // Keep the rule below for a mintue
+        // top: 3rem;
+        top: 47%;
+      }
+
+      float: left;
+      position: static;
+      width: 20%;
+
+    } // /.pager-previous / .pager-next
+    .previous {
+      @include media($mobile-breakpoint) {
+        border: 0;
+        padding: 2.75% 0 0 2rem;
+      }
+
+      border-right: ($general-border-width / 1.5) solid $nypl-light-gray;
+      margin-right: 1rem;
+      padding: 0.5rem 2rem;
+      width: 10%;
+    }
+
+    .next {
+      @include media($mobile-breakpoint) {
+        border: 0;
+        padding: 2.75% 6% 0 0;
+        right: 1rem;
+        text-align: right;
+      }
+
+      border-left: ($general-border-width / 1.5) solid $nypl-light-gray;
+      padding: 0.5rem 0;
+      text-align: right;
+      width: 10%;
+    } // /.pager-next
+  }
+} // /.nypl-numbered-pager-2

--- a/src/client/styles/sass/example-styles.scss
+++ b/src/client/styles/sass/example-styles.scss
@@ -1,0 +1,53 @@
+@import "nypl-normalize";
+@import "toolkit";
+@import "header";
+@import "footer";
+
+.nypl-header {
+  @include header;
+}
+
+.nypl-footer {
+  @include footer;
+}
+
+.views-table {
+  @include views-table;
+}
+
+hr {
+  border: 0;
+  border-top: 0.05rem solid $nypl-gray;
+  height: 2rem;
+
+  &::after {
+    content: "<!-- // start of new row // -->";
+  }
+}
+
+#skip a {
+  background-color: $nypl-white;
+  border: 0;
+  color: $link-color;
+  display: block;
+  font-size: 13px;
+  height: 1px;
+  left: -10000px;
+  line-height: 2;
+  overflow: hidden;
+  padding: 5px 10px 3px;
+  position: absolute;
+  top: 7px;
+  width: 1px;
+  z-index: 1000;
+
+  &:focus {
+    border: 5px solid $link-color;
+    height: auto;
+    left: 7px;
+    outline: 0;
+    overflow: visible;
+    width: auto;
+  }
+}
+

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,7 +3,6 @@ const webpack = require('webpack');
 const merge = require('webpack-merge');
 const CleanBuild = require('clean-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
-const sassPaths = require('@nypl/design-toolkit').includePaths;
 const globImporter = require('node-sass-glob-importer');
 const Visualizer = require('webpack-visualizer-plugin');
 
@@ -174,8 +173,8 @@ if (ENV === 'development') {
             {
               loader: 'sass-loader',
               options: {
-                includePaths: sassPaths,
-                importer: globImporter(),
+                sassOptions: {
+                  importer: globImporter(),
               },
             },
           ],
@@ -226,9 +225,8 @@ if (ENV === 'production') {
             {
               loader: 'sass-loader',
               options: {
-                sourceMap: true,
-                includePaths: sassPaths,
-                importer: globImporter(),
+                sassOptions: {
+                  importer: globImporter(),
               },
             },
           ],


### PR DESCRIPTION
The build process was difficult to upgrade due to a dependency on a specific package we were using. This package was the Design Toolkit. It required a version of node-sass which prevented our project from upgrading NodeJS. The fix was to remove Design Toolkit as a dependency and instead crop the sass directory from its repo into our project.