### PR TITLE
Add feature-flag enabling for parallels

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,4 +381,5 @@ To close all locations, add `all`. This will also remove EDD as a request option
 
 `SEARCH_RESULTS_NOTIFICATION`: Same as above, but will be added on the SearchResults page
 
-Specifying `no-onsite-edd` as a feature will ensure that the discovery api returns all onsite items as eddRequestable: false. 
+Specifying `no-onsite-edd` as a feature will ensure that the discovery api returns all onsite items as eddRequestable: false.
+Specifying `parallels` as a feature will enable interleaving of Bib fields with parallel fields.

--- a/src/app/components/BibPage/BibDetails.jsx
+++ b/src/app/components/BibPage/BibDetails.jsx
@@ -21,6 +21,7 @@ import { trackDiscovery } from '../../utils/utils';
 
 const BibDetails = (props) => {
   const { router } = React.useContext(RouterContext);
+  const useParallels = props.features && props.features.includes('parallels');
 
   /**
    * getDefinition(bibValues, fieldValue, fieldLinkable,
@@ -144,14 +145,14 @@ const BibDetails = (props) => {
               `${fieldLabel} - ${bibValue.prefLabel}`,
             )
           }
-          dir={stringDirection(linkText)}
+          dir={stringDirection(linkText, useParallels)}
         >
           {linkText}
         </a>
       );
     }
 
-    return <span dir={stringDirection(bibValue)}>{bibValue}</span>;
+    return <span dir={stringDirection(bibValue, useParallels)}>{bibValue}</span>;
   };
 
   /**
@@ -226,8 +227,8 @@ const BibDetails = (props) => {
             <ul>
               {notesGroupedByNoteType[noteType].map((note, index) => (
                 <li key={index}
-                  dir={stringDirection(note.prefLabel)}
-                  className={stringDirection(note.prefLabel)}
+                  dir={stringDirection(note.prefLabel, useParallels)}
+                  className={stringDirection(note.prefLabel, useParallels)}
                 >
                   {note.prefLabel}
                 </li>
@@ -361,7 +362,7 @@ const BibDetails = (props) => {
         key={label.trim().replace(/ /g, '')}
         onClick={onClick}
         to={`${appConfig.baseUrl}/search?${query}`}
-        dir={stringDirection(label)}
+        dir={stringDirection(label, useParallels)}
       >
         {label}
       </Link>
@@ -391,10 +392,12 @@ BibDetails.propTypes = {
   fields: PropTypes.array.isRequired,
   electronicResources: PropTypes.array,
   additionalData: PropTypes.array,
+  features: PropTypes.array,
 };
 BibDetails.defaultProps = {
   electronicResources: [],
   additionalData: [],
+  features: [],
 };
 
 export default BibDetails;

--- a/src/app/pages/BibPage.jsx
+++ b/src/app/pages/BibPage.jsx
@@ -76,9 +76,10 @@ const checkForMoreItems = (bib, dispatch) => {
 };
 
 export const BibPage = (
-  { bib, location, searchKeywords, dispatch, resultSelection },
+  { bib, location, searchKeywords, dispatch, resultSelection, features },
   context,
 ) => {
+  const useParallels = features && features.includes('parallels')
   if (!bib || parseInt(bib.status, 10) === 404) {
     return <BibNotFound404 context={context} />;
   }
@@ -108,7 +109,7 @@ export const BibPage = (
   // Make a copy of the `bib` so we can add additional fields with
   // computed data values that will make rendering them easier in
   // the `BibDetails` component.
-  const newBibModel = matchParallels(bib);
+  const newBibModel = matchParallels(bib, useParallels);
   newBibModel['notesGroupedByNoteType'] = getGroupedNotes(newBibModel);
   newBibModel['owner'] = getOwner(bib);
   newBibModel['updatedIdentifiers'] = getIdentifiers(newBibModel, bottomFields);
@@ -122,7 +123,7 @@ export const BibPage = (
         className='nypl-item-details'
         pageTitle='Item Details'
       >
-        <section className='nypl-item-details__heading' dir={stringDirection(mainHeading)}>
+        <section className='nypl-item-details__heading' dir={stringDirection(mainHeading, useParallels)}>
           <Heading level="two">
             { mainHeading }
           </Heading>
@@ -137,6 +138,7 @@ export const BibPage = (
               items,
             )}
             fields={topFields}
+            features={features}
           />
         </section>
 
@@ -171,6 +173,7 @@ export const BibPage = (
             bib={newBibModel}
             electronicResources={aggregatedElectronicResources}
             fields={bottomFields}
+            features={features}
           />
         </section>
 
@@ -189,6 +192,7 @@ BibPage.propTypes = {
   bib: PropTypes.object,
   dispatch: PropTypes.func,
   resultSelection: PropTypes.object,
+  features: PropTypes.array,
 };
 
 BibPage.contextTypes = {
@@ -203,6 +207,7 @@ const mapStateToProps = ({
   page,
   sortBy,
   resultSelection,
+  features,
 }) => ({
   bib,
   searchKeywords,
@@ -211,6 +216,7 @@ const mapStateToProps = ({
   page,
   sortBy,
   resultSelection,
+  features,
 });
 
 export default withRouter(connect(mapStateToProps)(BibPage));

--- a/src/app/utils/bibDetailsUtils.jsx
+++ b/src/app/utils/bibDetailsUtils.jsx
@@ -230,7 +230,8 @@ const isRtl  = (string) => {
  * @param {string} string
  * @return {string}
  */
-const stringDirection = (string) => {
+const stringDirection = (string, useParallels) => {
+  if (!useParallels) return null;
   return isRtl(string) ? 'rtl' : null
 }
 
@@ -279,7 +280,8 @@ const interleaveParallel = (arr1, arr2) => arr2.reduce(
  * @param {object} bib
  * @return {object}
  */
-const matchParallels = (bib) => {
+const matchParallels = (bib, useParallels) => {
+  if (!useParallels) return bib;
   const parallelFieldMatches = Object.keys(bib).map((key) => {
     if (key.match(/subject/i)) { return null }
     const match = key.match(/parallel(.)(.*)/)

--- a/test/unit/BibDetails.test.js
+++ b/test/unit/BibDetails.test.js
@@ -7,15 +7,16 @@ import { mount } from 'enzyme';
 import BibDetails from './../../src/app/components/BibPage/BibDetails';
 import { getGroupedNotes } from '../../src/app/utils/bibDetailsUtils';
 import { RouterProvider } from './../../src/app/context/RouterContext';
+import { Provider } from 'react-redux';
 import bibs from '../fixtures/bibs';
 
 describe('BibDetails', () => {
   describe('Invalid props', () => {
     it('should return null with no props passed', () => {
       const component = mount(
-        <RouterProvider value={{ push: () => {} }}>
-          <BibDetails />
-        </RouterProvider>,
+          <RouterProvider value={{ push: () => {} }}>
+              <BibDetails />
+          </RouterProvider>,
       );
       expect(component.children().html()).to.equal(null);
     });
@@ -327,14 +328,14 @@ describe('BibDetails', () => {
       const rtlComponent = mount(
         <RouterProvider value={{ push: () => {} }}>
           {
-            React.createElement(BibDetails, { bib: mockBibRtl, fields: mockFields })
+            React.createElement(BibDetails, { bib: mockBibRtl, fields: mockFields, features: ['parallels'] })
           }
         </RouterProvider>,
       );
       const ltrComponent = mount(
         <RouterProvider value={{ push: () => {} }}>
           {
-            React.createElement(BibDetails, { bib: mockBibLtr, fields: mockFields })
+            React.createElement(BibDetails, { bib: mockBibLtr, fields: mockFields, features: ['parallels'] })
           }
         </RouterProvider>,
       )
@@ -352,14 +353,14 @@ describe('BibDetails', () => {
       const rtlComponent = mount(
         <RouterProvider value={{ push: () => {} }}>
           {
-            React.createElement(BibDetails, { bib: mockBibRtl, fields: mockFields })
+            React.createElement(BibDetails, { bib: mockBibRtl, fields: mockFields, features: ['parallels'] })
           }
         </RouterProvider>,
       );
       const ltrComponent = mount(
         <RouterProvider value={{ push: () => {} }}>
           {
-            React.createElement(BibDetails, { bib: mockBibLtr, fields: mockFields })
+            React.createElement(BibDetails, { bib: mockBibLtr, fields: mockFields, features: ['parallels'] })
           }
         </RouterProvider>,
       )
@@ -380,14 +381,14 @@ describe('BibDetails', () => {
       const rtlComponent = mount(
         <RouterProvider value={{ push: () => {} }}>
           {
-            React.createElement(BibDetails, { bib: mockBibRtl, fields: mockFields })
+            React.createElement(BibDetails, { bib: mockBibRtl, fields: mockFields, features: ['parallels'] })
           }
         </RouterProvider>,
       );
       const ltrComponent = mount(
         <RouterProvider value={{ push: () => {} }}>
           {
-            React.createElement(BibDetails, { bib: mockBibLtr, fields: mockFields })
+            React.createElement(BibDetails, { bib: mockBibLtr, fields: mockFields, features: ['parallels'] })
           }
         </RouterProvider>,
       )
@@ -408,14 +409,14 @@ describe('BibDetails', () => {
       const rtlComponent = mount(
         <RouterProvider value={{ push: () => {} }}>
           {
-            React.createElement(BibDetails, { bib: mockBibRtl, fields: mockFields })
+            React.createElement(BibDetails, { bib: mockBibRtl, fields: mockFields, features: ['parallels'] })
           }
         </RouterProvider>,
       );
       const ltrComponent = mount(
         <RouterProvider value={{ push: () => {} }}>
           {
-            React.createElement(BibDetails, { bib: mockBibLtr, fields: mockFields })
+            React.createElement(BibDetails, { bib: mockBibLtr, fields: mockFields, features: ['parallels'] })
           }
         </RouterProvider>,
       )
@@ -429,14 +430,14 @@ describe('BibDetails', () => {
       const rtlComponent = mount(
         <RouterProvider value={{ push: () => {} }}>
           {
-            React.createElement(BibDetails, { bib: mockBibRtl, fields: mockFields })
+            React.createElement(BibDetails, { bib: mockBibRtl, fields: mockFields, features: ['parallels'] })
           }
         </RouterProvider>,
       );
       const ltrComponent = mount(
         <RouterProvider value={{ push: () => {} }}>
           {
-            React.createElement(BibDetails, { bib: mockBibLtr, fields: mockFields })
+            React.createElement(BibDetails, { bib: mockBibLtr, fields: mockFields, features: ['parallels'] })
           }
         </RouterProvider>,
       )
@@ -456,14 +457,14 @@ describe('BibDetails', () => {
       const rtlComponent = mount(
         <RouterProvider value={{ push: () => {} }}>
           {
-            React.createElement(BibDetails, { bib: mockBibRtl, fields: mockFields })
+            React.createElement(BibDetails, { bib: mockBibRtl, fields: mockFields, features: ['parallels'] })
           }
         </RouterProvider>,
       );
       const ltrComponent = mount(
         <RouterProvider value={{ push: () => {} }}>
           {
-            React.createElement(BibDetails, { bib: mockBibLtr, fields: mockFields })
+            React.createElement(BibDetails, { bib: mockBibLtr, fields: mockFields, features: ['parallels'] })
           }
         </RouterProvider>,
       )

--- a/test/unit/BibPage.test.js
+++ b/test/unit/BibPage.test.js
@@ -247,6 +247,7 @@ describe('BibPage', () => {
               fromUrl: '',
               bibId: '',
             }}
+            features={['parallels']}
           />
         </Provider>,
         {
@@ -276,6 +277,7 @@ describe('BibPage', () => {
               fromUrl: '',
               bibId: '',
             }}
+            features={['parallels']}
           />
         </Provider>,
         {
@@ -305,6 +307,7 @@ describe('BibPage', () => {
               fromUrl: '',
               bibId: '',
             }}
+            features={['parallels']}
           />
         </Provider>,
         {

--- a/test/unit/bibDetailsUtils.test.js
+++ b/test/unit/bibDetailsUtils.test.js
@@ -267,12 +267,14 @@ describe('bibDetailsUtils', () => {
   })
 
   describe('stringDirection', () => {
+    const useParallels = true;
+
     it('should return \'rtl\' for right-to-left strings', () => {
-      expect(stringDirection('\u200F\u00E9', true)).to.eql('rtl')
+      expect(stringDirection('\u200F\u00E9', useParallels)).to.eql('rtl')
     })
 
     it('should return null for left-to-right strings', () => {
-      expect(stringDirection('\u00E9', true)).to.eql(null)
+      expect(stringDirection('\u00E9', useParallels)).to.eql(null)
     })
   })
 

--- a/test/unit/bibDetailsUtils.test.js
+++ b/test/unit/bibDetailsUtils.test.js
@@ -268,11 +268,11 @@ describe('bibDetailsUtils', () => {
 
   describe('stringDirection', () => {
     it('should return \'rtl\' for right-to-left strings', () => {
-      expect(stringDirection('\u200F\u00E9')).to.eql('rtl')
+      expect(stringDirection('\u200F\u00E9', true)).to.eql('rtl')
     })
 
     it('should return null for left-to-right strings', () => {
-      expect(stringDirection('\u00E9')).to.eql(null)
+      expect(stringDirection('\u00E9', true)).to.eql(null)
     })
   })
 
@@ -330,7 +330,7 @@ describe('bibDetailsUtils', () => {
         parallelTitle: ['t3', 't4']
       }
 
-      expect(matchParallels(fakeBib)).to.eql(expectedBib)
+      expect(matchParallels(fakeBib, true)).to.eql(expectedBib)
     })
   });
 });


### PR DESCRIPTION
**What's this do?**
Makes the parallels work dependent on a feature flag to enable

**Why are we doing this? (w/ JIRA link if applicable)**
We are currently blocked on the feature flag work, I want to be able to merge it (so we don't create merge issues later) without it being enabled (since we aren't ready to show parallels in prod)

**Do these changes have automated tests?**
Yes

**How should this be QAed?**
Should not affect QA

**Dependencies for merging? Releasing to production?**
No

**Has the application documentation been updated for these changes?**
Yes

**Did someone actually run this code to verify it works?**
Yes
