### PR TITLE
Scc 3196

### DIFF
--- a/src/app/pages/BibPage.jsx
+++ b/src/app/pages/BibPage.jsx
@@ -112,8 +112,6 @@ export const BibPage = (
   newBibModel['updatedIdentifiers'] = getIdentifiers(newBibModel, bottomFields);
   newBibModel['updatedSubjectLiteral'] = compressSubjectLiteral(bib);
 
-  if (typeof window !== 'undefined') { window.bib = newBibModel }
-
   return (
     <RouterProvider value={context}>
       <SccContainer

--- a/src/app/pages/BibPage.jsx
+++ b/src/app/pages/BibPage.jsx
@@ -112,6 +112,8 @@ export const BibPage = (
   newBibModel['updatedIdentifiers'] = getIdentifiers(newBibModel, bottomFields);
   newBibModel['updatedSubjectLiteral'] = compressSubjectLiteral(bib);
 
+  if (typeof window !== 'undefined') { window.bib = newBibModel }
+
   return (
     <RouterProvider value={context}>
       <SccContainer
@@ -139,19 +141,23 @@ export const BibPage = (
           />
         </section>
 
-        {items.length && !isElectronicResources && (
-          <section style={{ marginTop: '20px' }}>
-            <ItemsContainer
-              key={bibId}
-              shortenItems={location.pathname.indexOf('all') !== -1}
-              items={items}
-              bibId={bibId}
-              itemPage={location.search}
-              searchKeywords={searchKeywords}
-              holdings={newBibModel.holdings}
-            />
-          </section>
-        )}
+        {
+          items.length && !isElectronicResources ?
+          (
+            <section style={{ marginTop: '20px' }}>
+              <ItemsContainer
+                key={bibId}
+                shortenItems={location.pathname.indexOf('all') !== -1}
+                items={items}
+                bibId={bibId}
+                itemPage={location.search}
+                searchKeywords={searchKeywords}
+                holdings={newBibModel.holdings}
+              />
+            </section>
+          ) :
+          null
+        }
 
         {newBibModel.holdings && (
           <section style={{ marginTop: '20px' }}>

--- a/test/unit/BibPage.test.js
+++ b/test/unit/BibPage.test.js
@@ -54,7 +54,7 @@ describe('BibPage', () => {
       );
       // The Bottom Bib Details Component has the original, Non altered, aggregated resources list.
       // It can be checked to see if the bib details would have been passed a list with Aeon links.
-      
+
       expect(bttBibComp.type()).to.equal(BibDetails);
       expect(bttBibComp.prop('electronicResources')).to.have.lengthOf(2);
 
@@ -123,6 +123,37 @@ describe('BibPage', () => {
       expect(linkToLegacy.length).to.equal(1);
       expect(linkToLegacy.is('a')).to.equal(true);
       expect(linkToLegacy.prop('href')).to.equal('https://legacyBaseUrl.nypl.org/record=b11417539~S1');
+    });
+  });
+
+  describe('No items', () => {
+    const testStore = makeTestStore({
+      bib: {
+        done: true,
+        numItems: 0,
+      },
+    });
+
+    let component;
+    before(() => {
+      const bib = { ...bibs[0], ...annotatedMarc };
+      bib.items = [];
+      component = mount(
+        <Provider store={testStore}>
+          <BibPage
+            location={{ search: 'search', pathname: '' }}
+            bib={bib}
+            dispatch={() => {}}
+            resultSelection={{
+              fromUrl: '',
+              bibId: '',
+            }}
+          />
+        </Provider>, { context, childContextTypes: { router: PropTypes.object } });
+    });
+
+    it('should not display ItemsContainer', () => {
+      expect(component.find('ItemsContainer').length).to.equal(0);
     });
   });
 


### PR DESCRIPTION
**What's this do?**
Fixes a small bug where bibs with no items display `0` in place of the `ItemsContainer`

**Why are we doing this? (w/ JIRA link if applicable)**
SCC-3196

**Do these changes have automated tests?**
Yes

**How should this be QAed?**
Navigate to any bib with 0 items, there should be no weird `0`

**Dependencies for merging? Releasing to production?**
No

**Has the application documentation been updated for these changes?**
NA

**Did someone actually run this code to verify it works?**
Yes
