### PR TITLE
Scc 3139 Fix linkable fields no author results bug 

### DIFF
--- a/src/app/components/BibPage/components/LinkableField.jsx
+++ b/src/app/components/BibPage/components/LinkableField.jsx
@@ -19,14 +19,17 @@ const LinkableBibField = ({
     ? bibValue.prefLabel || bibValue.label || bibValue.url
     : bibValue;
 
-  const partialUrlEncodedBibValue = bibValue
-    .split('')
-    .map((char) => (char === '&' ? '%26' : char === '+' ? '%2B' : char))
-    .join('');
+  let partialUrlEncodedBibValue
+  if (bibValue && typeof bibValue === 'string') {
+    partialUrlEncodedBibValue = bibValue
+      .split('')
+      .map((char) => (char === '&' ? '%26' : char === '+' ? '%2B' : char))
+      .join('');
+  }
+
   // react router url encoding ignores & and +, so such characters within bibValue need to be encoded manually
-  const filter = `filters[${field}]=${
-    filterPath ?? bibValue['@id'] ?? partialUrlEncodedBibValue ?? ''
-  }`;
+  const filter = `filters[${field}]=${filterPath ?? bibValue['@id'] ?? partialUrlEncodedBibValue ?? ''
+    }`;
 
   const url = outbound
     ? bibValue['@id'] || bibValue.url

--- a/src/app/components/BibPage/components/LinkableField.jsx
+++ b/src/app/components/BibPage/components/LinkableField.jsx
@@ -25,11 +25,11 @@ const LinkableBibField = ({
       .split('')
       .map((char) => (char === '&' ? '%26' : char === '+' ? '%2B' : char))
       .join('');
-  }
+  };
 
   // react router url encoding ignores & and +, so such characters within bibValue need to be encoded manually
-  const filter = `filters[${field}]=${filterPath ?? bibValue['@id'] ?? partialUrlEncodedBibValue ?? bibValue ?? ''
-    }`;
+  const queryString = `${filterPath ?? bibValue['@id'] ?? bibValue ?? ''}`;
+  const filter = `filters[${field}]=${encodeURIComponent(queryString)}`;
 
   const url = outbound
     ? bibValue['@id'] || bibValue.url

--- a/src/app/components/BibPage/components/LinkableField.jsx
+++ b/src/app/components/BibPage/components/LinkableField.jsx
@@ -15,13 +15,16 @@ const LinkableBibField = ({
   filterPath,
   bib,
 }) => {
-
   const text = outbound
     ? bibValue.prefLabel || bibValue.label || bibValue.url
     : bibValue;
-  
+
   // react router url encoding ignores & and +, so such characters within bibValue need to be encoded manually
-  const filter = `filters[${field}]=${ filterPath ?? bibValue['@id'] ?? bibValue.replace('&', '%26').replace('+', '%2B') ?? ''
+  const filter = `filters[${field}]=${
+    filterPath ??
+    bibValue['@id'] ??
+    bibValue.replace('&', '%26').replace('+', '%2B') ??
+    ''
   }`;
 
   const url = outbound

--- a/src/app/components/BibPage/components/LinkableField.jsx
+++ b/src/app/components/BibPage/components/LinkableField.jsx
@@ -19,11 +19,12 @@ const LinkableBibField = ({
     ? bibValue.prefLabel || bibValue.label || bibValue.url
     : bibValue;
 
+const partialUrlEncodedBibValue = bibValue.split('').map((char) => char === '&' ? '%26' : char === '+' ? '%2B' : char).join('')
   // react router url encoding ignores & and +, so such characters within bibValue need to be encoded manually
   const filter = `filters[${field}]=${
     filterPath ??
     bibValue['@id'] ??
-    bibValue.replace('&', '%26').replace('+', '%2B') ??
+    partialUrlEncodedBibValue ??
     ''
   }`;
 

--- a/src/app/components/BibPage/components/LinkableField.jsx
+++ b/src/app/components/BibPage/components/LinkableField.jsx
@@ -15,12 +15,13 @@ const LinkableBibField = ({
   filterPath,
   bib,
 }) => {
+
   const text = outbound
     ? bibValue.prefLabel || bibValue.label || bibValue.url
     : bibValue;
-
-  const filter = `filters[${field}]=${
-    filterPath ?? bibValue['@id'] ?? bibValue ?? ''
+  
+  // react router url encoding ignores & and +, so such characters within bibValue need to be encoded manually
+  const filter = `filters[${field}]=${ filterPath ?? bibValue['@id'] ?? bibValue.replace('&', '%26').replace('+', '%2B') ?? ''
   }`;
 
   const url = outbound

--- a/src/app/components/BibPage/components/LinkableField.jsx
+++ b/src/app/components/BibPage/components/LinkableField.jsx
@@ -19,13 +19,13 @@ const LinkableBibField = ({
     ? bibValue.prefLabel || bibValue.label || bibValue.url
     : bibValue;
 
-const partialUrlEncodedBibValue = bibValue.split('').map((char) => char === '&' ? '%26' : char === '+' ? '%2B' : char).join('')
+  const partialUrlEncodedBibValue = bibValue
+    .split('')
+    .map((char) => (char === '&' ? '%26' : char === '+' ? '%2B' : char))
+    .join('');
   // react router url encoding ignores & and +, so such characters within bibValue need to be encoded manually
   const filter = `filters[${field}]=${
-    filterPath ??
-    bibValue['@id'] ??
-    partialUrlEncodedBibValue ??
-    ''
+    filterPath ?? bibValue['@id'] ?? partialUrlEncodedBibValue ?? ''
   }`;
 
   const url = outbound

--- a/src/app/components/BibPage/components/LinkableField.jsx
+++ b/src/app/components/BibPage/components/LinkableField.jsx
@@ -28,7 +28,7 @@ const LinkableBibField = ({
   }
 
   // react router url encoding ignores & and +, so such characters within bibValue need to be encoded manually
-  const filter = `filters[${field}]=${filterPath ?? bibValue['@id'] ?? partialUrlEncodedBibValue ?? ''
+  const filter = `filters[${field}]=${filterPath ?? bibValue['@id'] ?? partialUrlEncodedBibValue ?? bibValue ?? ''
     }`;
 
   const url = outbound

--- a/src/app/components/BibPage/components/LinkableField.jsx
+++ b/src/app/components/BibPage/components/LinkableField.jsx
@@ -27,7 +27,6 @@ const LinkableBibField = ({
       .join('');
   };
 
-  // react router url encoding ignores & and +, so such characters within bibValue need to be encoded manually
   const queryString = `${filterPath ?? bibValue['@id'] ?? bibValue ?? ''}`;
   const filter = `filters[${field}]=${encodeURIComponent(queryString)}`;
 

--- a/test/unit/LinkableField.test.js
+++ b/test/unit/LinkableField.test.js
@@ -5,11 +5,20 @@ import LinkableField from '../../src/app/components/BibPage/components/LinkableF
 
 describe('Linkable Field ', () => {
   it('should url encode & and + symbols in linkable field values', () => {
-    const component = shallow(<LinkableField bibValue='&& ++' />);
+    const component = shallow(<LinkableField bibValue='&&++' />);
     const link = component.find('Link');
     const { to } = link.props();
     expect(to).to.not.include('&');
     expect(to).to.not.include('+');
-    expect(to).to.include('%26%26 %2B%2B');
+    expect(to).to.include('%26%26%2B%2B');
+  });
+  it('should url encode & and + symbols in linkable field values that are objects', () => {
+    const fakeBib = {'@id': '&&++'}
+    const component = shallow(<LinkableField bibValue={fakeBib} />);
+    const link = component.find('Link');
+    const { to } = link.props();
+    expect(to).to.not.include('&');
+    expect(to).to.not.include('+');
+    expect(to).to.include('%26%26%2B%2B');
   });
 });

--- a/test/unit/LinkableField.test.js
+++ b/test/unit/LinkableField.test.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+import LinkableField from '../../src/app/components/BibPage/components/LinkableField'
+
+describe('Linkable Field ', () => {
+  it('should url encode & and + symbols in linkable field bibValues', () => {
+    const component = shallow(<LinkableField bibValue = "&& ++"/>)
+    const link = component.find('Link')
+    const {to} = link.props()
+    expect(to).to.not.include('&')
+    expect(to).to.not.include('+')
+    expect(to).to.include('%26%26 %2B%2B')
+  })
+}) 

--- a/test/unit/LinkableField.test.js
+++ b/test/unit/LinkableField.test.js
@@ -1,15 +1,15 @@
 import React from 'react';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
-import LinkableField from '../../src/app/components/BibPage/components/LinkableField'
+import LinkableField from '../../src/app/components/BibPage/components/LinkableField';
 
 describe('Linkable Field ', () => {
-  it('should url encode & and + symbols in linkable field bibValues', () => {
-    const component = shallow(<LinkableField bibValue = "&& ++"/>)
-    const link = component.find('Link')
-    const {to} = link.props()
-    expect(to).to.not.include('&')
-    expect(to).to.not.include('+')
-    expect(to).to.include('%26%26 %2B%2B')
-  })
-}) 
+  it('should url encode & and + symbols in linkable field values', () => {
+    const component = shallow(<LinkableField bibValue='&& ++' />);
+    const link = component.find('Link');
+    const { to } = link.props();
+    expect(to).to.not.include('&');
+    expect(to).to.not.include('+');
+    expect(to).to.include('%26%26 %2B%2B');
+  });
+});


### PR DESCRIPTION
What's this do?
Ensures that linkable fields do not have erroneously encoded urls. Ampersands and plus signs that are part of linkable field values are encoded prior to creating the search filter.

Why are we doing this? (w/ JIRA link if applicable)
Clicking linkable fields was breaking when they contained & or +

How should this be QAed?
[Description of any tests that need to be performed once merged]
clicking through on some linkable fields with & and +
Dependencies for merging? Releasing to production?
[Description of any watchouts, dependencies, or issues we should be aware of]
N A
Has the application documentation been updated for these changes?
N A
Did someone actually run this code to verify it works?
Yes