### PR TITLE
remove old color overrides

### DIFF
--- a/src/client/styles/components/BibPage.scss
+++ b/src/client/styles/components/BibPage.scss
@@ -1,11 +1,5 @@
 @import 'toolkit';
 
-.nypl-item-details {
-  a {
-    text-decoration: underline;
-  }
-}
-
 .view-all-items-container {
   margin-top: 1.5rem;
 }
@@ -107,78 +101,8 @@ div .tabbed {
   display: inline-block;
 }
 
-// If there is a single hierarchical string of subjects,
-// they will appear as a's under a dd. If the dd is hovered, we make the
-// a's light blue
-.tabbed dd:hover a {
-  color: #3ab0df;
+a:hover {
   text-decoration: none;
-}
-
-// then we make the a's following the hovered a regular blue. We have to do it
-// this way because there is no 'younger sibling' selector
-.tabbed dd a:hover ~ a {
-  color: #1b7fa7;
-  text-decoration: underline;
-}
-
-.tabbed dd span:hover ~ a {
-  color: #1b7fa7;
-  text-decoration: underline;
-}
-
-// If there are multiple hierarchical strings of subjects, they will appear as
-// a ul of li's containing a's (each li is a single string of subjects)
-// So we need to cancel the above stylings in this case. Below we apply the same
-// trick as above, but to each li separately.
-.tabbed dd:hover ul li a {
-  color: #1b7fa7;
-  text-decoration: underline;
-}
-
-// Visited a's have a darker shade of blue as their default
-
-.tabbed dd a:hover ~ a:visited {
-  color: #104d65;
-}
-
-.tabbed dd span:hover ~ a:visited {
-  color: #104d65;
-}
-
-// If we have multiple subject strings, each li gets the styling above.
-// If an li is hovered, we make the links light blue
-
-.tabbed dd:hover ul li:hover a {
-  color: #3ab0df;
-  text-decoration: none;
-}
-
-// Then we restore links to their default if they come after the link
-.tabbed dd ul li:hover a:hover ~ a {
-  color: #1b7fa7;
-  text-decoration: underline;
-}
-
-.tabbed dd ul li:hover span:hover ~ a {
-  color: #1b7fa7;
-  text-decoration: underline;
-}
-
-// Visited links have a darker default
-.tabbed dd ul li:hover a:hover ~ a:visited {
-  color: #104d65;
-}
-
-.tabbed dd ul li:hover span:hover ~ a:visited {
-  color: #104d65;
-}
-
-.tabbed dd {
-  a {
-    color: #1b7fa7;
-    text-decoration: underline;
-  }
 }
 
 @media (max-width: 1120px) {


### PR DESCRIPTION
**What's this do?**
Removes old css styling that was overriding the design system colors for links.

**Why are we doing this? (w/ JIRA link if applicable)**
To match figma designs

**Do these changes have automated tests?**
no

**How should this be QAed?**
Ensure all links are the same color on Item Details view. The css styling mentioned subjects, so that should be double checked, but it does not appear to adversely affect the subjects styling. I checked this bib which has subjects http://local.nypl.org:3001/research/research-catalog/bib/b14382407

**Dependencies for merging? Releasing to production?**
nope

**Has the application documentation been updated for these changes?**

**Did someone actually run this code to verify it works?**
yes