### PR TITLE
Add extra spacing between different item-related elements in results

### DIFF
--- a/src/app/components/Item/ItemTable.jsx
+++ b/src/app/components/Item/ItemTable.jsx
@@ -32,7 +32,7 @@ const ItemTable = ({ items, bibId, id, searchKeywords, page }) => {
 
   return (
     itemGroups.map(group => (
-      <div key={`item-${group[0].id}-div`} className={ page === 'SearchResults' ? 'search-results-table-div' : null}>
+      <div key={`item-${group[0].id}-div`} className={ `results-items-element${page === 'SearchResults' ? ' search-results-table-div' : null}`}>
         <table className={`nypl-basic-table${page === 'SearchResults' ? ' fixed-table' : ''}`} id={id} >
           <caption className="hidden">Item details</caption>
           <thead>

--- a/src/app/components/Item/ItemsDefinitionLists.jsx
+++ b/src/app/components/Item/ItemsDefinitionLists.jsx
@@ -38,7 +38,7 @@ const ItemsDefinitionLists = ({ items, holdings, bibId, id, searchKeywords, page
             }
 
             return (
-              <div key={`item-${item.id}-div`} id={`item-${item.id}-div`} className="item-dl-wrapper">
+              <div key={`item-${item.id}-div`} id={`item-${item.id}-div`} className="results-items-element">
                 <dl key={`item-${item.id}-dl`} id={`item-${item.id}-dl`}>
                   <dt key={`item-${item.id}-format-dt`} id={`item-${item.id}-format-dt`}>Format</dt>
                   <dd key={`item-${item.id}-format-dd`} id={`item-${item.id}-format-dd`}>{item.format || ' '}</dd>

--- a/src/app/components/ResultsList/ResultsList.jsx
+++ b/src/app/components/ResultsList/ResultsList.jsx
@@ -163,7 +163,7 @@ const ResultsList = ({
                         className="search-results-list-link"
                         id="physical-items-link"
                       >
-                        <Text isBold size="caption">
+                        <Text isBold size="caption" className="results-items-element">
                           {`View All ${totalPhysicalItems} Items`} <RightWedgeIcon />
                         </Text>
                       </Link>

--- a/src/client/styles/components/ItemTable.scss
+++ b/src/client/styles/components/ItemTable.scss
@@ -120,6 +120,10 @@
   }
 }
 
+.results-items-element + .results-items-element {
+  margin-bottom: var(--nypl-space-s);
+}
+
 .items-definition-list {
   .item-dl-wrapper + .item-dl-wrapper {
     margin-top: var(--nypl-space-s);


### PR DESCRIPTION
**What's this do?**
Adds spacing between item table or item dl and the 'View all' button


**Did someone actually run this code to verify it works?**
yes
