### PR TITLE
Scc 3165

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,55 +1,54 @@
 language: node_js
 node_js:
-  - 10.17.0
+- 10.17.0
 install: npm rebuild node-sass && npm install
 before_script: npm run dist
 script: npm test
-before_deploy:
-  echo 'All unit tests passed; Successfull built distribution assets;
+before_deploy: echo 'All unit tests passed; Successfull built distribution assets;
   Preparing to deploy Discovery Research Catalog to AWS.'
 deploy:
-  - provider: elasticbeanstalk
-    skip_cleanup: true
-    access_key_id: '$AWS_ACCESS_KEY_ID_DEVELOPMENT'
-    secret_access_key: '$AWS_SECRET_ACCESS_KEY_DEVELOPMENT'
-    region: us-east-1
-    app: discovery-ui
-    env: discovery-ui-shep-development
-    bucket_name: elasticbeanstalk-us-east-1-224280085904
-    bucket_path: discovery-ui-development
-    on:
-      repo: NYPL/discovery-front-end
-      branch: development
-  - provider: elasticbeanstalk
-    skip_cleanup: false
-    access_key_id: '$AWS_ACCESS_KEY_ID_QA'
-    secret_access_key: '$AWS_SECRET_ACCESS_KEY_QA'
-    region: us-east-1
-    app: discovery-ui
-    env: DiscoveryUi-production
-    bucket_name: elasticbeanstalk-us-east-1-946183545209
-    bucket_path: discovery-ui-shep
-    on:
-      repo: NYPL/discovery-front-end
-      branch: production
-  - provider: elasticbeanstalk
-    skip_cleanup: false
-    access_key_id: '$AWS_ACCESS_KEY_ID_QA'
-    secret_access_key: '$AWS_SECRET_ACCESS_KEY_QA'
-    region: us-east-1
-    app: discovery-ui
-    env: DiscoveryUi-10-17-qa
-    bucket_name: elasticbeanstalk-us-east-1-946183545209
-    bucket_path: discovery-ui-shep
-    on:
-      repo: NYPL/discovery-front-end
-      all_branches: true
-      condition: $TRAVIS_TAG =~ ^qa-.*
-
-after_deploy: echo 'Successfully executed deploy trigger for Discovery Research
-  Catalog on AWS'
+- provider: elasticbeanstalk
+  skip_cleanup: true
+  access_key_id: "$AWS_ACCESS_KEY_ID_DEVELOPMENT"
+  secret_access_key: "$AWS_SECRET_ACCESS_KEY_DEVELOPMENT"
+  region: us-east-1
+  app: discovery-ui
+  env: discovery-ui-shep-development
+  bucket_name: elasticbeanstalk-us-east-1-224280085904
+  bucket_path: discovery-ui-development
+  on:
+    repo: NYPL/discovery-front-end
+    branch: development
+- provider: elasticbeanstalk
+  skip_cleanup: false
+  access_key_id: "$AWS_ACCESS_KEY_ID_QA"
+  secret_access_key: "$AWS_SECRET_ACCESS_KEY_QA"
+  region: us-east-1
+  app: discovery-ui
+  env: DiscoveryUi-production
+  bucket_name: elasticbeanstalk-us-east-1-946183545209
+  bucket_path: discovery-ui-shep
+  on:
+    repo: NYPL/discovery-front-end
+    branch: production
+- provider: elasticbeanstalk
+  skip_cleanup: false
+  access_key_id: "$AWS_ACCESS_KEY_ID_QA"
+  secret_access_key: "$AWS_SECRET_ACCESS_KEY_QA"
+  region: us-east-1
+  app: discovery-ui
+  env: DiscoveryUi-10-17-qa
+  bucket_name: elasticbeanstalk-us-east-1-946183545209
+  bucket_path: discovery-ui-shep
+  on:
+    repo: NYPL/discovery-front-end
+    all_branches: true
+    condition: "$TRAVIS_TAG =~ ^qa-.*"
+after_deploy: echo 'Successfully executed deploy trigger for Discovery Research Catalog
+  on AWS'
 env:
   global:
