### PR TITLE
Checking numItemsTotal to rener the ItemsContainer and not just if th…

### DIFF
--- a/src/app/components/Item/ItemsContainer.jsx
+++ b/src/app/components/Item/ItemsContainer.jsx
@@ -146,10 +146,6 @@ class ItemsContainer extends React.Component {
     let itemsToDisplay = [...this.state.items];
     let pagination = null;
 
-    if (!itemsToDisplay || !itemsToDisplay.length) {
-      return null;
-    }
-
     if (
       this.state.js &&
       itemsToDisplay &&

--- a/src/app/pages/BibPage.jsx
+++ b/src/app/pages/BibPage.jsx
@@ -213,25 +213,33 @@ export const BibPage = (
           {electronicResources.length ? <ElectronicResources electronicResources={electronicResources} id="electronic-resources"/> : null}
         </section>
 
-        {items && items.length && !isElectronicResources ?
-          <section style={{ marginTop: '20px' }} id="items-table">
-            <ItemsContainer
-              displayDateFilter={bib.hasItemDates}
-              key={bibId}
-              shortenItems={location.pathname.indexOf('all') !== -1}
-              items={items}
-              bibId={bibId}
-              itemPage={searchParams.get('itemPage')}
-              searchKeywords={searchKeywords}
-              holdings={newBibModel.holdings}
-              itemsAggregations={reducedItemsAggregations}
-              mappedItemsLabelToIds={mappedItemsLabelToIds}
-              numItemsTotal={numItemsTotal}
-              numItemsCurrent={numItemsCurrent}
-              checkForMoreItems={checkForMoreItems}
-            />
-          </section>
-          : null
+        {/* Display the items filter container component when:
+          1: there are items through the `numItemsTotal` property,
+          2: there are items and none of those items are electronic resources,
+          
+          Otherwise, if there are items but they are all electronic resources,
+          do not display the items filter container component.
+        */}
+        {(numItemsTotal && numItemsTotal > 0) ||
+          (!isElectronicResources && (!items || items.length > 0)) ?
+            <section style={{ marginTop: '20px' }} id="items-table">
+              <ItemsContainer
+                displayDateFilter={bib.hasItemDates}
+                key={bibId}
+                shortenItems={location.pathname.indexOf('all') !== -1}
+                items={items}
+                bibId={bibId}
+                itemPage={searchParams.get('itemPage')}
+                searchKeywords={searchKeywords}
+                holdings={newBibModel.holdings}
+                itemsAggregations={reducedItemsAggregations}
+                mappedItemsLabelToIds={mappedItemsLabelToIds}
+                numItemsTotal={numItemsTotal}
+                numItemsCurrent={numItemsCurrent}
+                checkForMoreItems={checkForMoreItems}
+              />
+            </section>
+            : null
         }
 
         {newBibModel.holdings && (

--- a/src/app/pages/BibPage.jsx
+++ b/src/app/pages/BibPage.jsx
@@ -215,7 +215,7 @@ export const BibPage = (
 
         {/* Display the items filter container component when:
           1: there are items through the `numItemsTotal` property,
-          2: there are items and none of those items are electronic resources,
+          2: there are items and they are not all electronic resources.
           
           Otherwise, if there are items but they are all electronic resources,
           do not display the items filter container component.

--- a/test/fixtures/bibs.js
+++ b/test/fixtures/bibs.js
@@ -102,6 +102,7 @@ const bibs = [
     ],
     numAvailable: 1,
     numItems: 1,
+    numItemsTotal: 1,
     placeOfPublication: ['Oxford [England] : New York :'],
     publicationStatement: [
       'Oxford [England] : Clarendon Press ; New York : Oxford University Press, 1991.',

--- a/test/unit/BibPage.test.js
+++ b/test/unit/BibPage.test.js
@@ -125,7 +125,7 @@ describe('BibPage', () => {
     });
 
     it('has Details section', () => {
-      expect(component.find('Heading').at(2).prop('children')).to.equal('Details');
+      expect(component.find('h3').at(2).prop('children')).to.equal('Details');
     });
 
     it('has section with id items-table', () => {
@@ -154,7 +154,9 @@ describe('BibPage', () => {
 
     let component;
     before(() => {
-      const bib = { ...bibs[0], ...annotatedMarc };
+      const bib = { ...bibs[0], ...annotatedMarc, numItemsTotal: 0 };
+      // This is not enough. The ItemsContainer component renders based on
+      // the `numItemsTotal` prop from the API.
       bib.items = [];
       component = mountTestRender(
         <BibPage


### PR DESCRIPTION
**What's this do?**
Fixes [SCC-3474](https://jira.nypl.org/browse/SCC-3474).

We were hiding the item filter container component when there are no items or the items are electronic resources. This is not exactly correct because after searching or filtering, it's possible there are no item results. So this now takes a look at the `numItemsTotal` property to make sure that there are actually items for a bib and if no items are returned from a filter or a search, that the item filter container _still_ renders.

**Why are we doing this? (w/ JIRA link if applicable)**
Issue found while doing QA.

**Do these changes have automated tests?**
Yes, this was updated.

**How should this be QAed?**
[Description of any tests that need to be performed once merged]

**Dependencies for merging? Releasing to production?**
[Description of any watchouts, dependencies, or issues we should be aware of]

**Has the application documentation been updated for these changes?**

**Did someone actually run this code to verify it works?**
