### PR TITLE
Build Second Row for Table Items 

### DIFF
--- a/src/app/components/Buttons/ItemTableButtons/AeonButton.jsx
+++ b/src/app/components/Buttons/ItemTableButtons/AeonButton.jsx
@@ -1,0 +1,58 @@
+import PropTypes from 'prop-types';
+import React, { useState } from 'react';
+import appConfig from '../../../data/appConfig';
+import { isAeonLink } from '../../../utils/utils';
+
+const AeonButton = ({ item, onClick }) => {
+  const [aeonUrl] = useState(() => {
+    const aeonUrl = Array.isArray(item.aeonUrl)
+      ? item.aeonUrl[0]
+      : item.aeonUrl;
+
+    if (!isAeonLink(aeonUrl)) return `${appConfig.baseUrl}/404`;
+
+    const searchParams = new URL(aeonUrl).searchParams;
+
+    const paramMappings = {
+      ItemISxN: 'id',
+      itemNumber: 'barcode',
+      CallNumber: 'callNumber',
+    };
+
+    let params = Object.keys(paramMappings)
+      .map((paramName) => {
+        if (searchParams.has(paramName)) return null;
+        const mappedParamName = paramMappings[paramName];
+        if (!item[mappedParamName]) return null;
+        return `&${paramName}=${item[mappedParamName]}`;
+      })
+      .filter(Boolean)
+      .join('');
+
+    if (params && !aeonUrl.includes('?')) params = `?${params}`;
+
+    return encodeURI(`${aeonUrl}${params || ''}`);
+  });
+
+  return (
+    <div className='nypl-request-btn'>
+      <a href={aeonUrl} onClick={onClick} tabIndex='0'>
+        {`Make Appointment`}
+      </a>
+      <br />
+      <span className='nypl-request-btn-label'>
+        {`Appointment Required. `}
+        <a>
+          <i>{`Details`}</i>
+        </a>
+      </span>
+    </div>
+  );
+};
+
+AeonButton.propTypes = {
+  item: PropTypes.object,
+  onClick: PropTypes.function,
+};
+
+export default AeonButton;

--- a/src/app/components/Buttons/ItemTableButtons/EddButton.jsx
+++ b/src/app/components/Buttons/ItemTableButtons/EddButton.jsx
@@ -1,0 +1,23 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import { Link } from 'react-router';
+
+const EddButton = ({ display, link, onClick }) => {
+  if (!display) return null;
+
+  return (
+    <div className='nypl-request-btn'>
+      <Link to={link} onClick={onClick} tabIndex='0'>
+        {`Request Scan`}
+      </Link>
+    </div>
+  );
+};
+
+EddButton.propTypes = {
+  display: PropTypes.boolean,
+  link: PropTypes.string,
+  onClick: PropTypes.function,
+};
+
+export default EddButton;

--- a/src/app/components/Buttons/ItemTableButtons/ReCAPButton.jsx
+++ b/src/app/components/Buttons/ItemTableButtons/ReCAPButton.jsx
@@ -1,0 +1,35 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import { Link } from 'react-router';
+
+const ReCAPButton = ({ display, item, link, onClick }) => {
+  if (!display)
+    return (
+      <div>{item.status.preLabel ?? 'Not Available'}</div>
+      // <div>{(item.status && item.status.preLabel) ?? 'Not Available'}</div>
+    );
+
+  return (
+    <div className='nypl-request-btn'>
+      <Link to={link} onClick={onClick} tabIndex='0' className='secondary'>
+        {`Request for Onsite Use`}
+      </Link>
+      <br />
+      <span className='nypl-request-btn-label'>
+        {`Timeline `}
+        <a>
+          <i>{`Details`}</i>
+        </a>
+      </span>
+    </div>
+  );
+};
+
+ReCAPButton.propTypes = {
+  display: PropTypes.boolean,
+  item: PropTypes.object,
+  link: PropTypes.string,
+  onClick: PropTypes.function,
+};
+
+export default ReCAPButton;