-    - secure: GfEx9zdPWq4s8Q2vkPUMnnOl+j7eDmWQrM9un8dIQOj2hhWfAqVbes1iACnaueG/6JSR5lvr4sS/uZ2ukcVyvOwT0F9uDnejPt0gqi4mx5Q/Ztr2s0rHjY1lEn18NjWJzxEaeMzHOKbcAqG8R4d5wOvx7VEn6IRdTpZY/8oI4iqo7E9uonX1lJ6o2dc8KTtA4qnENLlnzKXN2W04MVK55CkWbQNtYOzgmyGj6/VYb3PQggweceSUapCl4+FWiqIS+BGY9yKWvZyfuvtxWCtG7wh+yEfvchFlfzR10FbSgBM/WsT07LrXXxF64H3xh/2D46QmCj4WQGwoDVG0itVSQbL201ujmTc2CTZRp5J0YxLOFnIG8OxqcvWc4zN7R4hhdsJ0Bn8+7TAoqY7f+3jAjdthjm2CD24Z2qxWKl/rtfT/YggxFsxJygsVTq9OO8D3la0RB7WO/pBy5uXcajc2ExcUE3DQGipgEqSYMBI0M0t2qghoUycManIpfs/PK87LZ7HOv55J1Yxq68xG2Y5d105RO+rHiE9+29UZXJdqxKU2ZLpuekiuINxbX0/qF4sG3Rt2b26IZn7mSOtj0UrPk7ueSunVVWAVio1wgDNekMYnbbkV3cd/JHvkPD0KiCziN6UFEmP89meDo82VoZRMnydr1y66sGzTLcTtO8nibAE=
-    - secure: cdnfdgDqBQadxSeNOmrImzfXQJyCy+StFyZXFa8Za36DWoL75LyIH8fYR9T9KJJSKc1LKPUrVLuXXJ9DmWNBByTXd35Qgkvd+AyurMvYj9F5zNLsMCLuQZkIQl2gkmMfmAZuOPZRnRLaKjMg/BuBdo/oI2j48uhPasq07aMfnncHUqQAkJ1hU3jqTuydSacrGXIxC6ONPL92z57CK5kBvb1Gx389SZKChJ7VpOd529n8K+KqXNmvZuz2i1dkNSOvtqNIcz9ljN8aDuBAka3fsvkB4HgqvrEDDBM03uZ1rKM2Ac7pSRYrQdBKceDzitxtoWP7d95gypLDeAoiY112tZfIyLRDTSxpNQGWJUMMstEs//ZtRoERnndZEC+qXrniqGu7PbtHxIZx041TgvOs2T2ImVACAvi6Btth7lEEzMZKz6bhttFaLLBsbH4b4HYArtHE2vl7FkcmcIkUO9iGghB1nx2grV2+Rx/ixh1KrSaye/8/0I69D9fSl4SReBIsn3bKt1QXNJqrODBVLsp2Eox72D2YWL04TzcaABdZNgsuHvzwxbOaJ5kFqVTB+cLHdjVm8RcXcBGTdw6SIs5QkwkcmKflyQliDwnqvihM8H7caAcFL3Cup0MH2amik10S66e0HT14tPKMBTiyFwDiQeRMsh9jQPjgTn/wxCNMp+M=
-    - secure: QlhELo/yrCO2QcREmWed5EMHpEMQd3w53j4cR5qYyJ5UXWcNLGYfczRBFKXkpdAdplCjsugWauQ6DnhX36oFv7ZKmpblkrWXW7cWXnXKa15j3+CCvq+/pi1XvXFKpbUPopr18BoXZbfZaHcbsKQktwyw5F0mXZois7M6t7MqkulS694NKvmdJTunAHixWkkA4md5udYO9IsGM4xua1BvWra6YsnLDT2VzYdKR+1Yq5YjJ42HFsTharRl/6FPuLLJ5jp5YawTquPD24YARJog8RT9/jbsqiIaooYf4Udl4n1aFOZmy4alhs5etq1+v2eF+0aIiAsmrfGKM2rGXKTOpKpr+WwjG+n5klRMBqaU9o9jkvXjx5Koa2m3yojC4vBonP3XQrhbRxf+6yLnu2QIEguuL7heLyRpW6aicyrJqAVa1ZRzbuMQdiAU3FCRxNKJdKGW2pXww3dpZb7gV0yjF9B8BSrwa2j9jG/REhVz7SZUz6txp9WcV9wyRdmUJ3h+h2zsNpOTFN6qnV08USErNLNw7JGwYRn/JuBNEdrlGIw6YznwkK1HkbG5yR3g/KSwJ/c5q2UX/KV+mNDe0r9lbJVpEpJw87sR4GDrJI4J2ne1nzAwQJ6nzsqmZmjn0momYPKIRcDSGsEPnlzBcpTHl3zEWD1c/AkHGgT3A0CRXP4=
+  - secure: GfEx9zdPWq4s8Q2vkPUMnnOl+j7eDmWQrM9un8dIQOj2hhWfAqVbes1iACnaueG/6JSR5lvr4sS/uZ2ukcVyvOwT0F9uDnejPt0gqi4mx5Q/Ztr2s0rHjY1lEn18NjWJzxEaeMzHOKbcAqG8R4d5wOvx7VEn6IRdTpZY/8oI4iqo7E9uonX1lJ6o2dc8KTtA4qnENLlnzKXN2W04MVK55CkWbQNtYOzgmyGj6/VYb3PQggweceSUapCl4+FWiqIS+BGY9yKWvZyfuvtxWCtG7wh+yEfvchFlfzR10FbSgBM/WsT07LrXXxF64H3xh/2D46QmCj4WQGwoDVG0itVSQbL201ujmTc2CTZRp5J0YxLOFnIG8OxqcvWc4zN7R4hhdsJ0Bn8+7TAoqY7f+3jAjdthjm2CD24Z2qxWKl/rtfT/YggxFsxJygsVTq9OO8D3la0RB7WO/pBy5uXcajc2ExcUE3DQGipgEqSYMBI0M0t2qghoUycManIpfs/PK87LZ7HOv55J1Yxq68xG2Y5d105RO+rHiE9+29UZXJdqxKU2ZLpuekiuINxbX0/qF4sG3Rt2b26IZn7mSOtj0UrPk7ueSunVVWAVio1wgDNekMYnbbkV3cd/JHvkPD0KiCziN6UFEmP89meDo82VoZRMnydr1y66sGzTLcTtO8nibAE=
+  - secure: cdnfdgDqBQadxSeNOmrImzfXQJyCy+StFyZXFa8Za36DWoL75LyIH8fYR9T9KJJSKc1LKPUrVLuXXJ9DmWNBByTXd35Qgkvd+AyurMvYj9F5zNLsMCLuQZkIQl2gkmMfmAZuOPZRnRLaKjMg/BuBdo/oI2j48uhPasq07aMfnncHUqQAkJ1hU3jqTuydSacrGXIxC6ONPL92z57CK5kBvb1Gx389SZKChJ7VpOd529n8K+KqXNmvZuz2i1dkNSOvtqNIcz9ljN8aDuBAka3fsvkB4HgqvrEDDBM03uZ1rKM2Ac7pSRYrQdBKceDzitxtoWP7d95gypLDeAoiY112tZfIyLRDTSxpNQGWJUMMstEs//ZtRoERnndZEC+qXrniqGu7PbtHxIZx041TgvOs2T2ImVACAvi6Btth7lEEzMZKz6bhttFaLLBsbH4b4HYArtHE2vl7FkcmcIkUO9iGghB1nx2grV2+Rx/ixh1KrSaye/8/0I69D9fSl4SReBIsn3bKt1QXNJqrODBVLsp2Eox72D2YWL04TzcaABdZNgsuHvzwxbOaJ5kFqVTB+cLHdjVm8RcXcBGTdw6SIs5QkwkcmKflyQliDwnqvihM8H7caAcFL3Cup0MH2amik10S66e0HT14tPKMBTiyFwDiQeRMsh9jQPjgTn/wxCNMp+M=
+  - secure: QlhELo/yrCO2QcREmWed5EMHpEMQd3w53j4cR5qYyJ5UXWcNLGYfczRBFKXkpdAdplCjsugWauQ6DnhX36oFv7ZKmpblkrWXW7cWXnXKa15j3+CCvq+/pi1XvXFKpbUPopr18BoXZbfZaHcbsKQktwyw5F0mXZois7M6t7MqkulS694NKvmdJTunAHixWkkA4md5udYO9IsGM4xua1BvWra6YsnLDT2VzYdKR+1Yq5YjJ42HFsTharRl/6FPuLLJ5jp5YawTquPD24YARJog8RT9/jbsqiIaooYf4Udl4n1aFOZmy4alhs5etq1+v2eF+0aIiAsmrfGKM2rGXKTOpKpr+WwjG+n5klRMBqaU9o9jkvXjx5Koa2m3yojC4vBonP3XQrhbRxf+6yLnu2QIEguuL7heLyRpW6aicyrJqAVa1ZRzbuMQdiAU3FCRxNKJdKGW2pXww3dpZb7gV0yjF9B8BSrwa2j9jG/REhVz7SZUz6txp9WcV9wyRdmUJ3h+h2zsNpOTFN6qnV08USErNLNw7JGwYRn/JuBNEdrlGIw6YznwkK1HkbG5yR3g/KSwJ/c5q2UX/KV+mNDe0r9lbJVpEpJw87sR4GDrJI4J2ne1nzAwQJ6nzsqmZmjn0momYPKIRcDSGsEPnlzBcpTHl3zEWD1c/AkHGgT3A0CRXP4=
+  - secure: AziyJMuxecogjJ6ygjpIa2HlSZcUF+duOatN5h9owNrKQsYfBy9hTeMWqRrpzVU4A/r6nXKXZll6M1wefhMyPba2cD3aDL116Ev3b7oqLC+NeeWWJ2wZPgVGKXngn3zZxVmrdTofIN6NuwcDFFcNtbzmXyrc+KynSznb864f3wksFmpVhXI32l47xTJbrhYWVm5o1TYm3xUHprCTYpp9RB91YxKEBhB85+0wqAUqe+BcNNjpgc37gFEz3AS7g5Q6qX/Ln6IXfEmYQ4E2gBkyXHl33DFeat3nvwiR0UbXwQjyPD5MlEYKsHul8og/eHO4v0axpDRiVzCzW+vTCE3yPOdlvtkjfOYZE6See5ZG5OWFWqf0gBtz6tjIU7GwqbbfONK+aeWUuxX6WuYHKBGW9nT4z5DmWX3Ydx+luOlMwxL+fOcXA2f9QkWKoba2pmFF6/nLThYbInBihTWKW1us7fP6V9BJ0KJOmg0dkhNx5ZGV2gbQ3f7qnRdoLsASmckF7pqtrDfRhat1vRC60l4oW68TgS19R5gfSe92SzlBMe9MpfUODEzY64rYskyDazVqDDouGPgsjIOlMnKfI79M3JTmXjvYSCHd2IqmWvPkWwOy7xG4tTX68eNPWvn8d+VwYs02qm8pZT9QuYuV3b+bDB8WSu1O+FEcy/YXsYSH9eg=

