### PR TITLE
SCC-3404: Adding a logout link to the subnav in the header

### DIFF
--- a/src/app/components/Application/Application.jsx
+++ b/src/app/components/Application/Application.jsx
@@ -12,6 +12,7 @@ import DataLoader from '../DataLoader/DataLoader';
 import appConfig from '../../data/appConfig';
 import { updateFeatures } from '../../actions/Actions';
 import { breakpoints } from '../../data/constants';
+import { PatronProvider } from '../../context/PatronContext';
 
 export const MediaContext = React.createContext('desktop');
 
@@ -80,23 +81,25 @@ export class Application extends React.Component {
     );
 
     return (
-      <MediaContext.Provider value={this.state.media}>
-        <div className="app-wrapper">
-          <Header
-            navData={navConfig.current}
-            patron={this.props.patron}
-            skipNav={{ target: 'mainContent' }}
-          />
-          <DataLoader
-            location={this.context.router.location}
-            key={JSON.stringify(dataLocation)}
-          >
-            {React.cloneElement(this.props.children)}
-          </DataLoader>
-          <Footer />
-          <Feedback />
-        </div>
-      </MediaContext.Provider>
+      <PatronProvider patron={this.props.patron}>
+        <MediaContext.Provider value={this.state.media}>
+          <div className="app-wrapper">
+            <Header
+              navData={navConfig.current}
+              patron={this.props.patron}
+              skipNav={{ target: 'mainContent' }}
+            />
+            <DataLoader
+              location={this.context.router.location}
+              key={JSON.stringify(dataLocation)}
+            >
+              {React.cloneElement(this.props.children)}
+            </DataLoader>
+            <Footer />
+            <Feedback />
+          </div>
+        </MediaContext.Provider>
+      </PatronProvider>
     );
   }
 }
