### PR TITLE
Add normalization of item filters by label

### DIFF
--- a/src/app/components/Item/ItemFilters.jsx
+++ b/src/app/components/Item/ItemFilters.jsx
@@ -35,15 +35,17 @@ const ItemFilters = (
   reducedItemsAggregations.forEach((agg) => {
     const values = agg.values
     const reducedValues = {}
-    values.filter(value => value.label && value.label.length)
+    values.filter(value => value.label?.length)
       .forEach((value) => {
-        if (!reducedValues[value.label]) {
-          reducedValues[value.label] = []
+        let label = value.label
+        if (label.toLowerCase().replace(/[^\w]/g, '') === 'offsite') { label = "Offsite" }
+        if (!reducedValues[label]) {
+          reducedValues[label] = new Set()
         }
-        reducedValues[value.label].push(value.value)
+        reducedValues[label].add(value.value)
       })
     agg.values = Object.keys(reducedValues)
-      .map(label => ({ value: reducedValues[label].join(","), label: label }))
+      .map(label => ({ value: Array.from(reducedValues[label]).join(","), label: label }))
   })
   // For every item aggregation, go through every filter in its `values` array
   // and map all the labels to their ids. This is done because the API expects

--- a/test/fixtures/itemFilterOptions.js
+++ b/test/fixtures/itemFilterOptions.js
@@ -76,9 +76,76 @@ const itemsAggregations = [
   },
 ];
 
+const itemsAggregations2 = [
+  {
+    '@id': 'res:location',
+    '@type': "nypl:Aggregation",
+    field: 'location',
+    id:  'location',
+    values: [
+      {
+        count: 4,
+        value: 'loc:maj03',
+        label: 'SASB M1 - General Research - Room 315'
+      },
+      {
+        count: 12,
+        label: 'Offsite',
+        value: 'loc:rc2ma'
+      },
+      {
+        count: 2,
+        value: 'offsite',
+        label: 'Offsite'
+      },
+      {
+        count: 2,
+        value: 'blank',
+        label: ''
+      },
+      {
+        count: 2,
+        value: 'blaaaank'
+      }
+    ]
+  },
+  {
+    '@id': 'res:format',
+    '@type': "nypl:Aggregation",
+    field: 'format',
+    id:  'format',
+    values: [
+      {
+        count: 12,
+        label: 'Text',
+        value: 'Text'
+      }
+    ]
+  },
+  {
+    '@id': 'res:status',
+    '@type': "nypl:Aggregation",
+    field: 'status',
+    id:  'status',
+    values: [
+      {
+        count: 12,
+        label: 'Available',
+        value: 'status:a'
+      },
+      {
+        count: 12,
+        label: 'Not Available (ReCAP',
+        value: 'status:na'
+      }
+    ]
+  },
+];
+
 export {
   locationFilters,
   formatFilters,
   statusFilters,
-  itemsAggregations
+  itemsAggregations,
+  itemsAggregations2
 };

--- a/test/fixtures/itemFilterOptions.js
+++ b/test/fixtures/itemFilterOptions.js
@@ -94,6 +94,26 @@ const itemsAggregations2 = [
         value: 'loc:rc2ma'
       },
       {
+        count: 12,
+        label: 'Off site',
+        value: 'loc:rc2ma'
+      },
+      {
+        count: 12,
+        label: 'Off-site',
+        value: 'loc:rc2ma'
+      },
+      {
+        count: 12,
+        label: 'off-site',
+        value: 'loc:rc2ma'
+      },
+      {
+        count: 12,
+        label: 'off site',
+        value: 'loc:rc2ma'
+      },
+      {
         count: 2,
         value: 'offsite',
         label: 'Offsite'

--- a/test/unit/ItemFilters.test.js
+++ b/test/unit/ItemFilters.test.js
@@ -201,6 +201,7 @@ describe('ItemFilters', () => {
         { context: contextWithMultipleFilters }
       );
     });
+
     it('should remove blank aggregations and combine duplicated ones', () => {
       const itemFilter = component.find(ItemFilter)
       const locations = itemFilter.at(0).prop('options')

--- a/test/unit/ItemFilters.test.js
+++ b/test/unit/ItemFilters.test.js
@@ -5,8 +5,9 @@ import { expect } from 'chai';
 import { mount } from 'enzyme';
 
 import ItemFilters from './../../src/app/components/Item/ItemFilters';
+import ItemFilter from './../../src/app/components/Item/ItemFilter';
 import item from '../fixtures/libraryItems';
-import { itemsAggregations } from '../fixtures/itemFilterOptions';
+import { itemsAggregations, itemsAggregations2 } from '../fixtures/itemFilterOptions';
 
 const context = {
   router: {
@@ -175,4 +176,39 @@ describe('ItemFilters', () => {
       expect(component.find('h3').text()).to.equal('No Results Found');
     });
   });
+
+  describe('with blank or duplicated items aggregations', () => {
+    let component;
+    before(() => {
+      const contextWithMultipleFilters = context;
+      contextWithMultipleFilters.router.location.query = {
+        format: 'PRINT',
+        status: 'Requestable',
+      };
+      component = mount(
+        <ItemFilters
+          items={[
+            item.full,
+            item.missingData,
+            item.requestable_ReCAP_available,
+            item.requestable_ReCAP_not_available,
+            item.requestable_nonReCAP_NYPL,
+          ]}
+          numOfFilteredItems={0}
+          itemsAggregations={itemsAggregations2}
+          hasFilterApplied
+        />,
+        { context: contextWithMultipleFilters }
+      );
+    });
+    it('should remove blank aggregations and combine duplicated ones', () => {
+      const itemFilter = component.find(ItemFilter)
+      const locations = itemFilter.at(0).prop('options')
+      expect(locations.length).to.equal(2)
+      expect(locations[0].value).to.equal('loc:maj03')
+      expect(locations[0].label).to.equal('SASB M1 - General Research - Room 315')
+      expect(locations[1].value).to.equal('loc:rc2ma,offsite')
+      expect(locations[1].label).to.equal('Offsite')
+    })
+  })
 });


### PR DESCRIPTION
**What's this do?**
- Normalized item filters by label so we don't get repeated or blank filters
- Adds tests

**Why are we doing this? (w/ JIRA link if applicable)**
This is for scc-3373

**Do these changes have automated tests?**
Yes

**Dependencies for merging? Releasing to production?**
No

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
yes