### PR TITLE
Updating colors to match DS colors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1803,22 +1803,22 @@
       "integrity": "sha512-ej5oVy6lykXsvieQtqZxCOaLT+xD4+QNarq78cIYISHmZXshCvROLudpQN3lfL8G0NL7plMSSK+zlyvCaIJ4Iw=="
     },
     "@emotion/babel-plugin": {
-      "version": "11.10.2",
-      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.10.2.tgz",
-      "integrity": "sha512-xNQ57njWTFVfPAc3cjfuaPdsgLp5QOSuRsj9MA6ndEhH/AzuZM86qIQzt6rq+aGBwj3n5/TkLmU5lhAfdRmogA==",
+      "version": "11.10.5",
+      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.10.5.tgz",
+      "integrity": "sha512-xE7/hyLHJac7D2Ve9dKroBBZqBT7WuPQmWcq7HSGb84sUuP4mlOWoB8dvVfD9yk5DHkU1m6RW7xSoDtnQHNQeA==",
       "requires": {
         "@babel/helper-module-imports": "^7.16.7",
         "@babel/plugin-syntax-jsx": "^7.17.12",
         "@babel/runtime": "^7.18.3",
         "@emotion/hash": "^0.9.0",
         "@emotion/memoize": "^0.8.0",
-        "@emotion/serialize": "^1.1.0",
+        "@emotion/serialize": "^1.1.1",
         "babel-plugin-macros": "^3.1.0",
         "convert-source-map": "^1.5.0",
         "escape-string-regexp": "^4.0.0",
         "find-root": "^1.1.0",
         "source-map": "^0.5.7",
-        "stylis": "4.0.13"
+        "stylis": "4.1.3"
       },
       "dependencies": {
         "escape-string-regexp": {
@@ -1829,15 +1829,15 @@
       }
     },
     "@emotion/cache": {
-      "version": "11.10.3",
-      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.10.3.tgz",
-      "integrity": "sha512-Psmp/7ovAa8appWh3g51goxu/z3iVms7JXOreq136D8Bbn6dYraPnmL6mdM8GThEx9vwSn92Fz+mGSjBzN8UPQ==",
+      "version": "11.10.5",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.10.5.tgz",
+      "integrity": "sha512-dGYHWyzTdmK+f2+EnIGBpkz1lKc4Zbj2KHd4cX3Wi8/OWr5pKslNjc3yABKH4adRGCvSX4VDC0i04mrrq0aiRA==",
       "requires": {
         "@emotion/memoize": "^0.8.0",
-        "@emotion/sheet": "^1.2.0",
+        "@emotion/sheet": "^1.2.1",
         "@emotion/utils": "^1.2.0",
         "@emotion/weak-memoize": "^0.3.0",
-        "stylis": "4.0.13"
+        "stylis": "4.1.3"
       }
     },
     "@emotion/hash": {
@@ -1859,14 +1859,14 @@
       "integrity": "sha512-G/YwXTkv7Den9mXDO7AhLWkE3q+I92B+VqAE+dYG4NGPaHZGvt3G8Q0p9vmE+sq7rTGphUbAvmQ9YpbfMQGGlA=="
     },
     "@emotion/react": {
-      "version": "11.10.4",
-      "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.10.4.tgz",
-      "integrity": "sha512-j0AkMpr6BL8gldJZ6XQsQ8DnS9TxEQu1R+OGmDZiWjBAJtCcbt0tS3I/YffoqHXxH6MjgI7KdMbYKw3MEiU9eA==",
+      "version": "11.10.5",
+      "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.10.5.tgz",
+      "integrity": "sha512-TZs6235tCJ/7iF6/rvTaOH4oxQg2gMAcdHemjwLKIjKz4rRuYe1HJ2TQJKnAcRAfOUDdU8XoDadCe1rl72iv8A==",
       "requires": {
         "@babel/runtime": "^7.18.3",
-        "@emotion/babel-plugin": "^11.10.0",
-        "@emotion/cache": "^11.10.0",
-        "@emotion/serialize": "^1.1.0",
+        "@emotion/babel-plugin": "^11.10.5",
+        "@emotion/cache": "^11.10.5",
+        "@emotion/serialize": "^1.1.1",
         "@emotion/use-insertion-effect-with-fallbacks": "^1.0.0",
         "@emotion/utils": "^1.2.0",
         "@emotion/weak-memoize": "^0.3.0",
@@ -1874,9 +1874,9 @@
       }
     },
     "@emotion/serialize": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.1.0.tgz",
-      "integrity": "sha512-F1ZZZW51T/fx+wKbVlwsfchr5q97iW8brAnXmsskz4d0hVB4O3M/SiA3SaeH06x02lSNzkkQv+n3AX3kCXKSFA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.1.1.tgz",
+      "integrity": "sha512-Zl/0LFggN7+L1liljxXdsVSVlg6E/Z/olVWpfxUTxOAmi8NU7YoeWeLfi1RmnB2TATHoaWwIBRoL+FvAJiTUQA==",
       "requires": {
         "@emotion/hash": "^0.9.0",
         "@emotion/memoize": "^0.8.0",
@@ -1886,19 +1886,19 @@
       }
     },
     "@emotion/sheet": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.2.0.tgz",
-      "integrity": "sha512-OiTkRgpxescko+M51tZsMq7Puu/KP55wMT8BgpcXVG2hqXc0Vo0mfymJ/Uj24Hp0i083ji/o0aLddh08UEjq8w=="
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.2.1.tgz",
+      "integrity": "sha512-zxRBwl93sHMsOj4zs+OslQKg/uhF38MB+OMKoCrVuS0nyTkqnau+BM3WGEoOptg9Oz45T/aIGs1qbVAsEFo3nA=="
     },
     "@emotion/styled": {
-      "version": "11.10.4",
-      "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.10.4.tgz",
-      "integrity": "sha512-pRl4R8Ez3UXvOPfc2bzIoV8u9P97UedgHS4FPX594ntwEuAMA114wlaHvOK24HB48uqfXiGlYIZYCxVJ1R1ttQ==",
+      "version": "11.10.5",
+      "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.10.5.tgz",
+      "integrity": "sha512-8EP6dD7dMkdku2foLoruPCNkRevzdcBaY6q0l0OsbyJK+x8D9HWjX27ARiSIKNF634hY9Zdoedh8bJCiva8yZw==",
       "requires": {
         "@babel/runtime": "^7.18.3",
-        "@emotion/babel-plugin": "^11.10.0",
+        "@emotion/babel-plugin": "^11.10.5",
         "@emotion/is-prop-valid": "^1.2.0",
-        "@emotion/serialize": "^1.1.0",
+        "@emotion/serialize": "^1.1.1",
         "@emotion/use-insertion-effect-with-fallbacks": "^1.0.0",
         "@emotion/utils": "^1.2.0"
       }
@@ -2158,9 +2158,9 @@
       }
     },
     "@nypl/design-system-react-components": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@nypl/design-system-react-components/-/design-system-react-components-1.1.2.tgz",
