### PR TITLE
SCC-3463: bib page item search focus management

### DIFF
--- a/src/app/components/Item/ItemFilters.jsx
+++ b/src/app/components/Item/ItemFilters.jsx
@@ -13,7 +13,8 @@ import ItemFiltersMobile from './ItemFiltersMobile';
 import DateSearchBar from './DateSearchBar';
 
 const ItemFilters = (
-  { displayDateFilter,
+  {
+    displayDateFilter,
     numOfFilteredItems,
     itemsAggregations = [],
     dispatch,
@@ -38,10 +39,13 @@ const ItemFilters = (
   const [selectedYear, setSelectedYear] = useState(query.date || '');
   const [selectedFilters, setSelectedFilters] = useState(initialFilters);
   const [selectedFilterDisplayStr, setSelectedFilterDisplayStr] = useState('');
-
-  // When new items are fetched, update the selected string dispaly.
+  
+  // When new items are fetched, update the selected string display.
   useEffect(() => {
     setSelectedFilterDisplayStr(parsedFilterSelections());
+    // Once the new items are fetched, focus on the
+    // filter UI and the results.
+    resultsRef.current &&  resultsRef.current.focus();
   }, [numOfFilteredItems, parsedFilterSelections]);
 
   /**
@@ -92,11 +96,6 @@ const ItemFilters = (
             }),
           }),
         );
-        // Once the new items are fetched, focus on the
-        // filter UI and the results.
-        if (resultsRef.current) {
-          resultsRef.current.focus();
-        }
       },
       (error) => {
         console.error(error);
@@ -207,7 +206,6 @@ const ItemFilters = (
         <div
           id="item-filters"
           className="item-table-filters"
-          ref={resultsRef}
           tabIndex="-1"
         >
           <div>
@@ -231,7 +229,7 @@ const ItemFilters = (
           <div></div>
         </div>
       )}
-      <div className="item-filter-info">
+      <div className="item-filter-info" ref={resultsRef} tabIndex="-1">
         <Heading level="three" size="callout">
           <>
             {resultsItemsNumber > 0 ? resultsItemsNumber : 'No'} Result
@@ -262,6 +260,7 @@ ItemFilters.propTypes = {
   numItemsTotal: PropTypes.number,
   numItemsCurrent: PropTypes.number,
   mappedItemsLabelToIds: PropTypes.object,
+  displayDateFilter: PropTypes.bool,
 };
 
 ItemFilters.contextTypes = {

--- a/src/app/components/Item/ItemsContainer.jsx
+++ b/src/app/components/Item/ItemsContainer.jsx
@@ -236,6 +236,7 @@ ItemsContainer.propTypes = {
   numItemsCurrent: PropTypes.number,
   mappedItemsLabelToIds: PropTypes.object,
   checkForMoreItems: PropTypes.func,
+  displayDateFilter: PropTypes.bool,
 };
 
 ItemsContainer.defaultProps = {


### PR DESCRIPTION
**What's this do?**
Resolves [SCC-3463](https://jira.nypl.org/browse/SCC-3463).
After making a year search or clearing a year search, the focus should go to the start of the results. Specifically, the focus should go to the results text that displays "X results found".

**Why are we doing this? (w/ JIRA link if applicable)**
For accessibility. The ref and code was already there but it was not finding the element that was being referenced correctly. I think because the DOM needs to be mounted before the `.focus()` function is triggered, and it was not set up to do so when the fetch/dispatch process is being performed. This works better in the useEffect function.

Some reference:
- https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Client-side_JavaScript_frameworks/React_accessibility#focusing_between_templates

**Do these changes have automated tests?**
N/A

**How should this be QAed?**
Perform year searches or clear the year search and the focus should go to the "X results found ..." text.

**Dependencies for merging? Releasing to production?**
[Description of any watchouts, dependencies, or issues we should be aware of]

**Has the application documentation been updated for these changes?**

**Did someone actually run this code to verify it works?**
