### PR TITLE
Scc 3330 item table columns

### DIFF
--- a/src/app/components/Item/ItemTable.jsx
+++ b/src/app/components/Item/ItemTable.jsx
@@ -43,6 +43,7 @@ const ItemTable = ({ items, bibId, id, searchKeywords, page }) => {
               {isBibPage ? <th className={`status-links ${isDesktop ? '' : 'mobile'}`} scope="col">Status</th> : null}
               {includeVolColumn ? <th scope="col">{volText}</th> : null}
               <th scope="col">Format</th>
+              { (!includeVolColumn && !isDesktop) ? <th scope="col">Call Number</th> : null }
               {isBibPage && isDesktop ? <th scope="col">Access</th> : null}
               {isDesktop ? <><th scope="col">Call Number</th>
                 <th scope="col">Item Location</th></> : null}

--- a/src/app/components/Item/ItemTableRow.jsx
+++ b/src/app/components/Item/ItemTableRow.jsx
@@ -71,6 +71,11 @@ class ItemTableRow extends React.Component {
         <td data-th="Format">
           <span>{item.format || ' '}</span>
         </td>
+        {
+          (!includeVolColumn && !isDesktop) ?
+          <td data-th="Call Number"><span>{itemCallNumber}</span></td> :
+          null
+        }
         {isBibPage && isDesktop ? <td data-th="Access">{this.message()}</td> : null}
         {isDesktop ? <> <td data-th="Call Number"><span>{itemCallNumber}</span></td>
           <td data-th="Location"><span>{item.location}</span></td></> : null}

--- a/test/unit/ItemTableRow_bib_mobile.test.js
+++ b/test/unit/ItemTableRow_bib_mobile.test.js
@@ -25,7 +25,7 @@ describe('ItemTableRow - mobile bib page view', () => {
         expect(tr.prop('className')).to.equal('available');
       });
 
-      it('should return two <td>', () => {
+      it('should return three <td>', () => {
         expect(component.find('td').length).to.equal(3);
       });
 

--- a/test/unit/ItemTableRow_bib_mobile.test.js
+++ b/test/unit/ItemTableRow_bib_mobile.test.js
@@ -26,7 +26,7 @@ describe('ItemTableRow - mobile bib page view', () => {
       });
 
       it('should return two <td>', () => {
-        expect(component.find('td').length).to.equal(2);
+        expect(component.find('td').length).to.equal(3);
       });
 
       it('should not have a format as the third <td> column data', () => {


### PR DESCRIPTION
**What's this do?**
Adds the call number column to the item table for non-serials

**Why are we doing this? (w/ JIRA link if applicable)**
Right now the non-serials have a lot of extra space. It is also very difficult to tell what distinguishes the different items when there is no call number or volume info. 

**Do these changes have automated tests?**
Yes

**How should this be QAed?**
Should see the call number for non-serials items in mobile

**Dependencies for merging? Releasing to production?**
No

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
yes.
