### PR TITLE
SCC-3466: Bib page item pagination and view all update

### DIFF
--- a/src/app/components/Item/ItemsContainer.jsx
+++ b/src/app/components/Item/ItemsContainer.jsx
@@ -20,8 +20,6 @@ class ItemsContainer extends React.Component {
     super(props, context);
 
     this.state = {
-      // TODO: REMOVE THIS.
-      showAll: this.props.showAll || false,
       js: false,
       page: parseInt(props.itemPage, 10) || 1,
     };
@@ -38,23 +36,22 @@ class ItemsContainer extends React.Component {
   }
 
   /*
-   * getTable(items, shortenItems, showAll)
+   * getTable(items, shortenItems,)
    * @description Display an HTML table with item data.
    * @param {array} items The array of items.
    * @param {bool} shortenItems Whether the array needs to be cut off or not.
-   * @param {bool} showAll Whether all items should be shown on the client side.
    */
-  getTable(items, shortenItems = false, showAll) {
+  getTable(items, shortenItems = false) {
     /*
      * If there are more items than the page limit AND
      * we need to shorten it to the page limit AND
      * not show all
      */
+    const { bibId, holdings, searchKeywords, showAll } = this.props;
     const itemsToDisplay =
       items && shortenItems && !showAll
         ? items.slice(0, itemsListPageLimit)
         : items;
-    const { bibId, holdings, searchKeywords } = this.props;
 
     return itemsToDisplay &&
       _isArray(itemsToDisplay) &&
@@ -101,17 +98,16 @@ class ItemsContainer extends React.Component {
       query: this.query,
       hash: "#view-all-items"
     });
-    this.setState({ showAll: true });
   }
 
   render() {
     const {
       bibId,
-      dispatch,
       items,
       itemsAggregations,
       numItemsMatched,
-      fieldToOptionsMap
+      fieldToOptionsMap,
+      showAll
     } = this.props;
     const shortenItems = !this.props.shortenItems;
     let itemsToDisplay = [...items];
@@ -120,7 +116,7 @@ class ItemsContainer extends React.Component {
     if (
       this.state.js &&
       numItemsMatched > itemsListPageLimit &&
-      !this.state.showAll
+      !showAll
     ) {
       pagination = (
         <Pagination
@@ -133,11 +129,7 @@ class ItemsContainer extends React.Component {
         />
       );
     }
-    const itemTable = this.getTable(
-      itemsToDisplay,
-      shortenItems,
-      this.state.showAll,
-    );
+    const itemTable = this.getTable(itemsToDisplay, shortenItems);
 
     return (
       <>
@@ -145,19 +137,17 @@ class ItemsContainer extends React.Component {
         <div className="nypl-results-item">
           <ItemFilters
             displayDateFilter={this.props.displayDateFilter}
-            items={itemsToDisplay}
-            numOfFilteredItems={itemsToDisplay && itemsToDisplay.length}
-            itemsAggregations={itemsAggregations}
-            dispatch={dispatch}
-            numItemsMatched={numItemsMatched}
             fieldToOptionsMap={fieldToOptionsMap}
-            showAll={this.state.showAll}
+            itemsAggregations={itemsAggregations}
+            numItemsMatched={numItemsMatched}
+            numOfFilteredItems={itemsToDisplay && itemsToDisplay.length}
+            showAll={showAll}
           />
           {itemTable}
           {!!(
             shortenItems &&
             numItemsMatched > itemsListPageLimit &&
-            !this.state.showAll
+            !showAll
           ) && (
             <div className="view-all-items-container">
               {this.state.js ? (
@@ -192,17 +182,16 @@ class ItemsContainer extends React.Component {
 }
 
 ItemsContainer.propTypes = {
-  items: PropTypes.array,
-  itemPage: PropTypes.string,
   bibId: PropTypes.string,
-  shortenItems: PropTypes.bool,
-  searchKeywords: PropTypes.string,
-  holdings: PropTypes.array,
-  itemsAggregations: PropTypes.array,
-  dispatch: PropTypes.func,
-  numItemsMatched: PropTypes.number,
-  fieldToOptionsMap: PropTypes.object,
   displayDateFilter: PropTypes.bool,
+  fieldToOptionsMap: PropTypes.object,
+  holdings: PropTypes.array,
+  itemPage: PropTypes.string,
+  items: PropTypes.array,
+  itemsAggregations: PropTypes.array,
+  numItemsMatched: PropTypes.number,
+  searchKeywords: PropTypes.string,
+  shortenItems: PropTypes.bool,
   showAll: PropTypes.bool,
 };
 

--- a/src/app/components/Item/ItemsContainer.jsx
+++ b/src/app/components/Item/ItemsContainer.jsx
@@ -107,7 +107,8 @@ class ItemsContainer extends React.Component {
       itemsAggregations,
       numItemsMatched,
       fieldToOptionsMap,
-      showAll
+      showAll,
+      finishedLoadingItems,
     } = this.props;
     const shortenItems = !this.props.shortenItems;
     let itemsToDisplay = [...items];
@@ -142,6 +143,7 @@ class ItemsContainer extends React.Component {
             numItemsMatched={numItemsMatched}
             numOfFilteredItems={itemsToDisplay && itemsToDisplay.length}
             showAll={showAll}
+            finishedLoadingItems={finishedLoadingItems}
           />
           {itemTable}
           {!!(
@@ -193,6 +195,7 @@ ItemsContainer.propTypes = {
   searchKeywords: PropTypes.string,
   shortenItems: PropTypes.bool,
   showAll: PropTypes.bool,
+  finishedLoadingItems: PropTypes.bool,
 };
 
 ItemsContainer.defaultProps = {

--- a/src/app/components/ItemFilters/ItemFilter.jsx
+++ b/src/app/components/ItemFilters/ItemFilter.jsx
@@ -120,6 +120,7 @@ const ItemFilter = ({
     mobile ? setMobileIsOpen(prevState => !prevState) : manageFilterDisplay(field)
   );
   const open = mobile ? mobileIsOpen : isOpen;
+
   return (
     <FocusTrap
       focusTrapOptions={{
@@ -191,15 +192,15 @@ const ItemFilter = ({
 
 ItemFilter.propTypes = {
   field: PropTypes.string,
-  options: PropTypes.array,
+  fieldToOptionsMap: PropTypes.object,
+  initialFilters: PropTypes.object,
   isOpen: PropTypes.bool,
   manageFilterDisplay: PropTypes.func,
   mobile: PropTypes.bool,
+  options: PropTypes.array,
   selectedFields: PropTypes.object,
-  submitFilterSelections: PropTypes.func,
   setSelectedFields: PropTypes.func,
-  initialFilters: PropTypes.object,
-  fieldToOptionsMap: PropTypes.object
+  submitFilterSelections: PropTypes.func,
 };
 
 ItemFilter.defaultProps = {

--- a/src/app/components/ItemFilters/ItemFilters.jsx
+++ b/src/app/components/ItemFilters/ItemFilters.jsx
@@ -17,6 +17,7 @@ const ItemFilters = (
     fieldToOptionsMap = {},
     itemsAggregations = [],
     showAll = false,
+    finishedLoadingItems = false,
   },
   { router },
 ) => {
@@ -40,13 +41,13 @@ const ItemFilters = (
   useEffect(() => {
     setSelectedFieldDisplayStr(parsedFilterSelections());
     // Once the new items are fetched, focus on the filter UI and the
-    // results, but don't do this if the user requested to view all items.
-    // It is annoying if the text keeps getting focused and the page
-    // keeps jumping around.
-    if (!showAll) {
+    // results, but don't do this if the user requested to view all items
+    // until all the items are fetched. It is annoying if the text keeps
+    // getting focused and the page keeps jumping around.
+    if (selectedFieldDisplayStr || finishedLoadingItems) {
       resultsRef.current && resultsRef.current.focus();
     }
-  }, [numOfFilteredItems, parsedFilterSelections, showAll]);
+  }, [numOfFilteredItems, parsedFilterSelections, finishedLoadingItems, selectedFieldDisplayStr]);
 
   /**
    * When filters are applied or cleared, build new filter query
@@ -226,6 +227,11 @@ const ItemFilters = (
             </Button>
           </>
         ) : null}
+        {showAll ?
+          <p id="view-all-items">
+            Loading all items {finishedLoadingItems ? "complete." : "..."}
+          </p> : null
+        }
       </div>
     </Fragment>
   );
@@ -236,8 +242,9 @@ ItemFilters.propTypes = {
   fieldToOptionsMap: PropTypes.object,
   itemsAggregations: PropTypes.array,
   numItemsMatched: PropTypes.number,
-  numOfFilteredItems: PropTypes.object,
+  numOfFilteredItems: PropTypes.number,
   showAll: PropTypes.bool,
+  finishedLoadingItems: PropTypes.bool,
 };
 
 ItemFilters.contextTypes = {

--- a/src/app/components/ItemFilters/ItemFilters.jsx
+++ b/src/app/components/ItemFilters/ItemFilters.jsx
@@ -39,10 +39,10 @@ const ItemFilters = (
   // When new items are fetched, update the selected string display.
   useEffect(() => {
     setSelectedFieldDisplayStr(parsedFilterSelections());
-    // Once the new items are fetched, focus on the
-    // filter UI and the results.
-    // this is annoying if you're using a screen reader and focus gets
-    /// added after every call!
+    // Once the new items are fetched, focus on the filter UI and the
+    // results, but don't do this if the user requested to view all items.
+    // It is annoying if the text keeps getting focused and the page
+    // keeps jumping around.
     if (!showAll) {
       resultsRef.current && resultsRef.current.focus();
     }
@@ -155,16 +155,16 @@ const ItemFilters = (
       'Search Filters',
       `Apply Filter - ${JSON.stringify(selectedFields)}`,
     );
-    console.log({ query })
     router.push(href);
   };
 
   const itemFilterComponentProps = {
     initialFilters,
+    manageFilterDisplay,
     selectedFields,
     setSelectedFields,
-    manageFilterDisplay,
     submitFilterSelections,
+    fieldToOptionsMap,
   };
   // If there are filters, display the number of items that match the filters.
   // Otherwise, display the total number of items.
@@ -179,7 +179,6 @@ const ItemFilters = (
           selectedYear={selectedYear}
           setSelectedYear={setSelectedYear}
           {...itemFilterComponentProps}
-          fieldToOptionsMap={fieldToOptionsMap}
         />
       ) : (
         <div
@@ -191,12 +190,11 @@ const ItemFilters = (
             <Text isBold fontSize="text.caption" mb="xs">Filter by</Text>
               {itemsAggregations.map((field) => (
               <ItemFilter
-                  field={field.field}
-                  key={field.id}
-                  options={field.options}
-                  isOpen={openFilter === field.field}
+                field={field.field}
+                isOpen={openFilter === field.field}
+                key={field.id}
+                options={field.options}
                 {...itemFilterComponentProps}
-                  fieldToOptionsMap={fieldToOptionsMap}
               />
             ))}
           </div>
@@ -234,12 +232,11 @@ const ItemFilters = (
 };
 
 ItemFilters.propTypes = {
+  displayDateFilter: PropTypes.bool,
+  fieldToOptionsMap: PropTypes.object,
   itemsAggregations: PropTypes.array,
-  dispatch: PropTypes.func,
   numItemsMatched: PropTypes.number,
   numOfFilteredItems: PropTypes.object,
-  fieldToOptionsMap: PropTypes.object,
-  displayDateFilter: PropTypes.bool,
   showAll: PropTypes.bool,
 };
 

--- a/src/app/components/ItemFilters/ItemFilters.jsx
+++ b/src/app/components/ItemFilters/ItemFilters.jsx
@@ -14,9 +14,10 @@ const ItemFilters = (
     displayDateFilter,
     numOfFilteredItems,
     numItemsTotal,
-    numItemsCurrent,
+    numItemsMatched,
     fieldToOptionsMap = {},
-    itemsAggregations = []
+    itemsAggregations = [],
+    showAll = false,
   },
   { router },
 ) => {
@@ -41,8 +42,12 @@ const ItemFilters = (
     setSelectedFieldDisplayStr(parsedFilterSelections());
     // Once the new items are fetched, focus on the
     // filter UI and the results.
-    resultsRef.current && resultsRef.current.focus();
-  }, [numOfFilteredItems, parsedFilterSelections]);
+    // this is annoying if you're using a screen reader and focus gets
+    /// added after every call!
+    if (!showAll) {
+      resultsRef.current && resultsRef.current.focus();
+    }
+  }, [numOfFilteredItems, parsedFilterSelections, showAll]);
 
   /**
    * When new filters are selected or unselected, fetch new items.
@@ -104,7 +109,7 @@ const ItemFilters = (
     }
 
     return filterSelectionString.join(', ');
-  }, [itemsAggregations, selectedFields, selectedYear]);
+  }, [itemsAggregations, selectedFields, selectedYear, fieldToOptionsMap]);
 
   const resetFilters = () => {
     setSelectedFields(initialFilters);
@@ -149,7 +154,7 @@ const ItemFilters = (
   };
   // If there are filters, display the number of items that match the filters.
   // Otherwise, display the total number of items.
-  const resultsItemsNumber = selectedFieldDisplayStr ? numItemsCurrent : numItemsTotal;
+  const resultsItemsNumber = selectedFieldDisplayStr ? numItemsMatched : numItemsTotal;
   return (
     <Fragment>
       {['mobile', 'tabletPortrait'].includes(mediaType) ? (
@@ -217,9 +222,11 @@ ItemFilters.propTypes = {
   itemsAggregations: PropTypes.array,
   dispatch: PropTypes.func,
   numItemsTotal: PropTypes.number,
-  numItemsCurrent: PropTypes.number,
+  numItemsMatched: PropTypes.number,
   fieldToOptionsMap: PropTypes.object,
   displayDateFilter: PropTypes.bool,
+  numOfFilteredItems: PropTypes.number,
+  showAll: PropTypes.bool,
 };
 
 ItemFilters.contextTypes = {

--- a/src/app/components/ItemFilters/ItemFiltersMobile.jsx
+++ b/src/app/components/ItemFilters/ItemFiltersMobile.jsx
@@ -43,8 +43,7 @@ const ItemFiltersMobile = ({
                 initialFilters={initialFilters}
                 fieldToOptionsMap={fieldToOptionsMap}
               />
-            )
-            )
+            ))
           }
         </div>
       </div>

--- a/src/app/data/constants.js
+++ b/src/app/data/constants.js
@@ -1,4 +1,4 @@
-import appConfig from "@appConfig";
+// import appConfig from "@appConfig";
 
 // breakpoints ordered by `maxValue` ascending
 const breakpoints = [
@@ -18,7 +18,7 @@ const breakpoints = [
 
 const bibPageItemsListLimit = 20;
 const searchResultItemsListLimit = 3;
-const itemBatchSize = appConfig.itemBatchSize;
+const itemBatchSize = 20; //appConfig.itemBatchSize;
 
 const noticePreferenceMapping = {
   'z': 'Email',

--- a/src/app/data/constants.js
+++ b/src/app/data/constants.js
@@ -1,5 +1,3 @@
-// import appConfig from "@appConfig";
-
 // breakpoints ordered by `maxValue` ascending
 const breakpoints = [
   {
@@ -18,7 +16,7 @@ const breakpoints = [
 
 const bibPageItemsListLimit = 20;
 const searchResultItemsListLimit = 3;
-const itemBatchSize = 20; //appConfig.itemBatchSize;
+const itemBatchSize = 20;
 
 const noticePreferenceMapping = {
   'z': 'Email',

--- a/src/app/utils/bibPage.js
+++ b/src/app/utils/bibPage.js
@@ -1,0 +1,93 @@
+import { useCallback, useEffect } from 'react';
+import { ajaxCall } from '@utils';
+import appConfig from '../data/appConfig';
+import { itemBatchSize } from '../data/constants';
+
+/**
+ * useViewAllItems: fetch more items only when the patron wants to
+ * view all items. Uses the `use` prefix to indicate that this is a
+ * custom React hook.
+ * @param {object} bib - the bib object.
+ * @param {function} dispatch - Redux dispatch function.
+ * @param {number} numItemsMatched - the total number of items matched, used
+ *  when filtering and to determine if we have fetched all the items.
+ * @param {boolean} showAll - boolean to indicate if we should fetch all the
+ *   items from a bib.
+ * @param {function} updateBibPage - Redux action to update the bib object.
+ */
+export const useViewAllItems = (
+  bib,
+  dispatch,
+  numItemsMatched,
+  showAll = false,
+  updateBibPage
+) => {
+  // If the patron switches to another bib page, or performs a new filter,
+  // then stop fetching more items. This happens when the `showAll` prop
+  // is true, but the patron performs a new action and the `showAll` prop
+  // is set to false.
+  useEffect(() => {
+    if (bib && bib.fetchMoreItems || showAll) {
+      fetchMoreItems(showAll);
+    }
+  }, [fetchMoreItems, bib, showAll]);
+
+  /*
+   * Helper function that checks to see if we need to fetch more items. If the
+   * "View All Items" button is clicked, we want to make multiple batch
+   * requests to get all the items.
+   */
+  const fetchMoreItems = useCallback((showAll = false) => {
+    if (!bib || !bib.items || !bib.items.length || (bib && bib.done)) {
+      // Nothing to do.
+    } else if (bib && bib.items.length >= numItemsMatched || !showAll) {
+      // 1. Once we have fetched all the items, we're done, so stop fetching
+      //   more items. `fetchMoreItems` is used to trigger the useEffect but
+      //   `done` is used to stop the API requests.
+      // 2. If `showAll` is false, stop fetching more items. This can happen
+      //   if the patron clicks on another bib page or performs a new filter
+      //   search.
+      dispatch(
+        updateBibPage({
+          bib: Object.assign({}, bib, { done: true, fetchMoreItems: false })
+        })
+      );
+    } else {
+      // We need to fetch for more items.
+      const searchStr =
+        window.location.search ? `&${window.location.search.substring(1)}` : '';
+      const baseUrl = appConfig.baseUrl;
+      const itemFrom = !bib.itemFrom ? 0 : bib.itemFrom;
+
+      // Fetch the next batch of items using the `itemFrom` param.
+      const bibApi = `${window.location.pathname.replace(
+        baseUrl,
+        `${baseUrl}/api`,
+      )}?items_from=${itemFrom}${searchStr}`;
+
+      ajaxCall(
+        bibApi,
+        (resp) => {
+          // Merge in the new items with the existing items.
+          const bibResp = resp.data.bib;
+          const done =
+            !bibResp || !bibResp.items || bibResp.items.length < itemBatchSize;
+          dispatch(
+            updateBibPage({
+              bib: Object.assign({}, bib, {
+                items: bib.done !== undefined ?
+                bib.items.concat((bibResp && bibResp.items) || []) : bibResp.items,
+                done,
+                fetchMoreItems: true,
+                itemFrom: parseInt(itemFrom, 10) + parseInt(itemBatchSize, 10),
+              }),
+            }),
+          );
+        },
+        (error) => {
+          console.error(error);
+        },
+      );
+    }
+  }, [bib, dispatch, numItemsMatched, updateBibPage]);
+};

--- a/src/server/ApiRoutes/Bib.js
+++ b/src/server/ApiRoutes/Bib.js
@@ -189,8 +189,10 @@ function fetchBib (bibId, cb, errorcb, reqOptions, res) {
 function bibSearch (req, res, resolve) {
   const bibId = req.params.bibId;
   const query = req.query;
-  const { features, itemFrom } = req.query;
+  const { features, item_page = 1, items_from } = req.query;
   const urlEnabledFeatures = extractFeatures(features);
+  delete query.items_from;
+
   let filterItemsStr = Object.keys(query)
     .map((key) => `${key}=${query[key]}`)
     .join('&');
@@ -202,7 +204,7 @@ function bibSearch (req, res, resolve) {
     {
       features: urlEnabledFeatures,
       fetchSubjectHeadingData: true,
-      itemFrom,
+      itemFrom: items_from ? items_from : (item_page - 1) * itemBatchSize,
       filterItemsStr
     },
     res,

--- a/src/server/ApiRoutes/Bib.js
+++ b/src/server/ApiRoutes/Bib.js
@@ -204,6 +204,8 @@ function bibSearch (req, res, resolve) {
     {
       features: urlEnabledFeatures,
       fetchSubjectHeadingData: true,
+      // If items_from is set, use that value, otherwise calculate it
+      // based on the current page and the batch size.
       itemFrom: items_from ? items_from : (item_page - 1) * itemBatchSize,
       filterItemsStr
     },

--- a/test/unit/ItemFilters.test.js
+++ b/test/unit/ItemFilters.test.js
@@ -137,7 +137,7 @@ describe('ItemFilters', () => {
           items={items}
           numOfFilteredItems={items.length}
           numItemsTotal={items.length}
-          numItemsCurrent={items.length}
+          numItemsMatched={items.length}
           itemsAggregations={reducedAggregations}
           fieldToOptionsMap={fieldToOptionsMap}
         />,
@@ -175,7 +175,7 @@ describe('ItemFilters', () => {
           // This comes from the `ItemsContainer` parent
           // component after filtering the items.
           numItemsTotal={1}
-          numItemsCurrent={1}
+          numItemsMatched={1}
           itemsAggregations={itemsAggregations}
           fieldToOptionsMap={fieldToOptionsMap}
         />,
@@ -252,7 +252,7 @@ describe('ItemFilters', () => {
           items={items}
           numOfFilteredItems={0}
           numItemsTotal={items.length}
-          numItemsCurrent={items.length}
+          numItemsMatched={items.length}
           itemsAggregations={itemsAggregations2}
         />,
         { context: contextWithMultipleFilters }

--- a/test/unit/ItemFilters.test.js
+++ b/test/unit/ItemFilters.test.js
@@ -30,10 +30,9 @@ describe('ItemFilters', () => {
       component = mount(
         <ItemFilters
           displayDateFilter={true}
-          items={items}
+          itemsAggregations={itemsAggregations}
           numOfFilteredItems={items.length}
           numItemsTotal={items.length}
-          itemsAggregations={itemsAggregations}
         />,
         { context }
       );
@@ -44,7 +43,6 @@ describe('ItemFilters', () => {
       component = mount(
         <ItemFilters
           displayDateFilter={false}
-          items={items}
           numOfFilteredItems={items.length}
           numItemsTotal={items.length}
           itemsAggregations={itemsAggregations}
@@ -68,7 +66,6 @@ describe('ItemFilters', () => {
       ];
       component = mount(
         <ItemFilters
-          items={items}
           numOfFilteredItems={items.length}
           numItemsTotal={items.length}
           itemsAggregations={reducedAggregations}
@@ -134,7 +131,6 @@ describe('ItemFilters', () => {
       contextWithOneFilter.router.location.query = { item_format: 'Text' };
       component = mount(
         <ItemFilters
-          items={items}
           numOfFilteredItems={items.length}
           numItemsMatched={items.length}
           itemsAggregations={reducedAggregations}
@@ -169,7 +165,6 @@ describe('ItemFilters', () => {
       contextWithMultipleFilters.router.location.query = { item_format: 'Text,PRINT' };
       component = mount(
         <ItemFilters
-          items={items}
           numOfFilteredItems={items.length}
           // This comes from the `ItemsContainer` parent
           // component after filtering the items.
@@ -209,7 +204,6 @@ describe('ItemFilters', () => {
       };
       component = mount(
         <ItemFilters
-          items={items}
           numOfFilteredItems={0}
           // This comes from the `ItemsContainer` parent
           // component after filtering the items.
@@ -247,11 +241,10 @@ describe('ItemFilters', () => {
       };
       component = mount(
         <ItemFilters
-          items={items}
+        itemsAggregations={itemsAggregations2}
           numOfFilteredItems={0}
           numItemsTotal={items.length}
           numItemsMatched={items.length}
-          itemsAggregations={itemsAggregations2}
         />,
         { context: contextWithMultipleFilters }
       );
@@ -283,11 +276,10 @@ describe('ItemFilters', () => {
       component = mount(
         <ItemFilters
           displayDateFilter={false}
-          items={items}
+          fieldToOptionsMap={fieldToOptionsMap}
+          itemsAggregations={reducedAggregations}
           numOfFilteredItems={items.length}
           numItemsTotal={items.length}
-          itemsAggregations={reducedAggregations}
-          fieldToOptionsMap={fieldToOptionsMap}
         />,
         { context });
     })

--- a/test/unit/ItemsContainer.test.js
+++ b/test/unit/ItemsContainer.test.js
@@ -145,7 +145,7 @@ describe('ItemsContainer', () => {
           items={longListItems}
           bib={testBib}
           numItemsTotal={longListItems.length}
-          numItemsCurrent={longListItems.length}
+          numItemsMatched={longListItems.length}
         />,
         { context });
     });
@@ -173,7 +173,7 @@ describe('ItemsContainer', () => {
           shortenItems={false}
           bib={testBib} 
           numItemsTotal={longListItems.length}
-          numItemsCurrent={longListItems.length}
+          numItemsMatched={longListItems.length}
         />,
         { context }
       );
@@ -210,7 +210,7 @@ describe('ItemsContainer', () => {
           shortenItems={false}
           bib={testBib}
           numItemsTotal={longListItems.length}
-          numItemsCurrent={longListItems.length}
+          numItemsMatched={longListItems.length}
         />,
         { context },
       );
@@ -253,37 +253,6 @@ describe('ItemsContainer', () => {
       // Reset back to the first page.
       component.instance().updatePage(1);
     });
-
-    it('should make an API request to get more items when using the Pagination', () => {
-      const checkForMoreItems = () => {
-        madeAPIRequest = true;
-      };
-      let madeAPIRequest = false;
-
-      const component = mount(
-        <ItemsContainer
-          items={longListItems}
-          shortenItems={false}
-          bib={testBib}
-          numItemsTotal={longListItems.length}
-          numItemsCurrent={longListItems.length}
-          checkForMoreItems={checkForMoreItems}
-        />,
-        { context },
-      );
-      const container = component.find('ItemsContainer').instance()
-      
-      expect(component.state('page')).to.equal(1);
-      expect(madeAPIRequest).to.equal(false);
-      
-      // There are only two pages for this example, so once
-      // get to the second page, make the call to fetch more
-      // items by calling `checkForMoreItems`.
-      container.updatePage(2, 'Next')
-      
-      expect(component.state('page')).to.equal(2);
-      expect(madeAPIRequest).to.equal(true);
-    });
   });
 
   describe('High page value', () => {
@@ -299,32 +268,6 @@ describe('ItemsContainer', () => {
     it('should have "page" state updated to 1 since page 4 should not exist with the ' +
       'small amount of items passed', () => {
       expect(component.state('page')).to.equal(1);
-    });
-  });
-
-  describe('Breaking up the items passed into a chunked array', () => {
-    let component
-    const store = makeTestStore({
-      bib: {
-        items: longListItems
-      }
-    })
-    before(() => {
-      component = mountTestRender(
-        <WrappedItemsContainer itemsAggregations={itemsAggregations} />
-        , { store, childContextTypes: { router: PropTypes.object } });
-    })
-    after(() => {
-      component.unmount()
-    })
-    it(`should have ${itemsListPageLimit} on the first page of the item table and ${longListItems.length - itemsListPageLimit} on the second`, () => {
-      const container = component.find('ItemsContainer').instance()
-      let items = component.find('ItemTableRow')
-      expect(items.length).to.equal(itemsListPageLimit)
-      container.updatePage(2, 'Next')
-      component.setProps()
-      items = component.find('ItemTableRow')
-      expect(items.length).to.equal(longListItems.length - itemsListPageLimit)
     });
   });
 

--- a/test/unit/ItemsContainer.test.js
+++ b/test/unit/ItemsContainer.test.js
@@ -3,16 +3,13 @@
 import React from 'react';
 import { expect } from 'chai';
 import { mount, shallow } from 'enzyme';
-import PropTypes from 'prop-types';
 
 import itemsContainerModule from './../../src/app/components/Item/ItemsContainer';
 import LibraryItem from './../../src/app/utils/item';
 import { bibPageItemsListLimit as itemsListPageLimit } from './../../src/app/data/constants';
-import { makeTestStore, mountTestRender } from '../helpers/store';
 import { itemsAggregations } from '../fixtures/itemFilterOptions';
 
 const ItemsContainer = itemsContainerModule.unwrappedItemsContainer;
-const WrappedItemsContainer = itemsContainerModule.ItemsContainer
 const items = [
   {
     accessMessage: {
@@ -213,33 +210,12 @@ describe('ItemsContainer', () => {
       );
     });
 
-    it('should have showAll state equal to false', () => {
-      expect(component.state('showAll')).to.equal(false);
-    });
-
-    it('should have showAll state equal to true when the show all link is clicked', () => {
-      const allItemsLink = component.find('.view-all-items-container').find('button');
-
-      expect(component.state('showAll')).to.equal(false);
-      allItemsLink.simulate('click');
-      expect(component.state('showAll')).to.equal(true);
-    });
-
-    it('should have "js" state equal to false', () => {
-      expect(component.state('showAll')).to.equal(true);
+    it('should have "js" state equal to true after the component mounts', () => {
+      expect(component.state('js')).to.equal(true);
     });
 
     it('should have "page" state equal to 1 by default', () => {
       expect(component.state('page')).to.equal(1);
-    });
-
-    it('should have "showAll" state equal to true when the showAll function is invoked', () => {
-      // The component's 'showAll' state has been updated so here we are reverting it back:
-      component.setState({ showAll: false });
-
-      expect(component.state('showAll')).to.equal(false);
-      component.instance().showAll();
-      expect(component.state('showAll')).to.equal(true);
     });
 
     it('should have "page" state updated when the updatePage function is invoked', () => {
@@ -252,19 +228,34 @@ describe('ItemsContainer', () => {
     });
   });
 
-  describe('High page value', () => {
-    let component;
-
-    before(() => {
-      component = shallow(
-        <ItemsContainer items={longListItems} shortenItems={false} page="4" bib={testBib} />,
+  describe('ShowAll feature', () => {
+    it('should not display the "view all items" link when showAll is true', () => {
+      const component = shallow(
+        <ItemsContainer
+          items={longListItems}
+          shortenItems={false}
+          bib={testBib}
+          numItemsMatched={longListItems.length}
+          showAll={true}
+        />,
         { context },
       );
+      expect(component.find('.view-all-items-container').length).to.equal(0);
     });
 
-    it('should have "page" state updated to 1 since page 4 should not exist with the ' +
-      'small amount of items passed', () => {
-      expect(component.state('page')).to.equal(1);
+    it('should display the "view all items" link when showAll is false', () => {
+      const component = shallow(
+        <ItemsContainer
+          items={longListItems}
+          shortenItems={false}
+          bib={testBib}
+          // Mocking that we have more items to display.
+          numItemsMatched={100}
+          showAll={false}
+        />,
+        { context },
+      );
+      expect(component.find('.view-all-items-container').length).to.equal(1);
     });
   });
 
@@ -272,7 +263,7 @@ describe('ItemsContainer', () => {
     let component;
     before(() => {
       component = shallow(
-        <ItemsContainer items={twentyItems} shortenItems={false} page="4" bib={testBib} />,
+        <ItemsContainer items={twentyItems} shortenItems={false} itemPage="4" bib={testBib} />,
         { context },
       );
     });


### PR DESCRIPTION
**What's this do?**
Resolves [SCC-3466](https://jira.nypl.org/browse/SCC-3466).

This removes all remnants of client-side filtering or pagination on a bib page. The only exception is when then "view all items" button is clicked and client-side requests are made to incrementally fetch more items for a bib. 

This is done by setting the hash `#view-all-items` in the URL. When a page with this hash is shared, the client-side incremental item fetching is performed. This also means that the state for the the `ItemsContainer` component is slightly cleaner because now it only needs to care about the `js` value. All other values have been removed or moved to the parent.

When requesting the next or previous set of items, all previous items are removed and replaced with the next batch of items. This means that `ItemsContainer` does not need to keep track of items in its state anymore nor deal with React lifecycle functions in the component.

One big update is `itemPage` is now `item_page` to be consistent with the rest of the URL query params.

**Why are we doing this? (w/ JIRA link if applicable)**
[Quick blurb about why the code is needed and Jira link/ Do these changes meet the business requirements of the story?]

**Do these changes have automated tests?**
Yes

**How should this be QAed?**
Review multiple bib pages.
1. Test out the "View all items" button.
2. Test the pagination. Each new page (next or previous) should make an API call and display the next or previous 20 items).
3. Test the filters.
4. Test the filters _and_ the pagination.
5. Test the filters _and_ clicking on the "view all items" button.

**Dependencies for merging? Releasing to production?**
[Description of any watchouts, dependencies, or issues we should be aware of]

**Has the application documentation been updated for these changes?**

**Did someone actually run this code to verify it works?**
