### PR TITLE
User EDD Form Session Storage 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6151,6 +6151,12 @@
         "entities": "^1.1.1"
       }
     },
+    "dom-walk": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
+      "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w==",
+      "dev": true
+    },
     "domain-browser": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
@@ -9738,6 +9744,16 @@
         "is-glob": "^2.0.0"
       }
     },
+    "global": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
+      "integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
+      "dev": true,
+      "requires": {
+        "min-document": "^2.19.0",
+        "process": "^0.11.10"
+      }
+    },
     "global-modules": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz",
@@ -11919,6 +11935,15 @@
         "mime-db": "1.43.0"
       }
     },
+    "min-document": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
+      "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
+      "dev": true,
+      "requires": {
+        "dom-walk": "^0.1.0"
+      }
+    },
     "mini-create-react-context": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/mini-create-react-context/-/mini-create-react-context-0.4.1.tgz",
@@ -12107,6 +12132,24 @@
           "requires": {
             "has-flag": "^2.0.0"
           }
+        }
+      }
+    },
+    "mock-local-storage": {
+      "version": "1.1.20",
+      "resolved": "https://registry.npmjs.org/mock-local-storage/-/mock-local-storage-1.1.20.tgz",
+      "integrity": "sha512-JsV1bVnHA0lhdoGeJDBrOtC1X8j2ZJ5ZttoyZMp3cZCgbnh2MuQaQGpHwfwha+Jczhmd40lOmzYmBKExvsbBaA==",
+      "dev": true,
+      "requires": {
+        "core-js": "^3.19.0",
+        "global": "^4.3.2"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "3.21.0",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.21.0.tgz",
+          "integrity": "sha512-YUdI3fFu4TF/2WykQ2xzSiTQdldLB4KVuL9WeAy5XONZYt5Cun/fpQvctoKbCgvPhmzADeesTk/j2Rdx77AcKQ==",
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "jsdom": "9.0.0",
     "mini-css-extract-plugin": "^0.9.0",
     "mocha": "4.0.1",
+    "mock-local-storage": "^1.1.20",
     "nightwatch": "^1.3.5",
     "nock": "^13.0.11",
     "nyc": "^13.0.0",

--- a/src/app/components/ElectronicDeliveryForm/ElectronicDeliveryForm.jsx
+++ b/src/app/components/ElectronicDeliveryForm/ElectronicDeliveryForm.jsx
@@ -17,13 +17,17 @@ class ElectronicDeliveryForm extends React.Component {
     // in the no-js scenario. If they're not available, then we use this
     // 'fallback', but the empty object structure is needed.
     this.state = {
-      form: !_isEmpty(this.props.form) ? this.props.form :
-        {
-          emailAddress: this.props.defaultEmail,
-          chapterTitle: '',
-          startPage: '',
-          endPage: '',
-        },
+      form: !_isEmpty(this.props.form)
+        ? this.props.form
+        : // Use Formstate session data if it exists
+        !_isEmpty(window.sessionStorage.getItem('formstate'))
+        ? JSON.parse(window.sessionStorage.getItem('formstate'))
+        : {
+            emailAddress: this.props.defaultEmail,
+            chapterTitle: '',
+            startPage: '',
+            endPage: '',
+          },
       error: !_isEmpty(this.props.error) ? this.props.error :
         {
           emailAddress: '',
@@ -46,6 +50,10 @@ class ElectronicDeliveryForm extends React.Component {
     };
 
     if (validate(this.state.form, errorCb)) {
+      // Remove session data if valid.
+      // The submit request prop func does not return a value
+      // It, on success, redirects, and it, on error, redirects.
+      window.sessionStorage.removeItem('formstate');
       this.props.submitRequest(this.state);
     }
   }
@@ -55,7 +63,11 @@ class ElectronicDeliveryForm extends React.Component {
     // and all the values are being retained. If we don't `extend` the object
     // value for `form`, then only the last value in the form gets updated
     // and the rest are gone.
-    this.setState({ form: _extend(this.state.form, { [input]: e.target.value }) });
+    this.setState({
+      form: _extend(this.state.form, { [input]: e.target.value }),
+    });
+    // Capture and save user input as it's being updated
+    window.sessionStorage.setItem('formstate', JSON.stringify(this.state.form));
   }
 
   render() {

--- a/src/app/components/ElectronicDeliveryForm/ElectronicDeliveryForm.jsx
+++ b/src/app/components/ElectronicDeliveryForm/ElectronicDeliveryForm.jsx
@@ -20,7 +20,8 @@ class ElectronicDeliveryForm extends React.Component {
       form: !_isEmpty(this.props.form)
         ? this.props.form
         : // Use Formstate session data if it exists
-        !_isEmpty(window.sessionStorage.getItem('formstate'))
+        typeof window !== 'undefined' &&
+          !_isEmpty(window.sessionStorage.getItem('formstate'))
         ? JSON.parse(window.sessionStorage.getItem('formstate'))
         : {
             emailAddress: this.props.defaultEmail,

--- a/src/app/components/ElectronicDeliveryForm/helpers.js
+++ b/src/app/components/ElectronicDeliveryForm/helpers.js
@@ -1,0 +1,18 @@
+import { isEmpty as _isEmpty } from 'underscore';
+
+export const fetchFromLocal = (key) => {
+  // Return an empty object to avoid
+  // asking for props from null or undefined;
+  const initial = {};
+
+  if (typeof window === 'undefined') {
+    return initial;
+  }
+
+  const item = window.localStorage.getItem(key);
+  return !_isEmpty(item) ? JSON.parse(item) : initial;
+};
+
+export const minSinceMil = (mills) => {
+  return Math.floor((Date.now() - mills) / 60000);
+};

--- a/test/helpers/browser.js
+++ b/test/helpers/browser.js
@@ -34,6 +34,7 @@ global.navigator = {
 };
 
 window.sessionStorage = global.sessionStorage;
+window.localStorage = global.localStorage;
 
 const noop = () => {};
 require.extensions['.png'] = noop;

--- a/test/helpers/browser.js
+++ b/test/helpers/browser.js
@@ -3,6 +3,10 @@
 // Perhaps we can instead point mocah to run a setupfile
 // which then executes this file to set up the browser
 require('dotenv').config({ path: 'test.env' });
+
+require('mock-local-storage');
+global.window = {};
+
 const enzyme = require('enzyme');
 const Adapter = require('enzyme-adapter-react-16');
 
@@ -17,6 +21,7 @@ const exposedProperties = ['window', 'navigator', 'document'];
 global.document = jsdom('');
 const { document } = global;
 global.window = document.defaultView;
+
 Object.keys(document.defaultView).forEach((property) => {
   if (typeof global[property] === 'undefined') {
     exposedProperties.push(property);
@@ -27,6 +32,8 @@ Object.keys(document.defaultView).forEach((property) => {
 global.navigator = {
   userAgent: 'node.js',
 };
+
+window.sessionStorage = global.sessionStorage;
 
 const noop = () => {};
 require.extensions['.png'] = noop;

--- a/test/unit/ElectronicDelivery.test.js
+++ b/test/unit/ElectronicDelivery.test.js
@@ -1,46 +1,57 @@
 /* eslint-env mocha */
 /* eslint-disable react/jsx-filename-extension */
-import React from 'react';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
+import React from 'react';
 import { mock } from 'sinon';
-import { mountTestRender, makeTestStore } from '../helpers/store';
-
+import { makeTestStore, mountTestRender } from '../helpers/store';
 import ElectronicDeliveryForm from './../../src/app/components/ElectronicDeliveryForm/ElectronicDeliveryForm';
-import ElectronicDelivery from './../../src/app/pages/ElectronicDelivery';
 import appConfig from './../../src/app/data/appConfig';
+import ElectronicDelivery from './../../src/app/pages/ElectronicDelivery';
 
 describe('ElectronicDeliveryForm', () => {
   describe('default form', () => {
     let component;
     let appConfigMock;
+
     before(() => {
       appConfigMock = mock(appConfig);
       appConfig.features = [];
       appConfig.eddAboutUrl.default = 'example.com/edd-default-url';
-      component = shallow(
-        <ElectronicDeliveryForm fromUrl="example.com" />,
-      );
+      component = shallow(<ElectronicDeliveryForm fromUrl='example.com' />);
     });
+
     after(() => {
       appConfigMock.restore();
     });
+
     it('should have `pickupLocation` set to `edd`', () => {
-      expect(component.find('input').findWhere(n => n.props().name === 'pickupLocation').length).to.equal(1);
+      expect(
+        component
+          .find('input')
+          .findWhere((n) => n.props().name === 'pickupLocation').length,
+      ).to.equal(1);
     });
+
     it('should have default EDD about URL', () => {
-      expect(component.find('a').first().prop('href')).to.equal('example.com/edd-default-url');
+      expect(component.find('a').first().prop('href')).to.equal(
+        'example.com/edd-default-url',
+      );
     });
   });
+
   describe('with "on-site-edd" feature flag', () => {
     let component;
     let appConfigMock;
+
     before(() => {
       appConfigMock = mock(appConfig);
       appConfigMock.object.eddAboutUrl = {
         onSiteEdd: 'example.com/scan-and-deliver',
       };
+
       const store = makeTestStore({ features: ['on-site-edd'] });
+
       component = mountTestRender(
         <ElectronicDelivery
           params={{ bibId: 'book1' }}
@@ -51,12 +62,16 @@ describe('ElectronicDeliveryForm', () => {
         { store },
       );
     });
+
     after(() => {
       component.unmount();
     });
+
     it('should have "Scan & Deliver" EDD about URL', () => {
       const form = component.find('ElectronicDeliveryForm');
-      expect(form.find('a').first().prop('href')).to.equal('example.com/scan-and-deliver');
+      expect(form.find('a').first().prop('href')).to.equal(
+        'example.com/scan-and-deliver',
+      );
     });
   });
 });


### PR DESCRIPTION
**What's this do?**
A method to which we can save the user form input and reuse the inputs if the users login session expires is to set the value on the browsers session state.

This PR processes the users form session state in three ways:
1. It captures the data input and sets the values, on update, in the session state.
2. It uses the form session input if it exists and after checking for passed in forms props,
3. It removes the values when the form is submitted.
    - Since the submittance of the form inputs do not return a value
    - and the page is redirected on success or failure
    - we can simply remove saved session item

**Why are we doing this? (w/ JIRA link if applicable)**
When a user is on the EDD submittal form and their login session is forced to be revalidated, capture and set any form inputs added by the user. This is a feature which provides convenience to the user if they fail to submit their request in the time allotted.

**Do these changes have automated tests?**
Yes - Located in ElectronicDeliver.test.js

**How should this be QAed?**
1. On Initial render, ensure no values are present in form input fields except for patrons email.
2. After input entry, ensure a local storage object is available (called `formstate`) with a property of the `itemId`
3. On page refresh or with same `itemId` the form input fields are prefilled with previously entered values
4. On submittal of the form, ensure local storage has been cleared
5. On re-entry of the EDD request after submittal, ensure clean form state

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Unknown
