### PR TITLE
SCC-2972: Attach dimensions to extent in bib details

### DIFF
--- a/src/app/utils/appendDimensionsToExtent.js
+++ b/src/app/utils/appendDimensionsToExtent.js
@@ -1,18 +1,9 @@
 export const appendDimensionsToExtent = (bib) => {
-  if (!bib.extent || bib.extent.length === 0) return
-  let extent = bib.extent[0]
-  let punctuationToAdd = ''
-  // Check if extent was cataloged with a semicolon already at the end:
-  const semicolon = (extent.slice(-2) === '; ' || extent.slice(-1) === ';')
-  if (semicolon) {
-    if (extent.slice(-1) !== ' ') punctuationToAdd += ' '
-  } else punctuationToAdd = '; '
-  if (bib.dimensions && bib.dimensions[0].length) {
-    // If there is a dimensions field, append  it to the extent and make sure they are separated by a semicolon and a space:
-    extent = extent + punctuationToAdd + bib.dimensions[0]
-  } else {
-    // If there is no dimensions field, remove the semicolon
-    extent = punctuationToAdd.length === 0 ? extent.slice(0, -2) : extent.slice(0, -1)
+    if (!bib.extent || bib.extent.length === 0 || !bib.extent[0]) return;
+    
+    let parts = [ bib.extent[0].replace(/\s*;\s*$/, '') ]
+    if (bib.dimensions && bib.dimensions[0]) parts.push(bib.dimensions[0])
+    
+    return [parts.join('; ')]
   }
-  return [extent]
-}
+

--- a/src/app/utils/appendDimensionsToExtent.js
+++ b/src/app/utils/appendDimensionsToExtent.js
@@ -6,9 +6,8 @@ export const appendDimensionsToExtent = (bib) => {
   let parts = [bib.extent[0].replace(/\s*;\s*$/, '')]
   if (bib.dimensions && bib.dimensions[0]) {
     parts.push(bib.dimensions[0])
-    parts = parts.join('; ')
-  } else parts = parts[0]
-  bib.extent[0] = parts
+  }
+  bib.extent[0] = parts.join('; ')
   return bib
 }
 

--- a/src/app/utils/appendDimensionsToExtent.js
+++ b/src/app/utils/appendDimensionsToExtent.js
@@ -1,0 +1,19 @@
+export const appendDimensionsToExtent = (bib) => {
+  if (!bib.extent || bib.extent.length === 0) return
+  let extent = bib.extent[0]
+  let punctuationToAdd = ''
+  // Check if extent was cataloged with a semicolon already at the end:
+  const semicolon = (extent.slice(-2) === '; ' || extent.slice(-1) === ';')
+  if (semicolon) {
+    if (extent.slice(-1) !== ' ') punctuationToAdd += ' '
+  } else punctuationToAdd = '; '
+  if (bib.dimensions && bib.dimensions[0].length) {
+    // If there is a dimensions field, append  it to the extent and make sure they are separated by a semicolon and a space:
+    extent = extent + punctuationToAdd + bib.dimensions[0]
+  } else {
+    // If there is no dimensions field, remove the semicolon
+    extent = punctuationToAdd.length === 0 ? extent.slice(0, -2) : extent.slice(0, -1)
+  }
+  return [extent]
+}
+

--- a/src/app/utils/appendDimensionsToExtent.js
+++ b/src/app/utils/appendDimensionsToExtent.js
@@ -16,4 +16,3 @@ export const appendDimensionsToExtent = (bib) => {
   }
   return [extent]
 }
-

--- a/src/app/utils/appendDimensionsToExtent.js
+++ b/src/app/utils/appendDimensionsToExtent.js
@@ -1,9 +1,12 @@
 export const appendDimensionsToExtent = (bib) => {
-    if (!bib.extent || bib.extent.length === 0 || !bib.extent[0]) return;
+    if (!bib.extent || bib.extent.length === 0 || !bib.extent[0]) return bib;
     
     let parts = [ bib.extent[0].replace(/\s*;\s*$/, '') ]
-    if (bib.dimensions && bib.dimensions[0]) parts.push(bib.dimensions[0])
-    
-    return [parts.join('; ')]
+    if (bib.dimensions && bib.dimensions[0]) {
+      parts.push(bib.dimensions[0])
+      parts = parts.join('; ')
+    } else parts = parts[0]
+    bib.extent[0] = parts
+    return bib
   }
 

