### PR TITLE
SCC-3463: Focus management - aria-live update

### DIFF
--- a/src/app/components/Item/ItemFilters.jsx
+++ b/src/app/components/Item/ItemFilters.jsx
@@ -229,7 +229,12 @@ const ItemFilters = (
           <div></div>
         </div>
       )}
-      <div className="item-filter-info" ref={resultsRef} tabIndex="-1">
+      <div
+        aria-live="polite"
+        className="item-filter-info"
+        ref={resultsRef}
+        tabIndex="-1"
+      >
         <Heading level="three" size="callout">
           <>
             {resultsItemsNumber > 0 ? resultsItemsNumber : 'No'} Result


### PR DESCRIPTION
**What's this do?**
Updates a feedback comment on [SCC-3463](https://jira.nypl.org/browse/SCC-3463). While the focus management is updated and working, the text is not always read by a screenreader. An `aria-live` attribute is added with a value of "polite" to announce it to a screenreader.

**Why are we doing this? (w/ JIRA link if applicable)**
Minor issue found in QA.

**Do these changes have automated tests?**
N/A

**How should this be QAed?**
[Description of any tests that need to be performed once merged]

**Dependencies for merging? Releasing to production?**
[Description of any watchouts, dependencies, or issues we should be aware of]

**Has the application documentation been updated for these changes?**

**Did someone actually run this code to verify it works?**
