### PR TITLE
SCC-3301

### DIFF
--- a/src/client/styles/components/HoldRequest.scss
+++ b/src/client/styles/components/HoldRequest.scss
@@ -139,10 +139,10 @@ form.electronic-delivery-form {
 
       input {
         background-color: var(--nypl-colors-ui-white);
-        border: 0;
+        border: 1px solid $darkColorBoxShadow;
         border-radius: 0.25rem;
         font-size: 1rem;
-        box-shadow: inset 0 0 0 1px $darkColorBoxShadow;
+        // box-shadow: inset 0 0 0 1px $darkColorBoxShadow;
         height: 2rem;
         padding: 1rem 0;
         text-indent: 0.5rem;
@@ -151,8 +151,8 @@ form.electronic-delivery-form {
       }
 
       textarea {
-        box-shadow: inset 0 0 0 1px $darkColorBoxShadow;
-        border: 0;
+        // box-shadow: inset 0 0 0 1px $darkColorBoxShadow;
+        border: 1px solid $darkColorBoxShadow;
         border-radius: 0.25rem;
         box-sizing: border-box;
         font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";

--- a/src/client/styles/components/HoldRequest.scss
+++ b/src/client/styles/components/HoldRequest.scss
@@ -139,10 +139,13 @@ form.electronic-delivery-form {
 
       input {
         background-color: var(--nypl-colors-ui-white);
-        border: 1px solid $darkColorBoxShadow;
         border-radius: 0.25rem;
         font-size: 1rem;
-        // box-shadow: inset 0 0 0 1px $darkColorBoxShadow;
+        box-shadow: inset 0 0 0 1px $darkColorBoxShadow;
+        @include media($mobile-breakpoint) {
+          box-shadow: none;
+          border: 1px solid $darkColorBoxShadow;
+        }
         height: 2rem;
         padding: 1rem 0;
         text-indent: 0.5rem;
@@ -151,8 +154,11 @@ form.electronic-delivery-form {
       }
 
       textarea {
-        // box-shadow: inset 0 0 0 1px $darkColorBoxShadow;
-        border: 1px solid $darkColorBoxShadow;
+        box-shadow: inset 0 0 0 1px $darkColorBoxShadow;
+        @include media($mobile-breakpoint) {
+          box-shadow: none;
+          border: 1px solid $darkColorBoxShadow;
+        }
         border-radius: 0.25rem;
         box-sizing: border-box;
         font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";


### PR DESCRIPTION
**What's this do?**
Changes the styling for EDD form input fields in mobile 

**Why are we doing this? (w/ JIRA link if applicable)**
For some reason, box-shadow doesn't show up correctly on iPhones. I've added a simple black border for mobile, which visually comes pretty close and is interpreted correctly by the phone.

**Do these changes have automated tests?**
No, these are just css changes.

**How should this be QAed?**
See ticket.

**Dependencies for merging? Releasing to production?**
No.

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Yes.
