### PR TITLE
Set Direction for Parallel Fields 

### DIFF
--- a/src/app/components/BibPage/BibHeading.jsx
+++ b/src/app/components/BibPage/BibHeading.jsx
@@ -1,3 +1,4 @@
+import { Heading } from '@nypl/design-system-react-components';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { useBib } from '../../context/Bib.Provider';
@@ -12,9 +13,9 @@ const BibHeading = ({ searched }) => {
 
   return (
     <section className='nypl-item-details__heading'>
-      <ParallelsFields headingLevel={2} field={'title'}>
-        {title[0]}
-      </ParallelsFields>
+      <Heading level={2}>
+        <ParallelsFields field={'title'} content={title[0]} />
+      </Heading>
 
       <BackToSearchResults result={searched} bibId={bibId} />
     </section>

--- a/src/app/components/BibPage/BibHeading.jsx
+++ b/src/app/components/BibPage/BibHeading.jsx
@@ -12,7 +12,7 @@ const BibHeading = ({ searched }) => {
 
   return (
     <section className='nypl-item-details__heading'>
-      <ParallelsFields headingLevel={2} pField={'title'}>
+      <ParallelsFields headingLevel={2} field={'title'}>
         {title[0]}
       </ParallelsFields>
 

--- a/src/app/components/BibPage/components/DefinitionField.jsx
+++ b/src/app/components/BibPage/components/DefinitionField.jsx
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { flatten as _flatten } from 'underscore';
 import { useBibParallel } from '../../../context/Bib.Provider';
+import ParallelsFields from '../../Parallels/ParallelsFields';
 import IdentifierField from './IndentifierNode';
 import LinkableBibField from './LinkableField';
 
@@ -23,23 +24,26 @@ const DefinitionField = ({ field, bibValues = [], additional = false }) => {
             return <IdentifierField entity={value} />;
           }
 
-          const element = { value };
-
           if (field.linkable) {
-            element.value = (
-              <LinkableBibField
-                label={field.label}
-                field={field.value}
-                bibValue={value}
-                outbound={field.selfLinkable}
-              />
+            return (
+              <li key={`${value}-${idx}`}>
+                <LinkableBibField
+                  label={field.label}
+                  field={field.value}
+                  bibValue={value}
+                  outbound={field.selfLinkable}
+                />
+              </li>
             );
           }
 
-          const definition =
-            element.value.prefLabel ?? element.value.label ?? element.value;
+          const definition = value.prefLabel ?? value.label ?? value;
 
-          return <li key={`${value}-${idx}`}>{definition}</li>;
+          return (
+            <li key={`${value}-${idx}`}>
+              <ParallelsFields content={definition} />
+            </li>
+          );
 
           // TODO: Handle case below
           // const url = `filters[${field.value}]=${value['@id']}`;

--- a/src/app/components/BibPage/components/DefinitionNoteField.jsx
+++ b/src/app/components/BibPage/components/DefinitionNoteField.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import ParallelsFields from '../../Parallels/ParallelsFields';
 
 const DefinitionNoteField = ({ values }) => {
   // type value = Note[]
@@ -10,7 +11,9 @@ const DefinitionNoteField = ({ values }) => {
           return note && note.prefLabel ? (
             <>
               {note.parallel ? (
-                <li key={`${note.noteType}_${idx}`}>{note.parallel}</li>
+                <li key={`${note.noteType}_${idx}`}>
+                  <ParallelsFields content={note.parallel} />
+                </li>
               ) : null}
               <li key={idx.toString()}>{note.prefLabel}</li>
             </>

--- a/src/app/components/BibPage/components/LinkableField.jsx
+++ b/src/app/components/BibPage/components/LinkableField.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { Link } from 'react-router';
 import appConfig from '../../../data/appConfig';
 import { trackDiscovery } from '../../../utils/utils';
+import ParallelsFields from '../../Parallels/ParallelsFields';
 
 const LinkableBibField = ({ bibValue, field, label, outbound, onClick }) => {
   const text = outbound
@@ -22,7 +23,7 @@ const LinkableBibField = ({ bibValue, field, label, outbound, onClick }) => {
 
   return (
     <Link onClick={handler} to={url} target={outbound ? '_blank' : undefined}>
-      {text}
+      <ParallelsFields content={text} />
     </Link>
   );
 };

--- a/src/app/components/Parallels/ParallelsFields.jsx
+++ b/src/app/components/Parallels/ParallelsFields.jsx
@@ -34,8 +34,3 @@ ParallelsFields.propTypes = {
   headingLevel: PropTypes.number,
   children: PropTypes.node,
 };
-
-ParallelsFields.default = {
-  fieldIndex: 0,
-  headingLevel: undefined,
-};

--- a/src/app/components/Parallels/ParallelsFields.jsx
+++ b/src/app/components/Parallels/ParallelsFields.jsx
@@ -4,19 +4,19 @@ import React from 'react';
 import { useBibParallel } from '../../context/Bib.Provider';
 
 const ParallelsFields = ({
-  pField,
+  field,
   children,
   fieldIndex = 0,
   headingLevel = undefined,
 }) => {
-  const { parallel } = useBibParallel(pField);
+  const { parallel } = useBibParallel(field);
 
   return (
     <Heading level={headingLevel}>
       <>
         {(parallel &&
           parallel[fieldIndex].map((value, idx) => (
-            <span key={`${pField}_${idx}`} style={{ display: 'block' }}>
+            <span key={`${field}_${idx}`} style={{ display: 'block' }}>
               {value}
             </span>
           ))) ||

--- a/src/app/components/Parallels/ParallelsFields.jsx
+++ b/src/app/components/Parallels/ParallelsFields.jsx
@@ -11,7 +11,7 @@ const ParallelsFields = ({ field, content = '', fieldIndex = 0 }) => {
         parallel[fieldIndex].map((value, idx) => (
           <span
             dir={unicodeDirection(value)}
-            key={`${field}_${idx}`}
+            key={`${field}_${idx}_para`}
             style={{ display: 'block' }}
           >
             {value}

--- a/src/app/components/Parallels/ParallelsFields.jsx
+++ b/src/app/components/Parallels/ParallelsFields.jsx
@@ -1,36 +1,39 @@
 import PropTypes from 'prop-types';
-import { Heading } from '@nypl/design-system-react-components';
 import React from 'react';
 import { useBibParallel } from '../../context/Bib.Provider';
 
-const ParallelsFields = ({
-  field,
-  children,
-  fieldIndex = 0,
-  headingLevel = undefined,
-}) => {
+const ParallelsFields = ({ field, content = '', fieldIndex = 0 }) => {
   const { parallel } = useBibParallel(field);
 
   return (
-    <Heading level={headingLevel}>
-      <>
-        {(parallel &&
-          parallel[fieldIndex].map((value, idx) => (
-            <span key={`${field}_${idx}`} style={{ display: 'block' }}>
-              {value}
-            </span>
-          ))) ||
-          children}
-      </>
-    </Heading>
+    <>
+      {(parallel &&
+        parallel[fieldIndex].map((value, idx) => (
+          <span
+            dir={unicodeDirection(value)}
+            key={`${field}_${idx}`}
+            style={{ display: 'block' }}
+          >
+            {value}
+          </span>
+        ))) || (
+        <span dir={unicodeDirection(content)} style={{ display: 'block' }}>
+          {content}
+        </span>
+      )}
+    </>
   );
 };
 
 export default ParallelsFields;
 
 ParallelsFields.propTypes = {
-  pField: PropTypes.string.isRequired,
+  content: PropTypes.string,
+  field: PropTypes.string,
   fieldIndex: PropTypes.number,
   headingLevel: PropTypes.number,
-  children: PropTypes.node,
 };
+
+function unicodeDirection(text) {
+  return text[0] === '\u200F' ? 'rtl' : 'ltr';
+}


### PR DESCRIPTION
When a text string is passed to Parallel Field determine the direction of the field to be displayed. If the strings character Unicode value is `u200F` we will display the field direction as `rtl`, otherwise `ltr`. The direction argument is placed on the html blocked tag. EX: `<span dir='rtl' >{text}</span>`