### PR TITLE
Add deployment trigger for qa2 tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,19 @@ deploy:
     repo: NYPL/discovery-front-end
     all_branches: true
     condition: "$TRAVIS_TAG =~ ^qa-.*"
+- provider: elasticbeanstalk
+  skip_cleanup: false
+  access_key_id: "$AWS_ACCESS_KEY_ID_QA"
+  secret_access_key: "$AWS_SECRET_ACCESS_KEY_QA"
+  region: us-east-1
+  app: discovery-ui
+  env: DiscoveryUi-edd-training
+  bucket_name: elasticbeanstalk-us-east-1-946183545209
+  bucket_path: discovery-ui-edd-training
+  on:
+    repo: NYPL/discovery-front-end
+    all_branches: true
+    condition: "$TRAVIS_TAG =~ ^qa2-.*"
 after_deploy: echo 'Successfully executed deploy trigger for Discovery Research Catalog
   on AWS'
 env:

--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ This app has an unusual Git Workflow / deployment scheme:
 - Cut feature branches off of the `development` branch
 - Post a PR targeting `development`
 - After an approved PR to `development`, tag your feature branch\* `qa-deployment-{YYYY}-{MM}-{DD}` to deploy to QA
+  - Alternatively, use `qa2-` as a tag prefix to deploy the change to ["edd-training"](https://discoveryui-edd-training.nypl.org/), our "QA2" server. This may be preferable when QA is locked up with another review and/or when you're seeking feedback on a feature while it's in active development.
 - Only after feature branch is approved in QA, merge to `development`
 - Merge `development` into `production` to deploy to production
 


### PR DESCRIPTION
**What's this do?**
Deploy anything tagged qa2-* to DiscoveryUi-edd-training beanstalk app

**Why are we doing this? (w/ JIRA link if applicable)**
In Retro we discussed having a secondary place to deploy things for visual review. In lieu of doing something like vercel, let's make better use of our "edd-training" deployment, which we'll treat as a "QA2"

**Do these changes have automated tests?**
n/a

**How should this be QAed?**
Add a tag starting "qa2-" and verify it deploys to edd-training

**Dependencies for merging? Releasing to production?**
n/a

**Has the application documentation been updated for these changes?**
Added notes on `qa2-*` deployment tag to README

**Did someone actually run this code to verify it works?**
That will happen after merge