### PR TITLE
Add item format based on formatLiteral

### DIFF
--- a/src/app/components/Item/ItemFilter.jsx
+++ b/src/app/components/Item/ItemFilter.jsx
@@ -37,7 +37,7 @@ const ItemFilter = ({
   const [selectionMade, setSelectionMade] = useState(false);
   const [mobileIsOpen, setMobileIsOpen] = useState(false);
 
-  if (!options || !filter) return null;
+  if (!options || !options.length || !filter) return null;
 
   /**
    * When a filter is selected, let the parent know through
@@ -60,7 +60,7 @@ const ItemFilter = ({
   /**
    * When a filter is deselected, let the parent know through
    * the `setSelectedFilters` function.
-   */   
+   */
   const deselectFilter = (value) => {
     setSelectedFilters((prevSelectedFilters) => {
       const updatedSelectedFilters = { ...prevSelectedFilters };

--- a/src/app/utils/item.js
+++ b/src/app/utils/item.js
@@ -247,10 +247,11 @@ function LibraryItem() {
     );
     const materialType =
       bib && bib.materialType && bib.materialType[0] ? bib.materialType[0] : {};
+    const materialTypePrefLabel = materialType.prefLabel || ''
     const format =
-      bib && bib.holdings && bib.holdings.format
-        ? bib.holdings.format
-        : materialType.prefLabel;
+      item.formatLiteral && item.formatLiteral.length ?
+        item.formatLiteral[0]
+        : materialTypePrefLabel;
 
     if (availability === 'available') {
       // For all items that we want to send to the Hold Request Form.

--- a/test/unit/ItemFilter.test.js
+++ b/test/unit/ItemFilter.test.js
@@ -23,6 +23,15 @@ describe('ItemFilter', () => {
       );
       expect(component.type()).to.equal(null);
     });
+    it('should not render with empty `options`', () => {
+      component = shallow(
+        <ItemFilter
+          filter="category"
+          options={[]}
+        />,
+      );
+      expect(component.type()).to.equal(null);
+    })
     it('should not render without `filter`', () => {
       component = shallow(
         <ItemFilter

--- a/test/unit/utils-item.test.js
+++ b/test/unit/utils-item.test.js
@@ -35,6 +35,35 @@ describe('utils/item', () => {
         const libraryItem = LibraryItem.mapItem(unavailableItem)
         expect(libraryItem.available).to.eq(true);
       });
+
+
+      it('gets format from item\'s formatLiteral if available', () => {
+        const mockItem = Object.assign({}, items[0], { formatLiteral: ['MockItemFormat'] })
+        const mockBib = { materialType: [{ prefLabel: 'MockBibFormat' }] }
+        const libraryItem = LibraryItem.mapItem(mockItem, mockBib)
+        expect(libraryItem.format).to.eq('MockItemFormat')
+      })
+
+      it('gets format from bib\'s materialType in case there is no formatLiteral', () => {
+        const mockItem = Object.assign({}, items[0])
+        const mockBib = { materialType: [{ prefLabel: 'MockBibFormat' }] }
+        const libraryItem = LibraryItem.mapItem(mockItem, mockBib)
+        expect(libraryItem.format).to.eq('MockBibFormat')
+      })
+
+      it('gets format from bib\'s materialType in case formatLiteral is empty', () => {
+        const mockItem = Object.assign({}, items[0], { formatLiteral: [] })
+        const mockBib = { materialType: [{ prefLabel: 'MockBibFormat' }] }
+        const libraryItem = LibraryItem.mapItem(mockItem, mockBib)
+        expect(libraryItem.format).to.eq('MockBibFormat')
+      })
+
+      it('sets default format to empty string in case neither item nor bib has format', () => {
+        const mockItem = Object.assign({}, items[0], { formatLiteral: [] })
+        const mockBib = {}
+        const libraryItem = LibraryItem.mapItem(mockItem, mockBib)
+        expect(libraryItem.format).to.eq('')
+      })
     });
   });
 });


### PR DESCRIPTION
**What's this do?**
- Change the way we calculate item formats to use the `formatLiteral`  property from the backend, using `materialType` from the bib as a fallback
- Change `ItemFilter` component to render null in case there are no options
- Add some tests 

**Why are we doing this? (w/ JIRA link if applicable)**

Right now we are getting confusing results for formats because the aggregations (which come from the API) don't match the displayed formats. This change will base the displayed formats on the API so that they match.

We are still using the bib's materialType as a fallback in case there are non-populated formats, so in that case we remove the format filter (since the filter doesn't make sense in that situation).

The relevant ticket is SCC-3399

**Do these changes have automated tests?**
Yes

**Dependencies for merging? Releasing to production?**
No

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Yes
