### PR TITLE
Scc 3052

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ npx prettier --write path/to/file
 This app has an unusual Git Workflow / deployment scheme:
 
 - Cut feature branches off of the `development` branch
+- After an approved PR to `development`,
 - Tag your feature branch\* `qa-deployment-{YYYY}-{MM}-{DD}` to deploy to QA
 - Merge your feature branch into `production` to deploy to production
 

--- a/src/app/pages/ElectronicDelivery.jsx
+++ b/src/app/pages/ElectronicDelivery.jsx
@@ -19,7 +19,7 @@ import LibraryItem from '../utils/item';
 import { institutionNameByNyplSource, trackDiscovery } from '../utils/utils';
 
 class ElectronicDelivery extends React.Component {
-  constructor (props) {
+  constructor(props) {
     super(props);
 
     const bib =
@@ -55,7 +55,6 @@ class ElectronicDelivery extends React.Component {
     this.submitRequest = this.submitRequest.bind(this);
     this.raiseError = this.raiseError.bind(this);
     this.fromUrl = this.fromUrl.bind(this);
-    // this.props.isEddRequestable = true
   }
 
   componentDidMount() {
@@ -207,8 +206,8 @@ class ElectronicDelivery extends React.Component {
     const { error, form } = this.props;
     const patronEmail =
       this.props.patron.emails &&
-        _isArray(this.props.patron.emails) &&
-        this.props.patron.emails.length
+      _isArray(this.props.patron.emails) &&
+      this.props.patron.emails.length
         ? this.props.patron.emails[0]
         : '';
     const searchKeywords = this.props.searchKeywords;
@@ -238,11 +237,13 @@ class ElectronicDelivery extends React.Component {
             </div>
           )}
         </div>
-        {!this.props.isEddRequestable ? <h2 className='nypl-request-form-title'>
-          Electronic delivery options for this item are currently unavailable. Please try
-          again later or contact 917-ASK-NYPL (
-          <a href='tel:917-275-6975'>917-275-6975</a>).
-        </h2> :
+        {!this.props.isEddRequestable ? (
+          <h2 className='nypl-request-form-title'>
+            Electronic delivery options for this item are currently unavailable.
+            Please try again later or contact 917-ASK-NYPL (
+            <a href='tel:917-275-6975'>917-275-6975</a>).
+          </h2>
+        ) : (
           <div>
             {!_isEmpty(raiseError) && (
               <div className='nypl-form-error' ref='nypl-form-error'>
@@ -271,7 +272,7 @@ class ElectronicDelivery extends React.Component {
               />
             ) : null}
           </div>
-        }
+        )}
       </SccContainer>
     );
   }
@@ -291,6 +292,7 @@ ElectronicDelivery.propTypes = {
   patron: PropTypes.object,
   updateLoadingStatus: PropTypes.func,
   features: PropTypes.array,
+  isEddRequestable: PropTypes.bool,
 };
 
 ElectronicDelivery.defaultProps = {
@@ -302,7 +304,7 @@ const mapStateToProps = (state) => ({
   bib: state.bib,
   searchKeywords: state.searchKeywords,
   features: state.features,
-  isEddRequestable: state.isEddRequestable
+  isEddRequestable: state.isEddRequestable,
 });
 
 const mapDispatchToProps = (dispatch) => ({

--- a/src/app/pages/ElectronicDelivery.jsx
+++ b/src/app/pages/ElectronicDelivery.jsx
@@ -19,7 +19,7 @@ import LibraryItem from '../utils/item';
 import { institutionNameByNyplSource, trackDiscovery } from '../utils/utils';
 
 class ElectronicDelivery extends React.Component {
-  constructor(props) {
+  constructor (props) {
     super(props);
 
     const bib =
@@ -206,8 +206,8 @@ class ElectronicDelivery extends React.Component {
     const { error, form } = this.props;
     const patronEmail =
       this.props.patron.emails &&
-      _isArray(this.props.patron.emails) &&
-      this.props.patron.emails.length
+        _isArray(this.props.patron.emails) &&
+        this.props.patron.emails.length
         ? this.props.patron.emails[0]
         : '';
     const searchKeywords = this.props.searchKeywords;
@@ -237,35 +237,40 @@ class ElectronicDelivery extends React.Component {
             </div>
           )}
         </div>
-
-        <div>
-          {!_isEmpty(raiseError) && (
-            <div className='nypl-form-error' ref='nypl-form-error'>
-              <h2>Error</h2>
-              <p>
-                Please check the following required fields and resubmit your
-                request:
-              </p>
-              <ul>{this.getRaisedErrors(raiseError)}</ul>
-            </div>
-          )}
-          {!closedLocations.includes('') ? (
-            <ElectronicDeliveryForm
-              bibId={bibId}
-              itemId={itemId}
-              itemSource={this.state.itemSource}
-              submitRequest={this.submitRequest}
-              raiseError={this.raiseError}
-              error={error}
-              form={form}
-              defaultEmail={patronEmail}
-              searchKeywords={searchKeywords}
-              serverRedirect={serverRedirect}
-              fromUrl={this.fromUrl()}
-              onSiteEddEnabled={this.props.features.includes('on-site-edd')}
-            />
-          ) : null}
-        </div>
+        {!this.props.eddRequestable ? <h2 className='nypl-request-form-title'>
+          Electronic delivery options for this item are currently unavailable. Please try
+          again later or contact 917-ASK-NYPL (
+          <a href='tel:917-275-6975'>917-275-6975</a>).
+        </h2> :
+          <div>
+            {!_isEmpty(raiseError) && (
+              <div className='nypl-form-error' ref='nypl-form-error'>
+                <h2>Error</h2>
+                <p>
+                  Please check the following required fields and resubmit your
+                  request:
+                </p>
+                <ul>{this.getRaisedErrors(raiseError)}</ul>
+              </div>
+            )}
+            {!closedLocations.includes('') ? (
+              <ElectronicDeliveryForm
+                bibId={bibId}
+                itemId={itemId}
+                itemSource={this.state.itemSource}
+                submitRequest={this.submitRequest}
+                raiseError={this.raiseError}
+                error={error}
+                form={form}
+                defaultEmail={patronEmail}
+                searchKeywords={searchKeywords}
+                serverRedirect={serverRedirect}
+                fromUrl={this.fromUrl()}
+                onSiteEddEnabled={this.props.features.includes('on-site-edd')}
+              />
+            ) : null}
+          </div>
+        }
       </SccContainer>
     );
   }
@@ -296,6 +301,7 @@ const mapStateToProps = (state) => ({
   bib: state.bib,
   searchKeywords: state.searchKeywords,
   features: state.features,
+  eddRequestable: state.isEddRequestable
 });
 
 const mapDispatchToProps = (dispatch) => ({

--- a/src/app/pages/ElectronicDelivery.jsx
+++ b/src/app/pages/ElectronicDelivery.jsx
@@ -10,7 +10,7 @@ import {
   isEmpty as _isEmpty,
   mapObject as _mapObject,
 } from 'underscore';
-import { updateIsEddRequestable, updateLoadingStatus } from '../actions/Actions';
+import { updateLoadingStatus } from '../actions/Actions';
 import ElectronicDeliveryForm from '../components/ElectronicDeliveryForm/ElectronicDeliveryForm';
 import Notification from '../components/Notification/Notification';
 import SccContainer from '../components/SccContainer/SccContainer';

--- a/src/app/pages/ElectronicDelivery.jsx
+++ b/src/app/pages/ElectronicDelivery.jsx
@@ -10,7 +10,7 @@ import {
   isEmpty as _isEmpty,
   mapObject as _mapObject,
 } from 'underscore';
-import { updateLoadingStatus } from '../actions/Actions';
+import { updateIsEddRequestable, updateLoadingStatus } from '../actions/Actions';
 import ElectronicDeliveryForm from '../components/ElectronicDeliveryForm/ElectronicDeliveryForm';
 import Notification from '../components/Notification/Notification';
 import SccContainer from '../components/SccContainer/SccContainer';
@@ -41,8 +41,10 @@ class ElectronicDelivery extends React.Component {
       selectedItem && selectedItem.itemSource ? selectedItem.itemSource : null;
     const raiseError = _isEmpty(this.props.error) ? {} : this.props.error;
     const serverRedirect = true;
+    const isEddRequestable = selectedItem.eddRequestable
 
     this.state = _extend({
+      isEddRequestable,
       title,
       bibId,
       itemId,
@@ -55,7 +57,6 @@ class ElectronicDelivery extends React.Component {
     this.submitRequest = this.submitRequest.bind(this);
     this.raiseError = this.raiseError.bind(this);
     this.fromUrl = this.fromUrl.bind(this);
-    // this.props.isEddRequestable = true
   }
 
   componentDidMount() {
@@ -199,7 +200,7 @@ class ElectronicDelivery extends React.Component {
   }
 
   render() {
-    const { bibId, itemId, title, raiseError, serverRedirect } = this.state;
+    const { bibId, itemId, title, raiseError, serverRedirect, isEddRequestable } = this.state;
     const bib =
       this.props.bib && !_isEmpty(this.props.bib) ? this.props.bib : null;
     const callNo =
@@ -238,7 +239,7 @@ class ElectronicDelivery extends React.Component {
             </div>
           )}
         </div>
-        {!this.props.isEddRequestable ? <h2 className='nypl-request-form-title'>
+        {!isEddRequestable ? <h2 className='nypl-request-form-title'>
           Electronic delivery options for this item are currently unavailable. Please try
           again later or contact 917-ASK-NYPL (
           <a href='tel:917-275-6975'>917-275-6975</a>).

--- a/src/app/pages/ElectronicDelivery.jsx
+++ b/src/app/pages/ElectronicDelivery.jsx
@@ -237,7 +237,7 @@ class ElectronicDelivery extends React.Component {
             </div>
           )}
         </div>
-        {!this.props.eddRequestable ? <h2 className='nypl-request-form-title'>
+        {!this.props.isEddRequestable ? <h2 className='nypl-request-form-title'>
           Electronic delivery options for this item are currently unavailable. Please try
           again later or contact 917-ASK-NYPL (
           <a href='tel:917-275-6975'>917-275-6975</a>).
@@ -301,7 +301,7 @@ const mapStateToProps = (state) => ({
   bib: state.bib,
   searchKeywords: state.searchKeywords,
   features: state.features,
-  eddRequestable: state.isEddRequestable
+  isEddRequestable: state.isEddRequestable
 });
 
 const mapDispatchToProps = (dispatch) => ({

--- a/src/app/pages/ElectronicDelivery.jsx
+++ b/src/app/pages/ElectronicDelivery.jsx
@@ -55,6 +55,7 @@ class ElectronicDelivery extends React.Component {
     this.submitRequest = this.submitRequest.bind(this);
     this.raiseError = this.raiseError.bind(this);
     this.fromUrl = this.fromUrl.bind(this);
+    // this.props.isEddRequestable = true
   }
 
   componentDidMount() {

--- a/src/app/pages/HoldRequest.jsx
+++ b/src/app/pages/HoldRequest.jsx
@@ -315,7 +315,7 @@ export class HoldRequest extends React.Component {
         : '';
     const itemId = params && params.itemId ? params.itemId : '';
     const selectedItem = bib && itemId ? LibraryItem.getItem(bib, itemId) : {};
-    const selectedItemAvailable = selectedItem ? selectedItem.available : false;
+    const selectedItemAvailable = selectedItem ? selectedItem.physRequestable : false;
     const bibLink =
       bibId && title ? (
         <h2>

--- a/src/app/utils/item.js
+++ b/src/app/utils/item.js
@@ -183,6 +183,7 @@ function LibraryItem() {
    */
   this.mapItem = (item = {}, bib) => {
     const id = item && item['@id'] ? item['@id'].substring(4) : '';
+    const eddRequestable = item.eddRequestable
     const itemSource = item.idNyplSourceId ? item.idNyplSourceId['@type'] : '';
     // Taking the first object in the accessMessage array.
     const accessMessage =
@@ -258,6 +259,7 @@ function LibraryItem() {
     }
 
     return {
+      eddRequestable,
       id,
       status,
       availability,

--- a/src/app/utils/item.js
+++ b/src/app/utils/item.js
@@ -183,8 +183,6 @@ function LibraryItem() {
    */
   this.mapItem = (item = {}, bib) => {
     const id = item && item['@id'] ? item['@id'].substring(4) : '';
-    const eddRequestable = item.eddRequestable
-    const physRequestable = item.physRequestable
     const itemSource = item.idNyplSourceId ? item.idNyplSourceId['@type'] : '';
     // Taking the first object in the accessMessage array.
     const accessMessage =
@@ -260,8 +258,8 @@ function LibraryItem() {
     }
 
     return {
-      physRequestable,
-      eddRequestable,
+      physRequestable: item.physRequestable,
+      eddRequestable: item.eddRequestable,
       id,
       status,
       availability,

--- a/src/app/utils/item.js
+++ b/src/app/utils/item.js
@@ -184,6 +184,7 @@ function LibraryItem() {
   this.mapItem = (item = {}, bib) => {
     const id = item && item['@id'] ? item['@id'].substring(4) : '';
     const eddRequestable = item.eddRequestable
+    const physRequestable = item.physRequestable
     const itemSource = item.idNyplSourceId ? item.idNyplSourceId['@type'] : '';
     // Taking the first object in the accessMessage array.
     const accessMessage =
@@ -259,6 +260,7 @@ function LibraryItem() {
     }
 
     return {
+      physRequestable,
       eddRequestable,
       id,
       status,

--- a/src/server/ApiRoutes/Hold.js
+++ b/src/server/ApiRoutes/Hold.js
@@ -17,6 +17,7 @@ import {
   updateBib,
   updateSearchKeywords,
   updateHoldRequestPage,
+  updateIsEddRequestable,
 } from '../../app/actions/Actions';
 import extractFeatures from '../../app/utils/extractFeatures';
 import isAeonUrl from '../utils/isAeonUrl';
@@ -399,6 +400,8 @@ function newHoldRequestServerEdd(req, res, next) {
   const item = Bib.fetchBib(
     bibId,
     (data) => {
+      const item = LibraryItem.getItem(data.bib, req.params.itemId)
+      dispatch(updateIsEddRequestable(item.eddRequestable))
       dispatch(updateBib(data.bib));
       dispatch(updateSearchKeywords(req.query.searchKeywords));
       next();

--- a/src/server/ApiRoutes/Hold.js
+++ b/src/server/ApiRoutes/Hold.js
@@ -391,6 +391,7 @@ function newHoldRequestServerEdd(req, res, next) {
   const error = req.query.error ? JSON.parse(req.query.error) : {};
   const form = req.query.form ? JSON.parse(req.query.form) : {};
   const bibId = req.params.bibId || '';
+  const itemId = req.params.itemId || '';
   const { features } = req.query;
   const urlEnabledFeatures = extractFeatures(features);
 
@@ -398,7 +399,7 @@ function newHoldRequestServerEdd(req, res, next) {
 
   // Retrieve item
   const item = Bib.fetchBib(
-    bibId,
+    bibId + (itemId.length ? `-${itemId}` : ''),
     (data) => {
       const item = LibraryItem.getItem(data.bib, req.params.itemId)
       dispatch(updateIsEddRequestable(item.eddRequestable))

--- a/src/server/ApiRoutes/Hold.js
+++ b/src/server/ApiRoutes/Hold.js
@@ -402,7 +402,6 @@ function newHoldRequestServerEdd(req, res, next) {
     bibId + (itemId.length ? `-${itemId}` : ''),
     (data) => {
       const item = LibraryItem.getItem(data.bib, req.params.itemId)
-      dispatch(updateIsEddRequestable(item.eddRequestable))
       dispatch(updateBib(data.bib));
       dispatch(updateSearchKeywords(req.query.searchKeywords));
       next();

--- a/test/fixtures/mocked-item.js
+++ b/test/fixtures/mocked-item.js
@@ -32,6 +32,7 @@ export default [
       },
     ],
     requestable: [true],
+    physRequestable: [true],
     accessMessage: [
       {
         '@id': 'accessMessage:2',

--- a/test/unit/ElectronicDelivery.test.js
+++ b/test/unit/ElectronicDelivery.test.js
@@ -48,7 +48,10 @@ describe('ElectronicDeliveryForm', () => {
         onSiteEdd: 'example.com/scan-and-deliver',
       };
 
-      const store = makeTestStore({ features: ['on-site-edd'] });
+      const store = makeTestStore({
+        features: ['on-site-edd'],
+        isEddRequestable: true
+      });
 
       component = mountTestRender(
         <ElectronicDelivery
@@ -192,4 +195,53 @@ describe('ElectronicDeliveryForm', () => {
       expect(formstate, 'Form State Still Exists').to.be.undefined;
     });
   });
-});
+
+  describe('EDD unavailable message', () => {
+    let appConfigMock;
+    let component;
+
+    before(() => {
+      appConfigMock = mock(appConfig);
+
+    })
+    after(() => {
+      appConfigMock.restore();
+    });
+    it('should render the message when the item is not eddRequestable', () => {
+      const store = makeTestStore({
+        isEddRequestable: false
+      });
+      component = mountTestRender(<ElectronicDelivery
+        params={{ bibId: 'bibId' }}
+      />, { store })
+      const message = component.find('h2')
+      setImmediate(() => {
+        expect(message.find('h2')).to.have.length(1);
+        expect(
+          message.contains(
+            <h2 className='nypl-request-form-title'>
+              Delivery options for this item are currently unavailable. Please
+              try again later or contact 917-ASK-NYPL (
+              <a href='tel:917-275-6975'>917-275-6975</a>).
+            </h2>,
+          ),
+        ).to.equal(true);
+      });
+    })
+    it('should render the edd form when the item is eddRequestable', () => {
+      const store = makeTestStore({
+        isEddRequestable: true
+      });
+      component = mountTestRender(<ElectronicDelivery
+      location={{query: "query"}}
+        params={{ bibId: 'bibId' }}
+      />, { store })
+      const message = component.find('h2')
+      expect(message).to.be.empty
+      const form = component.find('ElectronicDeliveryForm')
+      setImmediate(() => {
+        expect(form.props().method).to.equal('POST');
+      });
+    })
+  })
+})

--- a/test/unit/ElectronicDelivery.test.js
+++ b/test/unit/ElectronicDelivery.test.js
@@ -6,6 +6,7 @@ import { makeTestStore, mountTestRender } from '../helpers/store';
 import ElectronicDeliveryForm from './../../src/app/components/ElectronicDeliveryForm/ElectronicDeliveryForm';
 import appConfig from './../../src/app/data/appConfig';
 import ElectronicDelivery from './../../src/app/pages/ElectronicDelivery';
+import mockedItem from '../fixtures/mocked-item';
 
 describe('ElectronicDeliveryForm', () => {
   describe('default form', () => {
@@ -50,12 +51,16 @@ describe('ElectronicDeliveryForm', () => {
 
       const store = makeTestStore({
         features: ['on-site-edd'],
-        isEddRequestable: true
+        bib: {
+          title: ['Harry Potter'],
+          '@id': 'res:b17688688',
+          items: [{...mockedItem[0], eddRequestable: true}],
+        }
       });
 
       component = mountTestRender(
         <ElectronicDelivery
-          params={{ bibId: 'book1' }}
+          params={{ bibId: 'book1', itemId: 'i10000003' }}
           location={{
             query: '',
           }}
@@ -207,12 +212,18 @@ describe('ElectronicDeliveryForm', () => {
     after(() => {
       appConfigMock.restore();
     });
-    it('should render the message when the item is not eddRequestable', () => {
+
+    it('should render the error message when the item is not eddRequestable', () => {
+      const bib = {
+        title: ['Harry Potter'],
+        '@id': 'res:b17688688',
+        items: [{...mockedItem[0], eddRequestable: false}],
+      };
       const store = makeTestStore({
-        isEddRequestable: false
+        bib
       });
       component = mountTestRender(<ElectronicDelivery
-        params={{ bibId: 'bibId' }}
+        params={{ bibId: 'bibId', itemId: 'i10000003' }}
       />, { store })
       const message = component.find('h2')
       setImmediate(() => {
@@ -229,12 +240,18 @@ describe('ElectronicDeliveryForm', () => {
       });
     })
     it('should render the edd form when the item is eddRequestable', () => {
+      
+      const bib = {
+        title: ['Harry Potter'],
+        '@id': 'res:b17688688',
+        items: [{...mockedItem[0], eddRequestable: true}],
+      };
       const store = makeTestStore({
-        isEddRequestable: true
+        bib
       });
       component = mountTestRender(<ElectronicDelivery
       location={{query: "query"}}
-        params={{ bibId: 'bibId' }}
+        params={{ bibId: 'bibId', itemId: 'i10000003' }}
       />, { store })
       const message = component.find('h2')
       expect(message).to.be.empty

--- a/test/unit/HoldRequest.test.js
+++ b/test/unit/HoldRequest.test.js
@@ -4,6 +4,7 @@ import MockAdapter from 'axios-mock-adapter';
 import { expect } from 'chai';
 import React from 'react';
 import { spy, stub } from 'sinon';
+import Hold from 'src/server/ApiRoutes/Hold';
 import mockedItem from '../fixtures/mocked-item';
 import { makeTestStore, mountTestRender } from '../helpers/store';
 import WrappedHoldRequest, {
@@ -30,6 +31,9 @@ describe('HoldRequest', () => {
         () => true,
       );
     });
+    after(() => {
+      HoldRequest.prototype.redirectWithErrors.restore()
+    })
     describe('ineligible patrons', () => {
       before(() => {
         mock

--- a/test/unit/HoldRequest.test.js
+++ b/test/unit/HoldRequest.test.js
@@ -4,7 +4,6 @@ import MockAdapter from 'axios-mock-adapter';
 import { expect } from 'chai';
 import React from 'react';
 import { spy, stub } from 'sinon';
-import Hold from 'src/server/ApiRoutes/Hold';
 import mockedItem from '../fixtures/mocked-item';
 import { makeTestStore, mountTestRender } from '../helpers/store';
 import WrappedHoldRequest, {
@@ -159,7 +158,7 @@ describe('HoldRequest', () => {
 
   describe(
     'If the patron is logged in and the App receives invalid delivery location data, ' +
-      '<HoldRequest>',
+    '<HoldRequest>',
     () => {
       let component;
       const bib = {
@@ -212,7 +211,7 @@ describe('HoldRequest', () => {
 
   describe(
     'If the patron is logged in and the App receives valid delivery location data, ' +
-      '<HoldRequest>',
+    '<HoldRequest>',
     () => {
       let component;
       const bib = {
@@ -285,7 +284,7 @@ describe('HoldRequest', () => {
 
       it(
         'should display the avaialbe delivery locations, and the first location is selected ' +
-          'by default.',
+        'by default.',
         () => {
           setImmediate(() => {
             const form = component.find('form');
@@ -766,4 +765,71 @@ describe('HoldRequest', () => {
       );
     });
   });
-});
+
+  describe.only('if the item is not physRequestable', () => {
+    let component;
+    const bib = {
+      title: ['Harry Potter'],
+      '@id': 'res:b17688688',
+      items: { ...mockedItem, physRequestable: false },
+    };
+
+    const deliveryLocations = [
+      {
+        '@id': 'loc:myr',
+        address: '40 Lincoln Center Plaza',
+        prefLabel: 'Performing Arts Research Collections',
+        shortName: 'Library for the Performing Arts',
+      },
+      {
+        '@id': 'loc:sc',
+        prefLabel: 'Schomburg Center',
+        address: '515 Malcolm X Boulevard',
+        shortName: 'Schomburg Center',
+      },
+      {
+        '@id': 'loc:mala',
+        prefLabel: 'Schwarzman Building - Allen Scholar Room',
+        address: '476 Fifth Avenue (42nd St and Fifth Ave)',
+        shortName: 'Schwarzman Building',
+      },
+    ];
+
+    before(() => {
+      component = mountTestRender(
+        <WrappedHoldRequest params={{ itemId: 'i10000003' }} />,
+        {
+          attachTo: document.body,
+          store: makeTestStore({
+            patron: { id: 1 },
+            bib,
+            deliveryLocations,
+          }),
+        },
+      );
+    });
+
+    after(() => {
+      component.unmount();
+    });
+    it('should display error message instead of hold request form', () => {
+      let form = component.find('form');
+
+      setImmediate(() => {
+        expect(form.find('h2')).to.have.length(1);
+        expect(
+          form.contains(
+            <h2 className='nypl-request-form-title'>
+              Delivery options for this item are currently unavailable. Please
+              try again later or contact 917-ASK-NYPL (
+              <a href='tel:917-275-6975'>917-275-6975</a>).
+            </h2>,
+          ),
+        ).to.equal(true);
+        form = component.find('form').first();
+
+        expect(form.find('fieldset')).to.have.length(0);
+      })
+    })
+  })
+})

--- a/test/unit/HoldRequest.test.js
+++ b/test/unit/HoldRequest.test.js
@@ -766,7 +766,7 @@ describe('HoldRequest', () => {
     });
   });
 
-  describe.only('if the item is not physRequestable', () => {
+  describe('if the item is not physRequestable', () => {
     let component;
     const bib = {
       title: ['Harry Potter'],


### PR DESCRIPTION
**What's this do?**
Hitting /research/research-catalog/bibid-itemid now hits discovery endpoint resources/bibid-itemid, which updates the eddRequestable field on the item. If a patron clicks the edd request button and, that endpoint is hit, and if the eddrequestability is updated to false, an error message displays.

**Why are we doing this? (w/ JIRA link if applicable)**
To avoid patrons making edd requests on items that are not available 

**Do these changes have automated tests?**
NO

**How should this be QAed?**
I heard discussions of url hacking from paul... not sure otherwise 

**Dependencies for merging? Releasing to production?**
No

**Has the application documentation been updated for these changes?**

**Did someone actually run this code to verify it works?**
I ran it locally with an eddrequestable item and non edd requestable item.