### PR TITLE
SCC-3308: Reservoir DS breakpoints

### DIFF
--- a/src/app/components/Application/Application.jsx
+++ b/src/app/components/Application/Application.jsx
@@ -8,12 +8,9 @@ import { withRouter } from 'react-router';
 import { union as _union } from 'underscore';
 
 import Feedback from '../Feedback/Feedback';
-import LoadingLayer from '../LoadingLayer/LoadingLayer';
 import DataLoader from '../DataLoader/DataLoader';
 import appConfig from '../../data/appConfig';
-
 import { updateFeatures } from '../../actions/Actions';
-
 import { breakpoints } from '../../data/constants';
 
 export const MediaContext = React.createContext('desktop');

--- a/src/app/data/constants.js
+++ b/src/app/data/constants.js
@@ -3,7 +3,7 @@ import appConfig from "@appConfig";
 // breakpoints ordered by `maxValue` ascending
 const breakpoints = [
   {
-    maxValue: 490,
+    maxValue: 320,
     media: 'mobile',
   },
   {
@@ -11,7 +11,7 @@ const breakpoints = [
     media: 'tabletPortrait',
   },
   {
-    maxValue: 870,
+    maxValue: 960,
     media: 'tablet',
   },
 ];

--- a/src/client/styles/components/AdvancedSearch.scss
+++ b/src/client/styles/components/AdvancedSearch.scss
@@ -31,35 +31,35 @@
 
   #fields {
     width: 100%;
-    display: flex;
-    @include media($mobile-breakpoint) {
-      display: block;
+    display: block;
+    @include media($nypl-breakpoint-medium) {
+      display: flex;
     }
   }
 
   #advancedSearchButtons {
-    display: flex;
-    justify-content: flex-end;
+    display: block;
     width: 91%;
-
-    @include media($mobile-breakpoint) {
-      display: block;
+    
+    @include media($nypl-breakpoint-medium) {
+      justify-content: flex-end;
+      display: flex;
     }
 
     button {
       margin: 5px;
-      width: 139px;
-      @include media($mobile-breakpoint) {
-        width: 100%;
+      width: 100%;
+      @include media($nypl-breakpoint-medium) {
+        width: 139px;
       }
     }
   }
 
   #formats {
-    display: flex;
     border: none;
-    @include media($mobile-breakpoint) {
-      display: block;
+    display: block;
+    @include media($nypl-breakpoint-medium) {
+      display: flex;
     }
   }
 

--- a/src/client/styles/components/Feedback.scss
+++ b/src/client/styles/components/Feedback.scss
@@ -7,7 +7,7 @@
   background: $white;
   color: $black;
 
-  @include min-screen($tablet-portrait) {
+  @include media($nypl-breakpoint-large) {
     position: fixed;
     background: inherit;
     max-width: 571px;

--- a/src/client/styles/components/FilterPopup.scss
+++ b/src/client/styles/components/FilterPopup.scss
@@ -58,7 +58,7 @@
       }
     }
 
-    @include min-screen($xtrasmall-breakpoint) {
+    @include media($nypl-breakpoint-small) {
       margin-top: 35px;
     }
   }
@@ -84,7 +84,7 @@
     display: none;
     margin-bottom: 0;
 
-    @include min-screen($xtrasmall-breakpoint) {
+    @include media($nypl-breakpoint-small) {
       text-align: right;
       margin-bottom: 15px;
     }
@@ -102,7 +102,7 @@
         margin-bottom: 20px;
       }
 
-      @include min-screen($xtrasmall-breakpoint) {
+      @include media($nypl-breakpoint-small) {
         width: auto;
 
         button {
@@ -193,11 +193,11 @@
     width: auto;
     z-index: 10000;
 
-    @include min-screen($tablet-portrait) {
+    @include media($nypl-breakpoint-large) {
       width: 42rem;
     }
 
-    @include min-screen(966px) {
+    @include media(966px) {
       width: 52rem;
     }
 
@@ -260,7 +260,7 @@
     margin-bottom: 20px;
     @include border-radius(5px);
 
-    @include min-screen($xtrasmall-breakpoint) {
+    @include media($nypl-breakpoint-small) {
       margin-bottom: 0;
     }
 
@@ -317,13 +317,13 @@
 }
 
 .nypl-generic-columns {
-  column-count: 3;
+  column-count: 2;
   max-width: 100%;
 }
 
-@include media($mobile-breakpoint) {
+@include media($nypl-breakpoint-medium) {
   .nypl-generic-columns {
-    column-count: 2;
+    column-count: 3;
   }
 }
 

--- a/src/client/styles/components/SubjectHeadings/AlphabeticalPagination.scss
+++ b/src/client/styles/components/SubjectHeadings/AlphabeticalPagination.scss
@@ -8,7 +8,7 @@
   max-width: 100%;
   text-align: center;
   background-color: $borderDefault;
-  line-height: 32px;
+  line-height: 35px;
   padding: 1px;
 
   a {
@@ -20,7 +20,7 @@
     font-weight: 400;
     text-align: center;
     text-decoration: none;
-    min-width: 32px;
+    min-width: 35px;
     border: 1px solid $borderDefault;
     border-radius: 1px;
     margin: -1px;
@@ -32,12 +32,12 @@
   }
 }
 
-@include media($xtrasmall-breakpoint) {
+@include media($nypl-breakpoint-small) {
   .alphabeticalPagination {
-    line-height: 35px;
+    line-height: 32px;
 
     a {
-      min-width: 35px;
+      min-width: 32px;
     }
   }
 }

--- a/src/client/styles/components/SubjectHeadings/SubjectHeading.scss
+++ b/src/client/styles/components/SubjectHeadings/SubjectHeading.scss
@@ -35,9 +35,7 @@
 
   }
   .subjectHeadingAttribute {
-    @include media($mobile-breakpoint) {
-      vertical-align: top;
-    }
+    vertical-align: top;
   }
 }
 
@@ -78,7 +76,7 @@ tbody .subjectHeadingRow {
   }
 }
 
-@include media($mobile-breakpoint) {
+@include media($nypl-breakpoint-medium) {
   .subjectHeadingsTable {
     th {
       min-width: 32px;
@@ -95,10 +93,10 @@ tbody .subjectHeadingRow {
   }
 }
 
-@include media($xtrasmall-breakpoint) {
+@include media($nypl-breakpoint-small) {
   .subjectHeadingsTable:not(.related) .subjectHeadingsTableCell.subjectHeadingLabel,
   .seeMore .subjectHeadingsTableCell
   {
-    padding-left: 22px;
+    padding-left: 0px;
   }
 }

--- a/src/client/styles/components/SubjectHeadings/SubjectHeadingShow.scss
+++ b/src/client/styles/components/SubjectHeadings/SubjectHeadingShow.scss
@@ -1,7 +1,9 @@
 .subjectHeadingsSideBar {
   display: flex;
   flex-direction: column;
-  float: right;
+  // float: right;
+  float: left;
+  width: 100%;
 
   .subjectHeadingsTable {
     min-width: 100%;
@@ -88,27 +90,5 @@
   th {
     font-size: 12px;
     min-width: 45px;
-  }
-}
-
-@include media($mobile-breakpoint) {
-  .subjectHeadingsSideBar {
-    float: left;
-    width: 100%;
-
-    .subjectHeadingsTable {
-      width: 100%;
-    }
-  }
-
-  .subjectHeadingInfoBox {
-    min-width: auto;
-  }
-}
-
-@include media($xtrasmall-breakpoint) {
-  .subjectHeadingsSideBar {
-    float: left;
-    width: unset;
   }
 }

--- a/src/client/styles/components/SubjectHeadings/SubjectHeadingsTable.scss
+++ b/src/client/styles/components/SubjectHeadings/SubjectHeadingsTable.scss
@@ -28,18 +28,6 @@
   }
 }
 
-@include media($mobile-breakpoint) {
-  .titles {
-    width: 75px;
-  }
-
-  .subjectHeadingsTable {
-    width: 100%;
-  }
-}
-
-@include media($xtrasmall-breakpoint) {
-  .titles {
-    width: 45px;
-  }
+.titles {
+  width: 75px;
 }

--- a/src/client/styles/components/SubjectHeadings/SubjectHeadingsTableHeader.scss
+++ b/src/client/styles/components/SubjectHeadings/SubjectHeadingsTableHeader.scss
@@ -26,12 +26,12 @@
 
 .subjectHeadingsTable:not(.related) {
   .headingColumnHeader {
-    padding-left: 32px;
+    padding-left: 12px;
   }
 
-  @include media($mobile-breakpoint) {
+  @include media($nypl-breakpoint-medium) {
     .headingColumnHeader {
-      padding-left: 12px;
+      padding-left: 32px;
     }
   }
 }

--- a/src/client/styles/utils/mixins.scss
+++ b/src/client/styles/utils/mixins.scss
@@ -1,8 +1,6 @@
-@mixin media(
-  $max-width,
-  $min-width: false,
-  $ignore-for-ie: false) {
-  @media (max-width: $max-width) {
+// For all responsive designs, this is a mobile-first approach.
+@mixin media($min-width) {
+  @media (min-width: $min-width) {
     @content;
   }
 }
@@ -25,44 +23,6 @@
   left: 0;
   height: auto;
   width: 100%;
-}
-
-/* --- Media Query Generator ---
- * Reusable mixin used to generate
- * variations of media query properties.
- */
-@mixin generate-mq($args...) {
-  $media-type: 'only screen';
-  $media-type-key: 'media-type';
-  $args: keywords($args);
-  $expr: '';
-
-  @if map-has-key($args, $media-type-key) {
-    $media-type: map-get($args, $media-type-key);
-    $args: map-remove($args, $media-type-key);
-  }
-
-  @each $key, $value in $args {
-    @if $value {
-      $expr: "#{$expr} and (#{$key}: #{$value})";
-    }
-  }
-
-  @media #{$media-type} #{$expr} {
-    @content;
-  }
-}
-
-/* min-screen($min, $orientation)
- * $min - required
- * $orientation - optional
- * Ex #1: @include min-screen(768px, landscape) { ... }
- * Ex #2: @include min-screen(768px) { ... }
- */
-@mixin min-screen($min, $orientation: false) {
-  @include generate-mq($min-width: $min, $orientation: $orientation) {
-    @content;
-  }
 }
 
 // @mixin transition($params) {

--- a/src/client/styles/utils/variables.scss
+++ b/src/client/styles/utils/variables.scss
@@ -1,11 +1,13 @@
-$intermediate-breakpoint: 1120px;
-$mobile-breakpoint: 965px;
-$xtrasmall-breakpoint: 483px;
+// Note: Cannot use DS CSS variables because those return numbers
+// and not the entire value with the unit.
+$nypl-breakpoint-small: 320px;
+$nypl-breakpoint-medium: 600px;
+$nypl-breakpoint-large: 960px;
+$nypl-breakpoint-xl: 1280px;
+
 $basefontraw: 16;
 $max-width-raw: 1315;
 $max-width: ($max-width-raw / $basefontraw) * 1rem; // in rems
-
-$tablet-portrait: 768px !default;
 
 // Subject Headings variables
 $subject-heading-table-header: $bgHover;

--- a/src/client/styles/utils/variables.scss
+++ b/src/client/styles/utils/variables.scss
@@ -1,9 +1,9 @@
-// Note: Cannot use DS CSS variables because those return numbers
-// and not the entire value with the unit.
-$nypl-breakpoint-small: 320px;
-$nypl-breakpoint-medium: 600px;
-$nypl-breakpoint-large: 960px;
-$nypl-breakpoint-xl: 1280px;
+// Reservoir DS breakpoint note. There are four SCSS variables for
+// breakpoint values imported from the DS `resources.scss` file:
+//  $nypl-breakpoint-small: 320px;
+//  $nypl-breakpoint-medium: 600px;
+//  $nypl-breakpoint-large: 960px;
+//  $nypl-breakpoint-xl: 1280px;
 
 $basefontraw: 16;
 $max-width-raw: 1315;


### PR DESCRIPTION
**What's this do?**
Resolves [SCC-3308](https://jira.nypl.org/browse/SCC-3308).
This updates internal Research Catalog breakpoint values to DS breakpoint values. This also uses the `media` SCSS mixin which is now refactored to use a mobile-first approach when creating meadia queries. The `min-screen` and `generate-mqs` SCSS mixins were removed in favor of the `media` SCSS mixin.

There were some changes to the SCSS structure for the Advance Search and SHEP table where some styles had to be updated for the mobile-first approach, but they were minor updates.

**Why are we doing this? (w/ JIRA link if applicable)**
Get more values aligned with DS values.

**Do these changes have automated tests?**
N/A

**How should this be QAed?**
Review all the pages on mobile, tablet, and desktop views. The width values have changed but the UI and layout should remain the same on respective viewports.

**Dependencies for merging? Releasing to production?**
This will point to #1994 which should be reviewed/merged in first before this update.

**Has the application documentation been updated for these changes?**

**Did someone actually run this code to verify it works?**