--- a/src/app/utils/appendDimensionsToExtent.js
+++ b/src/app/utils/appendDimensionsToExtent.js
@@ -1,12 +1,14 @@
 export const appendDimensionsToExtent = (bib) => {
-    if (!bib.extent || bib.extent.length === 0 || !bib.extent[0]) return bib;
-    
-    let parts = [ bib.extent[0].replace(/\s*;\s*$/, '') ]
-    if (bib.dimensions && bib.dimensions[0]) {
-      parts.push(bib.dimensions[0])
-      parts = parts.join('; ')
-    } else parts = parts[0]
-    bib.extent[0] = parts
+  if (!bib.extent || bib.extent.length === 0 || !bib.extent[0]) {
+    if (bib.dimensions && bib.dimensions[0]) bib.extent = [bib.dimensions[0]]
     return bib
   }
+  let parts = [bib.extent[0].replace(/\s*;\s*$/, '')]
+  if (bib.dimensions && bib.dimensions[0]) {
+    parts.push(bib.dimensions[0])
+    parts = parts.join('; ')
+  } else parts = parts[0]
+  bib.extent[0] = parts
+  return bib
+}
 

--- a/src/server/ApiRoutes/Bib.js
+++ b/src/server/ApiRoutes/Bib.js
@@ -6,7 +6,7 @@ import appConfig from '../../app/data/appConfig';
 import extractFeatures from '../../app/utils/extractFeatures';
 import { itemBatchSize } from '../../app/data/constants';
 import { isNyplBnumber } from '../../app/utils/utils';
