### PR TITLE
Remove distinct encodedAggregationsQueryString and encodedResultsQueryString

### DIFF
--- a/src/server/ApiRoutes/Search.js
+++ b/src/server/ApiRoutes/Search.js
@@ -40,7 +40,7 @@ const nyplApiClientCall = (query, urlEnabledFeatures = []) => {
 };
 
 function fetchResults(searchKeywords = '', contributor, title, subject, page, sortBy, order, field, filters, identifierNumbers, expressRes, cb, errorcb, features) {
-  const encodedResultsQueryString = createAPIQuery({
+  const encodedQueryString = createAPIQuery({
     searchKeywords,
     contributor,
     title,
@@ -52,17 +52,10 @@ function fetchResults(searchKeywords = '', contributor, title, subject, page, so
     identifierNumbers,
   });
 
-  const encodedAggregationsQueryString = createAPIQuery({
-    searchKeywords,
-    selectedFilters: filters,
-    field,
-    identifierNumbers
-  });
-
-  const aggregationQuery = `/aggregations?${encodedAggregationsQueryString}`;
+  const aggregationQuery = `/aggregations?${encodedQueryString}`;
   // TODO: Why are we hard-coding per_page=50? Could we set this to the number
   // shown on Search Results pages (3)?
-  const resultsQuery = `?${encodedResultsQueryString}&per_page=50`;
+  const resultsQuery = `?${encodedQueryString}&per_page=50`;
   const queryObj = {
     query: { q: searchKeywords, sortBy, order, field, filters },
   };


### PR DESCRIPTION
**What's this do?**
Combines the two query strings into one

**Why are we doing this? (w/ JIRA link if applicable)**
This is for scc-3106. Previously, aggregations for advanced searches didn't match the actual search. Since I don't see any reason why these two queries should be different, I've combined them into one, which should ensure aggregations and query results always match

**Do these changes have automated tests?**
No new tests

**How should this be QAed?**
- Advanced Search results and WorldCat redirect results should have appropriate aggregations.
- Here is an example: https://qa-www.nypl.org/research/research-catalog/search?contributor=Morrison,%20Toni.&title=Beloved&originalUrl=https%3A%2F%2Fcatalog.nypl.org%2Fsearch%2FX%3FSEARCH%3Dt%3A(Beloved)and%2520a%3A(Morrison%2C%2520Toni.)

**Dependencies for merging? Releasing to production?**
No

**Has the application documentation been updated for these changes?**
NA

**Did someone actually run this code to verify it works?**
Yes
