### PR TITLE
SCC-3463: Item search focus management

### DIFF
--- a/src/app/components/Item/ItemsContainer.jsx
+++ b/src/app/components/Item/ItemsContainer.jsx
@@ -141,7 +141,6 @@ class ItemsContainer extends React.Component {
             fieldToOptionsMap={fieldToOptionsMap}
             itemsAggregations={itemsAggregations}
             numItemsMatched={numItemsMatched}
-            numOfFilteredItems={itemsToDisplay && itemsToDisplay.length}
             showAll={showAll}
             finishedLoadingItems={finishedLoadingItems}
           />

--- a/src/app/components/ItemFilters/ItemFilters.jsx
+++ b/src/app/components/ItemFilters/ItemFilters.jsx
@@ -12,7 +12,6 @@ import DateSearchBar from './DateSearchBar';
 const ItemFilters = (
   {
     displayDateFilter,
-    numOfFilteredItems,
     numItemsMatched,
     fieldToOptionsMap = {},
     itemsAggregations = [],
@@ -29,7 +28,7 @@ const ItemFilters = (
     format: query.item_format ? query.item_format.split(',') : [],
     status: query.item_status ? query.item_status.split(',') : [],
   };
-  const resultsRef = useRef(null);
+  // const resultsRef = useRef(null);
   const [openFilter, setOpenFilter] = useState('none');
   // The "year" filter is not used for the `ItemFilter` dropdown component
   // and must be handled separately in the `SearchBar` component.
@@ -40,14 +39,7 @@ const ItemFilters = (
   // When new items are fetched, update the selected string display.
   useEffect(() => {
     setSelectedFieldDisplayStr(parsedFilterSelections());
-    // Once the new items are fetched, focus on the filter UI and the
-    // results, but don't do this if the user requested to view all items
-    // until all the items are fetched. It is annoying if the text keeps
-    // getting focused and the page keeps jumping around.
-    if (selectedFieldDisplayStr || finishedLoadingItems) {
-      resultsRef.current && resultsRef.current.focus();
-    }
-  }, [numOfFilteredItems, parsedFilterSelections, finishedLoadingItems, selectedFieldDisplayStr]);
+  }, [parsedFilterSelections]);
 
   /**
    * When filters are applied or cleared, build new filter query
@@ -208,7 +200,7 @@ const ItemFilters = (
           <div></div>
         </div>
       )}
-      <div className="item-filter-info" ref={resultsRef} tabIndex="-1">
+      <div className="item-filter-info" tabIndex="-1" aria-live="polite" aria-atomic={true}>
         <Heading level="three" size="callout">
           <>
             {resultsItemsNumber > 0 ? resultsItemsNumber : 'No'} Result
@@ -242,7 +234,6 @@ ItemFilters.propTypes = {
   fieldToOptionsMap: PropTypes.object,
   itemsAggregations: PropTypes.array,
   numItemsMatched: PropTypes.number,
-  numOfFilteredItems: PropTypes.number,
   showAll: PropTypes.bool,
   finishedLoadingItems: PropTypes.bool,
 };

--- a/src/app/pages/BibPage.jsx
+++ b/src/app/pages/BibPage.jsx
@@ -49,7 +49,7 @@ export const BibPage = (
   const showAll = hash === '#view-all-items';
 
   // Fetch more items only when the patron wants to view all items.
-  useViewAllItems(bib, dispatch, updateBibPage, numItemsMatched, showAll);
+  useViewAllItems(bib, dispatch, numItemsMatched, showAll, updateBibPage);
 
   if (!bib || parseInt(bib.status, 10) === 404) {
     return <BibNotFound404 context={context} />;


### PR DESCRIPTION
**What's this do?**
This resolves [SCC-3463](https://jira.nypl.org/browse/SCC-3463).

This updates how the ref is used to focus on the results text DOM element that gets updated after filtering, searching, or when the "View All Items" button is clicked. It now has the id `view-all-items` so that the page jumps to the top once "view all items" is clicked.

The ref is then used to focus on the element so it is read by screenreaders.

**Why are we doing this? (w/ JIRA link if applicable)**
[Quick blurb about why the code is needed and Jira link/ Do these changes meet the business requirements of the story?]

**Do these changes have automated tests?**
[Brief description of new automated tests]

**How should this be QAed?**
[Description of any tests that need to be performed once merged]

**Dependencies for merging? Releasing to production?**
[Description of any watchouts, dependencies, or issues we should be aware of]

**Has the application documentation been updated for these changes?**

**Did someone actually run this code to verify it works?**
