### PR TITLE
add logging for patron eligibility response time

### DIFF
--- a/src/app/pages/HoldRequest.jsx
+++ b/src/app/pages/HoldRequest.jsx
@@ -182,13 +182,15 @@ export class HoldRequest extends React.Component {
   // checks whether a patron is eligible to place a hold. Uses cookie to get the patron's id
   checkEligibility () {
     this.setState({ checkingPatronEligibility: true })
+    let checkingEligibility = true
     const startTime = Date.now()
     let eligible = false
     setTimeout(() => {
-      if (this.state.checkingPatronEligibility) console.log(`Patron eligibility check taking at least 3 seconds`)
+      if (checkingEligibility) console.log(`Patron eligibility check taking at least 3 seconds`)
     }, 3000)
     return axios.get(`${appConfig.baseUrl}/api/patronEligibility`)
       .then((response) => {
+        eligible = response.data.eligibility
         return response.data
       })
       .catch(() => {
@@ -199,8 +201,10 @@ export class HoldRequest extends React.Component {
         const elapsed = Date.now() - startTime
         console.log(`Patron eligibility check took ${elapsed}ms. Patron eligibility: ${eligible}`)
         // not 100% on this return, it was implicitly returned in the original code
+        checkingEligibility = false
         return this.setState({ checkingPatronEligibility: false })
       });
+
   }
 
   redirectWithErrors (path, status, message) {

--- a/src/app/pages/HoldRequest.jsx
+++ b/src/app/pages/HoldRequest.jsx
@@ -25,7 +25,7 @@ import {
 import { updateLoadingStatus } from '../actions/Actions';
 
 export class HoldRequest extends React.Component {
-  constructor(props) {
+  constructor (props) {
     super(props);
     const deliveryLocationsFromAPI = this.props.deliveryLocations;
     const isEddRequestable = this.props.isEddRequestable;
@@ -61,7 +61,7 @@ export class HoldRequest extends React.Component {
   }
 
 
-  componentDidMount() {
+  componentDidMount () {
     this.requireUser();
     this.conditionallyRedirect();
     const title = document.getElementById('item-title');
@@ -71,7 +71,7 @@ export class HoldRequest extends React.Component {
     if (this.state.serverRedirect) this.setState({ serverRedirect: false });
   }
 
-  onRadioSelect(e, i) {
+  onRadioSelect (e, i) {
     trackDiscovery('Delivery Location', e.target.value);
     this.setState({
       delivery: e.target.value,
@@ -83,7 +83,7 @@ export class HoldRequest extends React.Component {
    * submitRequest()
    * Client-side submit call.
    */
-  submitRequest(e, bibId, itemId, itemSource, title) {
+  submitRequest (e, bibId, itemId, itemSource, title) {
     e.preventDefault();
     const searchKeywordsQuery =
       (this.props.searchKeywords) ? `q=${this.props.searchKeywords}` : '';
@@ -132,7 +132,7 @@ export class HoldRequest extends React.Component {
    *
    * @return {Boolean}
    */
-  requireUser() {
+  requireUser () {
     if (this.props.patron && this.props.patron.id) {
       return true;
     }
@@ -151,7 +151,7 @@ export class HoldRequest extends React.Component {
    * @param {String} shortName
    * @return {String}
    */
-  modelDeliveryLocationName(prefLabel, shortName) {
+  modelDeliveryLocationName (prefLabel, shortName) {
     if (prefLabel && typeof prefLabel === 'string' && shortName) {
       const deliveryRoom = (prefLabel.split(' - ')[1]) ? ` - ${prefLabel.split(' - ')[1]}` : '';
 
@@ -163,7 +163,7 @@ export class HoldRequest extends React.Component {
 
   // Redirects to HoldConfirmation if patron is ineligible to place holds. We are particularly
   // checking for manual blocks, expired cards, and excessive fines.
-  conditionallyRedirect() {
+  conditionallyRedirect () {
     const { params } = this.props;
     return this.checkEligibility().then((eligibility) => {
       if (!eligibility.eligibility) {
@@ -180,16 +180,30 @@ export class HoldRequest extends React.Component {
     });
   }
   // checks whether a patron is eligible to place a hold. Uses cookie to get the patron's id
-  checkEligibility() {
+  checkEligibility () {
     this.setState({ checkingPatronEligibility: true })
-
+    const startTime = Date.now()
+    let eligible = false
+    setTimeout(() => {
+      if (this.state.checkingPatronEligibility) console.log(`Patron eligibility check taking at least 3 seconds`)
+    }, 3000)
     return axios.get(`${appConfig.baseUrl}/api/patronEligibility`)
-      .then(response => response.data)
-      .catch(() => ({ eligibility: true }))
-      .finally(() => this.setState({ checkingPatronEligibility: false }));
+      .then((response) => {
+        return response.data
+      })
+      .catch(() => {
+        eligible = true
+        return { eligibility: true }
+      })
+      .finally(() => {
+        const elapsed = Date.now() - startTime
+        console.log(`Patron eligibility check took ${elapsed}ms. Patron eligibility: ${eligible}`)
+        // not 100% on this return, it was implicitly returned in the original code
+        return this.setState({ checkingPatronEligibility: false })
+      });
   }
 
-  redirectWithErrors(path, status, message) {
+  redirectWithErrors (path, status, message) {
     this.context.router.replace(
       `${path}?errorStatus=${status}` +
       `&errorMessage=${message}`,
@@ -202,7 +216,7 @@ export class HoldRequest extends React.Component {
      * @param {Array} deliveryLocations
      * @return {HTML Element}
      */
-  renderDeliveryLocation(deliveryLocations = []) {
+  renderDeliveryLocation (deliveryLocations = []) {
     const { closedLocations } = this.props;
     const { openLocations } = appConfig;
     return deliveryLocations.map((location, i) => {
@@ -242,7 +256,7 @@ export class HoldRequest extends React.Component {
   *
   * @return {HTML Element}
   */
-  renderEDD() {
+  renderEDD () {
     const { closedLocations } = this.props;
     if (closedLocations.includes('')) return null;
     return (
@@ -265,7 +279,7 @@ export class HoldRequest extends React.Component {
     );
   }
 
-  render() {
+  render () {
     const {
       closedLocations,
       recapClosedLocations,
@@ -325,10 +339,10 @@ export class HoldRequest extends React.Component {
       ((!deliveryLocations.length && !isEddRequestable) || allClosed) ?
         (
           <h2 className="nypl-request-form-title">
-          Delivery options for this item are currently unavailable. Please try again later or
-          contact 917-ASK-NYPL (<a href="tel:917-275-6975">917-275-6975</a>).
+            Delivery options for this item are currently unavailable. Please try again later or
+            contact 917-ASK-NYPL (<a href="tel:917-275-6975">917-275-6975</a>).
           </h2>) :
-          <h2 className="nypl-request-form-title">Choose a delivery option or location</h2>;
+        <h2 className="nypl-request-form-title">Choose a delivery option or location</h2>;
     let form = null;
 
     if (bib && selectedItemAvailable && !allClosed) {
@@ -355,9 +369,9 @@ export class HoldRequest extends React.Component {
           </div>
           {
             (deliveryLocations.length || isEddRequestable) &&
-              <button type="submit" className="nypl-request-button">
-                Submit Request
-              </button>
+            <button type="submit" className="nypl-request-button">
+              Submit Request
+            </button>
           }
           <input
             type="hidden"
@@ -374,7 +388,6 @@ export class HoldRequest extends React.Component {
     }
 
     const userLoggedIn = this.props.patron && this.props.patron.loggedIn;
-
     return (
       <>
         {
@@ -391,10 +404,10 @@ export class HoldRequest extends React.Component {
                 <div className="item">
                   {
                     (userLoggedIn && !loading && (!bib || !selectedItemAvailable)) &&
-                      <h2>
-                        This item cannot be requested at this time. Please try again later or
-                        contact 917-ASK-NYPL (<a href="tel:917-275-6975">917-275-6975</a>).
-                      </h2>
+                    <h2>
+                      This item cannot be requested at this time. Please try again later or
+                      contact 917-ASK-NYPL (<a href="tel:917-275-6975">917-275-6975</a>).
+                    </h2>
                   }
                   {bibLink}
                   {callNo}


### PR DESCRIPTION
**What's this do?**
 - timeout triggers a log after waiting three seconds for response from patron eligibility
 - after response returns from patron eligibility service, logs how long response took

**Why are we doing this? (w/ JIRA link if applicable)**
to address mysterious forever spins on hold request page

**Do these changes have automated tests?**
no

**How should this be QAed?**
check out the console in the browser

