### PR TITLE
SCC-2953 Update discovery-front-end to at least Node 14

### DIFF
--- a/.ebextensions/00_change_npm_permissions.config
+++ b/.ebextensions/00_change_npm_permissions.config
@@ -1,8 +1,0 @@
-files:
-  "/opt/elasticbeanstalk/hooks/appdeploy/post/00_set_tmp_permissions.sh":
-    mode: "000755"
-    owner: root
-    group: root
-    content: |
-      #!/usr/bin/env bash
-      chown -R nodejs:nodejs /tmp/.npm

--- a/.ebextensions/02_cloudwatch_agent_config.config
+++ b/.ebextensions/02_cloudwatch_agent_config.config
@@ -1,6 +1,10 @@
+packages:
+  yum:
+    awslogs: []
+
 files:
-  '/etc/awslogs/config/application_log.conf' :
-    mode: "000444"
+  "/etc/awslogs/config/application_log.conf" :
+    mode: "000600"
     owner: root
     group: root
     content: |
@@ -10,5 +14,7 @@ files:
       log_stream_name = {instance_id}
 
 commands:
-  restart_awslogs:
-    command: service awslogs restart
+  "01":
+    command: systemctl enable awslogsd.service
+  "02":
+    command: systemctl restart awslogsd

--- a/.ebextensions/03_enable_log_streaming.config
+++ b/.ebextensions/03_enable_log_streaming.config
@@ -2,4 +2,4 @@ option_settings:
   aws:elasticbeanstalk:cloudwatch:logs:
     StreamLogs: true
     DeleteOnTerminate: false
-    RetentionInDays: 180
+    RetentionInDays: 14

--- a/.ebextensions/node-settings.config
+++ b/.ebextensions/node-settings.config
@@ -1,5 +1,0 @@
-option_settings:
-  aws:elasticbeanstalk:container:nodejs:
-    NodeCommand: "npm run eb-start"
-  aws:elasticbeanstalk:container:nodejs:staticfiles:
-    /dist: dist

--- a/.platform/hooks/postdeploy/00_set_tmp_permissions.sh
+++ b/.platform/hooks/postdeploy/00_set_tmp_permissions.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+chown -R nodejs:nodejs /tmp/.npm

--- a/.platform/hooks/prebuild/09_falcon_sensor.sh
+++ b/.platform/hooks/prebuild/09_falcon_sensor.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+. /opt/elasticbeanstalk/support/envvars
+cd /home/ec2-user
+
+yum -q list installed falcon-sensor &> /dev/null && isInstalled="yes" || isInstalled="no"
+
+if [ $isInstalled == "no" ]; then
+    wget https://s3.amazonaws.com/nypl-rpms/falcon-sensor-6.33.0-13003.el7.x86_64.rpm
+    sudo yum -y install /home/ec2-user/falcon-sensor-6.33.0-13003.el7.x86_64.rpm
+    sudo /opt/CrowdStrike/falconctl -s --cid=2F323D2F1EF049D0BCE9A15DDC55D946-19
+fi
+
+sudo systemctl enable falcon-sensor
+sudo systemctl start falcon-sensor

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "1.7.1",
   "description": "Isomorphic React App for NYPL Research Catalog.",
   "main": "index.js",
+  "engines" : {
+    "npm" : ">=6.0.0",
+    "node" : ">=14.0.0"
+  },
   "scripts": {
     "start": "node index",
     "prod-start": "cross-env NODE_ENV=production PLATFORM_API_BASE_URL=https://platform.nypl.org/api/v0.1 node index",


### PR DESCRIPTION
- Adding Falcon Sensor Crowdstrike
- Elastic Beanstalk upgrades to use Amazon Linux 2
  - Adding Node and NPM version in package.json
  - Using Procfile to start npm
  - New configuration files for new Elastic Beanstalk
  - Removing node-settings since it is no longer in use

**What's this do?**
This PR is to include AWS Elastic Beanstalk into SCC-2953 branch.

**Why are we doing this? (w/ JIRA link if applicable)**
[SEB-2201](https://jira.nypl.org/browse/SEB-2201): Elastic Beanstalk upgrade for Discovery UI

**Do these changes have automated tests?**
Automated tests on base branch

**How should this be QAed?**
Deployment should integrate correct application from code repository.

**Dependencies for merging? Releasing to production?**
[Description of any watchouts, dependencies, or issues we should be aware of]

**Has the application documentation been updated for these changes?**

**Did someone actually run this code to verify it works?**
