### PR TITLE
Set Up Webpack to Run Under a Pro Build && Dev Build Load

### DIFF
--- a/server.js
+++ b/server.js
@@ -3,12 +3,10 @@ import express from 'express';
 import compress from 'compression';
 import DocumentTitle from 'react-document-title';
 import { match } from 'react-router';
-import webpack from 'webpack';
 import cookieParser from 'cookie-parser';
 import bodyParser from 'body-parser';
 
 import appConfig from './src/app/data/appConfig';
-import webpackConfig from './webpack.config';
 import apiRoutes from './src/server/ApiRoutes/ApiRoutes';
 import routes from './src/app/routes/routes';
 
@@ -158,25 +156,13 @@ process.on('SIGINT', gracefulShutdown);
  */
 if (!isProduction && !isTest) {
   const WebpackDevServer = require('webpack-dev-server');
+  const webpackConfig = require('./webpack.config');
+  const webpack = require('webpack');
 
-  new WebpackDevServer(webpack(webpackConfig), {
-    publicPath: webpackConfig.output.publicPath,
-    hot: true,
-    stats: false,
-    historyApiFallback: true,
-    headers: {
-      'Access-Control-Allow-Origin': 'http://localhost:3001',
-      'Access-Control-Allow-Headers': 'X-Requested-With',
-    },
-  }).listen(WEBPACK_DEV_PORT, 'localhost', (error) => {
-    if (error) {
-      logger.error(error);
-    }
-
-    logger.info(
-      `Webpack Dev Server listening at localhost: ${WEBPACK_DEV_PORT}.`,
-    );
-  });
+  new WebpackDevServer(
+    { ...webpackConfig.devServer },
+    webpack(webpackConfig),
+  ).start();
 }
 
 module.exports = app;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -47,30 +47,6 @@ const commonSettings = {
     new MiniCssExtractPlugin({
       filename: 'styles.css',
     }),
-    new webpack.DefinePlugin({
-      loadA11y: process.env.loadA11y || false,
-      appEnv: JSON.stringify(appEnv),
-      'process.env': {
-        SHEP_API: JSON.stringify(process.env.SHEP_API),
-        LOGIN_URL: JSON.stringify(process.env.LOGIN_URL),
-        LEGACY_BASE_URL: JSON.stringify(process.env.LEGACY_BASE_URL),
-        CLOSED_LOCATIONS: JSON.stringify(process.env.CLOSED_LOCATIONS),
-        RECAP_CLOSED_LOCATIONS: JSON.stringify(
-          process.env.RECAP_CLOSED_LOCATIONS,
-        ),
-        NON_RECAP_CLOSED_LOCATIONS: JSON.stringify(
-          process.env.NON_RECAP_CLOSED_LOCATIONS,
-        ),
-        OPEN_LOCATIONS: JSON.stringify(process.env.OPEN_LOCATIONS),
-        DISPLAY_TITLE: JSON.stringify(process.env.DISPLAY_TITLE),
-        ITEM_BATCH_SIZE: JSON.stringify(process.env.ITEM_BATCH_SIZE),
-        CIRCULATING_CATALOG: JSON.stringify(process.env.CIRCULATING_CATALOG),
-        BASE_URL: JSON.stringify(process.env.BASE_URL),
-        WEBPAC_BASE_URL: JSON.stringify(process.env.WEBPAC_BASE_URL),
-        FEATURES: JSON.stringify(process.env.FEATURES),
-        SHEP_BIBS_LIMIT: JSON.stringify(process.env.SHEP_BIBS_LIMIT),
-      },
-    }),
     // new BundleAnalyzerPlugin({
     //   // Can be `server`, `static` or `disabled`.
     //   // In `server` mode analyzer will start HTTP server to show bundle report.
@@ -142,8 +118,34 @@ if (ENV === 'development') {
     plugins: [new webpack.HotModuleReplacementPlugin()],
     resolve: {
       modules: ['node_modules'],
-      extensions: ['.js', '.jsx', '.scss', '.png'],
+      extensions: ['.js', '.jsx', '.css', '.scss', '.png'],
     },
+    plugins: [
+      new webpack.DefinePlugin({
+        loadA11y: process.env.loadA11y || false,
+        appEnv: JSON.stringify(appEnv),
+        'process.env': {
+          SHEP_API: JSON.stringify(process.env.SHEP_API),
+          LOGIN_URL: JSON.stringify(process.env.LOGIN_URL),
+          LEGACY_BASE_URL: JSON.stringify(process.env.LEGACY_BASE_URL),
+          CLOSED_LOCATIONS: JSON.stringify(process.env.CLOSED_LOCATIONS),
+          RECAP_CLOSED_LOCATIONS: JSON.stringify(
+            process.env.RECAP_CLOSED_LOCATIONS,
+          ),
+          NON_RECAP_CLOSED_LOCATIONS: JSON.stringify(
+            process.env.NON_RECAP_CLOSED_LOCATIONS,
+          ),
+          OPEN_LOCATIONS: JSON.stringify(process.env.OPEN_LOCATIONS),
+          DISPLAY_TITLE: JSON.stringify(process.env.DISPLAY_TITLE),
+          ITEM_BATCH_SIZE: JSON.stringify(process.env.ITEM_BATCH_SIZE),
+          CIRCULATING_CATALOG: JSON.stringify(process.env.CIRCULATING_CATALOG),
+          BASE_URL: JSON.stringify(process.env.BASE_URL),
+          WEBPAC_BASE_URL: JSON.stringify(process.env.WEBPAC_BASE_URL),
+          FEATURES: JSON.stringify(process.env.FEATURES),
+          SHEP_BIBS_LIMIT: JSON.stringify(process.env.SHEP_BIBS_LIMIT),
+        },
+      }),
+    ],
     module: {
       rules: [
         {
@@ -243,13 +245,15 @@ if (ENV === 'production') {
     },
     plugins: [
       new webpack.DefinePlugin({
+        loadA11y: process.env.loadA11y || false,
+        appEnv: JSON.stringify(appEnv),
         'process.env': {
           NODE_ENV: JSON.stringify('production'),
           GA_ENV: JSON.stringify(process.env.GA_ENV),
-          SHEP_API: process.env.SHEP_API,
-          LOGIN_URL: process.env.LOGIN_URL,
-          LEGACY_BASE_URL: process.env.LEGACY_BASE_URL,
-          CLOSED_LOCATIONS: process.env.CLOSED_LOCATIONS,
+          SHEP_API: JSON.stringify(process.env.SHEP_API),
+          LOGIN_URL: JSON.stringify(process.env.LOGIN_URL),
+          LEGACY_BASE_URL: JSON.stringify(process.env.LEGACY_BASE_URL),
+          CLOSED_LOCATIONS: JSON.stringify(process.env.CLOSED_LOCATIONS),
           RECAP_CLOSED_LOCATIONS: JSON.stringify(
             process.env.RECAP_CLOSED_LOCATIONS,
           ),
@@ -260,6 +264,10 @@ if (ENV === 'production') {
           ITEM_BATCH_SIZE: JSON.stringify(process.env.ITEM_BATCH_SIZE),
           CIRCULATING_CATALOG: JSON.stringify(process.env.CIRCULATING_CATALOG),
           WEBPAC_BASE_URL: JSON.stringify(process.env.WEBPAC_BASE_URL),
+          OPEN_LOCATIONS: JSON.stringify(process.env.OPEN_LOCATIONS),
+          BASE_URL: JSON.stringify(process.env.BASE_URL),
+          FEATURES: JSON.stringify(process.env.FEATURES),
+          SHEP_BIBS_LIMIT: JSON.stringify(process.env.SHEP_BIBS_LIMIT),
         },
       }),
     ],

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -28,8 +28,9 @@ const commonSettings = {
       path.resolve(ROOT_PATH, 'src/client/App.jsx'),
     ],
   },
+  target: ['web', 'es5'],
   resolve: {
-    extensions: ['.js', '.jsx'],
+    extensions: ['.js', '.jsx', '.css', '.scss'],
   },
   output: {
     // Sets the output path to ROOT_PATH/dist
@@ -166,7 +167,7 @@ if (ENV === 'development') {
           },
         },
         {
-          test: /\.scss?$/,
+          test: /\.s[ac]ss?$/,
           use: [
             'style-loader',
             'css-loader',
@@ -217,7 +218,7 @@ if (ENV === 'production') {
           use: 'babel-loader',
         },
         {
-          test: /\.scss$/,
+          test: /\.s[ac]ss$/i,
           include: path.resolve(ROOT_PATH, 'src'),
           use: [
             MiniCssExtractPlugin.loader,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -115,7 +115,6 @@ if (ENV === 'development') {
     output: {
       publicPath: 'http://localhost:3000/',
     },
-    plugins: [new webpack.HotModuleReplacementPlugin()],
     resolve: {
       modules: ['node_modules'],
       extensions: ['.js', '.jsx', '.css', '.scss', '.png'],

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,7 @@
 const path = require('path');
 const webpack = require('webpack');
-const merge = require('webpack-merge');
-const CleanBuild = require('clean-webpack-plugin');
+const { merge } = require('webpack-merge');
+const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const globImporter = require('node-sass-glob-importer');
 const Visualizer = require('webpack-visualizer-plugin');
@@ -42,7 +42,7 @@ const commonSettings = {
     // Cleans the Dist folder after every build.
     // Alternately, we can run rm -rf dist/ as
     // part of the package.json scripts.
-    new CleanBuild(['dist']),
+    new CleanWebpackPlugin(),
     new MiniCssExtractPlugin({
       filename: 'styles.css',
     }),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -106,6 +106,7 @@ if (ENV === 'development') {
   module.exports = merge(commonSettings, {
     mode: 'development',
     devtool: 'inline-source-map',
+    stats: 'errors-only',
     entry: {
       app: [
         'webpack-dev-server/client?http://localhost:3000',
@@ -186,6 +187,23 @@ if (ENV === 'development') {
           include: path.resolve(ROOT_PATH, 'src'),
         },
       ],
+    },
+    devServer: {
+      port: 3000,
+      hot: true,
+      historyApiFallback: true,
+      headers: {
+        'Access-Control-Allow-Origin': 'http://localhost:3001',
+        'Access-Control-Allow-Headers': 'X-Requested-With',
+      },
+      onListening(devServer) {
+        if (!devServer) throw new Error('webpack-dev-server is not defined');
+
+        console.log(
+          'Dev Server Listening on port:',
+          devServer.server.address().port,
+        );
+      },
     },
   });
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -176,6 +176,9 @@ if (ENV === 'development') {
               options: {
                 sassOptions: {
                   importer: globImporter(),
+                },
+                sourceMap: true,
+                implementation: require('sass'),
               },
             },
           ],
@@ -228,6 +231,10 @@ if (ENV === 'production') {
               options: {
                 sassOptions: {
                   importer: globImporter(),
+                  fiber: false,
+                },
+                sourceMap: false,
+                implementation: require('sass'),
               },
             },
           ],


### PR DESCRIPTION
It is necessary to update the Webpack configuration for both dev and pro builds for handling the sass bundling. 

Additionally, a benefit of this upgraded Webpack configuration is how the development server can be configured. While there is still dev server logic in our server.js file, the eventuality is to completely remove it from that file and use the Webpack configuration as the source for spinning up a dev server. 

The environment configurations were also address in this refactor of the Webpack configuration. The process environments were conflicting during bundle builds. There are some solutions for this however, they are marked for refactor at a later time. The separation of dev vs. pro environments resolves the conflict between the two modes.