### PR TITLE
Manage Route Redirects When Request Buttons Are Clicked

### DIFF
--- a/src/app/components/Buttons/ItemTableButtons/AeonButton.jsx
+++ b/src/app/components/Buttons/ItemTableButtons/AeonButton.jsx
@@ -59,8 +59,8 @@ const AeonButton = ({ item, onClick }) => {
 };
 
 AeonButton.propTypes = {
-  item: PropTypes.object,
-  onClick: PropTypes.func,
+  item: PropTypes.object.isRequired,
+  onClick: PropTypes.func.isRequired,
 };
 
 export default AeonButton;

--- a/src/app/components/Buttons/ItemTableButtons/AeonButton.jsx
+++ b/src/app/components/Buttons/ItemTableButtons/AeonButton.jsx
@@ -1,8 +1,8 @@
-import { Link } from '@nypl/design-system-react-components';
 import PropTypes from 'prop-types';
 import React, { useState } from 'react';
 import appConfig from '../../../data/appConfig';
 import { isAeonLink } from '../../../utils/utils';
+import RequestButton, { RequestButtonLabel } from './RequestButton';
 
 const AeonButton = ({ item, onClick }) => {
   const [aeonUrl] = useState(() => {
@@ -35,25 +35,32 @@ const AeonButton = ({ item, onClick }) => {
     return encodeURI(`${aeonUrl}${params || ''}`);
   });
 
+  const handleClick = (event) => {
+    event.preventDefault();
+    onClick(aeonUrl);
+  };
+
   return (
-    <div className='nypl-request-btn'>
-      <Link href={aeonUrl} onClick={onClick} tabIndex='0'>
-        {`Make Appointment`}
-      </Link>
-      <br />
-      <span className='nypl-request-btn-label'>
-        {`Appointment Required. `}
-        <a>
-          <i>{`Details`}</i>
-        </a>
-      </span>
-    </div>
+    <RequestButton
+      url={aeonUrl}
+      text={`Make Appointment`}
+      onClick={handleClick}
+    >
+      <RequestButtonLabel>
+        <span>
+          {`Appointment Required. `}
+          <a>
+            <i>{`Details`}</i>
+          </a>
+        </span>
+      </RequestButtonLabel>
+    </RequestButton>
   );
 };
 
 AeonButton.propTypes = {
   item: PropTypes.object,
-  onClick: PropTypes.function,
+  onClick: PropTypes.func,
 };
 
 export default AeonButton;

--- a/src/app/components/Buttons/ItemTableButtons/EddButton.jsx
+++ b/src/app/components/Buttons/ItemTableButtons/EddButton.jsx
@@ -19,9 +19,9 @@ const EddButton = ({ item, bibId, onClick }) => {
 };
 
 EddButton.propTypes = {
-  item: PropTypes.object,
-  bibId: PropTypes.string,
-  onClick: PropTypes.func,
+  item: PropTypes.object.isRequired,
+  bibId: PropTypes.string.isRequired,
+  onClick: PropTypes.func.isRequired,
 };
 
 export default EddButton;

--- a/src/app/components/Buttons/ItemTableButtons/EddButton.jsx
+++ b/src/app/components/Buttons/ItemTableButtons/EddButton.jsx
@@ -1,23 +1,27 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Link } from 'react-router';
+import appConfig from '../../../data/appConfig';
+import RequestButton from './RequestButton';
 
-const EddButton = ({ item, link, onClick }) => {
+const EddButton = ({ item, bibId, onClick }) => {
   if (!item.eddRequestable) return null;
 
+  const path = `${appConfig.baseUrl}/hold/request/${bibId}-${item.id}/edd`;
+
+  const handleClick = (event) => {
+    event.preventDefault();
+    onClick(path);
+  };
+
   return (
-    <div className='nypl-request-btn'>
-      <Link to={link} onClick={onClick} tabIndex='0'>
-        {`Request Scan`}
-      </Link>
-    </div>
+    <RequestButton url={path} text={`Request Scan`} onClick={handleClick} />
   );
 };
 
 EddButton.propTypes = {
   item: PropTypes.object,
-  link: PropTypes.string,
-  onClick: PropTypes.function,
+  bibId: PropTypes.string,
+  onClick: PropTypes.func,
 };
 
 export default EddButton;

--- a/src/app/components/Buttons/ItemTableButtons/ReCAPButton.jsx
+++ b/src/app/components/Buttons/ItemTableButtons/ReCAPButton.jsx
@@ -1,31 +1,42 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Link } from 'react-router';
+import appConfig from '../../../data/appConfig';
+import RequestButton, { RequestButtonLabel } from './RequestButton';
 
