### PR TITLE
Fix the requestability check in hold-request page

### DIFF
--- a/src/app/pages/HoldRequest.jsx
+++ b/src/app/pages/HoldRequest.jsx
@@ -318,7 +318,10 @@ export class HoldRequest extends React.Component {
     const itemId = params && params.itemId ? params.itemId : '';
     const selectedItem = bib && itemId ? LibraryItem.getItem(bib, itemId) : {};
     const selectedItemAvailable = selectedItem
-      ? selectedItem.physRequestable
+      // Note: The .eddRequestability check should be removed with separate
+      // request buttons rollout (i.e. when this page shows only physical,
+      // non-edd delivery options):
+      ? selectedItem.physRequestable || selectedItem.eddRequestable
       : false;
     const bibLink =
       bibId && title ? (


### PR DESCRIPTION
**What's this do?**
This changes the requestability check on the hold-request page from
checking `item.physRequestable` (formerly `item.available`) to checking
`item.eddRequestable` and `item.physRequestable`.

The `.physRequestable` property can not be checked alone because the
page currently presents both EDD and Phys delivery options. Separate
Request Buttons rollout will include removing the EDD option from this
page. Until that happens, we need to check for both `.physRequestable`
and `.eddRequestable` because some bibs (e.g. all on-site materials
available for EDD, like b16323928) are only EDD
requestable.

The reason to not revert to the original `.avilable` property is that it
was never quite the right choice for requestability anyway. It will
always be `true` when `physRequestable` and/or `eddRequestable` are
`true` because requestability requires an "available" status and
`.available` [is computed based on item
status](https://github.com/NYPL/discovery-front-end/blob/4b87da98c505093cb7a4687cd79a0241f6ed7811/src/app/utils/item.js#L216)
. But it seems likely that an item may not be `.eddRequestable` or
`.physRequestable` even though it's `.available`.

So this PR changes the check to use the two `..Requestable`
properties relevant for the page in it's current manifestation: A page
presenting EDD and Phys delivery options.

**Why are we doing this? (w/ JIRA link if applicable)**
This walks back a change in `development` that breaks some hold-requests in `development`, preventing us from merging `development` into `production`

**Do these changes have automated tests?**
n/a

**How should this be QAed?**
Verify that all the typical classes of item behave correctly on the hold-request page:
 - An item at ReCAP that has status 'Available' and which is EDD requestable should present the EDD delivery option
 - An item at ReCAP that has status 'Available' and which is has phys delivery options, should present those options
 - An item at ReCAP that has status 'Not available' should show error
 - An on-site NYPL item that has status 'Available' and which is available for on-site EDD should present EDD as an option
 - An on-site NYPL item that has status 'Available, but which is not available for on-site EDD should show error
 - An on-site NYPL item that does not have status 'Available' should show error

**Dependencies for merging? Releasing to production?**
n/a

**Has the application documentation been updated for these changes?**
n/a

**Did someone actually run this code to verify it works?**
Me I did
