### PR TITLE
conditionally render year filter

### DIFF
--- a/src/app/components/Item/ItemFilters.jsx
+++ b/src/app/components/Item/ItemFilters.jsx
@@ -193,6 +193,7 @@ const ItemFilters = (
     <Fragment>
       {['mobile', 'tabletPortrait'].includes(mediaType) ? (
         <ItemFiltersMobile
+          displayDateFilter={displayDateFilter}
           itemsAggregations={itemsAggregations}
           selectedYear={selectedYear}
           setSelectedYear={setSelectedYear}

--- a/src/app/components/Item/ItemFilters.jsx
+++ b/src/app/components/Item/ItemFilters.jsx
@@ -13,7 +13,7 @@ import ItemFiltersMobile from './ItemFiltersMobile';
 import DateSearchBar from './DateSearchBar';
 
 const ItemFilters = (
-  {
+  { displayDateFilter,
     numOfFilteredItems,
     itemsAggregations = [],
     dispatch,
@@ -217,11 +217,11 @@ const ItemFilters = (
               />
             ))}
           </div>
-          <DateSearchBar
+            {displayDateFilter && (<DateSearchBar
             selectedYear={selectedYear}
             setSelectedYear={setSelectedYear}
             submitFilterSelections={submitFilterSelections}
-          />
+            />)}
           {/* Empty div for flexbox even columns. */}
           <div></div>
         </div>

--- a/src/app/components/Item/ItemFiltersMobile.jsx
+++ b/src/app/components/Item/ItemFiltersMobile.jsx
@@ -11,6 +11,7 @@ import DateSearchBar from './DateSearchBar';
  * items filters.
  */
 const ItemFiltersMobile = ({
+  displayDateFilter,
   itemsAggregations,
   manageFilterDisplay,
   selectedFilters,
@@ -57,11 +58,11 @@ const ItemFiltersMobile = ({
   // On mobile, the date input field is rendered outside of the modal.
   return (
     <>
-      <DateSearchBar
+      {displayDateFilter && <DateSearchBar
         selectedYear={selectedYear}
         setSelectedYear={setSelectedYear}
         submitFilterSelections={submitFilterSelections}
-      />
+      />}
       <ModalTrigger
         buttonType="secondary"
         className="item-table-filters"

--- a/src/app/components/Item/ItemsContainer.jsx
+++ b/src/app/components/Item/ItemsContainer.jsx
@@ -175,6 +175,7 @@ class ItemsContainer extends React.Component {
         <Heading level="three">Items in the Library & Off-site</Heading>
         <div className="nypl-results-item">
           <ItemFilters
+            displayDateFilter={this.props.displayDateFilter}
             items={itemsToDisplay}
             numOfFilteredItems={itemsToDisplay.length}
             itemsAggregations={itemsAggregations}

--- a/src/app/pages/BibPage.jsx
+++ b/src/app/pages/BibPage.jsx
@@ -210,6 +210,7 @@ export const BibPage = (
 
         <section style={{ marginTop: '20px' }} id="items-table">
           <ItemsContainer
+            displayDateFilter={bib.hasItemDates}
             key={bibId}
             shortenItems={location.pathname.indexOf('all') !== -1}
             items={items}

--- a/test/unit/ItemFilters.test.js
+++ b/test/unit/ItemFilters.test.js
@@ -20,7 +20,39 @@ const context = {
 describe('ItemFilters', () => {
   const locationFilters = itemsAggregations[0];
   const statusFilters = itemsAggregations[2];
-
+  describe('DateSearchBar', () => {
+    const items = [
+      item.full
+    ];
+    let component
+    it('renders date filter', () => {
+      component = mount(
+        <ItemFilters
+          displayDateFilter={true}
+          items={items}
+          numOfFilteredItems={items.length}
+          numItemsTotal={items.length}
+          itemsAggregations={itemsAggregations}
+        />,
+        { context }
+      );
+      const displayDateFilter = component.html().includes('Search by year')
+      expect(displayDateFilter)
+    })
+    it('doesn\'t render date filter', () => {
+      component = mount(
+        <ItemFilters
+          displayDateFilter={false}
+          items={items}
+          numOfFilteredItems={items.length}
+          numItemsTotal={items.length}
+          itemsAggregations={itemsAggregations}
+        />,
+        { context });
+      const DateSearchBar = component.find('DateSearchBar');
+      expect(DateSearchBar).to.be.empty
+    })
+  })
   describe('with valid `items`, no filters', () => {
     let component;
     let itemFilters;

--- a/test/unit/ItemFiltersMobile.test.js
+++ b/test/unit/ItemFiltersMobile.test.js
@@ -4,6 +4,7 @@ import React from 'react';
 import { expect } from 'chai';
 import { shallow, mount } from 'enzyme';
 
+import item from '../fixtures/libraryItems';
 import ItemFiltersMobile from '../../src/app/components/Item/ItemFiltersMobile';
 import { itemsAggregations } from '../fixtures/itemFilterOptions';
 
@@ -16,6 +17,35 @@ const context = {
 };
 
 describe('ItemFiltersMobile', () => {
+  describe('DateSearchBar', () => {
+    const items = [
+      item.full
+    ];
+    let component
+    it('renders date filter', () => {
+      component = mount(
+        <ItemFiltersMobile
+          displayDateFilter={true}
+          items={items}
+          itemsAggregations={itemsAggregations}
+        />,
+        { context }
+      );
+      const displayDateFilter = component.html().includes('Search by year')
+      expect(displayDateFilter)
+    })
+    it('doesn\'t render date filter', () => {
+      component = mount(
+        <ItemFiltersMobile
+          displayDateFilter={false}
+          items
+          itemsAggregations={itemsAggregations}
+        />,
+        { context });
+      const DateSearchBar = component.find('DateSearchBar');
+      expect(DateSearchBar).to.be.empty
+    })
+  })
   describe('without props', () => {
     it('should not render without props', () => {
       const component = shallow(<ItemFiltersMobile />, { context });


### PR DESCRIPTION
**What's this do?**
passes bib.hasItemVolumes as a prop down to the itemsfilter and itemsfiltermobile components, then conditionally renders the datesearchbar component based on that value. 

**Why are we doing this? (w/ JIRA link if applicable)**
to avoid rendering the datesearchbar on bibs that don't have items with parsed dates

**How should this be QAed?**
[Description of any tests that need to be performed once merged]

**Dependencies for merging? Releasing to production?**
[Description of any watchouts, dependencies, or issues we should be aware of]

**Has the application documentation been updated for these changes?**

**Did someone actually run this code to verify it works?**
