### PR TITLE
Scc-3080: Ensure Call Number is Added to All Aeon URL Links on Item Table Row

### DIFF
--- a/src/app/components/Item/ItemTableRow.jsx
+++ b/src/app/components/Item/ItemTableRow.jsx
@@ -40,27 +40,24 @@ class ItemTableRow extends React.Component {
   }
 
   aeonUrl(item) {
-    const url = Array.isArray(item.aeonUrl) ? item.aeonUrl[0] : item.aeonUrl;
-    const searchParams = new URL(url).searchParams;
-    const paramMappings = {
+    const itemUrl = Array.isArray(item.aeonUrl)
+      ? item.aeonUrl[0]
+      : item.aeonUrl;
+
+    const AeonUrl = new URL(itemUrl);
+
+    const paramDict = {
       ItemISxN: 'id',
       itemNumber: 'barcode',
       CallNumber: 'callNumber',
     };
 
-    let params = Object.keys(paramMappings)
-      .map((paramName) => {
-        if (searchParams.has(paramName)) return null;
-        const mappedParamName = paramMappings[paramName];
-        if (!item[mappedParamName]) return null;
-        return `&${paramName}=${item[mappedParamName]}`;
-      })
-      .filter((paramString) => paramString)
-      .join('');
+    // Add/Replace query parameters on AeonURL with item key values
+    Object.entries(paramDict).forEach(([param, key]) => {
+      AeonUrl.searchParams.set(param, item[key]);
+    });
 
-    if (params && !url.includes('?')) params = `?${params}`;
-
-    return encodeURI(`${url}${params || ''}`);
+    return AeonUrl.toString();
   }
 
   requestButton() {

--- a/src/app/components/Item/ItemTableRow.jsx
+++ b/src/app/components/Item/ItemTableRow.jsx
@@ -54,7 +54,9 @@ class ItemTableRow extends React.Component {
 
     // Add/Replace query parameters on AeonURL with item key values
     Object.entries(paramDict).forEach(([param, key]) => {
-      AeonUrl.searchParams.set(param, item[key]);
+      // If item doesn't have a value use searchParams value
+      const value = item[key] ?? AeonUrl.searchParams.get(param);
+      AeonUrl.searchParams.set(param, value);
     });
 
     return AeonUrl.toString();

--- a/test/unit/ItemTableRow.test.js
+++ b/test/unit/ItemTableRow.test.js
@@ -215,9 +215,7 @@ describe('ItemTableRow', () => {
     describe('Aeon-requestable item without params', () => {
       const data = item.aeonRequestableWithoutParams;
       let component;
-      const expectedUrl = encodeURI(
-        'https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=[Songs+and+piano+solos+/&Site=SCHMA&Author=Bechet,+Sidney,&Date=1941-1960.&ItemInfo3=https://nypl-sierra-test.nypl.org/record=b11545018x&ReferenceNumber=b11545018x&ItemInfo1=USE+IN+LIBRARY&Genre=Score&Location=Schomburg+Center&shelfmark=Sc Scores Bechet&itemid=33299542&ItemISxN=i33299542&itemNumber=45678&CallNumber=Sc Scores Bechet',
-      );
+      const expectedUrl = `https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=%5BSongs+and+piano+solos+%2F&Site=SCHMA&Author=Bechet%2C+Sidney%2C&Date=1941-1960.&ItemInfo3=https%3A%2F%2Fnypl-sierra-test.nypl.org%2Frecord%3Db11545018x&ReferenceNumber=b11545018x&ItemInfo1=USE+IN+LIBRARY&Genre=Score&Location=Schomburg+Center&shelfmark=Sc+Scores+Bechet&itemid=33299542&ItemISxN=i33299542&itemNumber=45678&CallNumber=Sc+Scores+Bechet`;
 
       before(() => {
         component = shallow(<ItemTableRow item={data} bibId='b12345' />);
@@ -241,9 +239,7 @@ describe('ItemTableRow', () => {
     describe('Aeon-requestable item with params', () => {
       const data = item.aeonRequestableWithParams;
       let component;
-      const expectedUrl = encodeURI(
-        'https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=[Songs+and+piano+solos+/&Site=SCHMA&CallNumber=Sc+Scores+Bechet&Author=Bechet,+Sidney,&Date=1941-1960.&ItemInfo3=https://nypl-sierra-test.nypl.org/record=b11545018x&ReferenceNumber=b11545018x&ItemInfo1=USE+IN+LIBRARY&ItemISxN=i332995422&Genre=Score&Location=Schomburg+Center&shelfmark=Sc Scores Bechet&itemid=33299542&itemNumber=4567',
-      );
+      const expectedUrl = `https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=%5BSongs+and+piano+solos+%2F&Site=SCHMA&CallNumber=Sc+Scores+Bechet&Author=Bechet%2C+Sidney%2C&Date=1941-1960.&ItemInfo3=https%3A%2F%2Fnypl-sierra-test.nypl.org%2Frecord%3Db11545018x&ReferenceNumber=b11545018x&ItemInfo1=USE+IN+LIBRARY&ItemISxN=i33299542&Genre=Score&Location=Schomburg+Center&shelfmark=Sc+Scores+Bechet&itemid=33299542&itemNumber=45678`;
 
       before(() => {
         component = shallow(<ItemTableRow item={data} bibId='b12345' />);


### PR DESCRIPTION
According to [Jira ticket 3080](https://jira.nypl.org/browse/SCC-3080) the `Call Number` must be applied to all Aeon URL links so the receiving party/program can take advantage of its value. To do so , the resulting refactor takes advantage of the JavaScript [URL Interface](https://developer.mozilla.org/en-US/docs/Web/API/URL) and sets to the [URLSearchParams Interface](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams) values defined in the item mapping dictionary (`paramDict`). The `set` method of URLSearchParams will replace or add any found mapped items value to the URL object. When a value is `null` or `undefined` from the `item` use the original search parameter instead to avoid overwriting the parameter with those values. 

The original tests were updated to reflect the changes in expected results.

It should be QA'ed as ordinary