-      "integrity": "sha512-ptNg7irbr4uoDrhdJO+d4gme+v1dZ1WCCqFYuamQiot+2G84mOiNl6dICMk+vW6gKoYjtpY1iA5t3GNm86USXg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@nypl/design-system-react-components/-/design-system-react-components-1.2.1.tgz",
+      "integrity": "sha512-J20gtWG1yF9SdoU8CWGDJqT4NI9YPK93b/nxkAOa1RnLDw5+Kq0dWLDKq6jQoaa7ussCowahAZG7ZxmZvvB+hw==",
       "requires": {
         "@chakra-ui/focus-lock": ">=1.2.6 <2.0.0",
         "@chakra-ui/react": ">=1.8.5 <=1.8.8",
@@ -2168,6 +2168,7 @@
         "@charlietango/use-native-lazy-loading": "1.10.0",
         "@emotion/react": ">=11.4.1",
         "@emotion/styled": ">=11.3.0",
+        "downshift": "^6.1.7",
         "framer-motion": "^4.1.17",
         "js-cookie": "3.0.1",
         "react-datepicker": "4.1.1",
@@ -2236,7 +2237,7 @@
         "classnames": {
           "version": "2.1.3",
           "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.1.3.tgz",
-          "integrity": "sha1-r5skU/wUOuhUbQ5zu+6kD3S342M="
+          "integrity": "sha512-NRhGX4ySdv1fCMZq/C7e8qwpfAyyx/WBksRVr0/S3nGEWTzAROmrZMZle5UuUJup1tPsCVVlAgfCxqNfCOsUmw=="
         },
         "core-js": {
           "version": "1.2.7",
@@ -2292,7 +2293,7 @@
     "@nypl/dgx-svg-icons": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/@nypl/dgx-svg-icons/-/dgx-svg-icons-0.2.5.tgz",
-      "integrity": "sha1-MfhCnhrkgmRMUJwUkgcZkuvsXHs="
+      "integrity": "sha512-ZxJijrBIx5DZISSMlZA6MkFc3gLH39ImvRMKYIKb9Ffe1RTh9G9jWjivp//oYVfQVbPmkajsBzQMWQaunEZfuQ=="
     },
     "@nypl/nypl-data-api-client": {
       "version": "1.0.5",
@@ -2472,9 +2473,9 @@
       "dev": true
     },
     "@types/lodash": {
-      "version": "4.14.186",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.186.tgz",
-      "integrity": "sha512-eHcVlLXP0c2FlMPm56ITode2AgLMSa6aJ05JTTbYbI+7EMkCEE5qk2E41d5g2lCVTqRe0GnnRFurmlCsDODrPw=="
+      "version": "4.14.187",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.187.tgz",
+      "integrity": "sha512-MrO/xLXCaUgZy3y96C/iOsaIqZSeupyTImKClHunL5GrmaiII2VwvWmLBu2hwa0Kp0sV19CsyjtrTc/Fx8rg/A=="
     },
     "@types/lodash.mergewith": {
       "version": "4.6.6",
@@ -3059,7 +3060,7 @@
     "alt-utils": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/alt-utils/-/alt-utils-1.0.0.tgz",
-      "integrity": "sha1-G8PXmv6cPNHTe4WBDeIEYNzHcjQ="
+      "integrity": "sha512-1+EU2Sl5BixQuV53fOcxDy+nLaoE9HNQYTpo8SzKnPELzaRjVfG1Jdt6Y9DCgy9sfkCgkb895ZCap3yfAt4cdA=="
     },
     "amdefine": {
       "version": "1.0.1",
@@ -3458,9 +3459,9 @@
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
     },
     "avsc": {
-      "version": "5.7.5",
-      "resolved": "https://registry.npmjs.org/avsc/-/avsc-5.7.5.tgz",
-      "integrity": "sha512-vkyt1+sj6qaD9oMtqqLE2pZ2IcHI66kFx8lpnVuXp55SnNPjKghfOhVfZpaDwDPpY0oVWP3Qu1uHZWxF3E856A=="
+      "version": "5.7.6",
+      "resolved": "https://registry.npmjs.org/avsc/-/avsc-5.7.6.tgz",
+      "integrity": "sha512-jyn9tfd9J3h7pgJSk4qQ/1c1Tk5qiXrvmdCDON2UjcFplqRu/KpmKmpi+Ess8ZKmmqK12U4Y3VHrfwQs1xSMZA=="
     },
     "aws-sdk": {
       "version": "2.99.0",
@@ -4768,7 +4769,7 @@
     "clone": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w=="
     },
     "clone-deep": {
       "version": "4.0.1",
@@ -5833,6 +5834,30 @@
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
       "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q=="
+    },
+    "downshift": {
+      "version": "6.1.12",
+      "resolved": "https://registry.npmjs.org/downshift/-/downshift-6.1.12.tgz",
+      "integrity": "sha512-7XB/iaSJVS4T8wGFT3WRXmSF1UlBHAA40DshZtkrIscIN+VC+Lh363skLxFTvJwtNgHxAMDGEHT4xsyQFWL+UA==",
+      "requires": {
+        "@babel/runtime": "^7.14.8",
+        "compute-scroll-into-view": "^1.0.17",
+        "prop-types": "^15.7.2",
+        "react-is": "^17.0.2",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "compute-scroll-into-view": {
+          "version": "1.0.17",
+          "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-1.0.17.tgz",
+          "integrity": "sha512-j4dx+Fb0URmzbwwMUrhqWM2BEWHdFGx+qZ9qqASHRPqvTYdqvWnHg0H1hIbcyLnvgnoNAVMlwkepyqM3DaIFUg=="
+        },
+        "react-is": {
+          "version": "17.0.2",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+          "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+        }
+      }
     },
     "duplexer": {
       "version": "0.1.2",
@@ -7266,7 +7291,7 @@
     "fbemitter": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/fbemitter/-/fbemitter-2.1.1.tgz",
-      "integrity": "sha1-Uj4U/a9SSIBbsC9i78M75wP1GGU=",
+      "integrity": "sha512-hd8PgD+Q6RQtlcGrkM9oY3MFIjq6CA6wurCK1TKn2eaA76Ww4VAOihmq98NyjRhjJi/axgznZnh9lF8+TcTsNQ==",
       "requires": {
         "fbjs": "^0.8.4"
       },
@@ -7274,7 +7299,7 @@
         "core-js": {
           "version": "1.2.7",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+          "integrity": "sha512-ZiPp9pZlgxpWRu0M+YWbm6+aQ84XEfH1JRXvfOc/fILWI0VKhLC2LX13X1NYq4fULzLMq7Hfh43CSo2/aIaUPA=="
         },
         "fbjs": {
           "version": "0.8.18",
@@ -7295,7 +7320,7 @@
     "fbjs": {
       "version": "0.1.0-alpha.7",
       "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.1.0-alpha.7.tgz",
-      "integrity": "sha1-rUMIuPIy+zxzYDNJ6nJdHpw5Mjw=",
+      "integrity": "sha512-dJbzq7AfRYmVXZ3a/dsKLe2B00KGmsOlmKeUcyOCKZWixK6F4Fz8JM6btWgEoHxs2uwxJ1bTR9L+OKkVGPOyag==",
       "requires": {
         "core-js": "^1.0.0",
         "promise": "^7.0.3",
@@ -7305,12 +7330,12 @@
         "core-js": {
           "version": "1.2.7",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+          "integrity": "sha512-ZiPp9pZlgxpWRu0M+YWbm6+aQ84XEfH1JRXvfOc/fILWI0VKhLC2LX13X1NYq4fULzLMq7Hfh43CSo2/aIaUPA=="
         },
         "whatwg-fetch": {
           "version": "0.9.0",
           "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-0.9.0.tgz",
-          "integrity": "sha1-DjaExsuZlbQ+/J3wPkw2XZX9nMA="
+          "integrity": "sha512-DIuh7/cloHxHYwS/oRXGgkALYAntijL63nsgMQsNSnBj825AysosAqA2ZbYXGRqpPRiNH7335dTqV364euRpZw=="
         }
       }
     },
@@ -7532,7 +7557,7 @@
     "flux": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/flux/-/flux-2.1.1.tgz",
-      "integrity": "sha1-LGrGUtQzdIiWhInGWG86/yajjqQ=",
+      "integrity": "sha512-A1t4GVH4QNxwHN+n/aXHi5xH4FN4gmHMrIRdHZrt011rcuTGfjbx6rdVyOi1+1eE/JautcFgUm4cGGUXYQEKAg==",
       "requires": {
         "fbemitter": "^2.0.0",
         "fbjs": "0.1.0-alpha.7",
@@ -8639,7 +8664,7 @@
     "immutable": {
       "version": "3.7.6",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.7.6.tgz",
-      "integrity": "sha1-E7TTyxK++hVIKib+Gy665kAHHks="
+      "integrity": "sha512-AizQPcaofEtO11RZhPPHBOJRdo/20MKQF9mBLnVkBoyHi1/zXK8fzVdnEpSV9gxqtnh6Qomfp3F0xT5qP/vThw=="
     },
     "import-fresh": {
       "version": "3.3.0",
@@ -9057,7 +9082,7 @@
     "is-promise": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
+      "integrity": "sha512-NECAi6wp6CgMesHuVUEK8JwjCvm/tvnn5pCbB42JOHp3mgUizN0nagXu4HEqQZBkieGEQ+jVcMKWqoVd6CDbLQ=="
     },
     "is-regex": {
       "version": "1.1.4",
@@ -11838,7 +11863,7 @@
     "oauth": {
       "version": "0.9.15",
       "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.9.15.tgz",
-      "integrity": "sha1-vR/vr2hslrdUda7VGWQS/2DPucE="
+      "integrity": "sha512-a5ERWK1kh38ExDEfoO6qUHJb32rd7aYmPHuyCu3Fta/cnICvYmgd2uhuKXvPD+PXB+gCEYYEaQdIRAjCOwAKNA=="
     },
     "oauth-sign": {
       "version": "0.9.0",
@@ -13153,9 +13178,9 @@
       }
     },
     "react-remove-scroll-bar": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.3.tgz",
-      "integrity": "sha512-i9GMNWwpz8XpUpQ6QlevUtFjHGqnPG4Hxs+wlIJntu/xcsZVEpJcIV71K3ZkqNy2q3GfgvkD7y6t/Sv8ofYSbw==",
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.4.tgz",
+      "integrity": "sha512-63C4YQBUt0m6ALadE9XV56hV8BgJWDmmTPY758iIJjfQKt2nYwoUrPk0LXRXcB/yIj82T1/Ixfdpdk68LwIB0A==",
       "requires": {
         "react-style-singleton": "^2.2.1",
         "tslib": "^2.0.0"
@@ -13263,7 +13288,7 @@
     "read": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
-      "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
+      "integrity": "sha512-rSOKNYUmaxy0om1BNjMN4ezNT6VKK+2xF4GBhc81mkH7L60i6dp8qPYrkndNLT3QPphoII3maL9PVC9XmhHwVQ==",
       "requires": {
         "mute-stream": "~0.0.4"
       }
@@ -13673,7 +13698,7 @@
     "revalidator": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/revalidator/-/revalidator-0.1.8.tgz",
-      "integrity": "sha1-/s5hv6DBtSoga9axgZgYS91SOjs="
+      "integrity": "sha512-xcBILK2pA9oh4SiinPEZfhP8HfrB/ha+a2fTMyl7Om2WjlDVrOQy99N2MXXlUHqGJz4qEu2duXxHJjDWuK/0xg=="
     },
     "rimraf": {
       "version": "2.7.1",
@@ -14718,9 +14743,9 @@
       }
     },
     "stylis": {
-      "version": "4.0.13",
-      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.0.13.tgz",
-      "integrity": "sha512-xGPXiFVl4YED9Jh7Euv2V220mriG9u4B2TA6Ybjc1catrstKD2PpIdU3U0RKpkVBC2EhmL/F0sPCr9vrFTNRag=="
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.1.3.tgz",
+      "integrity": "sha512-GP6WDNWf+o403jrEp9c5jibKavrtLW+/qYGhFxFrG8maXhwTBI7gLLhiBb0o7uFccWN+EOS9aMO6cGHWAO07OA=="
     },
     "superagent": {
       "version": "8.0.0",
@@ -15162,7 +15187,7 @@
     "transmitter": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/transmitter/-/transmitter-1.1.0.tgz",
-      "integrity": "sha1-Cya33RIxUK4S46hwDgEUnsgaRj4="
+      "integrity": "sha512-OkQ9y07aSga2FoKOUm3ZDvAy2I8epBXkx5P4MyjI0mMbLAxSdBlbZNmqjMY6I0Tv6PP+bP1ciw6rdxOzUerMBg=="
     },
     "traverse": {
       "version": "0.6.6",
@@ -15210,9 +15235,9 @@
       }
     },
     "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "tsutils": {
       "version": "3.21.0",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "@babel/preset-env": "^7.7.7",
     "@babel/preset-react": "^7.7.4",
     "@babel/register": "^7.7.7",
-    "@nypl/design-system-react-components": "^1.1.2",
+    "@nypl/design-system-react-components": "1.2.1",
     "@nypl/dgx-header-component": "git+https://git@github.com/NYPL/dgx-header-component#reactupdate",
     "@nypl/dgx-react-footer": "0.5.6",
     "@nypl/dgx-svg-icons": "0.2.5",

--- a/src/app/components/Application/Application.jsx
+++ b/src/app/components/Application/Application.jsx
@@ -8,12 +8,9 @@ import { withRouter } from 'react-router';
 import { union as _union } from 'underscore';
 
 import Feedback from '../Feedback/Feedback';
-import LoadingLayer from '../LoadingLayer/LoadingLayer';
 import DataLoader from '../DataLoader/DataLoader';
 import appConfig from '../../data/appConfig';
-
 import { updateFeatures } from '../../actions/Actions';
-
 import { breakpoints } from '../../data/constants';
 
 export const MediaContext = React.createContext('desktop');

--- a/src/app/components/Item/ItemTable.jsx
+++ b/src/app/components/Item/ItemTable.jsx
@@ -18,8 +18,7 @@ const ItemTable = ({ items, bibId, id, searchKeywords, page }) => {
   }
 
   const isBibPage = page !== 'SearchResults'
-  const isDesktop = media === 'desktop'
-
+  const isDesktop = media === 'desktop' || media === 'tablet'
   const includeVolColumn = (
     items.some(item => item.volume && item.volume.length) && isBibPage
   );

--- a/src/app/data/constants.js
+++ b/src/app/data/constants.js
@@ -3,7 +3,7 @@ import appConfig from "@appConfig";
 // breakpoints ordered by `maxValue` ascending
 const breakpoints = [
   {
-    maxValue: 490,
+    maxValue: 320,
     media: 'mobile',
   },
   {
@@ -11,7 +11,7 @@ const breakpoints = [
     media: 'tabletPortrait',
   },
   {
-    maxValue: 870,
+    maxValue: 960,
     media: 'tablet',
   },
 ];

--- a/src/client/styles/components/AccountPage.scss
+++ b/src/client/styles/components/AccountPage.scss
@@ -83,30 +83,30 @@
       display: inline-block !important;
       
       &:hover {
-        color: var(--nypl-colors-ui-link-secondary);
+        color: $linkSecondary;
       }
     }
   }
 
   .tabbed ul[role="tablist"] {
     &> li {
-      border-color: $accountBlue;
+      border-color: $linkPrimary;
     }
 
     &> li > span > a[aria-selected='true'] {
-      color: $accountBlue;
+      color: $linkPrimary;
     }
 
     &> li.activeTab {
-      border-color: $accountBlue;
+      border-color: $linkPrimary;
     }
   }
 
   .account-button {
     background: transparent;
     border-radius: 2px;
-    background-color: var(--nypl-colors-ui-white);
-    border: 1px solid var(--nypl-colors-ui-gray-light-cool);
+    background-color: $white;
+    border: 1px solid $grayLightCool;
     color: inherit;
     display: inline-block;
     font-size: 14px;
@@ -114,12 +114,12 @@
     padding: var(--nypl-space-xs);
 
     &:hover {
-      background-color: var(--nypl-colors-ui-gray-xx-light-cool);
+      background-color: $grayXXLightCool;
     }
   }
 
   tr.patFuncHeaders {
-    background-color: $accountBGLight;
+    background-color: $bgDefault;
     width: 100%;
   }
 
@@ -152,7 +152,7 @@
   }
 
   tr.patFuncFinesEntryTitle {
-    border-top: solid 1px $accountLightBorder;
+    border-top: solid 1px $borderDefault;
   }
 
   td {
@@ -201,13 +201,13 @@
     }
 
     tr:nth-last-of-type(2), tr:nth-last-of-type(3) {
-      border-bottom: solid 1px $accountLightBorder;
+      border-bottom: solid 1px $borderDefault;
     }
   }
 
   .items, .holds {
     tr {
-      border-bottom: solid 1px $accountLightBorder;
+      border-bottom: solid 1px $borderDefault;
     }
   }
 }
