### PR TITLE
Rebuild Webpack Dev Server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ log/*.log
 
 # VS code Configuration Files
 .vscode
+
+__play.*

--- a/package-lock.json
+++ b/package-lock.json
@@ -14431,14 +14431,19 @@
       },
       "dependencies": {
         "prop-types": {
-          "version": "15.7.2",
-          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-          "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+          "version": "15.8.1",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+          "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
           "requires": {
             "loose-envify": "^1.4.0",
             "object-assign": "^4.1.1",
-            "react-is": "^16.8.1"
+            "react-is": "^16.13.1"
           }
+        },
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
         }
       }
     },
@@ -14519,14 +14524,19 @@
       },
       "dependencies": {
         "prop-types": {
-          "version": "15.7.2",
-          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-          "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+          "version": "15.8.1",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+          "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
           "requires": {
             "loose-envify": "^1.4.0",
             "object-assign": "^4.1.1",
-            "react-is": "^16.8.1"
+            "react-is": "^16.13.1"
           }
+        },
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -132,6 +132,7 @@
     "webpack": "^5.67.0",
     "webpack-bundle-analyzer": "^3.8.0",
     "webpack-cli": "^4.9.2",
+    "webpack-dev-middleware": "^5.3.1",
     "webpack-dev-server": "^4.7.3",
     "webpack-merge": "^5.8.0",
     "webpack-visualizer-plugin": "^0.1.11"

--- a/server.js
+++ b/server.js
@@ -30,6 +30,23 @@ const app = express();
 
 app.use(compress());
 
+/* Development Environment Configuration
+ * -------------------------------------
+ * - Using Webpack Dev Server
+ */
+if (!isProduction && !isTest) {
+  const wpdMiddleware = require('webpack-dev-middleware');
+  const webpack = require('webpack');
+  const webpackConfig = require('./webpack.config');
+  const compiler = webpack({ ...webpackConfig });
+
+  app.use(
+    wpdMiddleware(compiler, {
+      publicPath: webpackConfig.output.publicPath,
+    }),
+  );
+}
+
 // Disables the Server response from
 // displaying Express as the server engine
 app.disable('x-powered-by');
@@ -149,20 +166,5 @@ const gracefulShutdown = () => {
 process.on('SIGTERM', gracefulShutdown);
 // listen for INT signal e.g. Ctrl-C
 process.on('SIGINT', gracefulShutdown);
-
-/* Development Environment Configuration
- * -------------------------------------
- * - Using Webpack Dev Server
- */
-if (!isProduction && !isTest) {
-  const WebpackDevServer = require('webpack-dev-server');
-  const webpackConfig = require('./webpack.config');
-  const webpack = require('webpack');
-
-  new WebpackDevServer(
-    { ...webpackConfig.devServer },
-    webpack(webpackConfig),
-  ).start();
-}
 
 module.exports = app;

--- a/src/app/data/appConfig.js
+++ b/src/app/data/appConfig.js
@@ -11,7 +11,7 @@ const appConfig = {
   legacyBaseUrl: process.env.LEGACY_BASE_URL,
   favIconPath: 'https://ux-static.nypl.org/images/favicon.ico',
   port: 3001,
-  webpackDevServerPort: 3000,
+  webpackDevServerPort: 3001,
   environment: process.env.APP_ENV || 'production',
   api: {
     discovery: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -108,18 +108,20 @@ if (ENV === 'development') {
   console.log('webpack dev');
 
   module.exports = merge(commonSettings, {
+    name: 'client',
     mode: 'development',
     devtool: 'inline-source-map',
     stats: 'errors-only',
-    entry: {
-      app: [
-        'webpack-dev-server/client?http://localhost:3000',
-        'webpack/hot/only-dev-server',
-      ],
-    },
-    output: {
-      publicPath: 'http://localhost:3000/',
-    },
+    // Keep for Past Context
+    // entry: {
+    //   app: [
+    //     'webpack-dev-server/client?http://localhost:3000',
+    //     'webpack/hot/only-dev-server',
+    //   ],
+    // },
+    // output: {
+    //   publicPath: 'http://localhost:3000/',
+    // },
     resolve: {
       modules: ['node_modules'],
       extensions: ['.js', '.jsx', '.css', '.scss', '.png'],
@@ -192,23 +194,26 @@ if (ENV === 'development') {
         },
       ],
     },
-    devServer: {
-      port: 3000,
-      hot: true,
-      historyApiFallback: true,
-      headers: {
-        'Access-Control-Allow-Origin': 'http://localhost:3001',
-        'Access-Control-Allow-Headers': 'X-Requested-With',
-      },
-      onListening(devServer) {
-        if (!devServer) throw new Error('webpack-dev-server is not defined');
-
-        console.log(
-          'Dev Server Listening on port:',
-          devServer.server.address().port,
-        );
-      },
-    },
+    // Keep for Past Context
+    // devServer: {
+    // allowedHosts: ['all'],
+    // port: 3001,
+    // hot: false,
+    // historyApiFallback: true,
+    // headers: {
+    //   'Access-Control-Allow-Origin': 'http://localhost:3001',
+    //   'Access-Control-Allow-Headers': 'X-Requested-With',
+    // },
+    //
+    // onListening(devServer) {
+    //   if (!devServer) throw new Error('webpack-dev-server is not defined');
+    //
+    //   console.log(
+    //     'Dev Server Listening on port:',
+    //     devServer.server.address().port,
+    //   );
+    // },
+    // },
   });
 }
 


### PR DESCRIPTION
During configuration of the Node v14 bump the webpack development environment was changed. Unfortunately, the configuration is now a bit broken, but this PR corrects _some_ of the issues.  The changes created WebSocket issues, causing multiple errors inside the browsers log and Hot Module Replacement became useless. While the HMR is still not working the WebSocket issue has been resolved because we are now not using HMR :)