--- a/src/app/utils/researchNowUtils.js
+++ b/src/app/utils/researchNowUtils.js
@@ -7,6 +7,7 @@ const mapSearchScope = {
   contributor: 'author',
   standard_number: 'standardNumber',
   title: 'title',
+  subject: 'subject',
   date: 'date',
 };
 
@@ -51,6 +52,9 @@ const createResearchNowQuery = (params) => {
 
   const {
     q,
+    contributor,
+    title,
+    subject,
     sort,
     sort_direction,
     filters,
@@ -58,10 +62,17 @@ const createResearchNowQuery = (params) => {
     per_page,
   } = params;
 
-  const mainQuery = [
+  const keywordQuery = [
     mapSearchScope[field] || 'keyword',
     q || '*'
   ].join(':')
+
+  const advancedQuery = ['contributor', 'title', 'subject'].map(fieldType => {
+    const fieldValue = params[fieldType];
+    return fieldValue && `${mapSearchScope[fieldType]}:${fieldValue}`
+  }).filter(str => str).join(",")
+
+  const mainQuery = keywordQuery + (advancedQuery ? ',' : '') + advancedQuery
 
   const query = {
     query: [ mainQuery ],

--- a/src/server/ApiRoutes/ResearchNow.js
+++ b/src/server/ApiRoutes/ResearchNow.js
@@ -11,7 +11,6 @@ import { createResearchNowQuery as createResearchNowQueryV3, getResearchNowQuery
  * Given a request, resolves the relevant response from the DRB API
  */
 const drbQueryFromRequest = (req) => {
-  console.log('req: ', JSON.stringify(req, null, 2));
   const query = Object.assign({ per_page: 3 }, req.query);
 
   let drbQueryString = null;
@@ -27,7 +26,6 @@ const drbQueryFromRequest = (req) => {
     drbQueryString = getResearchNowQueryStringV3(query);
   } else {
     const drbQuery = getResearchNowQueryString(query)
-    console.log('drbQueryString: ', JSON.stringify(drbQuery, null, 2));
     drbCall = nyplApiClient({ apiName: 'drbb' })
       .then(client => client.get(drbQuery));
     // Remove leading '?'

--- a/src/server/ApiRoutes/ResearchNow.js
+++ b/src/server/ApiRoutes/ResearchNow.js
@@ -11,6 +11,7 @@ import { createResearchNowQuery as createResearchNowQueryV3, getResearchNowQuery
  * Given a request, resolves the relevant response from the DRB API
  */
 const drbQueryFromRequest = (req) => {
+  console.log('req: ', JSON.stringify(req, null, 2));
   const query = Object.assign({ per_page: 3 }, req.query);
 
   let drbQueryString = null;
@@ -26,6 +27,7 @@ const drbQueryFromRequest = (req) => {
     drbQueryString = getResearchNowQueryStringV3(query);
   } else {
     const drbQuery = getResearchNowQueryString(query)
+    console.log('drbQueryString: ', JSON.stringify(drbQuery, null, 2));
     drbCall = nyplApiClient({ apiName: 'drbb' })
       .then(client => client.get(drbQuery));
     // Remove leading '?'

--- a/src/server/ApiRoutes/Search.js
+++ b/src/server/ApiRoutes/Search.js
@@ -64,7 +64,7 @@ function fetchResults(searchKeywords = '', contributor, title, subject, page, so
   // shown on Search Results pages (3)?
   const resultsQuery = `?${encodedResultsQueryString}&per_page=50`;
   const queryObj = {
-    query: { q: searchKeywords, sortBy, order, field, filters },
+    query: { q: searchKeywords, contributor, title, subject, sortBy, order, field, filters },
   };
 
   let drbRequesting = true;

--- a/test/unit/researchNowUtils.test.js
+++ b/test/unit/researchNowUtils.test.js
@@ -57,5 +57,22 @@ describe('researchNowUtils', () => {
     it('should handle dateAfter & dateBefore filter', () => {
       expect(getResearchNowQueryString({ filters: { dateAfter: 2000, dateBefore: 2020 } })).to.equal('?query=keyword%3A*&page=1&source=catalog&filter=startYear%3A2000,endYear%3A2020')
     })
+
+    it('should handle contributor param', () => {
+      expect(getResearchNowQueryString({ contributor: 'Poe' })).to.equal('?query=keyword%3A*%2Cauthor%3APoe&page=1&source=catalog')
+    })
+
+    it('should handle title param', () => {
+      expect(getResearchNowQueryString({ title: 'Raven' })).to.equal('?query=keyword%3A*%2Ctitle%3ARaven&page=1&source=catalog')
+    })
+
+    it('should handle subject param', () => {
+      expect(getResearchNowQueryString({ subject: 'corvids' })).to.equal('?query=keyword%3A*%2Csubject%3Acorvids&page=1&source=catalog')
+    })
+
+    it('should combine query params', () => {
+      expect(getResearchNowQueryString({ contributor: 'Poe', subject: 'corvids', q: 'Raven' }))
+        .to.equal('?query=keyword%3ARaven%2Cauthor%3APoe%2Csubject%3Acorvids&page=1&source=catalog')
+    })
   })
 })


### PR DESCRIPTION
**What's this do?**
Adds some logic to map Advanced Search params to Research Now params

**Why are we doing this? (w/ JIRA link if applicable)**
This is for scc-3165. Since we weren't mapping all params before, some queries resulted in an empty query to DRB, which slowed down results. This was in particular an issue with WorldCat redirects, which search by author/title instead of keyword. 

**Do these changes have automated tests?**
Yes

**How should this be QAed?**
WorldCat links should not be slow anymore

**Dependencies for merging? Releasing to production?**
No

**Has the application documentation been updated for these changes?**
NA

**Did someone actually run this code to verify it works?**
Yes.