### PR TITLE
Handle Clicked Links for Outbound and Inbounds Paths

### DIFF
--- a/src/app/components/BibPage/components/LinkableField.jsx
+++ b/src/app/components/BibPage/components/LinkableField.jsx
@@ -14,10 +14,7 @@ const LinkableBibField = ({ bibValue, field, label, outbound, onClick }) => {
 
   const handler = (event) => {
     if (!outbound) {
-      event.preventDefault();
-      // get context router
-      // this.context.router.push(search);
-      !!onClick && onClick();
+      !!onClick && onClick(event);
     }
 
     trackDiscovery('Bib fields', `${label} - ${text}`);

--- a/src/app/components/BibPage/components/LinkableField.jsx
+++ b/src/app/components/BibPage/components/LinkableField.jsx
@@ -21,7 +21,7 @@ const LinkableBibField = ({ bibValue, field, label, outbound, onClick }) => {
   };
 
   return (
-    <Link onClick={handler} to={url}>
+    <Link onClick={handler} to={url} target={outbound ? '_blank' : undefined}>
       {text}
     </Link>
   );


### PR DESCRIPTION
When a link is clicked, we need to ensure we are processing the route correctly. Removed prevent default action to allow the react-router link component to handle the redirect. If desired a click callback can be passed to the links to prevent the default behavior. 

Additionally, added the _blank field to the Link component for outbound links. This will open a new tab in the browser.