-const ReCAPButton = ({ item, link, onClick }) => {
-  if (!item.physRequestable || !item.isAvailable)
+const ReCAPButton = ({ item, bibId, onClick }) => {
+  if (!item.physRequestable || !item.available)
     return <div>{item.status.prefLabel ?? 'Not Available'}</div>;
 
+  const path = `${appConfig.baseUrl}/hold/request/${bibId}-${item.id}`;
+
+  const handleClick = (event) => {
+    event.preventDefault();
+    onClick(path);
+  };
+
   return (
-    <div className='nypl-request-btn'>
-      <Link to={link} onClick={onClick} tabIndex='0' className='secondary'>
-        {`Request for Onsite Use`}
-      </Link>
-      <br />
-      <span className='nypl-request-btn-label'>
-        {`Timeline `}
-        <a>
-          <i>{`Details`}</i>
-        </a>
-      </span>
-    </div>
+    <RequestButton
+      url={path}
+      text={`Request for Onsite Use`}
+      onClick={handleClick}
+      secondary
+    >
+      <RequestButtonLabel>
+        <span>
+          {`Timeline `}
+          <a>
+            <i>{`Details`}</i>
+          </a>
+        </span>
+      </RequestButtonLabel>
+    </RequestButton>
   );
 };
 
 ReCAPButton.propTypes = {
   item: PropTypes.object,
-  link: PropTypes.string,
-  onClick: PropTypes.function,
+  bibId: PropTypes.string,
+  onClick: PropTypes.func,
 };
 
 export default ReCAPButton;

--- a/src/app/components/Buttons/ItemTableButtons/ReCAPButton.jsx
+++ b/src/app/components/Buttons/ItemTableButtons/ReCAPButton.jsx
@@ -34,9 +34,9 @@ const ReCAPButton = ({ item, bibId, onClick }) => {
 };
 
 ReCAPButton.propTypes = {
-  item: PropTypes.object,
-  bibId: PropTypes.string,
-  onClick: PropTypes.func,
+  item: PropTypes.object.isRequired,
+  bibId: PropTypes.string.isRequired,
+  onClick: PropTypes.func.isRequired,
 };
 
 export default ReCAPButton;

--- a/src/app/components/Buttons/ItemTableButtons/RequestButton.jsx
+++ b/src/app/components/Buttons/ItemTableButtons/RequestButton.jsx
@@ -19,9 +19,9 @@ const RequestButton = ({ text, secondary, url, onClick, children }) => {
 };
 
 RequestButton.propTypes = {
-  text: PropTypes.string,
-  url: PropTypes.string,
-  onClick: PropTypes.func,
+  text: PropTypes.string.isRequired,
+  url: PropTypes.string.isRequired,
+  onClick: PropTypes.func.isRequired,
   secondary: PropTypes.bool,
   children: PropTypes.node,
 };

--- a/src/app/components/Buttons/ItemTableButtons/RequestButton.jsx
+++ b/src/app/components/Buttons/ItemTableButtons/RequestButton.jsx
@@ -1,0 +1,42 @@
+import { Link } from '@nypl/design-system-react-components';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+const RequestButton = ({ text, secondary, url, onClick, children }) => {
+  return (
+    <div className='nypl-request-btn'>
+      <Link
+        href={url}
+        onClick={onClick}
+        className={(secondary && 'secondary') || null}
+        tabIndex='0'
+      >
+        {text}
+      </Link>
+      {children}
+    </div>
+  );
+};
+
+RequestButton.propTypes = {
+  text: PropTypes.string,
+  url: PropTypes.string,
+  onClick: PropTypes.func,
+  secondary: PropTypes.bool,
+  children: PropTypes.node,
+};
+
+export default RequestButton;
+
+export const RequestButtonLabel = ({ children }) => {
+  return (
+    <>
+      <br />
+      <span className='nypl-request-btn-label'>{children}</span>
+    </>
+  );
+};
+
+RequestButtonLabel.propTypes = {
+  children: PropTypes.node,
+};

--- a/src/app/components/Buttons/ItemTableButtons/RequestButton.jsx
+++ b/src/app/components/Buttons/ItemTableButtons/RequestButton.jsx
@@ -1,6 +1,6 @@
-import { Link } from '@nypl/design-system-react-components';
 import PropTypes from 'prop-types';
 import React from 'react';
+import { Link } from 'react-router';
 
 const RequestButton = ({ text, secondary, url, onClick, children }) => {
   return (

--- a/src/app/components/Item/ItemTableRow.jsx
+++ b/src/app/components/Item/ItemTableRow.jsx
@@ -158,10 +158,10 @@ class ItemTableRow extends React.Component {
 }
 
 ItemTableRow.propTypes = {
-  item: PropTypes.object,
-  bibId: PropTypes.string,
-  searchKeywords: PropTypes.string,
+  item: PropTypes.object.isRequired,
+  bibId: PropTypes.string.isRequired,
   page: PropTypes.string,
+  searchKeywords: PropTypes.string,
   includeVolColumn: PropTypes.bool,
 };
 

--- a/src/app/components/Item/ItemTableRow.jsx
+++ b/src/app/components/Item/ItemTableRow.jsx
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { isEmpty as _isEmpty } from 'underscore';
-import appConfig from '../../data/appConfig';
 import { trackDiscovery } from '../../utils/utils';
 import {
   AeonButton,
@@ -44,7 +43,7 @@ class ItemTableRow extends React.Component {
   }
 
   requestButton() {
-    const { item, bibId, searchKeywords, page } = this.props;
+    const { item, bibId, page } = this.props;
 
     // Currently Not Used
     // TODO Determine if we need these.
@@ -81,15 +80,10 @@ class ItemTableRow extends React.Component {
           </>
         )) || (
           <>
-            <EddButton
-              item={item}
-              link={`${appConfig.baseUrl}/hold/request/${bibId}-${item.id}/edd?searchKeywords=${searchKeywords}`}
-              onClick={this.getItemRecord}
-            />
-
+            <EddButton item={item} bibId={bibId} onClick={this.getItemRecord} />
             <ReCAPButton
               item={item}
-              link={`${appConfig.baseUrl}/hold/request/${bibId}-${item.id}?searchKeywords=${searchKeywords}`}
+              bibId={bibId}
               onClick={this.getItemRecord}
             />
           </>
@@ -168,7 +162,7 @@ ItemTableRow.propTypes = {
   bibId: PropTypes.string,
   searchKeywords: PropTypes.string,
   page: PropTypes.string,
-  includeVolColumn: PropTypes.boolean,
+  includeVolColumn: PropTypes.bool,
 };
 
 ItemTableRow.contextTypes = {

--- a/src/app/components/Item/ItemTableRow.jsx
+++ b/src/app/components/Item/ItemTableRow.jsx
@@ -13,12 +13,10 @@ class ItemTableRow extends React.Component {
   constructor(props) {
     super(props);
     this.getItemRecord = this.getItemRecord.bind(this);
+    this.track = this.track.bind(this);
   }
 
-  getItemRecord(event) {
-    event.preventDefault();
-    const { bibId, item } = this.props;
-
+  track() {
     const { routes } = this.context.router;
 
     const page = routes[routes.length - 1].component.name;
@@ -28,8 +26,14 @@ class ItemTableRow extends React.Component {
     if (page === 'SubjectHeadingShowPage') gaLabel = 'Subject Heading Details';
 
     trackDiscovery('Item Request', gaLabel);
+  }
+
+  getItemRecord(path) {
+    const { searchKeywords } = this.props;
+
+    this.track();
     this.context.router.push(
-      `${appConfig.baseUrl}/hold/request/${bibId}-${item.id}`,
+      (path + searchKeywords && `?searchKeywords=${searchKeywords}`) || '',
     );
   }
 

--- a/src/app/components/Item/ItemTableRow.jsx
+++ b/src/app/components/Item/ItemTableRow.jsx
@@ -74,7 +74,7 @@ class ItemTableRow extends React.Component {
             have the edd option */}
             {/* <EddButton
               item={item}
-              link={`${appConfig.baseUrl}/hold/request/${bibId}-${item.id}/edd?searchKeywords=${searchKeywords}`}
+              bibId={bibId}
               onClick={this.getItemRecord}
             /> */}
           </>


### PR DESCRIPTION
Allow the Buttons to define the route for which to be redirected instead of the Item Table Row. This allows us to remove the logic from the GetItemRecord handler by using the passed in path to direct to.