### PR TITLE
Scc 3053

### DIFF
--- a/src/app/components/BibPage/BottomBibDetails.jsx
+++ b/src/app/components/BibPage/BottomBibDetails.jsx
@@ -7,46 +7,37 @@ import BibDetails from './BibDetails';
 // `linkable` means that those values are links inside the app.
 // `selfLinkable` means that those values are external links and should be self-linked,
 // e.g. the prefLabel is the label and the URL is the id.
-const detailsFields = [
-  {
-    label: 'Additional Authors',
-    value: 'contributorLiteral',
-    linkable: true,
-  },
-  { label: 'Found In', value: 'partOf' },
-  { label: 'Publication Date', value: 'serialPublicationDates' },
-  { label: 'Description', value: 'extent' },
-  { label: 'Donor/Sponsor', value: 'donor' },
-  { label: 'Series Statement', value: 'seriesStatement' },
-  { label: 'Uniform Title', value: 'uniformTitle' },
-  { label: 'Alternative Title', value: 'titleAlt' },
-  { label: 'Former Title', value: 'formerTitle' },
-  { label: 'Subject', value: 'subjectHeadingData' },
-  { label: 'Genre/Form', value: 'genreForm' },
-  { label: 'Notes', value: 'React Component' },
-  { label: 'Contents', value: 'tableOfContents' },
-  { label: 'Bibliography', value: '' },
-  { label: 'Call Number', value: 'identifier', identifier: 'bf:ShelfMark' },
-  { label: 'ISBN', value: 'identifier', identifier: 'bf:Isbn' },
-  { label: 'ISSN', value: 'identifier', identifier: 'bf:Issn' },
-  { label: 'LCCN', value: 'identifier', identifier: 'bf:Lccn' },
-  { label: 'OCLC', value: 'identifier', identifier: 'nypl:Oclc' },
-  { label: 'GPO', value: '' },
-  { label: 'Other Titles', value: '' },
-  { label: 'Owning Institutions', value: '' },
-];
 
 const BottomBibDetails = ({ bib, resources }) => {
-  // if the subject heading API call failed for some reason,
-  // we will use the subjectLiteral property from the
-  // Discovery API response instead
-  if (!bib.subjectHeadingData) {
-    detailsFields.push({
-      label: 'Subject',
-      value: 'subjectLiteral',
+  const detailsFields = [
+    {
+      label: 'Additional Authors',
+      value: 'contributorLiteral',
       linkable: true,
-    });
-  }
+    },
+    { label: 'Found In', value: 'partOf' },
+    { label: 'Publication Date', value: 'serialPublicationDates' },
+    { label: 'Description', value: 'extent' },
+    { label: 'Donor/Sponsor', value: 'donor' },
+    { label: 'Series Statement', value: 'seriesStatement' },
+    { label: 'Uniform Title', value: 'uniformTitle' },
+    { label: 'Alternative Title', value: 'titleAlt' },
+    { label: 'Former Title', value: 'formerTitle' },
+    // if the subject heading API call failed for some reason,
+    bib.subjectHeadingData ? { label: 'Subject', value: 'subjectHeadingData' } : { label: 'Subject', value: 'subjectLiteral', linkabe: true },
+    { label: 'Genre/Form', value: 'genreForm' },
+    { label: 'Notes', value: 'React Component' },
+    { label: 'Contents', value: 'tableOfContents' },
+    { label: 'Bibliography', value: '' },
+    { label: 'Call Number', value: 'identifier', identifier: 'bf:ShelfMark' },
+    { label: 'ISBN', value: 'identifier', identifier: 'bf:Isbn' },
+    { label: 'ISSN', value: 'identifier', identifier: 'bf:Issn' },
+    { label: 'LCCN', value: 'identifier', identifier: 'bf:Lccn' },
+    { label: 'OCLC', value: 'identifier', identifier: 'nypl:Oclc' },
+    { label: 'GPO', value: '' },
+    { label: 'Other Titles', value: '' },
+    { label: 'Owning Institutions', value: '' },
+  ];
 
   return (
     <section style={{ marginTop: '20px' }}>

--- a/test/unit/BottomBibDetails.test.js
+++ b/test/unit/BottomBibDetails.test.js
@@ -1,0 +1,40 @@
+/* eslint-env mocha */
+/* eslint-disable react/jsx-filename-extension */
+import React from 'react';
+import { expect } from 'chai';
+import { shallow, mount } from 'enzyme';
+
+import BottomBibDetails from '../../src/app/components/BibPage/BottomBibDetails';
+import BibDetails from '../../src/app/components/BibPage/BibDetails';
+
+describe('BottomBibDetails', () => {
+
+  it('should pass the correct list of fields to the BibDetails component', () => {
+    let bibWithoutHeadings = {
+      uri: 'b12345'
+    }
+    let bibWithHeadings = {
+      uri: 'b12345',
+      subjectHeadingData: []
+    }
+    let component1 = shallow(
+      <BottomBibDetails
+        bib = {bibWithoutHeadings}
+        resources = {[]}
+      />);
+    let component2 = shallow(
+      <BottomBibDetails
+        bib = {bibWithHeadings}
+        resources = {[]}
+      />);
+    let bibDetails1 = component1.find(BibDetails)
+    let bibDetails2 = component2.find(BibDetails)
+    let subjects1 = bibDetails1.props().fields.filter(field => field.label === 'Subject')
+    let subjects2 = bibDetails2.props().fields.filter(field => field.label === 'Subject')
+    expect(subjects1.length).to.equal(1)
+    expect(subjects1[0].value).to.equal('subjectLiteral')
+    expect(subjects2.length).to.equal(1)
+    expect(subjects2[0].value).to.equal('subjectHeadingData')
+
+  })
+})


### PR DESCRIPTION
**What's this do?**
- Rewrites the way we calculate `fields` in `BottomBibDetails` to avoid use of mutation
- Adds tests

**Why are we doing this? (w/ JIRA link if applicable)**
This is for SCC-3053. We found that the subject fields were being duplicated on some of the bib pages, as well as some subject headings from past pages being included in later pages.

It looks to me that this is happening because the `BottomBibDetails` component was pushing subject-related details into a `fields` constant which was at a higher scope than the render method. This meant that data was being leaked across multiple renders.

The current fix moves the `fields` variable inside the render method so it isn't shared across renders, and also rewrites it to use a ternary instead of `push` so as to avoid mutation.

**Do these changes have automated tests?**
Yes

**How should this be QAed?**
[Description of any tests that need to be performed once merged]

**Dependencies for merging? Releasing to production?**
[Description of any watchouts, dependencies, or issues we should be aware of]

**Has the application documentation been updated for these changes?**

**Did someone actually run this code to verify it works?**
Yes