-import { appendDimensionsToExtent } from 'src/app/utils/appendDimensionsToExtent';
+import { appendDimensionsToExtent } from '../../app/utils/appendDimensionsToExtent';
 
 const nyplApiClientCall = (query, urlEnabledFeatures, itemFrom) => {
   // If on-site-edd feature enabled in front-end, enable it in discovery-api:

--- a/src/server/ApiRoutes/Bib.js
+++ b/src/server/ApiRoutes/Bib.js
@@ -172,7 +172,7 @@ function fetchBib(bibId, cb, errorcb, reqOptions, res) {
       return Object.assign({ status }, bib);
     })
     .then((bib) => {
-      bib.extent = appendDimensionsToExtent(bib)
+      appendDimensionsToExtent(bib)
       return addLocationUrls(bib)})
     .then((bib) => {
       if (bib.holdings) {

--- a/src/server/ApiRoutes/Bib.js
+++ b/src/server/ApiRoutes/Bib.js
@@ -6,6 +6,7 @@ import appConfig from '../../app/data/appConfig';
 import extractFeatures from '../../app/utils/extractFeatures';
 import { itemBatchSize } from '../../app/data/constants';
 import { isNyplBnumber } from '../../app/utils/utils';
+import { appendDimensionsToExtent } from 'src/app/utils/appendDimensionsToExtent';
 
 const nyplApiClientCall = (query, urlEnabledFeatures, itemFrom) => {
   // If on-site-edd feature enabled in front-end, enable it in discovery-api:
@@ -170,7 +171,9 @@ function fetchBib(bibId, cb, errorcb, reqOptions, res) {
       }
       return Object.assign({ status }, bib);
     })
-    .then(bib => addLocationUrls(bib))
+    .then((bib) => {
+      bib.extent = appendDimensionsToExtent(bib)
+      return addLocationUrls(bib)})
     .then((bib) => {
       if (bib.holdings) {
         addCheckInItems(bib);

--- a/test/unit/appendDimensionsToExtent.test.js
+++ b/test/unit/appendDimensionsToExtent.test.js
@@ -2,27 +2,28 @@ import { expect } from 'chai';
 import { appendDimensionsToExtent } from '../../src/app/utils/appendDimensionsToExtent'
 
 describe('appendDimensionsToExtent', () => {
-  const mockBib = { extent: ['99 bottles of beer'], dimensions: ['99 x 99 cm']}
   it('should add a semicolon after extent if there is not one already', () => {
-    const [newExtent] = appendDimensionsToExtent(mockBib)
-    expect(newExtent).to.include('; ')
+    const bib = { extent: ['99 bottles of beer'], dimensions: ['99 x 99 cm']}
+    appendDimensionsToExtent(bib)
+    expect(bib.extent[0]).to.include('; ')
   })
   it('should append dimensions to extent', () => {
-    const [newExtent] = appendDimensionsToExtent(mockBib)
-    expect(newExtent).to.equal('99 bottles of beer; 99 x 99 cm')
+    const bib = { extent: ['99 bottles of beer'], dimensions: ['99 x 99 cm']}
+    appendDimensionsToExtent(bib)
+    expect(bib.extent[0]).to.equal('99 bottles of beer; 99 x 99 cm')
   })
   it('should not add semicolon if it already is in extent', () => {
-    const [newExtent] = appendDimensionsToExtent({ extent: ['700 sheets of woven gold; '], dimensions: ['1 x 1 in.'] })
-    expect(newExtent).to.equal('700 sheets of woven gold; 1 x 1 in.')
+    const bib = appendDimensionsToExtent({ extent: ['700 sheets of woven gold; '], dimensions: ['1 x 1 in.'] })
+    expect(bib.extent[0]).to.equal('700 sheets of woven gold; 1 x 1 in.')
   })
   it('should remove semicolon if there is no dimensions', () => {
-    const [newExtent] = appendDimensionsToExtent({ extent: ['700 sheets of woven gold; '] })
-    const [anotherExtent] = appendDimensionsToExtent({ extent: ['700 sheets of woven gold;'] })
-    expect(newExtent).to.equal('700 sheets of woven gold')
-    expect(anotherExtent).to.equal('700 sheets of woven gold')
+    const bib = appendDimensionsToExtent({ extent: ['700 sheets of woven gold; '] })
+    const anotherBib = appendDimensionsToExtent({ extent: ['700 sheets of woven gold;'] })
+    expect(bib.extent[0]).to.equal('700 sheets of woven gold')
+    expect(anotherBib.extent[0]).to.equal('700 sheets of woven gold')
   })
-  it('should return undefined if there is no extent', () => {
-    const nullExtent = appendDimensionsToExtent({})
-    expect(nullExtent).to.equal(undefined)
+  it('should do nothing if there is no extent', () => {
+    const bib = appendDimensionsToExtent({ dimensions: 'lol' })
+    expect(bib).to.not.have.keys('extent')
   })
 })

--- a/test/unit/appendDimensionsToExtent.test.js
+++ b/test/unit/appendDimensionsToExtent.test.js
@@ -1,0 +1,28 @@
+import { expect } from 'chai';
+import { appendDimensionsToExtent } from '../../src/app/utils/appendDimensionsToExtent'
+
+describe('appendDimensionsToExtent', () => {
+  const mockBib = { extent: ['99 bottles of beer'], dimensions: ['99 x 99 cm']}
+  it('should add a semicolon after extent if there is not one already', () => {
+    const [newExtent] = appendDimensionsToExtent(mockBib)
+    expect(newExtent).to.include('; ')
+  })
+  it('should append dimensions to extent', () => {
+    const [newExtent] = appendDimensionsToExtent(mockBib)
+    expect(newExtent).to.equal('99 bottles of beer; 99 x 99 cm')
+  })
+  it('should not add semicolon if it already is in extent', () => {
+    const [newExtent] = appendDimensionsToExtent({ extent: ['700 sheets of woven gold; '], dimensions: ['1 x 1 in.'] })
+    expect(newExtent).to.equal('700 sheets of woven gold; 1 x 1 in.')
+  })
+  it('should remove semicolon if there is no dimensions', () => {
+    const [newExtent] = appendDimensionsToExtent({ extent: ['700 sheets of woven gold; '] })
+    const [anotherExtent] = appendDimensionsToExtent({ extent: ['700 sheets of woven gold;'] })
+    expect(newExtent).to.equal('700 sheets of woven gold')
+    expect(anotherExtent).to.equal('700 sheets of woven gold')
+  })
+  it('should return undefined if there is no extent', () => {
+    const nullExtent = appendDimensionsToExtent({})
+    expect(nullExtent).to.equal(undefined)
+  })
+})

--- a/test/unit/appendDimensionsToExtent.test.js
+++ b/test/unit/appendDimensionsToExtent.test.js
@@ -22,8 +22,12 @@ describe('appendDimensionsToExtent', () => {
     expect(bib.extent[0]).to.equal('700 sheets of woven gold')
     expect(anotherBib.extent[0]).to.equal('700 sheets of woven gold')
   })
-  it('should do nothing if there is no extent', () => {
-    const bib = appendDimensionsToExtent({ dimensions: 'lol' })
+  it('should display dimensions if there are dimensions and no extent', () => {
+    const bib = appendDimensionsToExtent({ dimensions: ['1,000,000mm x 7ft'] })
+    expect(bib.extent[0]).to.equal('1,000,000mm x 7ft')
+  })
+  it('should do nothing if there are no dimensions or extent', () => {
+    const bib = appendDimensionsToExtent({ })
     expect(bib).to.not.have.keys('extent')
   })
 })


### PR DESCRIPTION
What's this do?
Dimensions wasn't being extracted from the bib to become a display field. Now it is.

Why are we doing this? (w/ JIRA link if applicable)
[SCC-2972](https://jira.nypl.org/browse/SCC-2972)