### PR TITLE
fix items container display tests

### DIFF
--- a/src/app/pages/BibPage.jsx
+++ b/src/app/pages/BibPage.jsx
@@ -63,10 +63,8 @@ export const BibPage = (
   const fieldToOptionsMap = buildFieldToOptionsMap(reducedItemsAggregations)
   const items = LibraryItem.getItems(bib);
   const aggregatedElectronicResources = getAggregatedElectronicResources(items);
-  const isElectronicResources = items.every(
-    (item) => item.isElectronicResource,
-  );
-
+  const isOnlyElectronicResources = bib.numItemsTotal === 1 && bib.numElectronicResources > 0
+  const hasPhysicalItems = !isOnlyElectronicResources && bib.numItemsTotal > 0
   // Related to removing MarcRecord because the webpack MarcRecord is not working. Sep/28/2017
   // const isNYPLReCAP = LibraryItem.isNYPLReCAP(bib['@id']);
   // const bNumber = bib && bib.idBnum ? bib.idBnum : '';
@@ -113,15 +111,10 @@ export const BibPage = (
           {electronicResources.length ? <ElectronicResources electronicResources={electronicResources} id="electronic-resources"/> : null}
         </section>
 
-        {/* Display the items filter container component when:
-          1: there are items through the `numItemsMatched` property,
-          2: there are items and they are not all electronic resources.
-          
-          Otherwise, if there are items but they are all electronic resources,
-          do not display the items filter container component.
+        {/*
+          Display the Items Container only when there are physical items
         */}
-        {(numItemsMatched && numItemsMatched > 0) ||
-          (!isElectronicResources && (!items || items.length > 0)) ?
+        {hasPhysicalItems ?
             <section style={{ marginTop: '20px' }} id="items-table">
               <ItemsContainer
                 bibId={bibId}

--- a/test/unit/BibPage.test.js
+++ b/test/unit/BibPage.test.js
@@ -427,7 +427,7 @@ describe('BibPage', () => {
         expect(component.find('ItemsContainer').length).to.equal(1)
       })
     })
-    it('Multi item, electronic resources', () => {
+    describe('Multi item, electronic resources', () => {
       const multiItemsYesER = { ...bib, numItemsTotal: 20, numElectronicResources: 30 }
       before(() => {
         component = mountTestRender(

--- a/test/unit/BibPage.test.js
+++ b/test/unit/BibPage.test.js
@@ -182,11 +182,10 @@ describe('BibPage', () => {
     let component;
     before(() => {
       mockBibWithHolding.holdings.forEach(holding => addHoldingDefinition(holding));
-      const bib = { ...mockBibWithHolding, ...annotatedMarc };
+      const bib = { ...mockBibWithHolding, ...annotatedMarc, numItemsTotal: 1 };
       const testStore = makeTestStore({
         bib: {
           items: [{ holdingLocationCode: 'lol', id: 1234 }],
-          numItems: 0,
         },
       });
 
@@ -356,4 +355,113 @@ describe('BibPage', () => {
       expect(component.find('section').at(0).prop('dir')).to.eql(null)
     })
   });
+
+
+  describe('ItemsContainer conditional display', () => {
+    let component;
+    let testStore
+    const bib = { ...mockBibWithHolding, ...annotatedMarc }
+    before(() => {
+      mockBibWithHolding.holdings.forEach(holding => addHoldingDefinition(holding));
+
+      testStore = makeTestStore({
+        bib: {
+          items: [{ holdingLocationCode: 'lol', id: 1234 }],
+        },
+      });
+    })
+    describe('1 item, electronic resources', () => {
+      const oneItemYesER = { ...bib, numItemsTotal: 1, numElectronicResources: 20 }
+      before(() => {
+        component = mountTestRender(
+          <BibPage
+            location={{ search: 'search', pathname: '' }}
+            bib={oneItemYesER}
+            dispatch={() => { }}
+            resultSelection={{
+              fromUrl: '',
+              bibId: '',
+            }}
+          />,
+          { context, childContextTypes: { router: PropTypes.object }, store: testStore },
+        )
+      })
+      it('does not render ItemsContainer', () => { expect(component.find('ItemsContainer').length).to.equal(0) })
+    })
+    describe('No item, no electronic resources', () => {
+      const noItemsNoEr = { ...bib, numItemsTotal: 0, numElectronicResources: 0 }
+      before(() => {
+        component = mountTestRender(
+          <BibPage
+            location={{ search: 'search', pathname: '' }}
+            bib={noItemsNoEr}
+            dispatch={() => { }}
+            resultSelection={{
+              fromUrl: '',
+              bibId: '',
+            }}
+          />,
+          { context, childContextTypes: { router: PropTypes.object }, store: testStore },
+        )
+      })
+      it(' does not render ItemsContainer', () => { expect(component.find('ItemsContainer').length).to.equal(0) });
+    })
+    describe('1 item, no electronic resources does render ItemsContainer', () => {
+
+      const oneItemNoER = { ...bib, numItemsTotal: 1 };
+      before(() => {
+        component = mountTestRender(
+          <BibPage
+            location={{ search: 'search', pathname: '' }}
+            bib={oneItemNoER}
+            dispatch={() => { }}
+            resultSelection={{
+              fromUrl: '',
+              bibId: '',
+            }}
+          />,
+          { context, childContextTypes: { router: PropTypes.object }, store: testStore },
+        )
+      })
+      it(' does render ItemsContainer', () => {
+        expect(component.find('ItemsContainer').length).to.equal(1)
+      })
+    })
+    it('Multi item, electronic resources', () => {
+      const multiItemsYesER = { ...bib, numItemsTotal: 20, numElectronicResources: 30 }
+      before(() => {
+        component = mountTestRender(
+          <BibPage
+            location={{ search: 'search', pathname: '' }}
+            bib={multiItemsYesER}
+            dispatch={() => { }}
+            resultSelection={{
+              fromUrl: '',
+              bibId: '',
+            }}
+          />,
+          { context, childContextTypes: { router: PropTypes.object }, store: testStore },
+        )
+      })
+      it(' does render ItemsContainer', () => { expect(component.find('ItemsContainer').length).to.equal(1); })
+    })
+    describe('Multi item, no electronic resources does render ItemsContainer', () => {
+      const multiItemsNoER = { ...bib, numItemsTotal: 10 }
+      before(() => {
+        component = mountTestRender(
+          <BibPage
+            location={{ search: 'search', pathname: '' }}
+            bib={multiItemsNoER}
+            dispatch={() => { }}
+            resultSelection={{
+              fromUrl: '',
+              bibId: '',
+            }}
+          />,
+          { context, childContextTypes: { router: PropTypes.object }, store: testStore },
+        )
+      })
+      it(' does render ItemsContainer', () => { expect(component.find('ItemsContainer').length).to.equal(1); })
+    })
+  })
 });


### PR DESCRIPTION
What's this do?

ItemsContainer display is dependent on there being only electronic resources and there being physical items
lots of tests for different combinations of electronic resources and numitems
Why are we doing this? (w/ JIRA link if applicable)
items container was not displaying when filters returned no items because display was dependent on numitemsmatched

Do these changes have automated tests?
lots of tests

How should this be QAed?
try to find invalid filter combos - you can try status loaned (a status only used for onsite items) with offsite location, or just play around until something hits.
also, if the logic seems confusing, you can see the readme of the [discovery api](https://github.com/NYPL/discovery-api) which now has documented the meanings of the numitems counts on the api response