@@ -228,7 +228,7 @@
   }
 
   .edit-link {
-    color: $colorBlueText;
+    color: $linkPrimary;
     float: right;
     font-size: 20px;
     font-weight: 600;
@@ -282,7 +282,7 @@
 @media (max-width: 600px) {
   .nypl-patron-page .tabbed ul[role="tablist"] {
     &> li:last-of-type {
-      border-bottom: 1px solid $accountBlue;
+      border-bottom: 1px solid $linkPrimary;
     }
 
     a {
@@ -300,8 +300,8 @@
 
     .items, .holds {
       td {
-        border-left: 1px solid $accountLightBorder;
-        border-right: 1px solid $accountLightBorder;
+        border-left: 1px solid $borderDefault;
+        border-right: 1px solid $borderDefault;
         display: block;
         padding-right: 1%;
         width: auto;
@@ -314,7 +314,7 @@
       }
 
       td.patFuncTitle {
-        border-top: 1px solid $accountLightBorder;
+        border-top: 1px solid $borderDefault;
         border-top-left-radius: 5px;
         border-top-right-radius: 5px;
       }
@@ -386,7 +386,7 @@
     }
 
     .account-table-buttons {
-      border-bottom: 1px solid $accountLightBorder;
+      border-bottom: 1px solid $borderDefault;
       border-bottom-left-radius: 5px;
       border-bottom-right-radius: 5px;
       display: flex;

--- a/src/client/styles/components/AccountPage.scss
+++ b/src/client/styles/components/AccountPage.scss
@@ -77,8 +77,6 @@
     padding-top: var(--nypl-space-xl);
 
     a {
-      width: 165px;
-      text-align: center;
       text-decoration: none;
       display: inline-block !important;
       
@@ -183,7 +181,7 @@
     }
   }
 
-  @media (min-width: 920px) {
+  @include media($nypl-breakpoint-large) {
     .overdues {
       table {
         min-width: 846px;
@@ -279,20 +277,26 @@
 }
 
 
-@media (max-width: 600px) {
+.nypl-patron-page .tabbed ul[role="tablist"] {
+  &> li:last-of-type {
+    border-bottom: 1px solid $linkPrimary;
+  }
+  
+  a {
+    text-align: initial;
+    width: 100%;
+  }
+}
+@include media($nypl-breakpoint-medium) {
   .nypl-patron-page .tabbed ul[role="tablist"] {
-    &> li:last-of-type {
-      border-bottom: 1px solid $linkPrimary;
-    }
-
     a {
-      text-align: initial;
-      width: 100%;
+      text-align: center;
+      width: 165px;
     }
   }
 }
 
-@media (max-width: 650px) {
+@media (max-width: $nypl-breakpoint-medium) {
   .nypl-patron-page {
     select {
       width: 100%;

--- a/src/client/styles/components/AdvancedSearch.scss
+++ b/src/client/styles/components/AdvancedSearch.scss
@@ -31,35 +31,35 @@
 
   #fields {
     width: 100%;
-    display: flex;
-    @include media($mobile-breakpoint) {
-      display: block;
+    display: block;
+    @include media($nypl-breakpoint-medium) {
+      display: flex;
     }
   }
 
   #advancedSearchButtons {
-    display: flex;
-    justify-content: flex-end;
+    display: block;
     width: 91%;
-
-    @include media($mobile-breakpoint) {
-      display: block;
+    
+    @include media($nypl-breakpoint-medium) {
+      justify-content: flex-end;
+      display: flex;
     }
 
     button {
       margin: 5px;
-      width: 139px;
-      @include media($mobile-breakpoint) {
-        width: 100%;
+      width: 100%;
+      @include media($nypl-breakpoint-medium) {
+        width: 139px;
       }
     }
   }
 
   #formats {
-    display: flex;
     border: none;
-    @include media($mobile-breakpoint) {
-      display: block;
+    display: block;
+    @include media($nypl-breakpoint-medium) {
+      display: flex;
     }
   }
 

--- a/src/client/styles/components/AdvancedSearch.scss
+++ b/src/client/styles/components/AdvancedSearch.scss
@@ -7,8 +7,8 @@
 }
 
 #advancedSearchAside {
-  color: $advanceSearchColor;
-  background-color: $advanceSearchBGColor;
+  color: $brandPrimary;
+  background-color: $bgDefault;
   width: 100%;
   font-weight: 500;
   font-size: 18px;

--- a/src/client/styles/components/BibPage.scss
+++ b/src/client/styles/components/BibPage.scss
@@ -18,20 +18,20 @@ div .tabbed {
   }
 
   ul[role="tablist"] >  li {
-    border-bottom: 1px solid var(--nypl-colors-ui-black);
+    border-bottom: 1px solid $black;
     display: table-cell;
     margin-bottom: 0;
     white-space: nowrap;
   }
 
   ul[role="tablist"] > li.activeTab {
-    border: 1px solid var(--nypl-colors-ui-black);
+    border: 1px solid $black;
     border-bottom: none;
   }
 
   ul[role="tablist"] > li > a,
   ul[role="tablist"] > li > span > a {
-    color: $bibTextColor;
+    color: $grayDark;
     padding: 5px 8px;
     display: table-cell;
     font-weight: 300;
@@ -39,16 +39,16 @@ div .tabbed {
   }
 
   ul[role="tablist"] > li:target > a {
-    color: var(--nypl-colors-ui-black);
+    color: $black;
   }
 
   ul[role="tablist"] > li > a[aria-selected='true'] {
-    color: var(--nypl-colors-ui-black);
+    color: $black;
     font-weight: 500;
   }
 
   .blank {
-    border-bottom: 1px solid var(--nypl-colors-ui-black);
+    border-bottom: 1px solid $black;
     color: white;
     content: '';
     width: 100%;
@@ -60,7 +60,7 @@ div .tabbed {
     }
 
     li:target {
-      border: 1px solid var(--nypl-colors-ui-black);
+      border: 1px solid $black;
       border-bottom: 0;
     }
   }
@@ -99,19 +99,19 @@ div .tabbed {
 // they will appear as a's under a dd. If the dd is hovered, we make the
 // a's light blue
 .tabbed dd:hover a {
-  color: $bibLinkColor;
+  color: $linkSecondary;
   text-decoration: none;
 }
 
 // then we make the a's following the hovered a regular blue. We have to do it
 // this way because there is no 'younger sibling' selector
 .tabbed dd a:hover ~ a {
-  color: $generalBlueColor;
+  color: $linkPrimary;
   text-decoration: underline;
 }
 
 .tabbed dd span:hover ~ a {
-  color: $generalBlueColor;
+  color: $linkPrimary;
   text-decoration: underline;
 }
 
@@ -120,51 +120,51 @@ div .tabbed {
 // So we need to cancel the above stylings in this case. Below we apply the same
 // trick as above, but to each li separately.
 .tabbed dd:hover ul li a {
-  color: $generalBlueColor;
+  color: $linkPrimary;
   text-decoration: underline;
 }
 
 // Visited a's have a darker shade of blue as their default
 
 .tabbed dd a:hover ~ a:visited {
-  color: $generalDarkerBlueColor;
+  color: $linkSecondary;
 }
 
 .tabbed dd span:hover ~ a:visited {
-  color: $generalDarkerBlueColor;
+  color: $linkSecondary;
 }
 
 // If we have multiple subject strings, each li gets the styling above.
 // If an li is hovered, we make the links light blue
 
 .tabbed dd:hover ul li:hover a {
-  color: $bibLinkColor;
+  color: $linkSecondary;
   text-decoration: none;
 }
 
 // Then we restore links to their default if they come after the link
 .tabbed dd ul li:hover a:hover ~ a {
-  color: $generalBlueColor;
+  color: $linkPrimary;
   text-decoration: underline;
 }
 
 .tabbed dd ul li:hover span:hover ~ a {
-  color: $generalBlueColor;
+  color: $linkPrimary;
   text-decoration: underline;
 }
 
 // Visited links have a darker default
 .tabbed dd ul li:hover a:hover ~ a:visited {
-  color: $generalDarkerBlueColor;
+  color: $linkSecondary;
 }
 
 .tabbed dd ul li:hover span:hover ~ a:visited {
-  color: $generalDarkerBlueColor;
+  color: $linkSecondary;
 }
 
 .tabbed dd {
   a {
-    color: $generalBlueColor;
+    color: $linkPrimary;
     text-decoration: underline;
   }
 }
@@ -180,7 +180,7 @@ div .tabbed {
 @media (max-width: 600px) {
   div .tabbed {
     ul[role="tablist"] >  li, ul[role="tablist"] > li.activeTab {
-      border: 1px solid var(--nypl-colors-ui-black);
+      border: 1px solid $black;
       border-bottom: none;
       display: block;
       width: 100%;

--- a/src/client/styles/components/BibPage.scss
+++ b/src/client/styles/components/BibPage.scss
@@ -169,7 +169,7 @@ div .tabbed {
   }
 }
 
-@media (max-width: 1120px) {
+@media (max-width: $nypl-breakpoint-xl) {
   .additionalDetails {
     dt {
       float: none;
@@ -177,7 +177,7 @@ div .tabbed {
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width: $nypl-breakpoint-medium) {
   div .tabbed {
     ul[role="tablist"] >  li, ul[role="tablist"] > li.activeTab {
       border: 1px solid $black;

--- a/src/client/styles/components/Drbb/Drbb.scss
+++ b/src/client/styles/components/Drbb/Drbb.scss
@@ -3,9 +3,10 @@
   border-radius: 8px;
   float: right;
   margin: auto;
-  margin-left: 15px;
+  margin-left: 0;
+  margin-bottom: 20px;
   padding: 2.5%;
-  width: 30%;
+  width: 100%;
 
   .loadingLayer-texts-loadingWord {
     margin-bottom: unset;
@@ -120,10 +121,9 @@ a.drbb-download-pdf {
 .nypl-results-list.drbb-integration {
   box-sizing: border-box;
   display: inline-block;
-  padding-right: 10%;
-  width: 65%;
+  padding-right: 0;
+  width: 100%;
   list-style-type: none;
-
 }
 
 .nypl-select-field-results {
@@ -166,21 +166,21 @@ a.drbb-download-pdf {
 }
 
 .nypl-results-summary.no-scc-results.drbb-integration {
-  width: 65%;
+  width: 100%;
 }
 
-@media(max-width: 870px) {
+@include media($nypl-breakpoint-large) {
   .nypl-results-list.drbb-integration {
-    width: 100%;
-    padding-right: 0;
+    width: 65%;
+    padding-right: 10%;
   }
 
   .drbb-container {
-    width: unset;
-    margin-left: 0;
+    width: 30%;
+    margin-left: 15px;
   }
 
   .nypl-results-summary.no-scc-results.drbb-integration {
-    width: 100%
+    width: 65%
   }
 }

--- a/src/client/styles/components/Drbb/Drbb.scss
+++ b/src/client/styles/components/Drbb/Drbb.scss
@@ -1,5 +1,5 @@
 .drbb-container {
-  border: 1px solid $lightBorder;
+  border: 1px solid $borderDefault;
   border-radius: 8px;
   float: right;
   margin: auto;
@@ -28,7 +28,7 @@
 }
 
 .drbb-result {
-  background-color: $lightBackgroundColor;
+  background-color: $bgDefault;
   border-radius: 6px;
   font-size: 14px;
   margin: 20px 0;
@@ -46,10 +46,10 @@
 }
 
 a.drbb-read-online {
-  background-color: $results-list-item-button;
-  border: 0.08333rem solid $results-list-item-button;
+  background-color: $linkPrimary;
+  border: 0.08333rem solid $linkPrimary;
   border-radius: 0.13333rem;
-  color: var(--nypl-colors-ui-white);
+  color: $white;
   display: inline-block;
   font-size: 12px;
   font-weight: normal;
@@ -60,13 +60,13 @@ a.drbb-read-online {
 
   &:hover,
   &:focus {
-    color: $results-list-item-button;
-    background-color: var(--nypl-colors-ui-white);
+    color: $linkPrimary;
+    background-color: $white;
   }
 }
 
 a.drbb-download-pdf {
-  color: var(--nypl-colors-ui-black);
+  color: $black;
   fill: currentColor;
   padding: 2% 0;
   font-size: 0.8rem;
@@ -96,7 +96,7 @@ a.drbb-download-pdf {
   display: flex;
   justify-content: center;
   align-items: center;
-  background-color: $lightBackgroundColor;
+  background-color: $bgDefault;
   border-radius: 4px;
 
   img {
@@ -145,7 +145,7 @@ a.drbb-download-pdf {
 
     select {
       appearance: none;
-      background: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4NCjxzdmcgdmVyc2lvbj0iMS4xIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB3aWR0aD0iMzAuNSIgaGVpZ2h0PSIxOC40Mjc3NCIgdmlld0JveD0iMCAwIDMwLjUgMTguNDI3NzQiIGFyaWEtaGlkZGVuPSJ0cnVlIiBwcmVzZXJ2ZUFzcGVjdFJhdGlvPSJ4TWlkWU1pZCBtZWV0Ij4NCjxzdHlsZSB0eXBlPSJ0ZXh0L2NzcyI+DQogIHBhdGggeyBmaWxsOiAjMTExMTExOyB9DQo8L3N0eWxlPg0KICA8dGl0bGU+ZG93biB3ZWRnZTwvdGl0bGU+DQogIDxwYXRoIGQ9Ik0yNi44MTguNjc5LDE1LjI4OCwxMi4yMjMxNSwzLjU5MTUzLjU5NTkyQTIuMDc0OCwyLjA3NDgsMCwwLDAsLjY5MDg0LjU4NjM2aDBhMi4yNzc1MywyLjI3NzUzLDAsMCwwLS4wMjYsMy4yNDIxMUwxNS4yMjQwNywxOC40Mjc3NCwyOS44NywzLjczNDMxQTIuMTU5MywyLjE1OTMsMCwwLDAsMjkuODU0MzYuNjdoMEEyLjE1OTMsMi4xNTkzLDAsMCwwLDI2LjgxOC42NzlaIi8+DQo8L3N2Zz4=) no-repeat 99% var(--nypl-colors-ui-white);
+      background: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4NCjxzdmcgdmVyc2lvbj0iMS4xIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB3aWR0aD0iMzAuNSIgaGVpZ2h0PSIxOC40Mjc3NCIgdmlld0JveD0iMCAwIDMwLjUgMTguNDI3NzQiIGFyaWEtaGlkZGVuPSJ0cnVlIiBwcmVzZXJ2ZUFzcGVjdFJhdGlvPSJ4TWlkWU1pZCBtZWV0Ij4NCjxzdHlsZSB0eXBlPSJ0ZXh0L2NzcyI+DQogIHBhdGggeyBmaWxsOiAjMTExMTExOyB9DQo8L3N0eWxlPg0KICA8dGl0bGU+ZG93biB3ZWRnZTwvdGl0bGU+DQogIDxwYXRoIGQ9Ik0yNi44MTguNjc5LDE1LjI4OCwxMi4yMjMxNSwzLjU5MTUzLjU5NTkyQTIuMDc0OCwyLjA3NDgsMCwwLDAsLjY5MDg0LjU4NjM2aDBhMi4yNzc1MywyLjI3NzUzLDAsMCwwLS4wMjYsMy4yNDIxMUwxNS4yMjQwNywxOC40Mjc3NCwyOS44NywzLjczNDMxQTIuMTU5MywyLjE1OTMsMCwwLDAsMjkuODU0MzYuNjdoMEEyLjE1OTMsMi4xNTkzLDAsMCwwLDI2LjgxOC42NzlaIi8+DQo8L3N2Zz4=) no-repeat 99% $white;
       background-size: 1rem;
       border: 0;
       border-radius: 0.2rem;
@@ -155,7 +155,7 @@ a.drbb-download-pdf {
       padding-left: 0.5rem;
       width: inherit;
       background-position-x: 92%;
-      border: 0.0625rem solid $darkColorBoxShadow;
+      border: 0.0625rem solid $borderDefault;
       padding: 0 1.25rem 0 0.75rem;
     }
   }

--- a/src/client/styles/components/Feedback.scss
+++ b/src/client/styles/components/Feedback.scss
@@ -4,8 +4,8 @@
   right: 0;
   z-index: 100;
   text-align: right;
-  background: var(--nypl-colors-ui-white);
-  color: var(--nypl-colors-ui-black);
+  background: $white;
+  color: $black;
 
   @include min-screen($tablet-portrait) {
     position: fixed;
@@ -14,10 +14,10 @@
     min-width: 571px;
   }
   button.feedback-button {
-    background: $dsresearchprimary;
-    border: 1px solid $dsresearchprimary;
+    background: $researchPrimary;
+    border: 1px solid $researchPrimary;
     box-sizing: border-box;
-    color: var(--nypl-colors-ui-white);
+    color: $white;
     display: inline-block;
     font-size: 1rem;
     padding: .5rem 1rem;
@@ -25,15 +25,15 @@
     text-align: center;
   
     &:hover {
-      background: var(--nypl-colors-ui-white);
-      color: $dsresearchprimary;
+      background: $white;
+      color: $researchPrimary;
     }
   }
 }
 
 
 .cancel-button {
-  border: 1px solid $feedbackBorder;
+  border: 1px solid $borderDefault;
   font-size: 1rem;
   margin-right: 15px;
   text-align: center;
@@ -42,8 +42,8 @@
 
 #feedback-menu {
   display: none;
-  background: var(--nypl-colors-ui-white);
-  border: 1px solid $border-color;
+  background: $white;
+  border: 1px solid $borderDefault;
   box-shadow: -1px 0 1px 0 rgba(0,0,0,0.3);
   padding: 50px 42px;
   text-align: left;
@@ -71,12 +71,11 @@
   textarea {
     display: block;
     width: 100%;
-    // background-color: $page-background-color;
     background-color: white;
     font-size: 1rem;
     line-height: 1.2;
     box-sizing: border-box;
-    border: 1px solid var(--nypl-colors-ui-gray-medium);
+    border: 1px solid $grayMedium;
   }
 
   textarea {

--- a/src/client/styles/components/Feedback.scss
+++ b/src/client/styles/components/Feedback.scss
@@ -7,7 +7,7 @@
   background: $white;
   color: $black;
 
-  @include min-screen($tablet-portrait) {
+  @include media($nypl-breakpoint-large) {
     position: fixed;
     background: inherit;
     max-width: 571px;

--- a/src/client/styles/components/Feedback.scss
+++ b/src/client/styles/components/Feedback.scss
@@ -1,18 +1,15 @@
 .feedback {
-  position: static;
   bottom: 0;
   right: 0;
   z-index: 100;
   text-align: right;
   background: $white;
   color: $black;
+  position: fixed;
+  background: inherit;
+  max-width: 571px;
+  min-width: 571px;
 
-  @include media($nypl-breakpoint-large) {
-    position: fixed;
-    background: inherit;
-    max-width: 571px;
-    min-width: 571px;
-  }
   button.feedback-button {
     background: $researchPrimary;
     border: 1px solid $researchPrimary;
@@ -105,7 +102,7 @@
   }
 }
 
-@media (max-width: 768px) {
+@media (max-width: $nypl-breakpoint-large) {
   #feedback-menu {
     height: 400px;
     padding: 34px;

--- a/src/client/styles/components/FilterPopup.scss
+++ b/src/client/styles/components/FilterPopup.scss
@@ -48,13 +48,13 @@
     margin: 0 0 25px;
 
     svg {
-      fill: var(--nypl-colors-ui-white);
+      fill: $white;
       margin: 0 0 2px 0px;
     }
 
     &:hover {
       svg {
-        fill: $generalBlueColor;
+        fill: $linkPrimary;
       }
     }
 
@@ -67,8 +67,8 @@
     padding-top: 3px;
 
     &:hover {
-      color: $generalHoverBlue;
-      border: 1px solid $generalHoverBlue;
+      color: $linkSecondary;
+      border: 1px solid $linkSecondary;
     }
   }
 
@@ -130,26 +130,26 @@
 
   .cancel-button,
   .apply-button {
-    background: var(--nypl-colors-ui-white);
+    background: $white;
     border: 1px solid;
-    border-color: $generalBlueColor;
+    border-color: $linkPrimary;
     border-radius: 0.25rem;
-    color: $generalBlueColor;
+    color: $linkPrimary;
 
     svg {
-      fill: $generalBlueColor;
-      background: var(--nypl-colors-ui-white);
+      fill: $linkPrimary;
+      background: $white;
       margin: 0 0 3px 3px;
     }
 
     &:hover {
-      background-color: $generalBlueColor;
-      border: 1px solid $generalBlueColor;
-      color: var(--nypl-colors-ui-white);
+      background-color: $linkPrimary;
+      border: 1px solid $linkPrimary;
+      color: $white;
 
       svg {
-        fill: var(--nypl-colors-ui-white);
-        background-color: $generalBlueColor;
+        fill: $white;
+        background-color: $linkPrimary;
       }
     }
   }
@@ -189,7 +189,7 @@
 
   .popup,
   .popup-no-js {
-    background: var(--nypl-colors-ui-gray-x-light-cool);
+    background: $grayXLightCool;
     width: auto;
     z-index: 10000;
 
@@ -228,7 +228,7 @@
 
   // need to override the background color
   .nypl-fieldset {
-    background-color: var(--nypl-colors-ui-gray-x-light-cool);
+    background-color: $grayXLightCool;
   }
 
   .nypl-generic-checkbox {
@@ -237,7 +237,7 @@
       padding-left: 0.65rem;
 
       &::before {
-        background: var(--nypl-colors-ui-white);
+        background: $white;
       }
     }
   }
@@ -246,12 +246,12 @@
 .filter-container {
   a.clear-filters-button {
     -webkit-appearance: initial;
-    color: $generalRedColor;
+    color: $brandPrimary;
 
     &:hover {
-      border: 1px solid $generalRedColor;
-      color: var(--nypl-colors-ui-white);
-      background: $generalRedColor;
+      border: 1px solid $brandPrimary;
+      color: $white;
+      background: $brandPrimary;
     }
   }
 
@@ -272,8 +272,8 @@
     }
     &:hover {
       svg {
-        fill: var(--nypl-colors-ui-white);
-        background: $generalRedColor;
+        fill: $white;
+        background: $brandPrimary;
       }
     }
   }
@@ -332,7 +332,7 @@
 }
 
 .nypl-name-field {
-  background: var(--nypl-colors-ui-gray-x-light-cool);
+  background: $grayXLightCool;
   margin: 1rem 0;
 
   &::after,
@@ -342,8 +342,8 @@
   }
 
   .nypl-field-status {
-    background: var(--nypl-colors-ui-gray-x-light-cool);
-    color: $darkGrayTextColor;
+    background: $grayXLightCool;
+    color: $grayDark;
     display: block;
     font-size: 0.9rem;
     line-height: 1.5;
@@ -359,9 +359,8 @@
     }
     input {
       width: 100%;
-      border: 0;
+      border: 1px solid $borderDefault;
       border-radius: 0.25rem;
-      box-shadow: inset 0 0 0 1px $darkColorBoxShadow;
       padding: 0.5rem;
       height: 1.5rem;
     }
@@ -369,7 +368,7 @@
 }
 
 .date-hyphen {
-  background: var(--nypl-colors-ui-gray-x-light-cool);
+  background: $grayXLightCool;
   width: 25px;
   margin: 0px 15px;
   height: 10px;
@@ -432,5 +431,5 @@
 }
 
 .chakra-modal__close-btn {
-  background-color: var(--nypl-colors-ui-white)fff;
+  background-color: $white;
 }

--- a/src/client/styles/components/FilterPopup.scss
+++ b/src/client/styles/components/FilterPopup.scss
@@ -376,7 +376,7 @@
 
 .filter-error-box {
   margin: 0 3.125rem;
-  @media (max-width: 483px) {
+  @media (max-width: $nypl-breakpoint-medium) {
     margin: 0 1rem;
   }
 }

--- a/src/client/styles/components/FilterPopup.scss
+++ b/src/client/styles/components/FilterPopup.scss
@@ -58,7 +58,7 @@
       }
     }
 
-    @include min-screen($xtrasmall-breakpoint) {
+    @include media($nypl-breakpoint-small) {
       margin-top: 35px;
     }
   }
@@ -84,7 +84,7 @@
     display: none;
     margin-bottom: 0;
 
-    @include min-screen($xtrasmall-breakpoint) {
+    @include media($nypl-breakpoint-small) {
       text-align: right;
       margin-bottom: 15px;
     }
@@ -102,7 +102,7 @@
         margin-bottom: 20px;
       }
 
-      @include min-screen($xtrasmall-breakpoint) {
+      @include media($nypl-breakpoint-small) {
         width: auto;
 
         button {
@@ -193,11 +193,11 @@
     width: auto;
     z-index: 10000;
 
-    @include min-screen($tablet-portrait) {
+    @include media($nypl-breakpoint-large) {
       width: 42rem;
     }
 
-    @include min-screen(966px) {
+    @include media(966px) {
       width: 52rem;
     }
 
@@ -260,7 +260,7 @@
     margin-bottom: 20px;
     @include border-radius(5px);
 
-    @include min-screen($xtrasmall-breakpoint) {
+    @include media($nypl-breakpoint-small) {
       margin-bottom: 0;
     }
 
@@ -317,13 +317,13 @@
 }
 
 .nypl-generic-columns {
-  column-count: 3;
+  column-count: 2;
   max-width: 100%;
 }
 
-@include media($mobile-breakpoint) {
+@include media($nypl-breakpoint-medium) {
   .nypl-generic-columns {
-    column-count: 2;
+    column-count: 3;
   }
 }
 

--- a/src/client/styles/components/HoldRequest.scss
+++ b/src/client/styles/components/HoldRequest.scss
@@ -7,7 +7,7 @@
 }
 
 .edd-copyright-notice {
-  border: 1px solid $lightBorder;
+  border: 1px solid $borderDefault;
   border-radius: 4px;
   margin-top: 16px;
   padding: 15px;
@@ -37,7 +37,7 @@
 }
 form.place-hold-form {
   .nypl-request-radiobutton-field {
-    background-color: var(--nypl-colors-ui-white);
+    background-color: $white;
     border: 0;
     margin: 1rem 0;
     padding: 0;
@@ -52,10 +52,10 @@ form.place-hold-form {
     }
 
     label {
-      background-color: var(--nypl-colors-ui-white);
+      background-color: $white;
       border-radius: 0;
       font-weight: 400;
-      border: $lightBorder solid 0.0625rem;
+      border: $borderDefault solid 0.0625rem;
       margin: 0;
       display: block;
       padding: 1rem 1rem 2rem 4rem;
@@ -70,10 +70,10 @@ form.place-hold-form {
     }
   }
   .nypl-request-button {
-    background-color: $generalRedColor;
-    border: 0.04167rem solid $generalRedColor;
+    background-color: $brandPrimary;
+    border: 0.04167rem solid $brandPrimary;
     border-radius: 0.25rem;
-    color: var(--nypl-colors-ui-white);
+    color: $white;
     cursor: pointer;
     display: inline-block;
     font-size: 1rem;
@@ -102,14 +102,13 @@ form.electronic-delivery-form {
     }
 
     .nypl-required-field {
-      color: $requiredRedColor;
+      color: $errorPrimary;
       font-size: 0.9rem;
       font-weight: 400;
     }
 
     .nypl-field-status {
-      background-color: var(--nypl-colors-ui-white);
-      color: $darkGrayTextColor;
+      color: $grayDark;
       display: block;
       font-size: 0.9rem;
       line-height: 1.5;
@@ -131,18 +130,15 @@ form.electronic-delivery-form {
 
       label {
         background-color: transparent;
-        color: $darkColorBoxShadow;
         display: inline-block;
         font-weight: 400;
         margin-bottom: 0.25rem;
       }
 
       input {
-        background-color: var(--nypl-colors-ui-white);
-        border: 0;
+        border: 1px solid $borderDefault;
         border-radius: 0.25rem;
         font-size: 1rem;
-        box-shadow: inset 0 0 0 1px $darkColorBoxShadow;
         height: 2rem;
         padding: 1rem 0;
         text-indent: 0.5rem;
@@ -151,8 +147,7 @@ form.electronic-delivery-form {
       }
 
       textarea {
-        box-shadow: inset 0 0 0 1px $darkColorBoxShadow;
-        border: 0;
+        border: 1px solid $borderDefault;
         border-radius: 0.25rem;
         box-sizing: border-box;
         font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";

--- a/src/client/styles/components/ItemTable.scss
+++ b/src/client/styles/components/ItemTable.scss
@@ -9,8 +9,8 @@
   text-align: center;
   padding: 8px 16px;
   text-decoration: none;
-  color: #fff;
-  border: 0.08333rem solid var(--nypl-colors-ui-link-primary);
+  color: $white;
+  border: 0.08333rem solid $linkPrimary;
   line-height: 1.5;
   border-radius: var(--nypl-radii-sm);
   font-weight: var(--nypl-fontWeights-button-default);
@@ -31,19 +31,19 @@
 }
 
 .avail-request-button {
-  background-color: white;
-  color: var(--nypl-colors-ui-link-primary);
+  background-color: $white;
+  color: $linkPrimary;
   &:hover {
-    background-color: var(--nypl-colors-ui-bg-hover);
-    border: 0.08333rem solid var(--nypl-colors-ui-link-secondary);
-    color: var(--nypl-colors-ui-link-secondary);
+    background-color: $bgHover;
+    border: 0.08333rem solid $linkSecondary;
+    color: $linkSecondary;
   }
 }
 .unavail-request-button {
   cursor: default;
-  background-color: var(--nypl-colors-ui-gray-x-light-cool);
-  color: var(--nypl-colors-ui-gray-dark);
-  border: 0.08333rem solid var(--nypl-colors-ui-gray-light-cool);
+  background-color: $grayXLightCool;
+  color: $grayDark;
+  border: 0.08333rem solid $grayLightCool;
 }
 
 .info-link {
@@ -60,10 +60,10 @@
   }
 }
 .available-text {
-  color: var(--nypl-colors-ui-success-primary);
+  color: $succesPrimary;
 }
 .unavailable-text {
-  color: var(--nypl-colors-ui-warning-primary);
+  color: $warningPrimary;
 }
 
 .nypl-results-item .nypl-basic-table .item-email-inquiry {
@@ -79,37 +79,28 @@
     letter-spacing: unset;
 
     &:link {
-      // color: $link-color;
-      color: #1b7fa7;
-    }
-
-    &:visited {
-      // color: $link-visited-color;
-      color: darken(#1b7fa7, 15%);
+      color: $linkPrimary;
     }
 
     &:hover,
+    &:visited,
     &:visited:hover {
-      // color: $link-hover-color;
-      color: darken(#1b7fa7, 5%);
+      color: $linkSecondary;
       text-decoration: none;
     }
 
     &.inverted {
       &:link {
-        // color: $inverted-link-color;
-        color: white;
+        color: $white;
       }
 
       &:visited {
-        // color: $inverted-link-visited-color;
         color: darken(white, 10%);
       }
 
       &:hover,
       &:visited:hover {
-        // color: $inverted-link-color;
-        color: white;
+        color: $white;
       }
     }
   }
@@ -141,7 +132,7 @@
 
     tr,
     .nypl-results-item .nypl-basic-table tbody tr:last-child {
-      border: 1px solid var(--nypl-colors-ui-gray-light-cool);
+      border: 1px solid $grayLightCool;
     }
 
     .nypl-basic-table,
@@ -158,7 +149,7 @@
       }
 
       td.vol-date-col {
-        background-color: var(--nypl-colors-ui-gray-light-cool);
+        background-color: $grayLightCool;
       }
 
       span {

--- a/src/client/styles/components/ItemTable.scss
+++ b/src/client/styles/components/ItemTable.scss
@@ -25,7 +25,7 @@
   font-size: var(--nypl-fontSizes-button-default);
   margin-right: var(--nypl-space-xs);
 
-  @media screen and (min-width: 38em) {
+  @include media($nypl-breakpoint-medium) {
     min-height: auto;
   }
 }
@@ -124,7 +124,7 @@
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width: $nypl-breakpoint-medium) {
   .tabbed {
     thead {
       display: none;

--- a/src/client/styles/components/ItemsContainer.scss
+++ b/src/client/styles/components/ItemsContainer.scss
@@ -28,7 +28,7 @@
     }
   }
 
-  @media (min-width: 600px) {
+  @include media($nypl-breakpoint-medium) {
     .item-filter-button {
       width: 90%;
 
@@ -169,7 +169,7 @@ button.item-table-filters {
 }
 
 // this is the minimum width at which the `Status` options will not go beyond the screenwidth
-@media (max-width: 600px) {
+@media (max-width: $nypl-breakpoint-medium) {
   .item-filter {
     display: block;
     margin: 10px 0;

--- a/src/client/styles/components/ItemsContainer.scss
+++ b/src/client/styles/components/ItemsContainer.scss
@@ -10,7 +10,7 @@
 
   .item-filter-button {
     color: black;
-    border: 1px solid var(--nypl-colors-ui-gray-medium);
+    border: 1px solid $grayMedium;
     justify-content: space-between;
     text-transform: capitalize;
     width: 100%;
@@ -60,9 +60,9 @@
 }
 
 .item-filter-content {
-  background-color: var(--nypl-colors-ui-white);
+  background-color: $white;
   border: 1px solid;
-  border-color: var(--nypl-colors-ui-gray-medium);
+  border-color: $grayMedium;
   position: absolute;
   width: 230px;
   z-index: 1;
@@ -74,7 +74,7 @@
 }
 
 div.item-table-filters {
-  background-color: var(--nypl-colors-ui-gray-x-light-cool);
+  background-color: $grayXLightCool;
   padding: 10px;
 }
 
@@ -113,13 +113,13 @@ button.item-table-filters {
 
   button {
     border: none;
-    color: $generalRedColor;
+    color: $brandPrimary;
     display: inline-block;
     padding-left: 0;
     padding-top: 0;
 
     &:hover {
-      color: $colorBlueText;
+      color: $linkPrimary;
     }
   }
 }
@@ -152,16 +152,15 @@ button.item-table-filters {
 }
 .nypl-results-item .nypl-basic-table#bib-item-table {
  thead > tr {
-    border-bottom: 1px solid var(--nypl-colors-ui-gray-light-cool);
+    border-bottom: 1px solid $grayLightCool;
 
     th {
       padding-top: 0;
-      // width: auto;
     }
   }
 
   tbody tr, tbody tr:last-child {
-    border-bottom: 1px solid var(--nypl-colors-ui-gray-light-cool);
+    border-bottom: 1px solid $grayLightCool;
   }
 }
 

--- a/src/client/styles/components/LoadingLayer.scss
+++ b/src/client/styles/components/LoadingLayer.scss
@@ -9,7 +9,7 @@
     position: fixed;
     width: 100%;
     height: 100%;
-    background: $loadingLayerBG;
+    background: $bgDefault;
     opacity: .95;
   }
 
@@ -23,7 +23,7 @@
 
     &-loadingWord {
       text-transform: uppercase;
-      color: red;
+      color: $brandPrimary;
       display: block;
       margin: 15px;
       margin-bottom: 35px;
@@ -48,7 +48,7 @@
     width: 10px;
     height: 10px;
     margin: 0px 5px;
-    background: red;
+    background: $brandPrimary;
     border-radius: 50px;
     -webkit-animation: loadingDots 0.8s infinite alternate;
     -moz-animation: loadingDots 0.8s infinite alternate;

--- a/src/client/styles/components/Notification.scss
+++ b/src/client/styles/components/Notification.scss
@@ -1,15 +1,15 @@
 .research-alert {
-  background-color: $notificationBG;
+  background-color: $grayXLightCool;
   font-size: var(--nypl-fontSizes-1);
   margin: var(--nypl-space-m) 0;
   padding: var(--nypl-space-m) 4vw;
 
   a {
-    color: var(--nypl-colors-ui-link-primary);
+    color: $linkPrimary;
     display: inline;
 
     &:hover {
-      color: var(--nypl-colors-ui-link-secondary);
+      color: $linkSecondary;
     }
   }
 }

--- a/src/client/styles/components/Redirect404.scss
+++ b/src/client/styles/components/Redirect404.scss
@@ -18,7 +18,7 @@
     bottom: 82.04%;
       display: inline-block;
       text-align: left;
-      border: 1px solid $accountLightBorder;
+      border: 1px solid $borderDefault;
       border-radius: 8px;
       box-sizing: border-box;
 

--- a/src/client/styles/components/SccContainer.scss
+++ b/src/client/styles/components/SccContainer.scss
@@ -3,18 +3,18 @@
   margin-right: calc(-50vw + 50%);
 
   a:hover {
-    color: var(--nypl-colors-ui-gray-light-cool);;
+    color: $grayLightCool;
   }
 }
 
 .catalog__heading {
-  background-color: var(--nypl-colors-section-research-primary);
+  background-color: $researchPrimary;
   padding-bottom: var(--nypl-space-xs);
   padding-top: var(--nypl-space-l);
 
   h1 {
     @include wrapper;
-    color: var(--nypl-colors-ui-white);
+    color: $white;
     max-width: 1280px;
   }
 }

--- a/src/client/styles/components/Search.scss
+++ b/src/client/styles/components/Search.scss
@@ -1,5 +1,5 @@
 .research-search {
-  background-color: var(--nypl-colors-ui-gray-x-light-cool);
+  background-color: $grayXLightCool;
   margin-left: calc(-50vw + 50%);
   margin-right: calc(-50vw + 50%);
   padding: var(--nypl-space-l) 0;
@@ -89,6 +89,6 @@ h3.electronic-resources-search-header {
     height: 1.8rem;
     width: 1.8rem;
     margin-top: 0;
-    fill: var(--nypl-colors-ui-link-primary);
+    fill: $linkPrimary;
   }
 }

--- a/src/client/styles/components/Search.scss
+++ b/src/client/styles/components/Search.scss
@@ -32,7 +32,7 @@
     }
   }
 
-  @media (min-width: 870px) {
+  @include media($nypl-breakpoint-large) {
     &__inner-content > div {
       width: 85%;
     }
@@ -53,7 +53,7 @@
   }
 }
 
-@media (max-width: 490px) {
+@media (max-width: $nypl-breakpoint-medium) {
   .nypl-sorter-row {
     display: block;
   }

--- a/src/client/styles/components/SelectedFilters.scss
+++ b/src/client/styles/components/SelectedFilters.scss
@@ -37,16 +37,16 @@
   }
 
   .nypl-unset-filter {
-    background: var(--nypl-colors-ui-white);
-    border: 1px solid var(--nypl-colors-ui-black);
-    color: var(--nypl-colors-ui-black);
+    background: $white;
+    border: 1px solid $black;
+    color: $black;
     display: flex;
     align-items: center;
     padding: 5px 10px;
     border-radius: 0.25rem;
 
     svg {
-      fill: var(--nypl-colors-ui-black);
+      fill: $black;
       height: 25px;
       width: 25px;
       margin: 0 0 0 0px;
@@ -56,12 +56,12 @@
     }
 
     &:hover {
-      background: var(--nypl-colors-ui-black);
-      border: 1px solid var(--nypl-colors);
-      color: var(--nypl-colors);
+      background: $black;
+      border: 1px solid $white;
+      color: $white;
 
       svg {
-        fill: var(--nypl-colors);
+        fill: $white;
       }
     }
   }
@@ -69,7 +69,7 @@
 
 .clear-filters-button {
   svg {
-    fill: var(--nypl-colors-ui-black);
+    fill: $black;
     height: 25px;
     width: 25px;
     margin: 0 0 0 0px;

--- a/src/client/styles/components/SubNav.scss
+++ b/src/client/styles/components/SubNav.scss
@@ -1,5 +1,5 @@
 .sub-nav {
-  background-color: var(--nypl-colors-ui-black);
+  background-color: $black;
   padding-bottom: var(--nypl-space-xs);
   padding-top: var(--nypl-space-xs);
 
@@ -11,11 +11,11 @@
   &__link:link,
   &__link:visited,
   &__link:focus {
-    color: var(--nypl-colors-ui-white) !important;
+    color: $white !important;
     text-decoration: none;
   }
   &__link:hover {
-    color: var(--nypl-colors-ui-white) !important;
+    color: $white !important;
     text-decoration: underline;
   }
 
@@ -29,10 +29,10 @@
     padding: 0 var(--nypl-space-s);
     width: 100%;
 
-    color: var(--nypl-colors-ui-white);
+    color: $white;
   }
 
   .nypl--research & {
-    background-color: var(--nypl-colors-section-research-primary);
+    background-color: $researchPrimary;
   }
 }

--- a/src/client/styles/components/SubjectHeadings.scss
+++ b/src/client/styles/components/SubjectHeadings.scss
@@ -4,7 +4,7 @@
   justify-content: space-between;
 }
 
-@media (max-width: 600px) {
+@media (max-width: $nypl-breakpoint-medium) {
   .subject-heading-page-header {
     display: block;
   }

--- a/src/client/styles/components/SubjectHeadings/AdditionalSubjectHeadingsButton.scss
+++ b/src/client/styles/components/SubjectHeadings/AdditionalSubjectHeadingsButton.scss
@@ -1,5 +1,5 @@
 .seeMoreButton {
-  color: var(--nypl-colors-ui-link-primary);
+  color: $linkPrimary;
   font-size: 14px;
 
   em {
@@ -7,6 +7,6 @@
   }
 
   &:hover {
-    color: var(--nypl-colors-ui-link-secondary);
+    color: $linkSecondary;
   }
 }

--- a/src/client/styles/components/SubjectHeadings/AlphabeticalPagination.scss
+++ b/src/client/styles/components/SubjectHeadings/AlphabeticalPagination.scss
@@ -8,7 +8,7 @@
   max-width: 100%;
   text-align: center;
   background-color: $borderDefault;
-  line-height: 32px;
+  line-height: 35px;
   padding: 1px;
 
   a {
@@ -20,7 +20,7 @@
     font-weight: 400;
     text-align: center;
     text-decoration: none;
-    min-width: 32px;
+    min-width: 35px;
     border: 1px solid $borderDefault;
     border-radius: 1px;
     margin: -1px;
@@ -32,12 +32,12 @@
   }
 }
 
-@include media($xtrasmall-breakpoint) {
+@include media($nypl-breakpoint-small) {
   .alphabeticalPagination {
-    line-height: 35px;
+    line-height: 32px;
 
     a {
-      min-width: 35px;
+      min-width: 32px;
     }
   }
 }

--- a/src/client/styles/components/SubjectHeadings/AlphabeticalPagination.scss
+++ b/src/client/styles/components/SubjectHeadings/AlphabeticalPagination.scss
@@ -1,5 +1,5 @@
 .alphabeticalPagination {
-  border: 1px solid $lightBorder;
+  border: 1px solid $borderDefault;
   border-radius: .2rem;
   box-sizing: border-box;
   display: flex;
@@ -7,13 +7,13 @@
   margin-bottom: 1.5rem;
   max-width: 100%;
   text-align: center;
-  background-color: $lightBorder;
+  background-color: $borderDefault;
   line-height: 32px;
   padding: 1px;
 
   a {
     box-sizing: border-box;
-    background-color: var(--nypl-colors-ui-white);
+    background-color: $white;
     display: inline-block;
     flex: auto;
     font-size: 14px;
@@ -21,13 +21,13 @@
     text-align: center;
     text-decoration: none;
     min-width: 32px;
-    border: 1px solid $lightBorder;
+    border: 1px solid $borderDefault;
     border-radius: 1px;
     margin: -1px;
 
     &:focus {
       z-index: 1;
-      background-color: var(--nypl-colors-ui-white);
+      background-color: $white;
     }
   }
 }

--- a/src/client/styles/components/SubjectHeadings/BibsList.scss
+++ b/src/client/styles/components/SubjectHeadings/BibsList.scss
@@ -18,7 +18,7 @@
   }
 }
 
-@media (min-width: 966px) {
+@include media($nypl-breakpoint-large) {
   .bibsList {
     min-height: 22rem;
   }

--- a/src/client/styles/components/SubjectHeadings/NestedTableHeader.scss
+++ b/src/client/styles/components/SubjectHeadings/NestedTableHeader.scss
@@ -1,7 +1,7 @@
 .nestedTableHeader {
   border-bottom: $table-row-border;
   line-height: 32px;
-  background-color: $subjectHeadingBackground;
+  background-color: $bgDefault;
 
   th {
     font-style: italic;

--- a/src/client/styles/components/SubjectHeadings/PreviewComponents.scss
+++ b/src/client/styles/components/SubjectHeadings/PreviewComponents.scss
@@ -16,7 +16,7 @@
     }
 
     em {
-      color: $previewComponentsTextColor;
+      color: $researchPrimary;
     }
   }
 
@@ -43,7 +43,7 @@
     }
 
     &.bibCount {
-      color: $previewComponentsTextColor;
+      color: $researchPrimary;
     }
   }
 }

--- a/src/client/styles/components/SubjectHeadings/SubjectHeading.scss
+++ b/src/client/styles/components/SubjectHeadings/SubjectHeading.scss
@@ -35,9 +35,7 @@
 
   }
   .subjectHeadingAttribute {
-    @include media($mobile-breakpoint) {
-      vertical-align: top;
-    }
+    vertical-align: top;
   }
 }
 
@@ -78,7 +76,7 @@ tbody .subjectHeadingRow {
   }
 }
 
-@include media($mobile-breakpoint) {
+@include media($nypl-breakpoint-medium) {
   .subjectHeadingsTable {
     th {
       min-width: 32px;
@@ -95,10 +93,10 @@ tbody .subjectHeadingRow {
   }
 }
 
-@include media($xtrasmall-breakpoint) {
+@include media($nypl-breakpoint-small) {
   .subjectHeadingsTable:not(.related) .subjectHeadingsTableCell.subjectHeadingLabel,
   .seeMore .subjectHeadingsTableCell
   {
-    padding-left: 22px;
+    padding-left: 0px;
   }
 }

--- a/src/client/styles/components/SubjectHeadings/SubjectHeading.scss
+++ b/src/client/styles/components/SubjectHeadings/SubjectHeading.scss
@@ -44,7 +44,7 @@
 tbody .subjectHeadingRow {
   border-bottom: $table-row-border;
   line-height: 32px;
-  background-color: $subjectHeadingBackground;
+  background-color: $bgDefault;
 
   .selected .emph {
     font-weight: 700;
@@ -69,7 +69,7 @@ tbody .subjectHeadingRow {
 
 
 .emph {
-  color: var(--nypl-colors-ui-black);
+  color: $black;
   font-size: 14px;
   font-style: initial;
 

--- a/src/client/styles/components/SubjectHeadings/SubjectHeadingSearch.scss
+++ b/src/client/styles/components/SubjectHeadings/SubjectHeadingSearch.scss
@@ -17,7 +17,7 @@
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width: $nypl-breakpoint-medium) {
   .react-autosuggest__container {
     display: block;
     width: 100%;

--- a/src/client/styles/components/SubjectHeadings/SubjectHeadingSearch.scss
+++ b/src/client/styles/components/SubjectHeadings/SubjectHeadingSearch.scss
@@ -9,10 +9,10 @@
     width: 100%;
     margin-bottom: unset;
     padding: var(--nypl-space-xs);
-    border: 1px solid var(--nypl-colors-ui-gray-medium);
+    border: 1px solid $grayMedium;
 
     &::placeholder {
-      color: var(--nypl-colors-ui-gray-dark);
+      color: $grayDark;
     }
   }
 }

--- a/src/client/styles/components/SubjectHeadings/SubjectHeadingShow.scss
+++ b/src/client/styles/components/SubjectHeadings/SubjectHeadingShow.scss
@@ -17,7 +17,7 @@
 }
 
 .subjectHeadingInfoBox {
-  border-color: var(--nypl-colors-ui-black);
+  border-color: $black;
   border-style: solid;
   border-top-width: 3px;
   justify-self: end;
@@ -43,7 +43,7 @@
 
 .context {
   .contextMore {
-    color: gray;
+    color: $grayDark;
   }
 }
 

--- a/src/client/styles/components/SubjectHeadings/SubjectHeadingShow.scss
+++ b/src/client/styles/components/SubjectHeadings/SubjectHeadingShow.scss
@@ -1,7 +1,9 @@
 .subjectHeadingsSideBar {
   display: flex;
   flex-direction: column;
-  float: right;
+  // float: right;
+  float: left;
+  width: 100%;
 
   .subjectHeadingsTable {
     min-width: 100%;
@@ -88,27 +90,5 @@
   th {
     font-size: 12px;
     min-width: 45px;
-  }
-}
-
-@include media($mobile-breakpoint) {
-  .subjectHeadingsSideBar {
-    float: left;
-    width: 100%;
-
-    .subjectHeadingsTable {
-      width: 100%;
-    }
-  }
-
-  .subjectHeadingInfoBox {
-    min-width: auto;
-  }
-}
-
-@include media($xtrasmall-breakpoint) {
-  .subjectHeadingsSideBar {
-    float: left;
-    width: unset;
   }
 }

--- a/src/client/styles/components/SubjectHeadings/SubjectHeadingsTable.scss
+++ b/src/client/styles/components/SubjectHeadings/SubjectHeadingsTable.scss
@@ -28,18 +28,6 @@
   }
 }
 
-@include media($mobile-breakpoint) {
-  .titles {
-    width: 75px;
-  }
-
-  .subjectHeadingsTable {
-    width: 100%;
-  }
-}
-
-@include media($xtrasmall-breakpoint) {
-  .titles {
-    width: 45px;
-  }
+.titles {
+  width: 75px;
 }

--- a/src/client/styles/components/SubjectHeadings/SubjectHeadingsTableHeader.scss
+++ b/src/client/styles/components/SubjectHeadings/SubjectHeadingsTableHeader.scss
@@ -26,12 +26,12 @@
 
 .subjectHeadingsTable:not(.related) {
   .headingColumnHeader {
-    padding-left: 32px;
+    padding-left: 12px;
   }
 
-  @include media($mobile-breakpoint) {
+  @include media($nypl-breakpoint-medium) {
     .headingColumnHeader {
-      padding-left: 12px;
+      padding-left: 32px;
     }
   }
 }

--- a/src/client/styles/components/SubjectHeadings/SubjectHeadingsTableHeader.scss
+++ b/src/client/styles/components/SubjectHeadings/SubjectHeadingsTableHeader.scss
@@ -21,7 +21,7 @@
 }
 
 .index thead {
-  border-bottom: 1.5px solid var(--nypl-colors-ui-black);
+  border-bottom: 1.5px solid $black;
 }
 
 .subjectHeadingsTable:not(.related) {

--- a/src/client/styles/components/TimedLogoutModal.scss
+++ b/src/client/styles/components/TimedLogoutModal.scss
@@ -1,6 +1,6 @@
 .timed-logout {
   hr {
-    color: $timedlogoutModalHR;
+    color: $borderDefault;
   }
 
   p {

--- a/src/client/styles/main.scss
+++ b/src/client/styles/main.scss
@@ -225,7 +225,8 @@ select {
   border-radius: 5px;
   flex-flow: column wrap;
   min-height: 200px;
-  padding: var(--nypl-space-s) var(--nypl-space-l);
+  padding-left: var(--nypl-space-s);
+  padding-right: var(--nypl-space-s);
 
   .button-container {
     display: flex;
@@ -239,9 +240,8 @@ a:focus {
   box-shadow: none;
 }
 
-@media (max-width: 400px) {
+@include media($nypl-breakpoint-small) {
   .research-modal__content {
-    padding-left: var(--nypl-space-s);
-    padding-right: var(--nypl-space-s);
+    padding: var(--nypl-space-s) var(--nypl-space-l);
   }
 }

--- a/src/client/styles/main.scss
+++ b/src/client/styles/main.scss
@@ -35,7 +35,7 @@ Import style rules from NYPL React module components
 // to temporarily use its previous style rules for the UI component.
 .old-ds-modal {
   padding: var(--nypl-space-s);
-  background-color: var(--nypl-colors-ui-gray-x-light-warm);
+  background-color: $grayXLightWarm;
   height: 100vh;
   left: 0;
   overflow-y: auto;
@@ -91,7 +91,7 @@ input[type=submit]:focus {
 
   a {
     padding: 0.5rem;
-    border: 0.08333rem solid $lightBorder;
+    border: 0.08333rem solid $borderDefault;
     border-radius: 0.2rem;
     font-weight: 500;
     width: 15%;
@@ -107,7 +107,7 @@ input[type=submit]:focus {
       height: 1.8rem;
       width: 1.8rem;
       margin-top: 0;
-      fill: var(--nypl-colors-ui-link-primary);
+      fill: $linkPrimary;
     }
   }
 
@@ -119,7 +119,7 @@ input[type=submit]:focus {
 }
 
 select {
-  color: var(--nypl-colors-ui-black);
+  color: $black;
 }
 
 .nypl-basic-table {
@@ -156,7 +156,6 @@ select {
 .nypl-results-publication {
   display: inline-block;
   margin-right: 1rem;
-  color: $darkColorBoxShadow;
   font-size: "";
   font-weight: 400;
 }
@@ -186,7 +185,7 @@ select {
   padding-top: 25vh;
 
   div {
-    background-color: $lightBackgroundColor;
+    background-color: $bgDefault;
     margin: auto;
     opacity: 100%;
     width: 472px;
@@ -221,8 +220,8 @@ select {
 
 .research-modal__content {
   align-items: flex-start;
-  background: $lightBackgroundColor;
-  border: 1px solid var(--nypl-colors-ui-gray-light-cool);
+  background: $bgDefault;
+  border: 1px solid $grayLightCool;
   border-radius: 5px;
   flex-flow: column wrap;
   min-height: 200px;

--- a/src/client/styles/style-v2.scss
+++ b/src/client/styles/style-v2.scss
@@ -41,20 +41,21 @@
       font-weight: 700;
       letter-spacing: 0.04rem;
       margin: 0 0 1rem 0;
-      width: 20%;
-      float: left;
+      margin-bottom: 0.75rem;
+      float: none;
+      width: 100%;
       clear: both;
-
-      @media (max-width: 600px) {
-        float: none;
-        margin-bottom: 0.75rem;
-        width: 100%;
+      
+      @include media($nypl-breakpoint-medium) {
+        float: left;
+        width: 20%;
+        margin-bottom: 1rem;
       }
     }
 
     dd {
-      margin-bottom: 1rem;
-      width: 80%;
+      margin-bottom: 1.25rem;
+      width: 100%;
       max-width: 80%;
       font-size: 0.85rem;
 
@@ -62,9 +63,9 @@
         list-style-type: none;
       }
 
-      @media (max-width: 600px) {
-        margin-bottom: 1.25rem;
-        width: 100%;
+      @include media($nypl-breakpoint-medium) {
+        margin-bottom: 1rem;
+        width: 80%;
       }
 
       &.subject-listing a {
@@ -74,10 +75,13 @@
   }
 
 }
+.nypl-item-details__heading {
+  display: block;
+}
 
-@media (max-width: 600px) {
+@include media($nypl-breakpoint-medium) {
   .nypl-item-details__heading {
-    display: block;
+    display: flex;
   }
 }
 
@@ -121,11 +125,5 @@
     border-bottom: 0;
     padding-bottom: 0;
     margin-bottom: 0;
-  }
-}
-
-@media (max-width: 965px) {
-  .nypl-results-item .nypl-basic-table#bib-item-table {
-    display: table;
   }
 }

--- a/src/client/styles/style-v2.scss
+++ b/src/client/styles/style-v2.scss
@@ -37,8 +37,6 @@
     }
 
     dt {
-      // color: $nypl-dark-gray;
-      color: darken($darkGrayTextColor, 40%);
       font-size: 0.85rem;
       font-weight: 700;
       letter-spacing: 0.04rem;
@@ -84,7 +82,7 @@
 }
 
 .tabbed dl {
-  border-bottom: 1px solid var(--nypl-colors-ui-gray-light-cool);
+  border-bottom: 1px solid $grayLightCool;
   padding-top: 15px;
   &:first-of-type {
     padding-top: 0px;
@@ -103,7 +101,7 @@
 
 .nypl-results-item {
   margin-bottom: 3.25rem;
-  border-bottom: 0.0625rem solid $lightBorder;
+  border-bottom: 0.0625rem solid $borderDefault;
   padding-bottom: 2em;
 
   .nypl-results-item-description {

--- a/src/client/styles/utils/base.scss
+++ b/src/client/styles/utils/base.scss
@@ -2,15 +2,15 @@ a {
   text-decoration: underline;
 
   &.button {
-    color: var(--nypl-colors-ui-white);
-    background: var(--nypl-colors-ui-white);
+    color: $white;
+    background: $white;
     padding: 0.35rem 0.65rem;
     text-decoration: none;
     white-space: nowrap;
 
     &:hover {
-      color: var(--nypl-colors-ui-white);
-      background: var(--nypl-colors-ui-white);
+      color: $white;
+      background: $white;
     }
   }
 }

--- a/src/client/styles/utils/colors.scss
+++ b/src/client/styles/utils/colors.scss
@@ -1,45 +1,26 @@
-// Design System Research color
-$dsresearchprimary: #377f8b;
+// Recurring DS colors used throughout the app
+// assigned as SCSS variables.
 
-// semantic colors
-$subjectHeadingBackground: #edebe9;
+$black: var(--nypl-colors-ui-black);
+$white: var(--nypl-colors-ui-white);
 
-// Recurring colors throughout the app.
-// Some are only used once, some are only used in one file,
-// but they are all here for consistency.
+$borderDefault: var(--nypl-colors-ui-border-default);
+$bgDefault: var(--nypl-colors-ui-bg-default);
+$bgHover: var(--nypl-colors-ui-bg-hover);
 
-// mostly for borders
-$lightBorder: #d7d4d0;
-// for color and box-shadow
-$darkColorBoxShadow: #080807;
-// for background color
-$lightBackgroundColor: #F9F8F7;
-// dark text color
-$darkGrayTextColor: #776e64;
-// account page colors
-$accountBlue: #0576D3;
-$accountBGLight: #F5F5F5;
-$accountLightBorder: #C4C4C4;
-// blue color text
-$colorBlueText: #0071CE;
-// advance search aside color
-$advanceSearchColor: #A4241E;
-// advance search background color
-$advanceSearchBGColor: #F9F9F9;
-// bib page colors
-$bibTextColor: #54514a;
-$bibLinkColor: #3ab0df;
-$generalBlueColor: #1b7fa7;
-$generalDarkerBlueColor: #104d65;
-// feedback border
-$feedbackBorder: #E0E0E0;
-$generalHoverBlue: #176e91;
-$generalRedColor: #d0343a;
-$requiredRedColor: #aa272c;
-$loadingLayerBG: #eee;
-$notificationBG: #e6ecf0;
-$timedlogoutModalHR: #89969F;
-$previewComponentsTextColor: #31806a;
+$grayDark: var(--nypl-colors-ui-gray-dark);
+$grayMedium: var(--nypl-colors-ui-gray-medium);
+$grayLightCool: var(--nypl-colors-ui-gray-light-cool);
+$grayXLightCool: var(--nypl-colors-ui-gray-x-light-cool);
+$grayXXLightCool: var(--nypl-colors-ui-gray-xx-light-cool);
+$grayXLightWarm: var(--nypl-colors-ui-gray-x-light-warm);
 
-$border-color: darken($darkGrayTextColor, 40%);
-$results-list-item-button: $generalBlueColor;
+$linkPrimary: var(--nypl-colors-ui-link-primary);
+$linkSecondary: var(--nypl-colors-ui-link-secondary);
+
+$brandPrimary: var(--nypl-colors-brand-primary);
+$researchPrimary: var(--nypl-colors-section-research-primary);
+
+$succesPrimary: var(--nypl-colors-ui-success-primary);
+$errorPrimary: var(--nypl-colors-ui-error-primary);
+$warningPrimary: var(--nypl-colors-ui-warning-primary);

--- a/src/client/styles/utils/mixins.scss
+++ b/src/client/styles/utils/mixins.scss
@@ -87,9 +87,9 @@
 }
 
 @mixin clear-filters-button {
-  border: 1px solid $generalRedColor;
-  color: $generalRedColor;
-  background: var(--nypl-colors-ui-white);
+  border: 1px solid $brandPrimary;
+  color: $brandPrimary;
+  background: $white;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -97,16 +97,16 @@
   border-radius: 0.25rem;
 
   svg {
-    fill: $generalRedColor;
+    fill: $brandPrimary;
   }
 
   &:hover {
-    border: 1px solid var(--nypl-colors-ui-white);
-    color: var(--nypl-colors-ui-white);
-    background: $generalRedColor;
+    border: 1px solid $white;
+    color: $white;
+    background: $brandPrimary;
 
     svg {
-      fill: var(--nypl-colors-ui-white);
+      fill: $white;
     }
   }
 }

--- a/src/client/styles/utils/mixins.scss
+++ b/src/client/styles/utils/mixins.scss
@@ -1,8 +1,6 @@
-@mixin media(
-  $max-width,
-  $min-width: false,
-  $ignore-for-ie: false) {
-  @media (max-width: $max-width) {
+// For all responsive designs, this is a mobile-first approach.
+@mixin media($min-width) {
+  @media (min-width: $min-width) {
     @content;
   }
 }
@@ -25,44 +23,6 @@
   left: 0;
   height: auto;
   width: 100%;
-}
-
-/* --- Media Query Generator ---
- * Reusable mixin used to generate
- * variations of media query properties.
- */
-@mixin generate-mq($args...) {
-  $media-type: 'only screen';
-  $media-type-key: 'media-type';
-  $args: keywords($args);
-  $expr: '';
-
-  @if map-has-key($args, $media-type-key) {
-    $media-type: map-get($args, $media-type-key);
-    $args: map-remove($args, $media-type-key);
-  }
-
-  @each $key, $value in $args {
-    @if $value {
-      $expr: "#{$expr} and (#{$key}: #{$value})";
-    }
-  }
-
-  @media #{$media-type} #{$expr} {
-    @content;
-  }
-}
-
-/* min-screen($min, $orientation)
- * $min - required
- * $orientation - optional
- * Ex #1: @include min-screen(768px, landscape) { ... }
- * Ex #2: @include min-screen(768px) { ... }
- */
-@mixin min-screen($min, $orientation: false) {
-  @include generate-mq($min-width: $min, $orientation: $orientation) {
-    @content;
-  }
 }
 
 // @mixin transition($params) {

--- a/src/client/styles/utils/variables.scss
+++ b/src/client/styles/utils/variables.scss
@@ -8,6 +8,6 @@ $max-width: ($max-width-raw / $basefontraw) * 1rem; // in rems
 $tablet-portrait: 768px !default;
 
 // Subject Headings variables
-$subject-heading-table-header: rgb(224, 219, 214);
+$subject-heading-table-header: $bgHover;
 $emphasis-font-weight: 500;
-$table-row-border: 1px solid rgb(215, 210, 205);
+$table-row-border: 1px solid $borderDefault;

--- a/src/client/styles/utils/variables.scss
+++ b/src/client/styles/utils/variables.scss
@@ -1,11 +1,13 @@
-$intermediate-breakpoint: 1120px;
-$mobile-breakpoint: 965px;
-$xtrasmall-breakpoint: 483px;
+// Note: Cannot use DS CSS variables because those return numbers
+// and not the entire value with the unit.
+$nypl-breakpoint-small: 320px;
+$nypl-breakpoint-medium: 600px;
+$nypl-breakpoint-large: 960px;
+$nypl-breakpoint-xl: 1280px;
+
 $basefontraw: 16;
 $max-width-raw: 1315;
 $max-width: ($max-width-raw / $basefontraw) * 1rem; // in rems
-
-$tablet-portrait: 768px !default;
 
 // Subject Headings variables
 $subject-heading-table-header: $bgHover;

--- a/src/client/styles/utils/variables.scss
+++ b/src/client/styles/utils/variables.scss
@@ -1,9 +1,9 @@
-// Note: Cannot use DS CSS variables because those return numbers
-// and not the entire value with the unit.
-$nypl-breakpoint-small: 320px;
-$nypl-breakpoint-medium: 600px;
-$nypl-breakpoint-large: 960px;
-$nypl-breakpoint-xl: 1280px;
+// Reservoir DS breakpoint note. There are four SCSS variables for
+// breakpoint values imported from the DS `resources.scss` file:
+//  $nypl-breakpoint-small: 320px;
+//  $nypl-breakpoint-medium: 600px;
+//  $nypl-breakpoint-large: 960px;
+//  $nypl-breakpoint-xl: 1280px;
 
 $basefontraw: 16;
 $max-width-raw: 1315;


### PR DESCRIPTION
**What's this do?**
Resolves [SCC-3307](https://jira.nypl.org/browse/SCC-3307).

- No more hex code colors! Now all colors are based on DS colors through SCSS and CSS variables.
- The total number of SCSS variables have been reduced. There were a few variables with the same value and now those are streamlined into one variable for the value.

Besides the code review, Marty and Apoorva will also do VQA. There are subtle and obvious changes in this PR. Here are some examples:

**Feedback button color**
Current:
<img width="171" alt="Screen Shot 2022-11-03 at 2 52 07 PM" src="https://user-images.githubusercontent.com/1280564/200004656-0ff548b8-9e99-44aa-b5a6-8fa2c0c8027f.png">

DS Update:
<img width="165" alt="Screen Shot 2022-11-03 at 2 52 21 PM" src="https://user-images.githubusercontent.com/1280564/200004685-79b3450e-503a-4046-8149-4900c53ea502.png">

**DRBB sidebar cards**
Current:
<img width="339" alt="Screen Shot 2022-11-03 at 4 30 53 PM" src="https://user-images.githubusercontent.com/1280564/200005794-931da4a5-df77-42e0-9c35-22059293f681.png">

DS Update:
<img width="330" alt="Screen Shot 2022-11-03 at 4 31 04 PM" src="https://user-images.githubusercontent.com/1280564/200005813-b32f927d-0603-489c-8f47-c1ceec74d168.png">

**SHEP**
DS Update on the left side and current on the right side.
<img width="918" alt="Screen Shot 2022-11-03 at 3 38 33 PM" src="https://user-images.githubusercontent.com/1280564/200005039-17f1eed0-ff42-4105-91fc-17df19f68ab9.png">

**Error color**
Current:
<img width="542" alt="Screen Shot 2022-11-03 at 4 08 33 PM" src="https://user-images.githubusercontent.com/1280564/200005349-6b566115-0b5f-4e16-8e6b-b02bd42ec495.png">

DS Update:
<img width="547" alt="Screen Shot 2022-11-03 at 4 08 52 PM" src="https://user-images.githubusercontent.com/1280564/200005382-67a249df-e9ef-40a0-a24c-721ad3d05530.png">

Current:
<img width="170" alt="Screen Shot 2022-11-04 at 10 35 38 AM" src="https://user-images.githubusercontent.com/1280564/200006031-f5bb8a92-1cce-46cd-b34e-55a20c88d25e.png">

DS Update:
<img width="167" alt="Screen Shot 2022-11-04 at 10 35 42 AM" src="https://user-images.githubusercontent.com/1280564/200006060-a095d14f-2d63-4411-ac0e-623faeeec77b.png">

**Filter buttons**
Current:
<img width="265" alt="Screen Shot 2022-11-03 at 4 26 15 PM" src="https://user-images.githubusercontent.com/1280564/200005485-e63a91c3-fb1e-421d-a98d-43090142cce3.png">

DS Update:
<img width="243" alt="Screen Shot 2022-11-03 at 4 26 24 PM" src="https://user-images.githubusercontent.com/1280564/200005510-5ec0e89b-47d1-4204-80d8-6125dd5936b1.png">

**Refine Search button**
Current:
<img width="245" alt="Screen Shot 2022-11-03 at 4 28 42 PM" src="https://user-images.githubusercontent.com/1280564/200005576-9635ebb8-85b5-4530-8582-4d3e867937e8.png">

DS Update:
<img width="242" alt="Screen Shot 2022-11-03 at 4 28 45 PM" src="https://user-images.githubusercontent.com/1280564/200005602-2aca9ed7-8361-4c15-a1f7-4e47c4b40085.png">

**Link color**
All links have been updated.

Current:
<img width="172" alt="Screen Shot 2022-11-04 at 10 37 01 AM" src="https://user-images.githubusercontent.com/1280564/200006171-fbe98706-9f30-4e56-bc72-b09828d6056e.png">

DS Update:
<img width="148" alt="Screen Shot 2022-11-04 at 10 37 05 AM" src="https://user-images.githubusercontent.com/1280564/200006186-21476e03-95cb-418d-9d13-124b3b349c6a.png">


CC @bigfishdesign13 

**Why are we doing this? (w/ JIRA link if applicable)**

To match NYPL and DS brand and UI colors throughout the app.

**Do these changes have automated tests?**
N/A

**How should this be QAed?**
Review all the pages including EDD, SHEP, and the account page.

**Dependencies for merging? Releasing to production?**
Wait until #1985 is in production.

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
Yes, locally.
