### PR TITLE
Build && Incorporate Identifier Field into Definition Field Component

### DIFF
--- a/src/app/components/BibPage/BibDetails_Functional.jsx
+++ b/src/app/components/BibPage/BibDetails_Functional.jsx
@@ -10,7 +10,6 @@ import {
 import LibraryItem from '../../utils/item';
 import DefinitionField from './components/DefinitionField';
 import DefinitionNoteField from './components/DefinitionNoteField';
-import IdentifierNode from './components/IndentifierNode';
 import DefinitionList from './DefinitionList';
 
 const BibDetails_Functional = ({ fields = [], marcs, resources }) => {

--- a/src/app/components/BibPage/BibDetails_Functional.jsx
+++ b/src/app/components/BibPage/BibDetails_Functional.jsx
@@ -7,8 +7,10 @@ import {
   groupNotesBySubject,
   setParallelToNote,
 } from '../../utils/bibDetailsUtils';
+import LibraryItem from '../../utils/item';
 import DefinitionField from './components/DefinitionField';
 import DefinitionNoteField from './components/DefinitionNoteField';
+import IdentifierNode from './components/IndentifierNode';
 import DefinitionList from './DefinitionList';
 
 const BibDetails_Functional = ({ fields = [], marcs, resources }) => {
@@ -53,6 +55,23 @@ const BibDetails_Functional = ({ fields = [], marcs, resources }) => {
               // definition: <DefinitionField bibValues={notes} field={field} />,
             };
           }),
+        ];
+      }
+
+      if (field.value === 'identifier') {
+        const ident = validIdentifier(field, origin);
+
+        // To avoid adding a label with empty array for identifiers
+        if (ident && !ident.length) return store;
+
+        return [
+          ...store,
+          {
+            term: field.label,
+            definition: (
+              <IdentifierNode values={ident} type={field.identifier} />
+            ),
+          },
         ];
       }
 
@@ -105,3 +124,9 @@ BibDetails_Functional.contextTypes = {
 };
 
 export default BibDetails_Functional;
+
+function validIdentifier(field, origin) {
+  return field.value === 'identifier'
+    ? LibraryItem.getIdentifierEntitiesByType(origin, field.identifier)
+    : null;
+}

--- a/src/app/components/BibPage/BibDetails_Functional.jsx
+++ b/src/app/components/BibPage/BibDetails_Functional.jsx
@@ -58,9 +58,8 @@ const BibDetails_Functional = ({ fields = [], marcs, resources }) => {
         ];
       }
 
