### PR TITLE
SCC-2972: Add Dimensions Field to Bottom Bib Details

### DIFF
--- a/src/server/ApiRoutes/Bib.js
+++ b/src/server/ApiRoutes/Bib.js
@@ -48,14 +48,20 @@ export const addHoldingDefinition = (holding) => {
 };
 
 const appendDimensionsToExtent = (bib) => {
-  const semicolon = bib.extent.slice(-2) === '; ' || bib.extent.slice(-1) === ';'
-  if (bib.dimensions) {
-    const description = bib.extent + (semicolon ? '' : '; ') + bib.dimensions
-    return description
-  } else if (semicolon){
-    return bib.extent.slice(0,-1)
+  if (bib.extent) {
+    // Check if extent was cataloged with a semicolon already at the end
+    const semicolon = bib.extent.slice(-2) === '; ' || bib.extent.slice(-1) === ';'
+    if (bib.dimensions) {
+      // If there is a dimensions field, append  it to the extent and make sure they are separated by a semicolon
+      const description = bib.extent + (semicolon ? '' : '; ') + bib.dimensions
+      return [description]
+      // No dimensions field, remove semicolon if it exists
+    } else if (semicolon) {
+      return [bib.extent.slice(0, -1)]
+    }
   }
-  else return bib.extent
+  // No dimensions field, no semicolon, return unmutated
+  return bib.extent
 }
 
 export const findUrl = (location, urls) => {
@@ -191,7 +197,7 @@ function fetchBib (bibId, cb, errorcb, reqOptions, res) {
       // Make sure retrieved annotated-marc document is valid:
       if (!data.annotatedMarc || !data.annotatedMarc.bib)
         data.annotatedMarc = null;
-      data.extent[0] = appendDimensionsToExtent(data)
+      data.extent = appendDimensionsToExtent(data)
       return data;
     })
     .then((bib) => {

--- a/src/server/ApiRoutes/Bib.js
+++ b/src/server/ApiRoutes/Bib.js
@@ -48,6 +48,7 @@ export const addHoldingDefinition = (holding) => {
 };
 
 const appendDimensionsToExtent = (bib) => {
+  if (!bib.extent || bib.extent.length === 0) return 
   let extent = bib.extent[0]
   let punctuationToAdd = ''
   // Check if extent was cataloged with a semicolon already at the end:

--- a/src/server/ApiRoutes/Bib.js
+++ b/src/server/ApiRoutes/Bib.js
@@ -180,7 +180,12 @@ function fetchBib(bibId, cb, errorcb, reqOptions, res) {
       // Make sure retrieved annotated-marc document is valid:
       if (!data.annotatedMarc || !data.annotatedMarc.bib)
         data.annotatedMarc = null;
-
+      // Append dimensions to the extent field so it displays in the description of bottom bib details
+      if(data.dimensions){
+        const semicolon = data.extent[data.extent.length - 1] === ';' ? '' : '; '
+        const description = data.extent + semicolon + data.dimensions
+        data.extent = [description]
+      }
       return data;
     })
     .then((bib) => {

--- a/src/server/ApiRoutes/Bib.js
+++ b/src/server/ApiRoutes/Bib.js
@@ -49,15 +49,18 @@ export const addHoldingDefinition = (holding) => {
 
 const appendDimensionsToExtent = (bib) => {
   let extent = bib.extent[0]
-    // Check if extent was cataloged with a semicolon already at the end:
-    let punctuationToAdd = ''
-    const semicolon = (extent.slice(-2) === '; ' || extent.slice(-1) === ';')
-    if (semicolon){
-      if (extent.slice(-1) !== ' ') punctuationToAdd += ' '
-    } else punctuationToAdd = '; '
-    if (bib.dimensions && bib.dimensions[0].length) {
-      // If there is a dimensions field, append  it to the extent and make sure they are separated by a semicolon and a space:
-      extent = extent + punctuationToAdd + bib.dimensions[0]
+  let punctuationToAdd = ''
+  // Check if extent was cataloged with a semicolon already at the end:
+  const semicolon = (extent.slice(-2) === '; ' || extent.slice(-1) === ';')
+  if (semicolon) {
+    if (extent.slice(-1) !== ' ') punctuationToAdd += ' '
+  } else punctuationToAdd = '; '
+  if (bib.dimensions && bib.dimensions[0].length) {
+    // If there is a dimensions field, append  it to the extent and make sure they are separated by a semicolon and a space:
+    extent = extent + punctuationToAdd + bib.dimensions[0]
+  } else {
+    // If there is no dimensions field, remove the semicolon
+    extent = punctuationToAdd.length === 0 ? extent.slice(0, -2) : extent.slice(0, -1)
   }
   return [extent]
 }

--- a/src/server/ApiRoutes/Bib.js
+++ b/src/server/ApiRoutes/Bib.js
@@ -48,20 +48,18 @@ export const addHoldingDefinition = (holding) => {
 };
 
 const appendDimensionsToExtent = (bib) => {
-  if (bib.extent) {
-    // Check if extent was cataloged with a semicolon already at the end
-    const semicolon = bib.extent.slice(-2) === '; ' || bib.extent.slice(-1) === ';'
-    if (bib.dimensions) {
-      // If there is a dimensions field, append  it to the extent and make sure they are separated by a semicolon
-      const description = bib.extent + (semicolon ? '' : '; ') + bib.dimensions
-      return [description]
-      // No dimensions field, remove semicolon if it exists
-    } else if (semicolon) {
-      return [bib.extent.slice(0, -1)]
-    }
+  let extent = bib.extent[0]
+    // Check if extent was cataloged with a semicolon already at the end:
+    let punctuationToAdd = ''
+    const semicolon = (extent.slice(-2) === '; ' || extent.slice(-1) === ';')
+    if (semicolon){
+      if (extent.slice(-1) !== ' ') punctuationToAdd += ' '
+    } else punctuationToAdd = '; '
+    if (bib.dimensions && bib.dimensions[0].length) {
+      // If there is a dimensions field, append  it to the extent and make sure they are separated by a semicolon and a space:
+      extent = extent + punctuationToAdd + bib.dimensions[0]
   }
-  // No dimensions field, no semicolon, return unmutated
-  return bib.extent
+  return [extent]
 }
 
 export const findUrl = (location, urls) => {

--- a/src/server/ApiRoutes/Bib.js
+++ b/src/server/ApiRoutes/Bib.js
@@ -48,7 +48,7 @@ export const addHoldingDefinition = (holding) => {
 };
 
 const appendDimensionsToExtent = (bib) => {
-  if (!bib.extent || bib.extent.length === 0) return 
+  if (!bib.extent || bib.extent.length === 0) return
   let extent = bib.extent[0]
   let punctuationToAdd = ''
   // Check if extent was cataloged with a semicolon already at the end:
@@ -199,7 +199,6 @@ function fetchBib (bibId, cb, errorcb, reqOptions, res) {
       // Make sure retrieved annotated-marc document is valid:
       if (!data.annotatedMarc || !data.annotatedMarc.bib)
         data.annotatedMarc = null;
-      data.extent = appendDimensionsToExtent(data)
       return data;
     })
     .then((bib) => {
@@ -227,7 +226,10 @@ function fetchBib (bibId, cb, errorcb, reqOptions, res) {
       }
       return Object.assign({ status }, bib);
     })
-    .then((bib) => addLocationUrls(bib))
+    .then((bib) => {
+      bib.extent = appendDimensionsToExtent(bib)
+      return addLocationUrls(bib)
+    })
     .then((bib) => {
       if (bib.holdings) {
         addCheckInItems(bib);

--- a/test/unit/Bib.test.js
+++ b/test/unit/Bib.test.js
@@ -10,6 +10,8 @@ import Bib, { addCheckInItems } from './../../src/server/ApiRoutes/Bib';
 describe('Bib', () => {
   /* holding could lack location, as shown in second holding */
   const mockBib = {
+    extent: ['99 bottles of beer'],
+    dimensions: ['99 x 99 cm'],
     holdings: [
       {
         location: [
@@ -53,6 +55,21 @@ describe('Bib', () => {
       },
     ],
   };
+
+  describe.only('appendDimensionsToExtent', () => {
+    it('should add a semicolon after extent if there is not one already', () => {
+      const newExtent = Bib.appendDimensionsToExtent(mockBib)
+      expect(newExtent).to.include('; ')
+    })
+    it('should append dimensions to extent', () => {
+      const newExtent = Bib.appendDimensionsToExtent(mockBib)
+      expect(newExtent).to.equal('99 bottles of beer; 99 x 99 cm')
+    })
+    it('should not add semicolon if it already is in extent', () => {
+      const newExtent = Bib.appendDimensionsToExtent({extent: '700 sheets of woven gold; ', dimensions: '1 x 1 in.'})
+      expect(newExtent).to.equal('700 sheets of woven gold; 1 x 1 in.')
+    })
+  })
 
   describe('addCheckInItems', () => {
     it('should add correctly structured checkInItems', () => {

--- a/test/unit/Bib.test.js
+++ b/test/unit/Bib.test.js
@@ -69,6 +69,12 @@ describe('Bib', () => {
       const [newExtent] = Bib.appendDimensionsToExtent({extent: ['700 sheets of woven gold; '], dimensions: ['1 x 1 in.']})
       expect(newExtent).to.equal('700 sheets of woven gold; 1 x 1 in.')
     })
+    it('should remove semicolon if there is no dimensions', () => {
+      const [newExtent] = Bib.appendDimensionsToExtent({extent: ['700 sheets of woven gold; ']})
+      const [anotherExtent] = Bib.appendDimensionsToExtent({extent: ['700 sheets of woven gold;']})
+      expect(newExtent).to.equal('700 sheets of woven gold')
+      expect(anotherExtent).to.equal('700 sheets of woven gold')
+    })
   })
 
   describe('addCheckInItems', () => {

--- a/test/unit/Bib.test.js
+++ b/test/unit/Bib.test.js
@@ -75,6 +75,10 @@ describe('Bib', () => {
       expect(newExtent).to.equal('700 sheets of woven gold')
       expect(anotherExtent).to.equal('700 sheets of woven gold')
     })
+    it('should return undefined if there is no extent', () => {
+      const nullExtent = Bib.appendDimensionsToExtent({})
+      expect(nullExtent).to.equal(undefined)
+    })
   })
 
   describe('addCheckInItems', () => {

--- a/test/unit/Bib.test.js
+++ b/test/unit/Bib.test.js
@@ -58,15 +58,15 @@ describe('Bib', () => {
 
   describe('appendDimensionsToExtent', () => {
     it('should add a semicolon after extent if there is not one already', () => {
-      const newExtent = Bib.appendDimensionsToExtent(mockBib)
+      const [newExtent] = Bib.appendDimensionsToExtent(mockBib)
       expect(newExtent).to.include('; ')
     })
     it('should append dimensions to extent', () => {
-      const newExtent = Bib.appendDimensionsToExtent(mockBib)
+      const [newExtent] = Bib.appendDimensionsToExtent(mockBib)
       expect(newExtent).to.equal('99 bottles of beer; 99 x 99 cm')
     })
     it('should not add semicolon if it already is in extent', () => {
-      const newExtent = Bib.appendDimensionsToExtent({extent: '700 sheets of woven gold; ', dimensions: '1 x 1 in.'})
+      const [newExtent] = Bib.appendDimensionsToExtent({extent: '700 sheets of woven gold; ', dimensions: '1 x 1 in.'})
       expect(newExtent).to.equal('700 sheets of woven gold; 1 x 1 in.')
     })
   })

--- a/test/unit/Bib.test.js
+++ b/test/unit/Bib.test.js
@@ -56,7 +56,7 @@ describe('Bib', () => {
     ],
   };
 
-  describe.only('appendDimensionsToExtent', () => {
+  describe('appendDimensionsToExtent', () => {
     it('should add a semicolon after extent if there is not one already', () => {
       const newExtent = Bib.appendDimensionsToExtent(mockBib)
       expect(newExtent).to.include('; ')

--- a/test/unit/Bib.test.js
+++ b/test/unit/Bib.test.js
@@ -66,7 +66,7 @@ describe('Bib', () => {
       expect(newExtent).to.equal('99 bottles of beer; 99 x 99 cm')
     })
     it('should not add semicolon if it already is in extent', () => {
-      const [newExtent] = Bib.appendDimensionsToExtent({extent: '700 sheets of woven gold; ', dimensions: '1 x 1 in.'})
+      const [newExtent] = Bib.appendDimensionsToExtent({extent: ['700 sheets of woven gold; '], dimensions: ['1 x 1 in.']})
       expect(newExtent).to.equal('700 sheets of woven gold; 1 x 1 in.')
     })
   })


### PR DESCRIPTION
**What's this do?**
Dimensions wasn't being extracted from the bib to become a display field. Now it is. 

**Why are we doing this? (w/ JIRA link if applicable)**
[SCC-2972](https://jira.nypl.org/browse/SCC-2972)
