### PR TITLE
SCC-3468: Removing ItemsContainer for bibs w/ no items but electronic resources

### DIFF
--- a/src/app/components/Item/ItemsContainer.jsx
+++ b/src/app/components/Item/ItemsContainer.jsx
@@ -145,7 +145,10 @@ class ItemsContainer extends React.Component {
     const shortenItems = !this.props.shortenItems;
     let itemsToDisplay = [...this.state.items];
     let pagination = null;
-    
+
+    if (!itemsToDisplay || !itemsToDisplay.length) {
+      return null;
+    }
 
     if (
       this.state.js &&

--- a/src/app/pages/BibPage.jsx
+++ b/src/app/pages/BibPage.jsx
@@ -163,6 +163,9 @@ export const BibPage = (
   }, {});
   const items = LibraryItem.getItems(bib);
   const aggregatedElectronicResources = getAggregatedElectronicResources(items);
+  const isElectronicResources = items.every(
+    (item) => item.isElectronicResource,
+  );
 
   // Related to removing MarcRecord because the webpack MarcRecord is not working. Sep/28/2017
   // const isNYPLReCAP = LibraryItem.isNYPLReCAP(bib['@id']);
@@ -208,23 +211,26 @@ export const BibPage = (
           {electronicResources.length ? <ElectronicResources electronicResources={electronicResources} id="electronic-resources"/> : null}
         </section>
 
-        <section style={{ marginTop: '20px' }} id="items-table">
-          <ItemsContainer
-            displayDateFilter={bib.hasItemDates}
-            key={bibId}
-            shortenItems={location.pathname.indexOf('all') !== -1}
-            items={items}
-            bibId={bibId}
-            itemPage={location.search}
-            searchKeywords={searchKeywords}
-            holdings={newBibModel.holdings}
-            itemsAggregations={reducedItemsAggregations}
-            mappedItemsLabelToIds={mappedItemsLabelToIds}
-            numItemsTotal={numItemsTotal}
-            numItemsCurrent={numItemsCurrent}
-            checkForMoreItems={checkForMoreItems}
-          />
-        </section>
+        {items && items.length && !isElectronicResources ?
+          <section style={{ marginTop: '20px' }} id="items-table">
+            <ItemsContainer
+              displayDateFilter={bib.hasItemDates}
+              key={bibId}
+              shortenItems={location.pathname.indexOf('all') !== -1}
+              items={items}
+              bibId={bibId}
+              itemPage={location.search}
+              searchKeywords={searchKeywords}
+              holdings={newBibModel.holdings}
+              itemsAggregations={reducedItemsAggregations}
+              mappedItemsLabelToIds={mappedItemsLabelToIds}
+              numItemsTotal={numItemsTotal}
+              numItemsCurrent={numItemsCurrent}
+              checkForMoreItems={checkForMoreItems}
+            />
+          </section>
+          : null
+        }
 
         {newBibModel.holdings && (
           <section style={{ marginTop: '20px' }}>

--- a/test/unit/BibPage.test.js
+++ b/test/unit/BibPage.test.js
@@ -125,7 +125,7 @@ describe('BibPage', () => {
     });
 
     it('has Details section', () => {
-      expect(component.find('Heading').at(4).prop('children')).to.equal('Details');
+      expect(component.find('Heading').at(2).prop('children')).to.equal('Details');
     });
 
     it('has section with id items-table', () => {
@@ -141,6 +141,37 @@ describe('BibPage', () => {
       expect(linkToLegacy.length).to.equal(1);
       expect(linkToLegacy.is('a')).to.equal(true);
       expect(linkToLegacy.prop('href')).to.equal('https://legacyBaseUrl.nypl.org/record=b11417539~S1');
+    });
+  });
+
+  describe('No items', () => {
+    const testStore = makeTestStore({
+      bib: {
+        done: true,
+        numItems: 0,
+      },
+    });
+
+    let component;
+    before(() => {
+      const bib = { ...bibs[0], ...annotatedMarc };
+      bib.items = [];
+      component = mountTestRender(
+        <BibPage
+          location={{ search: 'search', pathname: '' }}
+          bib={bib}
+          dispatch={() => { }}
+          resultSelection={{
+            fromUrl: '',
+            bibId: '',
+          }}
+        />,
+        { context, childContextTypes: { router: PropTypes.object }, store: testStore },
+      );
+    });
+
+    it('should not display ItemsContainer', () => {
+      expect(component.find('ItemsContainer').length).to.equal(0);
     });
   });
 


### PR DESCRIPTION
**What's this do?**
Resolves [SCC-3468](https://jira.nypl.org/browse/SCC-3468).

For bibs that have no items but have online resources, the `ItemsContainer` component should not render. This removes the empty filter section that does not apply for bibs with electronic resources.

This was always in the codebase but I inadvertently removed it in the SCC-3281 and introduced the regression. So this is added back in now.

**Why are we doing this? (w/ JIRA link if applicable)**
Looks bad!

**Do these changes have automated tests?**
Yes.

**How should this be QAed?**
Review  https://www.nypl.org/research/research-catalog/bib/b21451623 as an example.

**Dependencies for merging? Releasing to production?**
[Description of any watchouts, dependencies, or issues we should be aware of]

**Has the application documentation been updated for these changes?**

**Did someone actually run this code to verify it works?**