-      if (field.value === 'identifier') {
+      if (origin) {
         const ident = validIdentifier(field, origin);
-
         // To avoid adding a label with empty array for identifiers
         if (ident && !ident.length) return store;
 
@@ -69,20 +68,8 @@ const BibDetails_Functional = ({ fields = [], marcs, resources }) => {
           {
             term: field.label,
             definition: (
-              <IdentifierNode values={ident} type={field.identifier} />
-            ),
-          },
-        ];
-      }
-
-      if (origin) {
-        return [
-          ...store,
-          {
-            term: field.label,
-            definition: (
               <DefinitionField
-                bibValues={origin}
+                bibValues={ident ?? origin}
                 field={field}
                 // TODO: This is not correct
                 // Additional checks for stying changes

--- a/src/app/components/BibPage/components/DefinitionField.jsx
+++ b/src/app/components/BibPage/components/DefinitionField.jsx
@@ -20,7 +20,7 @@ const DefinitionField = ({ field, bibValues = [], additional = false }) => {
           if (!value) return null;
 
           if (field.value === 'identifier') {
-            return <IdentifierField value={value} />;
+            return <IdentifierField entity={value} />;
           }
 
           const element = { value };

--- a/src/app/components/BibPage/components/DefinitionField.jsx
+++ b/src/app/components/BibPage/components/DefinitionField.jsx
@@ -19,9 +19,9 @@ const DefinitionField = ({ field, bibValues = [], additional = false }) => {
           if (!value) return null;
 
           // WIP
-          if (field.value === 'identifier') {
-            return null;
-          }
+          // if (field.value === 'identifier') {
+          //   return null;
+          // }
 
           const element = { value };
 

--- a/src/app/components/BibPage/components/DefinitionField.jsx
+++ b/src/app/components/BibPage/components/DefinitionField.jsx
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { flatten as _flatten } from 'underscore';
 import { useBibParallel } from '../../../context/Bib.Provider';
+import IdentifierNode from './IndentifierNode';
 import LinkableBibField from './LinkableField';
 
 const DefinitionField = ({ field, bibValues = [], additional = false }) => {
@@ -18,10 +19,9 @@ const DefinitionField = ({ field, bibValues = [], additional = false }) => {
         .map((value, idx) => {
           if (!value) return null;
 
-          // WIP
-          // if (field.value === 'identifier') {
-          //   return null;
-          // }
+          if (field.value === 'identifier') {
+            return <IdentifierNode value={value} />;
+          }
 
           const element = { value };
 

--- a/src/app/components/BibPage/components/DefinitionField.jsx
+++ b/src/app/components/BibPage/components/DefinitionField.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { flatten as _flatten } from 'underscore';
 import { useBibParallel } from '../../../context/Bib.Provider';
-import IdentifierNode from './IndentifierNode';
+import IdentifierField from './IndentifierNode';
 import LinkableBibField from './LinkableField';
 
 const DefinitionField = ({ field, bibValues = [], additional = false }) => {
@@ -20,7 +20,7 @@ const DefinitionField = ({ field, bibValues = [], additional = false }) => {
           if (!value) return null;
 
           if (field.value === 'identifier') {
-            return <IdentifierNode value={value} />;
+            return <IdentifierField value={value} />;
           }
 
           const element = { value };

--- a/src/app/components/BibPage/components/IndentifierNode.jsx
+++ b/src/app/components/BibPage/components/IndentifierNode.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-const IdentifierNode = ({ value }) => {
+const IdentifierField = ({ value }) => {
   const mark = value['@value'];
   const status = value.identifierStatus;
 
@@ -21,9 +21,9 @@ const IdentifierNode = ({ value }) => {
   );
 };
 
-IdentifierNode.propTypes = {
+IdentifierField.propTypes = {
   value: PropTypes.array,
   type: PropTypes.string,
 };
 
-export default IdentifierNode;
+export default IdentifierField;

--- a/src/app/components/BibPage/components/IndentifierNode.jsx
+++ b/src/app/components/BibPage/components/IndentifierNode.jsx
@@ -1,34 +1,28 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-const IdentifierNode = ({ values }) => {
-  return (
-    <ul>
-      {values.map((ent) => {
-        const mark = ent['@value'];
-        const status = ent.identifierStatus;
+const IdentifierNode = ({ value }) => {
+  const mark = value['@value'];
+  const status = value.identifierStatus;
 
-        return (
-          <li key={mark}>
-            <span>
-              {mark}
-              {(status && (
-                <>
-                  {' '}
-                  <em>{status}</em>
-                </>
-              )) ||
-                null}
-            </span>
-          </li>
-        );
-      })}
-    </ul>
+  return (
+    <li key={mark}>
+      <span>
+        {mark}
+        {(status && (
+          <>
+            {' '}
+            <em>{status}</em>
+          </>
+        )) ||
+          null}
+      </span>
+    </li>
   );
 };
 
 IdentifierNode.propTypes = {
-  values: PropTypes.array,
+  value: PropTypes.array,
   type: PropTypes.string,
 };
 

--- a/src/app/components/BibPage/components/IndentifierNode.jsx
+++ b/src/app/components/BibPage/components/IndentifierNode.jsx
@@ -1,9 +1,9 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-const IdentifierField = ({ value }) => {
-  const mark = value['@value'];
-  const status = value.identifierStatus;
+const IdentifierField = ({ entity }) => {
+  const mark = entity['@value'];
+  const status = entity.identifierStatus;
 
   return (
     <li key={mark}>
@@ -22,8 +22,7 @@ const IdentifierField = ({ value }) => {
 };
 
 IdentifierField.propTypes = {
-  value: PropTypes.array,
-  type: PropTypes.string,
+  entity: PropTypes.array,
 };
 
 export default IdentifierField;

--- a/src/app/components/BibPage/components/IndentifierNode.jsx
+++ b/src/app/components/BibPage/components/IndentifierNode.jsx
@@ -1,36 +1,28 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import LibraryItem from '../../../utils/item';
 
-const IdentifierNode = ({ values, type }) => {
-  const entities = LibraryItem.getIdentifierEntitiesByType(values, type);
-
-  if (!Array.isArray(entities) || !(entities.length > 0)) {
-    return null;
-  }
-
-  const markup = entities.map((ent) => {
-    const nodes = [<span key={`${ent['@value']}`}>{ent['@value']}</span>];
-
-    if (ent.identifierStatus) {
-      nodes.push(
-        <span key={`${ent['@value']}`}>
-          {' '}
-          <em>({ent.identifierStatus})</em>
-        </span>,
-      );
-    }
-
-    return nodes;
-  });
-
-  return markup.length === 1 ? (
-    markup.pop()
-  ) : (
+const IdentifierNode = ({ values }) => {
+  return (
     <ul>
-      {markup.map((mark) => (
-        <li key={mark[0].key}>{mark}</li>
-      ))}
+      {values.map((ent) => {
+        const mark = ent['@value'];
+        const status = ent.identifierStatus;
+
+        return (
+          <li key={mark}>
+            <span>
+              {mark}
+              {(status && (
+                <>
+                  {' '}
+                  <em>{status}</em>
+                </>
+              )) ||
+                null}
+            </span>
+          </li>
+        );
+      })}
     </ul>
   );
 };


### PR DESCRIPTION
For a cleaner approach to processing Identifiers the identifiers were incorporated into the Definition Field.  

The processing of the field is first checked against valid identifier items. When a field is not valid it skips adding the label to the definition list. If valid, the DefinitionField component will process the item and apply the IdentifierField comp for render.