### PR TITLE
Scc 3471/filter refactor

### DIFF
--- a/src/app/components/ItemFilters/ItemFilter.jsx
+++ b/src/app/components/ItemFilters/ItemFilter.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Button, Checkbox, Icon } from '@nypl/design-system-react-components';
 import FocusTrap from 'focus-trap-react';
 
-import { getLabelsForValues, isOptionSelected } from '../../utils/itemFilterUtils';
+import { getLabelsForValues, isOptionSelected } from './itemFilterUtils';
 
 /**
  * This is to better structure the data for the checkboxes.
@@ -91,13 +91,12 @@ const ItemFilter = ({
    * get the new results.
    */
   const clear = () => {
-    const clear = true;
     setSelectionMade(true);
     setSelectedFields(prevSelectedFields => ({
       ...prevSelectedFields,
       [field]: [],
     }));
-    submitFilterSelections && submitFilterSelections(clear);
+    submitFilterSelections && submitFilterSelections(field);
   };
 
   const isSelected = (option) => {

--- a/src/app/components/ItemFilters/ItemFilter.jsx
+++ b/src/app/components/ItemFilters/ItemFilter.jsx
@@ -96,7 +96,9 @@ const ItemFilter = ({
       ...prevSelectedFields,
       [field]: [],
     }));
