### PR TITLE
Scc 3170 fix internal linking

### DIFF
--- a/src/app/components/LoadingLayer/LoadingLayer.jsx
+++ b/src/app/components/LoadingLayer/LoadingLayer.jsx
@@ -1,11 +1,19 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import FocusTrap from 'focus-trap-react';
 
 const LoadingLayer = ({ loading, title, focus }) => {
+  useEffect(() => {
+    if (typeof window !== undefined) {
+      const element = document.getElementById(window.location.hash.slice(1));
+      if (element) element.scrollIntoView()
+    }
+  })
+
   if (loading === false) {
     return null;
   }
+
 
   return (
     <FocusTrap


### PR DESCRIPTION
**What's this do?**
Adds logic to jump to the appropriate part of the page when done loading, on pages that have a hash

**Why are we doing this? (w/ JIRA link if applicable)**
We want links to see electronic/physical items on the search results page to go to the appropriate part of the bib page. However, that section doesn't exist until after data is loaded.

This is the simplest solution I have been able to come up with: manually jump to the right part of the page when we are done loading. I'm not sure it's the best, but I don't have anything better.

**Do these changes have automated tests?**
No

**How should this be QAed?**
See 3170

**Dependencies for merging? Releasing to production?**
No

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Yes.