### PR TITLE
Fix: Failed Notes If Notes are Undefined

### DIFF
--- a/src/app/components/BibPage/BibDetails_Functional.jsx
+++ b/src/app/components/BibPage/BibDetails_Functional.jsx
@@ -31,7 +31,7 @@ const BibDetails_Functional = ({ fields = [], marcs, resources }) => {
           resources.length &&
           resources);
 
-      if (field.value === 'note') {
+      if (field.value === 'note' && origin) {
         // INVESTIGATE:
         // Can we avoid having to loop here?
         // Although unlikely what happens at groups of 10, 20, ...100


### PR DESCRIPTION
When Field value is "Note" when displaying the Bottom Bib Details but there are no notes on the Bib do not process the notes value. Do this by checking if we are on the notes field and there are notes.