### PR TITLE
add connection timeout to shepapicall

### DIFF
--- a/src/server/ApiRoutes/Bib.js
+++ b/src/server/ApiRoutes/Bib.js
@@ -1,4 +1,4 @@
-import axios, { AbortController } from 'axios';
+import axios from 'axios';
 
 import nyplApiClient from '../routes/nyplApiClient';
 import logger from '../../../logger';
@@ -20,7 +20,6 @@ const shepApiCall = (bibId) => {
   const timeout = setTimeout(() => {
     source.cancel()
   }, 5000)
-
   return axios({
     method: 'get',
     url: `${appConfig.shepApi}/bibs/${bibId}/subject_headings`,

--- a/src/server/ApiRoutes/SubjectHeadings.js
+++ b/src/server/ApiRoutes/SubjectHeadings.js
@@ -50,19 +50,27 @@ const convertShepBibsToDiscoveryBibs = response =>
  *    https://www.npmjs.com/package/axios#handling-errors )
  */
 const shepApiCall = (path, queryParams) => {
-  logger.debug(`Making shep api call: ${appConfig.shepApi}${path}`);
-
+  const source = axios.CancelToken.source()
+  const timeout = setTimeout(() => {
+    source.cancel()
+  }, 5000)
   return axios({
     method: 'GET',
     url: `${appConfig.shepApi}${path}`,
     params: queryParams,
+    timeout: 4000,
+    cancelToken: source.token
   }).then((response) => {
     if (/\/bibs/.test(path)) {
       return convertShepBibsToDiscoveryBibs(response);
     }
-
+    clearTimeout(timeout)
     return response;
-  });
+  }).catch((e) => {
+    if (axios.isCancel(e)) {
+      console.log('connection timeout')
+    }
+  })
 };
 
 /**


### PR DESCRIPTION
**What's this do?**
Adds separate timeout for failed connections to SHEP API.

**Why are we doing this? (w/ JIRA link if applicable)**
Necessary because axios timeout only works on response timeouts, not connection timeouts. 

**Do these changes have automated tests?**
no

**How should this be QAed?**
Accessing subject heading explorer and a bib with subjects with the VPN off.