--- a/src/app/components/Buttons/ItemTableButtons/index.js
+++ b/src/app/components/Buttons/ItemTableButtons/index.js
@@ -1,0 +1,6 @@
+export * from './AeonButton';
+export { default as AeonButton } from './AeonButton';
+export * from './EddButton';
+export { default as EddButton } from './EddButton';
+export * from './ReCAPButton';
+export { default as ReCAPButton } from './ReCAPButton';

--- a/src/app/components/Item/ItemTable.jsx
+++ b/src/app/components/Item/ItemTable.jsx
@@ -16,6 +16,7 @@ const ItemTable = ({ items, holdings, bibId, id, searchKeywords, page }) => {
     return null;
   }
   const SearchResultsPage = page === 'SearchResults';
+  const BibPage = page === 'BibPage';
 
   const includeVolColumn =
     items.some(({ volume = '' }) => volume.length) && !SearchResultsPage;
@@ -28,9 +29,7 @@ const ItemTable = ({ items, holdings, bibId, id, searchKeywords, page }) => {
           {includeVolColumn ? <th scope='col'>Vol/Date</th> : null}
           <th scope='col'>Format</th>
           <th scope='col'>Call Number</th>
-          <th scope='col'>
-            {((SearchResultsPage && `Item `) || '') + `Location`}
-          </th>
+          <th scope='col'>{((!BibPage && `Item `) || '') + `Location`}</th>
           {!SearchResultsPage ? (
             <th scope='col'>{`Availability & Access`}</th>
           ) : null}

--- a/src/app/components/Item/ItemTable.jsx
+++ b/src/app/components/Item/ItemTable.jsx
@@ -15,10 +15,10 @@ const ItemTable = ({ items, holdings, bibId, id, searchKeywords, page }) => {
   ) {
     return null;
   }
+  const SearchResultsPage = page === 'SearchResults';
 
   const includeVolColumn =
-    items.some((item) => item.volume && item.volume.length) &&
-    page !== 'SearchResults';
+    items.some(({ volume = '' }) => volume.length) && !SearchResultsPage;
 
   return (
     <table className='nypl-basic-table' id={id}>
@@ -26,11 +26,14 @@ const ItemTable = ({ items, holdings, bibId, id, searchKeywords, page }) => {
       <thead>
         <tr>
           {includeVolColumn ? <th scope='col'>Vol/Date</th> : null}
-          {page !== 'SearchResults' ? <th scope='col'>Format</th> : null}
-          <th scope='col'>Access</th>
-          <th scope='col'>Status</th>
+          {SearchResultsPage ? <th scope='col'>Format</th> : null}
           <th scope='col'>Call Number</th>
-          <th scope='col'>Location</th>
+          <th scope='col'>
+            {((SearchResultsPage && `Item `) || '') + `Location`}
+          </th>
+          {!SearchResultsPage ? (
+            <th scope='col'>{`Availability & Access`}</th>
+          ) : null}
         </tr>
       </thead>
       <tbody>

--- a/src/app/components/Item/ItemTable.jsx
+++ b/src/app/components/Item/ItemTable.jsx
@@ -26,7 +26,7 @@ const ItemTable = ({ items, holdings, bibId, id, searchKeywords, page }) => {
       <thead>
         <tr>
           {includeVolColumn ? <th scope='col'>Vol/Date</th> : null}
-          {SearchResultsPage ? <th scope='col'>Format</th> : null}
+          <th scope='col'>Format</th>
           <th scope='col'>Call Number</th>
           <th scope='col'>
             {((SearchResultsPage && `Item `) || '') + `Location`}

--- a/src/app/components/Item/ItemTableRow.jsx
+++ b/src/app/components/Item/ItemTableRow.jsx
@@ -1,11 +1,13 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Link } from 'react-router';
 import { isEmpty as _isEmpty } from 'underscore';
 import appConfig from '../../data/appConfig';
-import { isAeonLink, trackDiscovery } from '../../utils/utils';
-
-const { features } = appConfig;
+import { trackDiscovery } from '../../utils/utils';
+import {
+  AeonButton,
+  EddButton,
+  ReCAPButton,
+} from '../Buttons/ItemTableButtons';
 
 class ItemTableRow extends React.Component {
   constructor(props) {
@@ -37,47 +39,26 @@ class ItemTableRow extends React.Component {
     return item.accessMessage.prefLabel || ' ';
   }
 
-  aeonUrl(item) {
-    const url = Array.isArray(item.aeonUrl) ? item.aeonUrl[0] : item.aeonUrl;
-    const searchParams = new URL(url).searchParams;
-    const paramMappings = {
-      ItemISxN: 'id',
-      itemNumber: 'barcode',
-      CallNumber: 'callNumber',
-    };
-
-    let params = Object.keys(paramMappings)
-      .map((paramName) => {
-        if (searchParams.has(paramName)) return null;
-        const mappedParamName = paramMappings[paramName];
-        if (!item[mappedParamName]) return null;
-        return `&${paramName}=${item[mappedParamName]}`;
-      })
-      .filter(Boolean)
-      .join('');
-
-    if (params && !url.includes('?')) params = `?${params}`;
-
-    return encodeURI(`${url}${params || ''}`);
-  }
-
   requestButton() {
     const { item, bibId, searchKeywords, page } = this.props;
 
-    const isRequestable = (item.requestable = true);
-    const isAvailable = item.available;
-    const isOffSite = item.isOffsite;
-    const isSpecialCollection = isAeonLink(item.aeonUrl);
-    const isRecap = item.isRecap;
-    const isEddRequestable = item.eddRequestable;
+    const specRequestable = item.specRequestable;
+    const eddRequestable = item.eddRequestable;
+    const physRequestable = item.physRequestable;
 
-    const allClosed = appConfig.closedLocations
-      .concat(
-        item.isRecap
-          ? appConfig.recapClosedLocations
-          : appConfig.nonRecapClosedLocations,
-      )
-      .includes('');
+    // Currently Not Used
+    // TODO Determine if we need these.
+    // const isAvailable = item.available;
+    // const isRecap = item.isRecap;
+    // const isRequestable = (item.requestable = true);
+    // const isOffSite = item.isOffsite;
+    // const allClosed = appConfig.closedLocations
+    //   .concat(
+    //     item.isRecap
+    //       ? appConfig.recapClosedLocations
+    //       : appConfig.nonRecapClosedLocations,
+    //   )
+    //   .includes('');
 
     return (
       <div
@@ -85,30 +66,24 @@ class ItemTableRow extends React.Component {
           page === 'SearchResults' ? 'pan-left' : ''
         }`}
       >
-        <Link
-          to={`${appConfig.baseUrl}/hold/request/${bibId}-${item.id}?searchKeywords=${searchKeywords}`}
-          onClick={(event) => this.getItemRecord(event, bibId, item.id)}
-          tabIndex='0'
-          className='nypl-request-btn'
-        >
-          Request Scan
-        </Link>
-        {(isRequestable && (
-          <span>
-            <Link
-              to={`${appConfig.baseUrl}/hold/request/${bibId}-${item.id}?searchKeywords=${searchKeywords}`}
-              // to={this.aeonUrl(item)}
-              onClick={(event) => this.getItemRecord(event, bibId, item.id)}
-              tabIndex='-1'
-              className='nypl-request-btn sibling'
-            >
-              Request for Onsite Use
-            </Link>
-            <br />
-            <span className='aeonRequestText'>Appointment Required</span>
-          </span>
-        )) ||
-          null}
+        {(specRequestable && (
+          <AeonButton item={item} onClick={this.getItemRecord} />
+        )) || (
+          <>
+            <EddButton
+              display={eddRequestable}
+              link={`${appConfig.baseUrl}/hold/request/${bibId}-${item.id}/edd?searchKeywords=${searchKeywords}`}
+              onClick={this.getItemRecord}
+            />
+
+            <ReCAPButton
+              display={physRequestable}
+              item={item}
+              link={`${appConfig.baseUrl}/hold/request/${bibId}-${item.id}?searchKeywords=${searchKeywords}`}
+              onClick={this.getItemRecord}
+            />
+          </>
+        )}
       </div>
     );
 
@@ -201,9 +176,7 @@ class ItemTableRow extends React.Component {
             <span>{itemLocation}</span>
           </td>
           {BibPage ? (
-            <td data-th={`Availability & Access`}>
-              <span>{this.requestButton()}</span>
-            </td>
+            <td data-th={`Availability & Access`}>{this.requestButton()}</td>
           ) : null}
         </tr>
         {!BibPage ? (

--- a/src/app/components/Item/ItemTableRow.jsx
+++ b/src/app/components/Item/ItemTableRow.jsx
@@ -151,7 +151,7 @@ class ItemTableRow extends React.Component {
 
   render() {
     const { item, includeVolColumn, page } = this.props;
-    const SearchResultsPage = page === 'SearchResults';
+    const BibPage = page === 'BibPage';
 
     if (_isEmpty(item)) {
       return null;
@@ -200,13 +200,13 @@ class ItemTableRow extends React.Component {
           <td data-th='Location'>
             <span>{itemLocation}</span>
           </td>
-          {!SearchResultsPage ? (
+          {BibPage ? (
             <td data-th={`Availability & Access`}>
               <span>{this.requestButton()}</span>
             </td>
           ) : null}
         </tr>
-        {SearchResultsPage ? (
+        {!BibPage ? (
           <tr>
             <td colSpan='3' data-th={`Availability & Access`}>
               <span>{this.requestButton()}</span>

--- a/src/app/components/Item/ItemTableRow.jsx
+++ b/src/app/components/Item/ItemTableRow.jsx
@@ -42,10 +42,6 @@ class ItemTableRow extends React.Component {
   requestButton() {
     const { item, bibId, searchKeywords, page } = this.props;
 
-    const specRequestable = item.specRequestable;
-    const eddRequestable = item.eddRequestable;
-    const physRequestable = item.physRequestable;
-
     // Currently Not Used
     // TODO Determine if we need these.
     // const isAvailable = item.available;
@@ -66,18 +62,18 @@ class ItemTableRow extends React.Component {
           page === 'SearchResults' ? 'pan-left' : ''
         }`}
       >
-        {(specRequestable && (
+        {(item.specRequestable && (
           <AeonButton item={item} onClick={this.getItemRecord} />
         )) || (
           <>
             <EddButton
-              display={eddRequestable}
+              display={item.eddRequestable}
               link={`${appConfig.baseUrl}/hold/request/${bibId}-${item.id}/edd?searchKeywords=${searchKeywords}`}
               onClick={this.getItemRecord}
             />
 
             <ReCAPButton
-              display={physRequestable}
+              display={item.physRequestable}
               item={item}
               link={`${appConfig.baseUrl}/hold/request/${bibId}-${item.id}?searchKeywords=${searchKeywords}`}
               onClick={this.getItemRecord}

--- a/src/app/components/Item/ItemTableRow.jsx
+++ b/src/app/components/Item/ItemTableRow.jsx
@@ -188,11 +188,9 @@ class ItemTableRow extends React.Component {
               <span>{item.volume || ''}</span>
             </td>
           ) : null}
-          {SearchResultsPage ? (
-            <td data-th='Format'>
-              <span>{item.format || ' '}</span>
-            </td>
-          ) : null}
+          <td data-th='Format'>
+            <span>{item.format || ' '}</span>
+          </td>
           {/* <td data-th='Message'>
           <span>{this.message()}</span>
         </td> */}

--- a/src/app/components/Item/ItemTableRow.jsx
+++ b/src/app/components/Item/ItemTableRow.jsx
@@ -62,7 +62,7 @@ class ItemTableRow extends React.Component {
   }
 
   requestButton() {
-    const { item, bibId, searchKeywords } = this.props;
+    const { item, bibId, searchKeywords, page } = this.props;
 
     const isRequestable = (item.requestable = true);
     const isAvailable = item.available;
@@ -80,13 +80,16 @@ class ItemTableRow extends React.Component {
       .includes('');
 
     return (
-      <div id='request-btn-block'>
+      <div
+        className={`request-btn-block ${
+          page === 'SearchResults' ? 'pan-left' : ''
+        }`}
+      >
         <Link
           to={`${appConfig.baseUrl}/hold/request/${bibId}-${item.id}?searchKeywords=${searchKeywords}`}
           onClick={(event) => this.getItemRecord(event, bibId, item.id)}
           tabIndex='0'
           className='nypl-request-btn'
-          id='first'
         >
           Request Scan
         </Link>
@@ -97,8 +100,7 @@ class ItemTableRow extends React.Component {
               // to={this.aeonUrl(item)}
               onClick={(event) => this.getItemRecord(event, bibId, item.id)}
               tabIndex='-1'
-              className='nypl-request-btn'
-              id='second'
+              className='nypl-request-btn sibling'
             >
               Request for Onsite Use
             </Link>
@@ -208,7 +210,7 @@ class ItemTableRow extends React.Component {
         </tr>
         {SearchResultsPage ? (
           <tr>
-            <td data-th={`Availability & Access`}>
+            <td colSpan='3' data-th={`Availability & Access`}>
               <span>{this.requestButton()}</span>
             </td>
           </tr>

--- a/src/app/components/Item/ItemTableRow.jsx
+++ b/src/app/components/Item/ItemTableRow.jsx
@@ -149,6 +149,7 @@ class ItemTableRow extends React.Component {
 
   render() {
     const { item, includeVolColumn, page } = this.props;
+    const SearchResultsPage = page === 'SearchResults';
 
     if (_isEmpty(item)) {
       return null;
@@ -178,30 +179,41 @@ class ItemTableRow extends React.Component {
     }
 
     return (
-      <tr className={item.availability}>
-        {includeVolColumn ? (
-          <td className='vol-date-col' data-th='Vol/Date'>
-            <span>{item.volume || ''}</span>
-          </td>
-        ) : null}
-        {page !== 'SearchResults' ? (
-          <td data-th='Format'>
-            <span>{item.format || ' '}</span>
-          </td>
-        ) : null}
-        <td data-th='Message'>
+      <>
+        <tr className={item.availability}>
+          {includeVolColumn ? (
+            <td className='vol-date-col' data-th='Vol/Date'>
+              <span>{item.volume || ''}</span>
+            </td>
+          ) : null}
+          {SearchResultsPage ? (
+            <td data-th='Format'>
+              <span>{item.format || ' '}</span>
+            </td>
+          ) : null}
+          {/* <td data-th='Message'>
           <span>{this.message()}</span>
-        </td>
-        <td data-th='Status'>
-          <span>{this.requestButton()}</span>
-        </td>
-        <td data-th='Call Number'>
-          <span>{itemCallNumber}</span>
-        </td>
-        <td data-th='Location'>
-          <span>{itemLocation}</span>
-        </td>
-      </tr>
+        </td> */}
+          <td data-th='Call Number'>
+            <span>{itemCallNumber}</span>
+          </td>
+          <td data-th='Location'>
+            <span>{itemLocation}</span>
+          </td>
+          {!SearchResultsPage ? (
+            <td data-th={`Availability & Access`}>
+              <span>{this.requestButton()}</span>
+            </td>
+          ) : null}
+        </tr>
+        {SearchResultsPage ? (
+          <tr>
+            <td data-th={`Availability & Access`}>
+              <span>{this.requestButton()}</span>
+            </td>
+          </tr>
+        ) : null}
+      </>
     );
   }
 }

--- a/src/app/components/Item/ItemsContainer.jsx
+++ b/src/app/components/Item/ItemsContainer.jsx
@@ -93,6 +93,7 @@ class ItemsContainer extends React.Component {
         id='bib-item-table'
         searchKeywords={this.props.searchKeywords}
         holdings={this.props.holdings}
+        page='BibPage'
       />
     ) : null;
   }

--- a/src/app/components/ResultsList/ResultsList.jsx
+++ b/src/app/components/ResultsList/ResultsList.jsx
@@ -129,15 +129,31 @@ const ResultsList = (
             )}
           </ul>
         </div>
-        {hasRequestTable && (
-          <ItemTable
-            items={items.slice(0, itemTableLimit)}
-            bibId={bibId}
-            id={null}
-            searchKeywords={searchKeywords}
-            page='SearchResults'
-          />
-        )}
+        {hasRequestTable
+          ? (totalItems < 2 && (
+              <ItemTable
+                items={items.slice(0, itemTableLimit)}
+                bibId={bibId}
+                id={null}
+                searchKeywords={searchKeywords}
+                page='SearchResults'
+              />
+            )) || (
+              <Link
+                onClick={() => {
+                  updateResultSelection({
+                    fromUrl: `${pathname}${search}`,
+                    bibId,
+                  });
+                  trackDiscovery('Bib', bibTitle);
+                }}
+                to={bibUrl}
+                className='title'
+              >
+                {`View and Request Item`}
+              </Link>
+            )
+          : null}
       </li>
     );
   };

--- a/src/app/components/ResultsList/ResultsList.jsx
+++ b/src/app/components/ResultsList/ResultsList.jsx
@@ -97,7 +97,7 @@ const ResultsList = (
 
     return (
       <li
-        key={idx}
+        key={bibId}
         className={`nypl-results-item ${hasRequestTable ? 'has-request' : ''}`}
       >
         <h3>

--- a/src/app/utils/item.js
+++ b/src/app/utils/item.js
@@ -258,6 +258,7 @@ function LibraryItem() {
     }
 
     return {
+      ...item,
       id,
       status,
       availability,

--- a/src/client/styles/components/ItemTable.scss
+++ b/src/client/styles/components/ItemTable.scss
@@ -40,7 +40,6 @@ dl dd.multi-item-list .nypl-basic-table a,
     &.sibling {
       background-color: #fff;
       color: $results-list-item-button;
-      // margin-left: 10px;
 
       &:hover {
         background-color: $results-list-item-button;
@@ -154,7 +153,7 @@ dl dd.multi-item-list .nypl-basic-table a,
   }
 }
 
-@media (max-width: 463px) {
+@media (max-width: 445px) {
   .nypl-results-item .nypl-basic-table .request-btn-block {
     flex-wrap: wrap;
 
@@ -166,7 +165,7 @@ dl dd.multi-item-list .nypl-basic-table a,
       margin-left: 0;
     }
 
-    @media (max-width: 452px) {
+    @media (max-width: 435px) {
       & > span {
         margin-top: 10px;
       }

--- a/src/client/styles/components/ItemTable.scss
+++ b/src/client/styles/components/ItemTable.scss
@@ -1,6 +1,5 @@
 .nypl-results-item .nypl-basic-table .request-btn-block {
   display: flex;
-  justify-content: center;
 
   & > span {
     margin-left: 10px;

--- a/src/client/styles/components/ItemTable.scss
+++ b/src/client/styles/components/ItemTable.scss
@@ -22,7 +22,7 @@ dl dd.multi-item-list .nypl-basic-table a,
   font-weight: normal;
   letter-spacing: 0.06rem;
   text-decoration: none;
-  padding: 6px 28px;
+  padding: 8px 28px;
   white-space: nowrap;
   -webkit-transition: all, 0.1s, ease-in;
   -moz-transition: all, 0.1s, ease-in;
@@ -37,12 +37,12 @@ dl dd.multi-item-list .nypl-basic-table a,
     height: 33px;
 
     &.sibling {
-      background-color: #fff;
-      color: $results-list-item-button;
+      background-color: $button-background-color;
+      border: 0.08333rem solid #bdbdbd;
+      color: black;
 
       &:hover {
-        background-color: $results-list-item-button;
-        color: #fff;
+        background-color: #f5f5f5;
       }
     }
   }

--- a/src/client/styles/components/ItemTable.scss
+++ b/src/client/styles/components/ItemTable.scss
@@ -177,12 +177,12 @@ dl dd.multi-item-list .nypl-basic-table a,
       justify-content: space-between;
     }
 
-    & > span {
+    & > div:not(:first-child) {
       margin-left: 0;
     }
 
     @media (max-width: 435px) {
-      & > span {
+      & > div {
         margin-top: 10px;
       }
     }

--- a/src/client/styles/components/ItemTable.scss
+++ b/src/client/styles/components/ItemTable.scss
@@ -1,8 +1,41 @@
 .nypl-results-item .nypl-basic-table .request-btn-block {
   display: flex;
 
-  & > span {
+  & div:not(:first-child) {
     margin-left: 10px;
+  }
+
+  & .nypl-request-btn {
+    & a {
+      text-align: center;
+      width: 200px;
+      height: 33px;
+    }
+
+    & .nypl-request-btn-label {
+      font-size: 10px;
+
+      & a {
+        background-color: #fff;
+        border: 0;
+        border-radius: 0;
+        color: $results-list-item-button;
+        display: inline;
+        font-size: 10px;
+        padding: 0;
+        text-decoration: underline;
+      }
+    }
+
+    & .secondary {
+      background-color: $button-background-color;
+      border: 0.08333rem solid #bdbdbd;
+      color: black;
+
+      &:hover {
+        background-color: #f5f5f5;
+      }
+    }
   }
 
   &.pan-left {
@@ -30,22 +63,6 @@ dl dd.multi-item-list .nypl-basic-table a,
   -o-transition: all, 0.1s, ease-in;
   transition: all, 0.1s, ease-in;
   margin-top: 0;
-
-  &.nypl-request-btn {
-    text-align: center;
-    width: 200px;
-    height: 33px;
-
-    &.sibling {
-      background-color: $button-background-color;
-      border: 0.08333rem solid #bdbdbd;
-      color: black;
-
-      &:hover {
-        background-color: #f5f5f5;
-      }
-    }
-  }
 
   &:hover {
     background-color: #fff;

--- a/src/client/styles/components/ItemTable.scss
+++ b/src/client/styles/components/ItemTable.scss
@@ -1,10 +1,13 @@
-.nypl-results-item .nypl-basic-table #request-btn-block {
+.nypl-results-item .nypl-basic-table .request-btn-block {
   display: flex;
   justify-content: center;
-  align-content: space-between;
 
   & > span {
     margin-left: 10px;
+  }
+
+  &.pan-left {
+    justify-content: flex-start;
   }
 }
 
@@ -20,7 +23,7 @@ dl dd.multi-item-list .nypl-basic-table a,
   font-weight: normal;
   letter-spacing: 0.06rem;
   text-decoration: none;
-  padding: 8px 28px;
+  padding: 6px 28px;
   white-space: nowrap;
   -webkit-transition: all, 0.1s, ease-in;
   -moz-transition: all, 0.1s, ease-in;
@@ -34,7 +37,7 @@ dl dd.multi-item-list .nypl-basic-table a,
     width: 200px;
     height: 33px;
 
-    &#second {
+    &.sibling {
       background-color: #fff;
       color: $results-list-item-button;
       // margin-left: 10px;
@@ -147,6 +150,26 @@ dl dd.multi-item-list .nypl-basic-table a,
       max-width: 30%;
       min-width: 27%;
       vertical-align: top;
+    }
+  }
+}
+
+@media (max-width: 463px) {
+  .nypl-results-item .nypl-basic-table .request-btn-block {
+    flex-wrap: wrap;
+
+    &.pan-left {
+      justify-content: space-between;
+    }
+
+    & > span {
+      margin-left: 0;
+    }
+
+    @media (max-width: 452px) {
+      & > span {
+        margin-top: 10px;
+      }
     }
   }
 }


### PR DESCRIPTION
Added support for the updated Request Buttons. 

We now have three buttons opposed to one which a patron can select and be directed to the appropriate page. The three buttons are:

1. EDDButton
2. AeonButton
3. ReCAPButton

These buttons are a WIP in that some logic can be curated for DRY patterns and the logic for when a button is displayed is still being determined. However, for styling purposes and they're ready to do.

Some work to still be performed:
1. Button display logic is still being fine-tuned. Talk to @seanredmond.
2. EDD request page still needs to be cleared up.
3. The Button label links are still missing a defined `href` path.
4. Additional label text and options need to be cleared up.