-    submitFilterSelections && submitFilterSelections(field);
+    const clearAll = false
+    const clearYear = false
+    submitFilterSelections && submitFilterSelections(clearAll, clearYear, field);
   };
 
   const isSelected = (option) => {

--- a/src/app/components/ItemFilters/ItemFilters.jsx
+++ b/src/app/components/ItemFilters/ItemFilters.jsx
@@ -47,7 +47,7 @@ const ItemFilters = (
   /**
    * When new filters are selected or unselected, fetch new items.
    */
-  const buildFilterUrl = (clear = false, clearYear = false) => {
+  const buildFilterQuery = (clear = false, clearYear = false) => {
     let queryObj = {};
     if (!clear) {
       Object.keys(selectedFields).filter(field => selectedFields[field].length).forEach(field => {
@@ -116,7 +116,7 @@ const ItemFilters = (
   };
 
   const submitFilterSelections = (clear = false, clearYear = false) => {
-    const query = buildFilterUrl(clear, clearYear);
+    const query = buildFilterQuery(clear, clearYear);
     const updatedSelectedFields = { ...selectedFields };
     if (selectedYear) {
       updatedSelectedFields.date = selectedYear;

--- a/src/app/components/ItemFilters/ItemFilters.jsx
+++ b/src/app/components/ItemFilters/ItemFilters.jsx
@@ -45,24 +45,25 @@ const ItemFilters = (
   }, [numOfFilteredItems, parsedFilterSelections]);
 
   /**
-   * When filters are appied or cleared, build new filter query
+   * When filters are applied or cleared, build new filter query
    */
-  const buildFilterQuery = (clear = false, clearYear = false) => {
+  const buildFilterQuery = (clearAll = false, clearYear = false, fieldToClear) => {
     let queryObj = {}
     let fieldsToQuery
     // clear is only true when we are clearing all filters, so return 
     //   empty query object
-    if (clear === true) return queryObj
-    // clear equals false indicates a filter is being applied
-    if (clear === false) {
-      fieldsToQuery = selectedFields
-      // clear is a field, to indicate which field we want to clear
-    } else if (clear.length) {
-      const fieldToClear = clear
+    if (clearAll) return queryObj
+    // if there is a fieldToClear, need to build query with empty field.
+    //  this call happens right after a setSelectedFields, and selectedFields
+    //  is not yet updated with the new value by the time this query is built.
+    if (fieldToClear) {
       fieldsToQuery = {
         ...selectedFields,
         [fieldToClear]: [],
       }
+      // other wise, new filters are being applied
+    } else {
+      fieldsToQuery = selectedFields
     }
     Object.keys(fieldsToQuery).filter(field => fieldsToQuery[field].length).forEach(field => {
       const selectedFilterValues = fieldsToQuery[field].join(',')
@@ -128,8 +129,8 @@ const ItemFilters = (
     router.push(href);
   };
 
-  const submitFilterSelections = (clearAll = false, clearYear = false) => {
-    const query = buildFilterQuery(clearAll, clearYear);
+  const submitFilterSelections = (clearAll = false, clearYear = false, field) => {
+    const query = buildFilterQuery(clearAll, clearYear, field);
     const updatedSelectedFields = { ...selectedFields };
     if (selectedYear) {
       updatedSelectedFields.date = selectedYear;

--- a/src/app/components/ItemFilters/ItemFilters.jsx
+++ b/src/app/components/ItemFilters/ItemFilters.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import React, { Fragment, useEffect, useState, useRef, useCallback } from 'react';
 
 import { trackDiscovery } from '../../utils/utils';
-import { getLabelsForValues, initialLocations } from '../../utils/itemFilterUtils';
+import { getLabelsForValues, initialLocations } from './itemFilterUtils';
 import { MediaContext } from '../Application/Application';
 import ItemFilter from './ItemFilter';
 import ItemFiltersMobile from './ItemFiltersMobile';
@@ -45,13 +45,27 @@ const ItemFilters = (
   }, [numOfFilteredItems, parsedFilterSelections]);
 
   /**
-   * When new filters are selected or unselected, fetch new items.
+   * When filters are appied or cleared, build new filter query
    */
   const buildFilterQuery = (clear = false, clearYear = false) => {
-    let queryObj = {};
-    if (!clear) {
-      Object.keys(selectedFields).filter(field => selectedFields[field].length).forEach(field => {
-        const selectedFilterValues = selectedFields[field].join(',')
+    let queryObj = {}
+    let fieldsToQuery
+    // clear is only true when we are clearing all filters, so return 
+    //   empty query object
+    if (clear === true) return queryObj
+    // clear equals false indicates a filter is being applied
+    if (clear === false) {
+      fieldsToQuery = selectedFields
+      // clear is a field, to indicate which field we want to clear
+    } else if (clear.length) {
+      const fieldToClear = clear
+      fieldsToQuery = {
+        ...selectedFields,
+        [fieldToClear]: [],
+      }
+    }
+    Object.keys(fieldsToQuery).filter(field => fieldsToQuery[field].length).forEach(field => {
+      const selectedFilterValues = fieldsToQuery[field].join(',')
         // build query  object with discovery-api-friendly item_(field) params
         queryObj[`item_${field}`] = selectedFilterValues;
       });
@@ -59,7 +73,6 @@ const ItemFilters = (
       if (selectedYear && !clearYear) {
         queryObj['item_date'] = selectedYear;
       }
-    }
     return queryObj
   }
 
@@ -115,8 +128,8 @@ const ItemFilters = (
     router.push(href);
   };
 
-  const submitFilterSelections = (clear = false, clearYear = false) => {
-    const query = buildFilterQuery(clear, clearYear);
+  const submitFilterSelections = (clearAll = false, clearYear = false) => {
+    const query = buildFilterQuery(clearAll, clearYear);
     const updatedSelectedFields = { ...selectedFields };
     if (selectedYear) {
       updatedSelectedFields.date = selectedYear;
@@ -137,6 +150,7 @@ const ItemFilters = (
       'Search Filters',
       `Apply Filter - ${JSON.stringify(selectedFields)}`,
     );
+    console.log({ query })
     router.push(href);
   };
 

--- a/src/app/components/ItemFilters/itemFilterUtils.js
+++ b/src/app/components/ItemFilters/itemFilterUtils.js
@@ -39,7 +39,7 @@ export const buildFieldToOptionsMap = (reducedItemsAggregations) => reducedItems
     let value = option.value
     if (acc[option.label]) value = acc[option.label] + ',' + option.value
     return {
-    ...acc,
+      ...acc,
       [option.label]: value
     }
   }, {})
@@ -69,6 +69,10 @@ export const isOptionSelected = (filterValue, itemValue) => {
 export const initialLocations = (locations) => {
   // all ReCAP/Offsite materials have location codes beginning loc:rc
   const concatenatedRecapLocations = locations.filter((loc) => loc.startsWith('loc:rc')).join(',')
-  const removeRecap = locations.filter((loc) => !concatenatedRecapLocations.includes(loc))
-  return [...removeRecap, concatenatedRecapLocations.length ? concatenatedRecapLocations : null]
+  // joining an empty array creates an empty string! hooray!
+  if (concatenatedRecapLocations.length) {
+    const removeRecap = locations.filter((loc) => !concatenatedRecapLocations.includes(loc))
+    return [...removeRecap, concatenatedRecapLocations]
+  }
+  else return locations
 }

--- a/src/app/pages/BibPage.jsx
+++ b/src/app/pages/BibPage.jsx
@@ -30,7 +30,7 @@ import {
   isNyplBnumber,
   pluckAeonLinksFromResource,
 } from '../utils/utils';
-import { buildFieldToOptionsMap, buildReducedItemsAggregations } from '../utils/itemFilterUtils'
+import { buildFieldToOptionsMap, buildReducedItemsAggregations } from '../components/ItemFilters/itemFilterUtils'
 import getOwner from '../utils/getOwner';
 import appConfig from '../data/appConfig';
 import { itemBatchSize } from '../data/constants';

--- a/src/app/utils/itemFilterUtils.js
+++ b/src/app/utils/itemFilterUtils.js
@@ -70,5 +70,5 @@ export const initialLocations = (locations) => {
   // all ReCAP/Offsite materials have location codes beginning loc:rc
   const concatenatedRecapLocations = locations.filter((loc) => loc.startsWith('loc:rc')).join(',')
   const removeRecap = locations.filter((loc) => !concatenatedRecapLocations.includes(loc))
-  return [...removeRecap, concatenatedRecapLocations]
+  return [...removeRecap, concatenatedRecapLocations.length ? concatenatedRecapLocations : null]
 }

--- a/test/unit/ItemFilter.test.js
+++ b/test/unit/ItemFilter.test.js
@@ -6,7 +6,7 @@ import { shallow, mount } from 'enzyme';
 
 import ItemFilter from '../../src/app/components/ItemFilters/ItemFilter';
 import { itemsAggregations } from '../fixtures/itemFilterOptions';
-import { buildReducedItemsAggregations, buildFieldToOptionsMap } from '../../src/app/utils/itemFilterUtils';
+import { buildReducedItemsAggregations, buildFieldToOptionsMap } from '../../src/app/components/ItemFilters/itemFilterUtils';
 
 describe('ItemFilter', () => {
   const locationItemFilter = itemsAggregations[0];

--- a/test/unit/ItemFilters.test.js
+++ b/test/unit/ItemFilters.test.js
@@ -8,7 +8,7 @@ import ItemFilters from './../../src/app/components/ItemFilters/ItemFilters';
 import ItemFilter from '../../src/app/components/ItemFilters/ItemFilter';
 import item from '../fixtures/libraryItems';
 import { itemsAggregations, itemsAggregations2, itemsAggregationsOffsite } from '../fixtures/itemFilterOptions';
-import { buildReducedItemsAggregations, buildFieldToOptionsMap } from '../../src/app/utils/itemFilterUtils';
+import { buildReducedItemsAggregations, buildFieldToOptionsMap } from '../../src/app/components/ItemFilters/itemFilterUtils';
 
 const context = {
   router: {

--- a/test/unit/ItemFiltersMobile.test.js
+++ b/test/unit/ItemFiltersMobile.test.js
@@ -7,7 +7,7 @@ import { shallow, mount } from 'enzyme';
 import item from '../fixtures/libraryItems';
 import ItemFiltersMobile from '../../src/app/components/ItemFilters/ItemFiltersMobile';
 import { itemsAggregations } from '../fixtures/itemFilterOptions';
-import { buildFieldToOptionsMap, buildReducedItemsAggregations } from '../../src/app/utils/itemFilterUtils';
+import { buildFieldToOptionsMap, buildReducedItemsAggregations } from '../../src/app/components/ItemFilters/itemFilterUtils';
 
 const context = {
   router: {


### PR DESCRIPTION
Fixes to change how the clear filter function works. instead of clearing all the filters, now if only clears the filters for the specific field the user clicks clear for. i also moved the item filter utils to live in the item filter directory. if anyone feels strongly about that reverting to its original state, lmk. 😎 
