### PR TITLE
Scc 3437/broken link

### DIFF
--- a/src/app/components/BibPage/BibDetails.jsx
+++ b/src/app/components/BibPage/BibDetails.jsx
@@ -148,9 +148,7 @@ const BibDetails = (props) => {
           }
           dir={stringDirection(linkText, useParallels)}
         >
-          <Link>
           {linkText}
-          </Link>
         </DSLink>
       );
     }

--- a/src/app/components/BibPage/BibDetails.jsx
+++ b/src/app/components/BibPage/BibDetails.jsx
@@ -148,7 +148,9 @@ const BibDetails = (props) => {
           }
           dir={stringDirection(linkText, useParallels)}
         >
+          <Link>
           {linkText}
+          </Link>
         </DSLink>
       );
     }

--- a/src/app/components/BibPage/BibDetails.jsx
+++ b/src/app/components/BibPage/BibDetails.jsx
@@ -138,8 +138,8 @@ const BibDetails = (props) => {
     if (fieldSelfLinkable) {
       const linkText = bibValue.prefLabel || bibValue.label || bibValue.url
       return (
-        <Link
-          to={bibValue.url}
+        <DSLink
+          href={bibValue.url}
           onClick={() =>
             trackDiscovery(
               'Bib fields',
@@ -149,7 +149,7 @@ const BibDetails = (props) => {
           dir={stringDirection(linkText, useParallels)}
         >
           {linkText}
-        </Link>
+        </DSLink>
       );
     }
 

--- a/src/app/components/Item/InformationLinks.jsx
+++ b/src/app/components/Item/InformationLinks.jsx
@@ -3,19 +3,8 @@ import { Text, Link, Button } from '@nypl/design-system-react-components';
 import { isEmpty as _isEmpty } from 'underscore';
 import { FeedbackBoxContext } from '../../context/FeedbackContext';
 
-const locationUrlEndpoint = (location) => {
-  const loc = location.split(' ')[0]
-  const urls = {
-    'Schwarzman': 'schwarzman',
-    'Performing': 'lpa',
-    'Schomburg': 'schomburg'
-  }
-  return urls[loc]
-}
-
-const InformationLinks = ({ bibId, callNumber, id, barcode, isRecap, computedAeonUrl: aeonUrl, available, locationUrl: divisionUrl, dueDate, location }) => {
+const InformationLinks = ({ bibId, callNumber, id, barcode, isRecap, computedAeonUrl: aeonUrl, available, locationUrl: divisionUrl, dueDate, location, branchEndpoint }) => {
   let openFeedbackBox, setItemMetadata
-
   // conditional for testing 
   const feedback = useContext(FeedbackBoxContext)
   if (feedback) {
@@ -48,7 +37,7 @@ const InformationLinks = ({ bibId, callNumber, id, barcode, isRecap, computedAeo
         <Text className='availability-alert'>
           <span className='available-text'>Available </span>
           {'- Can be used on site. Please visit '}
-          <Link href={'https://www.nypl.org/locations/' + locationUrlEndpoint(location)}>{'New York Public Library - '}{locationShort}
+          <Link href={'https://www.nypl.org/locations/' + branchEndpoint}>{'New York Public Library - '}{locationShort}
           </Link>{' to submit a request in person.'}
         </Text>)
     }

--- a/src/app/components/ItemFilters/ItemFilters.jsx
+++ b/src/app/components/ItemFilters/ItemFilters.jsx
@@ -150,7 +150,6 @@ const ItemFilters = (
       'Search Filters',
       `Apply Filter - ${JSON.stringify(selectedFields)}`,
     );
-    console.log({ query })
     router.push(href);
   };
 

--- a/src/app/utils/item.js
+++ b/src/app/utils/item.js
@@ -272,6 +272,7 @@ function LibraryItem() {
       electronicResources,
       location: holdingLocation.prefLabel,
       locationUrl: holdingLocation.url,
+      branchEndpoint: holdingLocation.branchEndpoint,
       holdingLocationCode: holdingLocation['@id'] || '',
       callNumber,
       url,
@@ -387,7 +388,18 @@ function LibraryItem() {
 
     // this is a physical resource
     if (item.holdingLocation && item.holdingLocation.length) {
+      const prefLabel = item.holdingLocation[0].prefLabel.replace(/SASB/, 'Schwarzman')
+      const locationUrlEndpoint = (location) => {
+        const loc = location.split(' ')[0]
+        const urls = {
+          'Schwarzman': 'schwarzman',
+          'Performing': 'lpa',
+          'Schomburg': 'schomburg'
+        }
+        return urls[loc]
+      }
       location = item.holdingLocation[0];
+      location.branchEndpoint = locationUrlEndpoint(prefLabel)
     }
 
     return location;

--- a/test/fixtures/libraryItems.js
+++ b/test/fixtures/libraryItems.js
@@ -120,6 +120,7 @@ const item = {
     barcode: '33433078478272',
     callNumber: 'JFE 07-5007 ---',
     holdingLocationCode: 'loc:maj03',
+    branchEndpoint: 'schwarzman',
     id: 'i17326129',
     isElectronicResource: false,
     isOffsite: false,
@@ -136,33 +137,8 @@ const item = {
     url: 'http://www.questionpoint.org/crs/servlet/org.oclc.admin.BuildForm?' +
       '&institution=13777&type=1&language=1',
   },
-  requestable_nonReCAP_NYPL_schwarzman: {
-    accessMessage: {
-      '@id': 'accessMessage:1',
-      prefLabel: 'USE IN LIBRARY',
-    },
-    availability: 'available',
-    available: true,
-    barcode: '33433078478272',
-    callNumber: 'JFE 07-5007 ---',
-    holdingLocationCode: 'loc:maj03',
-    id: 'i17326129',
-    isElectronicResource: false,
-    isOffsite: false,
-    isRecap: false,
-    itemSource: 'sierra-nypl',
-    location: 'Schwarzman Building M2 - General Research Room 315',
-    nonRecapNYPL: true,
-    requestable: true,
-    status: {
-      '@id': 'status:a',
-      prefLabel: 'Available',
-    },
-    suppressed: false,
-    url: 'http://www.questionpoint.org/crs/servlet/org.oclc.admin.BuildForm?' +
-      '&institution=13777&type=1&language=1',
-  },
   requestable_nonReCAP_NYPL_lpa: {
+    branchEndpoint: 'lpa',
     accessMessage: {
       '@id': 'accessMessage:1',
       prefLabel: 'USE IN LIBRARY',
@@ -196,6 +172,7 @@ const item = {
     availability: 'available',
     available: true,
     barcode: '33433078478272',
+    branchEndpoint: 'schomburg',
     callNumber: 'JFE 07-5007 ---',
     holdingLocationCode: 'loc:maj03',
     id: 'i17326129',
@@ -215,6 +192,7 @@ const item = {
       '&institution=13777&type=1&language=1',
   },
   requestable_nonReCAP_NYPL_not_available: {
+    branchEndpoint: 'schwarzman',
     accessMessage: {
       '@id': 'accessMessage:1',
       prefLabel: 'USE IN LIBRARY',
@@ -242,6 +220,7 @@ const item = {
       '&institution=13777&type=1&language=1',
   },
   requestable_nonReCAP_NYPL: {
+    branchEndpoint: 'schwarzman',
     accessMessage: {
       '@id': 'accessMessage:1',
       prefLabel: 'USE IN LIBRARY',
@@ -268,6 +247,7 @@ const item = {
       '&institution=13777&type=1&language=1',
   },
   nonrequestable_nonReCAP_NYPL: {
+    branchEndpoint: 'schwarzman',
     accessMessage: {
       '@id': 'accessMessage:1',
       prefLabel: 'USE IN LIBRARY',

--- a/test/unit/BibDetails.test.js
+++ b/test/unit/BibDetails.test.js
@@ -323,8 +323,8 @@ describe('BibDetails', () => {
     ];
 
     it('should handle rtl text in a single self-linkable object value', () => {
-      const mockBibRtl = { field3: [{ '@id': 'id', prefLabel: '\u200F\u00E9' }]}
-      const mockBibLtr = { field3: [{ '@id': 'id', prefLabel: '\u00E9' }]}
+      const mockBibRtl = { field3: [{ '@id': 'id', prefLabel: '\u200F\u00E9', url: 'thebomb.com' }] }
+      const mockBibLtr = { field3: [{ '@id': 'id', prefLabel: '\u00E9', url: 'thebomb.com' }] }
       const rtlComponent = mount(
         <RouterProvider value={{ push: () => {} }}>
           {
@@ -348,8 +348,8 @@ describe('BibDetails', () => {
     })
 
     it('should handle rtl text in a list of self-linkable object values', () => {
-      const mockBibRtl = { field3: [{ '@id': 'id', prefLabel: '\u200F\u00E9'}, { '@id': 'id', prefLabel: '\u200F\u00E9'}] }
-      const mockBibLtr = { field3: [{ '@id': 'id', prefLabel: '\u00E9\u00E9'}, { '@id': 'id', prefLabel: '\u00E9\u00E9'}] }
+      const mockBibRtl = { field3: [{ url: 'thebomb.com', '@id': 'id', prefLabel: '\u200F\u00E9' }, { url: 'thebomb.com', '@id': 'id', prefLabel: '\u200F\u00E9' }] }
+      const mockBibLtr = { field3: [{ url: 'thebomb.com', '@id': 'id', prefLabel: '\u00E9\u00E9' }, { url: 'thebomb.com', '@id': 'id', prefLabel: '\u00E9\u00E9' }] }
       const rtlComponent = mount(
         <RouterProvider value={{ push: () => {} }}>
           {


### PR DESCRIPTION
**What's this do?**
* updates a bib detail link to use DSLink to avoid external link bug that occurs with react-router links
* moves the logic that calculates the branch endpoints for location labels out of .jsx file
* updates that logic to handle strings starting with SASB instead of Schwarzman

**Why are we doing this? (w/ JIRA link if applicable)**
links were going to [nowhere](https://www.youtube.com/watch?v=LQiOA7euaYA)

**Do these changes have automated tests?**
fixtures have been updated

**How should this be QAed?**
* [this search](https://qa-www.nypl.org/research/research-catalog/search?q=new%20york) gives a bunch of links that used to say check with staff and now have proper links. can cross check with a similar search in prod, i guess, because now its not apparent which links were broken. 
* to qa the link component swap, search for mixed media results and try to find links to finding aids and see if they go somewhere.

**Dependencies for merging? Releasing to production?**
[Description of any watchouts, dependencies, or issues we should be aware of]

**Has the application documentation been updated for these changes?**

**Did someone actually run this code to verify it works?**