@@ -105,6 +108,7 @@ Application.propTypes = {
   children: PropTypes.object,
   patron: PropTypes.object,
   features: PropTypes.array,
+  updateFeatures: PropTypes.func,
 };
 
 Application.defaultProps = {

--- a/src/app/components/LogoutLink/LogoutLink.jsx
+++ b/src/app/components/LogoutLink/LogoutLink.jsx
@@ -1,0 +1,56 @@
+import { Link as DSLink } from '@nypl/design-system-react-components';
+import PropTypes from 'prop-types';
+import React, { useContext, useEffect, useState } from 'react';
+
+import { PatronContext } from '../../context/PatronContext';
+import { trackDiscovery } from '../../utils/utils';
+
+/**
+ * Renders a simple link to log out the user out from the Catalog.
+ */
+const LogoutLink = ({
+  baseUrl = '/research/research-catalog',
+  delineate = false
+}) => {
+  const logoutLink = "https://login.nypl.org/auth/logout?redirect_uri=";
+  const [backLink, setBackLink] = useState('');
+  const { loggedIn } = useContext(PatronContext);
+
+  useEffect(() => {
+    const currentUrl = window.location.href;
+
+    // If the patron is on any hold or account page, then
+    // redirect them to the home page after logging out.
+    if (currentUrl.includes('hold') || currentUrl.includes('account')) {
+      setBackLink(`${window.location.origin}${baseUrl}/`);
+    } else {
+      // Otherwise, redirect back to the current page after logging out.
+      setBackLink(window.location.href);
+    }
+  }, [baseUrl]);
+
+  if (!loggedIn) return null;
+
+  return (
+    <>
+      {delineate ? <>&nbsp;|&nbsp;</> : null}
+      <DSLink
+        onClick={() => trackDiscovery("Click", "Log Out")}
+        href={`${logoutLink}${backLink}`}
+        sx={{
+          color: 'ui.white', textDecoration: 'none',
+          _focus: { textDecoration: 'underline' },
+        }}
+      >
+        Log Out
+      </DSLink>
+    </>
+  );
+};
+
+LogoutLink.propTypes = {
+  baseUrl: PropTypes.string,
+  delineate: PropTypes.bool,
+};
+
+export default LogoutLink;

--- a/src/app/components/SubNav/SubNav.jsx
+++ b/src/app/components/SubNav/SubNav.jsx
@@ -4,6 +4,7 @@ import { Link as DSLink } from '@nypl/design-system-react-components';
 import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
 
+import LogoutLink from '../LogoutLink/LogoutLink';
 import appConfig from '../../data/appConfig';
 
 const SubNavLink = ({ type, activeSection, href, children }) => (
@@ -24,6 +25,7 @@ SubNavLink.propTypes = {
 const SubNav = (props) => {
   const features = useSelector(state => state.features);
   const { baseUrl } = appConfig;
+
   return (
     <nav
       className="sub-nav"
@@ -58,6 +60,7 @@ const SubNav = (props) => {
             </>
           ) : null
         }
+        <LogoutLink baseUrl={baseUrl} delineate />
       </ul>
     </nav>
   );

--- a/src/app/context/PatronContext.jsx
+++ b/src/app/context/PatronContext.jsx
@@ -1,0 +1,18 @@
+import PropTypes from 'prop-types';
+import React, { createContext } from 'react';
+
+/**
+ * Wrapper context component that controls state for the Feedback component
+ */
+
+export const PatronContext = createContext(null);
+export const PatronProvider = ({ children, patron = {}}) => (
+  <PatronContext.Provider value={patron}>
+    {children}
+  </PatronContext.Provider>
+);
+
+PatronProvider.propTypes = {
+  children: PropTypes.node,
+  patron: PropTypes.object,
+};

--- a/src/app/context/PatronContext.jsx
+++ b/src/app/context/PatronContext.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React, { createContext } from 'react';
 
 /**
- * Wrapper context component that controls state for the Feedback component
+ * Wrapper context component to get patron data from the Redux store.
  */
 
 export const PatronContext = createContext(null);

--- a/test/helpers/store.js
+++ b/test/helpers/store.js
@@ -6,26 +6,32 @@ import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 
 import initialState from '../../src/app/stores/InitialState';
+import { PatronProvider } from '../../src/app/context/PatronContext';
 
-const TestProvider = ({
-  store,
-  children,
-}) => {
-
-  return < Provider store={store} > {children}</Provider >;
+const TestProvider = ({ store, children, patron }) => {
+  return (
+    <PatronProvider patron={patron}>
+      <Provider store={store}>
+        {children}
+      </Provider>
+    </PatronProvider>
+  );
 }
 
-function testRender(ui, renderFunc, { store, ...otherOpts }) {
-  return renderFunc(<TestProvider store={store}>{ui}</TestProvider>, {
-    context: {
-      router: {
-        location: { query: {}, pathname: '' },
-        createHref: () => {},
-        push: () => {},
+function testRender(ui, renderFunc, { store, patron, ...otherOpts }) {
+  return renderFunc(
+    <TestProvider store={store} patron={patron}>{ui}</TestProvider>,
+    {
+      context: {
+        router: {
+          location: { query: {}, pathname: '' },
+          createHref: () => {},
+          push: () => {},
+        },
       },
-    },
-    ...otherOpts,
-  });
+      ...otherOpts,
+    }
+  );
 }
 
 export const shallowTestRender = (ui, { store, ...otherOpts }) => testRender(

--- a/test/helpers/store.js
+++ b/test/helpers/store.js
@@ -8,6 +8,10 @@ import thunk from 'redux-thunk';
 import initialState from '../../src/app/stores/InitialState';
 import { PatronProvider } from '../../src/app/context/PatronContext';
 
+/**
+ * Helper component to wrap components being tested that need access to
+ * either the Redux store or the PatronContext.
+ */
 const TestProvider = ({ store, children, patron }) => {
   return (
     <PatronProvider patron={patron}>

--- a/test/unit/BibPage.test.js
+++ b/test/unit/BibPage.test.js
@@ -14,7 +14,7 @@ import { BibPage } from './../../src/app/pages/BibPage';
 import bibs from '../fixtures/bibs';
 import annotatedMarc from '../fixtures/annotatedMarc.json';
 import mockBibWithHolding from '../fixtures/mockBibWithHolding.json';
-import { makeTestStore } from '../helpers/store';
+import { makeTestStore, mountTestRender, shallowTestRender } from '../helpers/store';
 import { mockRouterContext } from '../helpers/routing';
 import BackToSearchResults from '../../src/app/components/BibPage/BackToSearchResults';
 import { Link } from 'react-router';
@@ -22,6 +22,7 @@ import BibDetails from '../../src/app/components/BibPage/BibDetails';
 import ElectronicResources from '../../src/app/components/BibPage/ElectronicResources'
 import { isAeonLink } from '../../src/app/utils/utils';
 import { Heading } from '@nypl/design-system-react-components';
+
 
 describe('BibPage', () => {
   const context = mockRouterContext();
@@ -34,19 +35,17 @@ describe('BibPage', () => {
     });
 
     const bib = { ...bibs[2] };
-    const page = mount(
-      <Provider store={testStore}>
-        <BibPage
-          location={{ search: 'search', pathname: '' }}
-          bib={bib}
-          dispatch={() => { }}
-          resultSelection={{
-            fromUrl: '',
-            bibId: '',
-          }}
-        />
-      </Provider>,
-      { context, childContextTypes: { router: PropTypes.object } },
+    const page = mountTestRender(
+      <BibPage
+        location={{ search: 'search', pathname: '' }}
+        bib={bib}
+        dispatch={() => {}}
+        resultSelection={{
+          fromUrl: '',
+          bibId: '',
+        }}
+      />,
+      { context, childContextTypes: { router: PropTypes.object }, store: testStore },
     );
 
     it('should have an Aeon link available', () => {
@@ -80,20 +79,18 @@ describe('BibPage', () => {
 
     it('should not render Electronic Resources component when there are no electronic resources', () => {
       const noElectronicResourcesBib = bibs[0]
-      const noElectronicResourcesBibPage = mount(
-        <Provider store={testStore}>
-          <BibPage
-            location={{ search: 'search', pathname: '' }}
-            bib={noElectronicResourcesBib}
-            dispatch={() => { }}
-            resultSelection={{
-              fromUrl: '',
-              bibId: '',
-            }}
-          />
-        </Provider>,
-        { context, childContextTypes: { router: PropTypes.object } })
-
+      const noElectronicResourcesBibPage = mountTestRender(
+        <BibPage
+          location={{ search: 'search', pathname: '' }}
+          bib={noElectronicResourcesBib}
+          dispatch={() => { }}
+          resultSelection={{
+            fromUrl: '',
+            bibId: '',
+          }}
+        />,
+        { context, childContextTypes: { router: PropTypes.object }, store: testStore }
+      );
       expect(noElectronicResourcesBibPage.find(ElectronicResources)).to.have.lengthOf(0)
     })
 
@@ -110,18 +107,18 @@ describe('BibPage', () => {
     let component;
     before(() => {
       const bib = { ...bibs[0], ...annotatedMarc };
-      component = mount(
-        <Provider store={testStore}>
-          <BibPage
-            location={{ search: 'search', pathname: '' }}
-            bib={bib}
-            dispatch={() => { }}
-            resultSelection={{
-              fromUrl: '',
-              bibId: '',
-            }}
-          />
-        </Provider>, { context, childContextTypes: { router: PropTypes.object } });
+      component = mountTestRender(
+        <BibPage
+          location={{ search: 'search', pathname: '' }}
+          bib={bib}
+          dispatch={() => { }}
+          resultSelection={{
+            fromUrl: '',
+            bibId: '',
+          }}
+        />,
+        { context, childContextTypes: { router: PropTypes.object }, store: testStore },
+      );
     });
 
 
@@ -161,18 +158,18 @@ describe('BibPage', () => {
     before(() => {
       const bib = { ...bibs[0], ...annotatedMarc };
       bib.items = [];
-      component = mount(
-        <Provider store={testStore}>
-          <BibPage
-            location={{ search: 'search', pathname: '' }}
-            bib={bib}
-            dispatch={() => { }}
-            resultSelection={{
-              fromUrl: '',
-              bibId: '',
-            }}
-          />
-        </Provider>, { context, childContextTypes: { router: PropTypes.object } });
+      component = mountTestRender(
+        <BibPage
+          location={{ search: 'search', pathname: '' }}
+          bib={bib}
+          dispatch={() => { }}
+          resultSelection={{
+            fromUrl: '',
+            bibId: '',
+          }}
+        />,
+        { context, childContextTypes: { router: PropTypes.object }, store: testStore },
+      );
     });
 
     it('should not display ItemsContainer', () => {
@@ -195,21 +192,18 @@ describe('BibPage', () => {
         },
       });
 
-      component = mount(
-        <Provider store={testStore}>
-          <BibPage
-            location={{ search: 'search', pathname: '' }}
-            bib={bib}
-            dispatch={() => { }}
-            resultSelection={{
-              fromUrl: '',
-              bibId: '',
-            }}
-          />
-        </Provider>, {
-        context,
-        childContextTypes: { router: PropTypes.object },
-      });
+      component = mountTestRender(
+        <BibPage
+          location={{ search: 'search', pathname: '' }}
+          bib={bib}
+          dispatch={() => { }}
+          resultSelection={{
+            fromUrl: '',
+            bibId: '',
+          }}
+        />,
+        { context, childContextTypes: { router: PropTypes.object }, store: testStore },
+      );
 
     });
 
@@ -288,22 +282,21 @@ describe('BibPage', () => {
           numItems: 0,
         },
       });
-      const component = mount(
-        <Provider store={testStore}>
-          <BibPage
-            location={{ search: 'search', pathname: '' }}
-            bib={bib}
-            dispatch={() => undefined}
-            resultSelection={{
-              fromUrl: '',
-              bibId: '',
-            }}
-            features={['parallels']}
-          />
-        </Provider>,
+      const component = mountTestRender(
+        <BibPage
+          location={{ search: 'search', pathname: '' }}
+          bib={bib}
+          dispatch={() => undefined}
+          resultSelection={{
+            fromUrl: '',
+            bibId: '',
+          }}
+          features={['parallels']}
+        />,
         {
           context,
           childContextTypes: { router: PropTypes.object },
+          store: testStore,
         },
       );
 
@@ -318,22 +311,21 @@ describe('BibPage', () => {
           numItems: 0,
         },
       });
-      const component = mount(
-        <Provider store={testStore}>
-          <BibPage
-            location={{ search: 'search', pathname: '' }}
-            bib={bib}
-            dispatch={() => undefined}
-            resultSelection={{
-              fromUrl: '',
-              bibId: '',
-            }}
-            features={['parallels']}
-          />
-        </Provider>,
+      const component = mountTestRender(
+        <BibPage
+          location={{ search: 'search', pathname: '' }}
+          bib={bib}
+          dispatch={() => undefined}
+          resultSelection={{
+            fromUrl: '',
+            bibId: '',
+          }}
+          features={['parallels']}
+        />,
         {
           context,
           childContextTypes: { router: PropTypes.object },
+          store: testStore,
         },
       );
 
@@ -348,22 +340,21 @@ describe('BibPage', () => {
           numItems: 0,
         },
       });
-      const component = mount(
-        <Provider store={testStore}>
-          <BibPage
-            location={{ search: 'search', pathname: '' }}
-            bib={bib}
-            dispatch={() => undefined}
-            resultSelection={{
-              fromUrl: '',
-              bibId: '',
-            }}
-            features={['parallels']}
-          />
-        </Provider>,
+      const component = mountTestRender(
+        <BibPage
+          location={{ search: 'search', pathname: '' }}
+          bib={bib}
+          dispatch={() => undefined}
+          resultSelection={{
+            fromUrl: '',
+            bibId: '',
+          }}
+          features={['parallels']}
+        />,
         {
           context,
           childContextTypes: { router: PropTypes.object },
+          store: testStore,
         },
       );
 

--- a/test/unit/ElectronicDelivery.test.js
+++ b/test/unit/ElectronicDelivery.test.js
@@ -19,7 +19,9 @@ describe('ElectronicDeliveryForm', () => {
       appConfigMock = mock(appConfig);
       appConfig.features = [];
       appConfig.eddAboutUrl.default = 'example.com/edd-default-url';
-      component = shallow(<ElectronicDeliveryForm fromUrl='example.com' />);
+      component = shallow(
+        <ElectronicDeliveryForm fromUrl='example.com' />
+      );
     });
 
     after(() => {

--- a/test/unit/Home.test.js
+++ b/test/unit/Home.test.js
@@ -2,22 +2,18 @@
 /* eslint-env mocha */
 import React from 'react';
 import { expect } from 'chai';
-import { mount } from 'enzyme';
-import { Provider } from 'react-redux';
-import { makeTestStore } from '../helpers/store';
+import { makeTestStore, mountTestRender } from '../helpers/store';
 
 import Home from '../../src/app/pages/Home';
-import appConfig from '../../src/app/data/appConfig';
 
 describe('Home', () => {
   let component;
 
   before(() => {
     const testStore = makeTestStore();
-    component = mount(
-      <Provider store={testStore}>
-        <Home />
-      </Provider>
+    component = mountTestRender(
+      <Home />,
+      { store: testStore }
     );
   });
 
@@ -47,10 +43,9 @@ describe('Home', () => {
   describe('with notification', () => {
     before(() => {
       const testStore = makeTestStore();
-      component = mount(
-        <Provider store={testStore}>
-          <Home />
-        </Provider>
+      component = mountTestRender(
+        <Home />,
+        { store: testStore }
       );
     });
 

--- a/test/unit/LogoutLink.test.js
+++ b/test/unit/LogoutLink.test.js
@@ -1,0 +1,106 @@
+/* eslint-env mocha */
+/* eslint-disable react/jsx-filename-extension */
+import React from 'react';
+import { expect } from 'chai';
+import { mount } from 'enzyme';
+
+import LogoutLink from './../../src/app/components/LogoutLink/LogoutLink';
+import { PatronProvider } from '../../src/app/context/PatronContext';
+
+const mountLogoutLink = ({ loggedIn = false, delineate = false }) => mount(
+  <PatronProvider patron={{ loggedIn }}>
+    <LogoutLink delineate={delineate} />
+  </PatronProvider>
+);
+const logoutLink = "https://login.nypl.org/auth/logout?redirect_uri=";
+
+describe('LogoutLink', () => {
+  it('does not render if patron is not logged in', () => {
+    const component = mountLogoutLink({ loggedIn : false });
+
+    expect(component.find('a').length).to.equal(0);
+  });
+
+  it('renders a link with "Log Out" text if patron is logged in', () => {
+    const component = mountLogoutLink({ loggedIn : true });
+
+    expect(component.find('a').length).to.equal(1);
+    expect(component.find('a').text()).to.equal("Log Out");
+  });
+
+  it('optionally renders a pipe | delineator', () => {
+    const component = mountLogoutLink({ loggedIn : true, delineate: true });
+
+    // Note, the pipe is outside the <a> tag.
+    expect(component.text()).to.equal(" | Log Out");
+    expect(component.find('a').text()).to.equal("Log Out");
+  });
+
+  it('links to the logout url', () => {
+    const component = mountLogoutLink({ loggedIn : true });
+
+    expect(component.find('a').prop('href')).to.contain(logoutLink);
+  });
+
+  it('links to the logout url with the current location as the redirect param', () => {
+    // Try a search results page.
+    let currentLocation = 'http://localhost:3001/research/research-catalog/search?q=national%20geographic';
+    Object.defineProperty(window.location, 'href', {
+      writable: true,
+      value: currentLocation
+    });
+    let component = mountLogoutLink({ loggedIn : true });
+
+    expect(component.find('a').prop('href')).to.equal(`${logoutLink}${currentLocation}`);
+
+    // Try a bib page.
+    currentLocation = 'http://localhost:3001/research/research-catalog/bib/pb5579193';
+    Object.defineProperty(window.location, 'href', {
+      writable: true,
+      value: currentLocation
+    });
+    component = mountLogoutLink({ loggedIn : true });
+
+    expect(component.find('a').prop('href')).to.equal(`${logoutLink}${currentLocation}`);
+
+    // Try a SHEP page.
+    currentLocation = 'http://localhost:3001/research/research-catalog/subject_headings/74a55648-e93a-4f5f-98fe-1740c4c9c8e8';
+    Object.defineProperty(window.location, 'href', {
+      writable: true,
+      value: currentLocation
+    });
+    component = mountLogoutLink({ loggedIn : true });
+
+    expect(component.find('a').prop('href')).to.equal(`${logoutLink}${currentLocation}`);
+  });
+
+  it('links to the logout url with the homepage as the redirect param on hold and account pages', () => {
+    const originUrl = 'http://localhost:3001';
+    const homepageUrl = `${originUrl}/research/research-catalog/`;
+    // Mock the origin property as localhost.
+    Object.defineProperty(window.location, 'origin', {
+      writable: true,
+      value: originUrl
+    });
+
+    // Try a hold page.
+    let currentLocation = 'http://localhost:3001/research/research-catalog/hold/request/cb7891544-ci7911509';
+    Object.defineProperty(window.location, 'href', {
+      writable: true,
+      value: currentLocation
+    });
+    let component = mountLogoutLink({ loggedIn : true });
+
+    expect(component.find('a').prop('href')).to.equal(`${logoutLink}${homepageUrl}`);
+
+    // Try an account page.
+    currentLocation = 'http://localhost:3001/research/research-catalog/account';
+    Object.defineProperty(window.location, 'href', {
+      writable: true,
+      value: currentLocation
+    });
+    component = mountLogoutLink({ loggedIn : true });
+
+    expect(component.find('a').prop('href')).to.equal(`${logoutLink}${homepageUrl}`);
+  });
+});

--- a/test/unit/SubNav.test.js
+++ b/test/unit/SubNav.test.js
@@ -2,11 +2,17 @@
 /* eslint-disable react/jsx-filename-extension */
 import React from 'react';
 import { expect } from 'chai';
-import { mount, shallow } from 'enzyme';
-import { Provider } from 'react-redux';
 
 import SubNav from './../../src/app/components/SubNav/SubNav';
-import { makeTestStore } from '../helpers/store';
+import { makeTestStore, mountTestRender } from '../helpers/store';
+
+// To test the "My Account" link feature.
+const storeWithMyAccount = makeTestStore({
+  features: ['my-account'],
+  appConfig: {
+    baseUrl: 'baseUrl.com',
+  },
+});
 
 const mountSubNav = (
   props,
@@ -16,13 +22,8 @@ const mountSubNav = (
       baseUrl: 'baseUrl.com',
     },
   }),
-) => mount(
-  <Provider
-    store={store}
-  >
-    <SubNav {...props} />
-  </Provider>
-);
+  patron = {},
+) => mountTestRender(<SubNav {...props} />,  { store, patron });
 
 describe('SubNav', () => {
   describe('Default rendering, no features', () => {
@@ -56,6 +57,29 @@ describe('SubNav', () => {
 
     it('should have <a> for active section', () => {
       expect(component.find('a').at(1).text()).to.equal('Subject Heading Explorer');
+    });
+  });
+
+  describe('With my-account feature', () => {
+    it('should display the "My Account" link', () => {
+      const component = mountSubNav({}, storeWithMyAccount);
+      expect(component.find('a').last().text()).to.equal('My Account');
+    });
+  });
+
+  describe('Patron log in', () => {
+    it('should not display the "Log Out" link when not signed in', () => {
+      const component = mountSubNav({}, storeWithMyAccount, { loggedIn: false });
+
+      expect(component.find('a').last().text()).to.equal('My Account');
+      expect(component.find('a').last().text()).to.not.equal('Log Out');
+    });
+
+    it('should display the "Log Out" link when signed in', () => {
+      const component = mountSubNav({}, storeWithMyAccount, { loggedIn: true });
+
+      expect(component.find('a').last().text()).to.not.equal('My Account');
+      expect(component.find('a').last().text()).to.equal('Log Out');
     });
   });
 });


### PR DESCRIPTION
**What's this do?**
This resolves [SCC-3404](https://jira.nypl.org/browse/SCC-3404). It adds a logout link to the subnav in the app's banner.

This link:
- only appears when a patron is signed in,
- displays "Log Out",
- fires a GA event with action of "Click" and label of "Log Out",
- links to `https://login.nypl.org/auth/logout?redirect_uri=[BACKLINK]` where `BACKLINK` is the current page except for any hold or account page.

Also updates any existing tests that now need access to the patron data through the `PatronContext`. Other components can be simplified to use this in the future.

**Why are we doing this? (w/ JIRA link if applicable)**
Because the logout button is being removed in the NYPL Header (as a separate task) and this apps needs a way to allow patrons to sign out.

**Do these changes have automated tests?**
Yes

**How should this be QAed?**
A note for local testing: this is a bit hard to test because locally and on QA, the log in will be Sierra test. When signing out, it doesn't always sign you out since the log out link points to the prod auth URL.

When not logged in: go through the app and make sure the link is not rendered.
When logged in: go through the app and click on it and make sure the redirect works after being logged out.

**Dependencies for merging? Releasing to production?**
[Description of any watchouts, dependencies, or issues we should be aware of]

**Has the application documentation been updated for these changes?**

**Did someone actually run this code to verify it works?**
