### PR TITLE
disable host check in webpackdev-server

### DIFF
--- a/server.js
+++ b/server.js
@@ -160,6 +160,7 @@ if (!isProduction && !isTest) {
   const WebpackDevServer = require('webpack-dev-server');
 
   new WebpackDevServer(webpack(webpackConfig), {
+    disableHostCheck: true,
     publicPath: webpackConfig.output.publicPath,
     hot: true,
     stats: false,


### PR DESCRIPTION
**What's this do?**
adds option to webpack dev server instantiation to disable host check

**Why are we doing this? (w/ JIRA link if applicable)**
to end the reign of (t)error

**Do these changes have automated tests?**
no

**How should this be QAed?**
double check that errors are no longer being logged in dev console

**Dependencies for merging? Releasing to production?**
[Description of any watchouts, dependencies, or issues we should be aware of]

**Has the application documentation been updated for these changes?**

**Did someone actually run this code to verify it works?**
