### PR TITLE
change division href

### DIFF
--- a/src/app/pages/Home.jsx
+++ b/src/app/pages/Home.jsx
@@ -81,7 +81,7 @@ const Home = (props, context) => (
         </div>
         <div className="nypl-column-three-quarters image-column-three-quarters">
           <Heading level="four">
-            <a href="/research-divisions/" onClick={() => trackDiscovery('Research Links', 'Divisions')}>Divisions</a>
+            <a href="/about/divisions" onClick={() => trackDiscovery('Research Links', 'Divisions')}>Divisions</a>
           </Heading>
           <p>Learn about the subject and media specializations of our research divisions.</p>
         </div>


### PR DESCRIPTION
**What's this do?**
update Divisions link from research-locations to about/divisions

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SCC-3035

**Do these changes have automated tests?**
no

**How should this be QAed?**
check that clicking the divisions link on the landing page goes to nypl.org/about/divisions 

**Did someone actually run this code to verify it works?**
Not yet. None of the links on the page work while running locally. Going to run QA and see if it works.