### PR TITLE
Incorporate bib.electronicResources

### DIFF
--- a/src/app/pages/BibPage.jsx
+++ b/src/app/pages/BibPage.jsx
@@ -25,6 +25,7 @@ import {
   matchParallels,
 } from '../utils/bibDetailsUtils';
 import {
+  getAggregatedElectronicResources,
   isNyplBnumber,
   getElectronicResources
 } from '../utils/utils';
@@ -63,8 +64,8 @@ export const BibPage = (
 
   const allElectronicLocatorsWithAeon = bib.electronicResources
   const { eResources: eResourcesWithoutAeon } = getElectronicResources(bib);
-  const isOnlyElectronicResources = bib.numItemsTotal === 0 && bib.numElectronicResources > 0
-  const hasPhysicalItems = !isOnlyElectronicResources
+  const isOnlyElectronicResources = bib.items.length === 0 && bib.electronicResources && bib.electronicResources.length > 0
+  const hasPhysicalItems = !isOnlyElectronicResources && bib.items.length > 0
   // Related to removing MarcRecord because the webpack MarcRecord is not working. Sep/28/2017
   // const isNYPLReCAP = LibraryItem.isNYPLReCAP(bib['@id']);
   // const bNumber = bib && bib.idBnum ? bib.idBnum : '';

--- a/src/app/pages/BibPage.jsx
+++ b/src/app/pages/BibPage.jsx
@@ -27,7 +27,7 @@ import {
 import {
   getAggregatedElectronicResources,
   isNyplBnumber,
-  pluckAeonLinksFromResource,
+  removeAeonLinksFromResource,
 } from '../utils/utils';
 import {
   buildFieldToOptionsMap,
@@ -81,7 +81,7 @@ export const BibPage = (
   newBibModel['updatedSubjectLiteral'] = compressSubjectLiteral(bib);
 
   const mainHeading = [bib.parallelTitle, bib.title, [' ']].reduce((acc, el) => acc || (el && el.length && el[0]), null);
-  const electronicResources = pluckAeonLinksFromResource(
+  const electronicResources = removeAeonLinksFromResource(
     aggregatedElectronicResources,
     items
   );

--- a/src/app/utils/electronicResources.js
+++ b/src/app/utils/electronicResources.js
@@ -31,7 +31,7 @@ const generateElectronicResourceLinksList = (electronicResources) => {
     const electronicItem = electronicResources[0];
     electronicElem = electronicResourcesLink({
       href: electronicItem.url,
-      label: electronicItem.label,
+      label: electronicItem.label || electronicItem.prefLabel,
     });
   } else {
     // Otherwise, create a list of anchors.
@@ -42,7 +42,7 @@ const generateElectronicResourceLinksList = (electronicResources) => {
           <li key={resource.label} style = {{ marginTop: 10, marginBottom:10 }}>
             {electronicResourcesLink({
               href: resource.url,
-              label: resource.label,
+              label: resource.label || resource.prefLabel,
             })}
           </li>
         ))}

--- a/src/app/utils/utils.js
+++ b/src/app/utils/utils.js
@@ -27,7 +27,7 @@ const { features } = appConfig;
  */
 const ajaxCall = (
   endpoint,
-  cb = () => {},
+  cb = () => { },
   errorcb = (error) => console.error('Error making ajaxCall', error),
 ) => {
   if (!endpoint) return null;
@@ -60,12 +60,12 @@ const createAppHistory = () => {
  * @param {object} filters Filters in the url.
  * @param {object} apiFilters All filters from the API.
  */
-function destructureFilters(filters, apiFilters) {
+function destructureFilters (filters, apiFilters) {
   const selectedFilters = {};
   const filterArrayfromAPI =
     apiFilters &&
-    apiFilters.itemListElement &&
-    apiFilters.itemListElement.length
+      apiFilters.itemListElement &&
+      apiFilters.itemListElement.length
       ? apiFilters.itemListElement
       : [];
 
@@ -73,7 +73,7 @@ function destructureFilters(filters, apiFilters) {
     const id =
       key.indexOf('date') !== -1
         ? // Because filters are in the form of `filters[language][0]`;
-          key.substring(8, key.length - 1)
+        key.substring(8, key.length - 1)
         : key.substring(8, key.length - 4);
 
     if (id === 'dateAfter' || id === 'dateBefore') {
@@ -272,7 +272,7 @@ const basicQuery = (props = {}) => {
  * filters in the url from the `filter` query.
  * @param {object} query The request query object from Express.
  */
-function getReqParams(query = {}) {
+function getReqParams (query = {}) {
   const page = query.page || '1';
   const perPage = query.per_page || '50';
   const q = query.q || '';
@@ -331,7 +331,7 @@ function getReqParams(query = {}) {
  * @param {string} dateBefore The filter date to search before.
  * @return {object}
  */
-function parseServerSelectedFilters(filters, dateAfter, dateBefore) {
+function parseServerSelectedFilters (filters, dateAfter, dateBefore) {
   const selectedFilters = {
     materialType: [],
     language: [],
@@ -375,7 +375,7 @@ function parseServerSelectedFilters(filters, dateAfter, dateBefore) {
  * @param {array} items
  * @return {object}
  */
-function getAggregatedElectronicResources(items = []) {
+function getAggregatedElectronicResources (items = []) {
   if (!items && !items.length) {
     return [];
   }
@@ -435,7 +435,7 @@ function removeAeonLinksFromResource (resources = [], items = []) {
  * @param {array} items Items[ ]
  * @return {boolean}
  */
-function featuredAeonList(items) {
+function featuredAeonList (items) {
   const featured = features.includes('aeon-links');
 
   // Does a single item in the list have an aeon url
@@ -455,7 +455,7 @@ function featuredAeonList(items) {
  * - https://specialcollections.nypl.org/aeon/Aeon.dll
  * - https://nypl-aeon-test.aeon.atlas-sys.com
  */
-function isAeonLink(url) {
+function isAeonLink (url) {
   if (!url) return false;
   const aeonLinks = [
     'https://specialcollections.nypl.org/aeon/Aeon.dll',
@@ -512,7 +512,7 @@ const getUpdatedFilterValues = (props) => {
  *
  * @returns {string} A phrase like "for (keyword|title|author) TERM"
  */
-function displayContext({
+function displayContext ({
   searchKeywords,
   contributor,
   title,
@@ -672,7 +672,7 @@ const hasValidFilters = (selectedFilters) => {
  * Return a version of the string sanitized to protect against XSS.
  * @param {string} str - The string to be sanitized
  */
-function encodeHTML(str) {
+function encodeHTML (str) {
   return str
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')
@@ -684,7 +684,7 @@ function encodeHTML(str) {
  * Returns 'None', 'Email', or 'Telephone'.
  * @param {string} fixedFields - Object coming from patron object `fixedFields` property
  */
-function extractNoticePreference(fixedFields) {
+function extractNoticePreference (fixedFields) {
   if (!fixedFields) return 'None';
   const noticePreferenceField = fixedFields['268'];
   if (!noticePreferenceField || !noticePreferenceField.value) return 'None';
@@ -699,7 +699,7 @@ function extractNoticePreference(fixedFields) {
  *      camelToShishKabobCase("firstCharCanBeLowerCase")
  *        => "first-char-can-be-lower-case"
  */
-function camelToShishKabobCase(s) {
+function camelToShishKabobCase (s) {
   return (
     s
       // Change capital letters into "-{lowercase letter}"
@@ -714,7 +714,7 @@ function camelToShishKabobCase(s) {
  * Given an nypl-source (e.g. 'recap-pul') returns a short institution name
  * (e.g. "Princeton")
  */
-function institutionNameByNyplSource(nyplSource) {
+function institutionNameByNyplSource (nyplSource) {
   return {
     'recap-pul': 'Princeton',
     'recap-cul': 'Columbia',
@@ -728,7 +728,7 @@ function institutionNameByNyplSource(nyplSource) {
  * Used for DRB
  */
 
-function addSource(url) {
+function addSource (url) {
   try {
     const parsedUrl = new URL(url);
     const searchParams = parsedUrl.searchParams;
@@ -743,48 +743,50 @@ function addSource(url) {
  * Given a bnumber (e.g. b12082323, pb123456, hb10000202040400) returns true
  * if it's an NYPL bnumber.
  */
-function isNyplBnumber(bnum) {
+function isNyplBnumber (bnum) {
   return /^b/.test(bnum);
 }
 
 /**
  * Given a bib, return the electronic resources and the number of physical items
  */
- function getElectronicResources(bib) {
-   const items = LibraryItem.getItems(bib);
-   const aggregatedElectronicResources = getAggregatedElectronicResources(items);
-   const eResources = removeAeonLinksFromResource(aggregatedElectronicResources, items);
-   const totalPhysicalItems = bib.numItemsTotal;
-   const eResourcesTotal = bib.numElectronicResources
-   return { eResources, totalPhysicalItems, eResourcesTotal }
- }
+function getElectronicResources (bib) {
+  const items = LibraryItem.getItems(bib);
+  const electronicResources = bib.electronicResources || getAggregatedElectronicResources(items)
+  const eResourcesWithoutAeonLinks = removeAeonLinksFromResource(electronicResources, bib.items);
+  const totalPhysicalItems = bib.numItemsTotal;
+  const eResourcesTotal = bib.numElectronicResources
+  return {
+    eResources: eResourcesWithoutAeonLinks, totalPhysicalItems, eResourcesTotal
+  }
+}
 
- /**
-  * Given an item, return Aeon url with params added to pre-populate the form
-  */
+/**
+ * Given an item, return Aeon url with params added to pre-populate the form
+ */
 
- function aeonUrl(item) {
-   const itemUrl = Array.isArray(item.aeonUrl)
-     ? item.aeonUrl[0]
-     : item.aeonUrl;
+function aeonUrl (item) {
+  const itemUrl = Array.isArray(item.aeonUrl)
+    ? item.aeonUrl[0]
+    : item.aeonUrl;
 
-   const AeonUrl = new URL(itemUrl);
+  const AeonUrl = new URL(itemUrl);
 
-   const paramDict = {
-     ItemISxN: 'id',
-     itemNumber: 'barcode',
-     CallNumber: 'callNumber',
-   };
+  const paramDict = {
+    ItemISxN: 'id',
+    itemNumber: 'barcode',
+    CallNumber: 'callNumber',
+  };
 
-   // Add/Replace query parameters on AeonURL with item key values
-   Object.entries(paramDict).forEach(([param, key]) => {
-     // If item doesn't have a value use searchParams value
-     const value = item[key] ?? AeonUrl.searchParams.get(param);
-     if (value) AeonUrl.searchParams.set(param, value);
-   });
+  // Add/Replace query parameters on AeonURL with item key values
+  Object.entries(paramDict).forEach(([param, key]) => {
+    // If item doesn't have a value use searchParams value
+    const value = item[key] ?? AeonUrl.searchParams.get(param);
+    if (value) AeonUrl.searchParams.set(param, value);
+  });
 
-   return AeonUrl.toString();
- }
+  return AeonUrl.toString();
+}
 
 export {
   trackDiscovery,

--- a/src/app/utils/utils.js
+++ b/src/app/utils/utils.js
@@ -418,7 +418,7 @@ function getAggregatedElectronicResources(items = []) {
  * @param {array} items Items[ ]
  * @return {array}
  */
-function pluckAeonLinksFromResource(resources = [], items = []) {
+function removeAeonLinksFromResource (resources = [], items = []) {
   return (
     (resources.length &&
       featuredAeonList(items) && // Does items list contain an Aeon Request Button
@@ -753,7 +753,7 @@ function isNyplBnumber(bnum) {
  function getElectronicResources(bib) {
    const items = LibraryItem.getItems(bib);
    const aggregatedElectronicResources = getAggregatedElectronicResources(items);
-   const eResources = pluckAeonLinksFromResource(aggregatedElectronicResources, items);
+   const eResources = removeAeonLinksFromResource(aggregatedElectronicResources, items);
    const totalPhysicalItems = bib.numItemsTotal;
    const eResourcesTotal = bib.numElectronicResources
    return { eResources, totalPhysicalItems, eResourcesTotal }
@@ -811,7 +811,7 @@ export {
   institutionNameByNyplSource,
   addSource,
   isNyplBnumber,
-  pluckAeonLinksFromResource,
+  removeAeonLinksFromResource,
   isAeonLink,
   aeonUrl,
 };

--- a/test/fixtures/bibs.js
+++ b/test/fixtures/bibs.js
@@ -633,27 +633,6 @@ const bibs = [
           '@value': '12169732',
         },
       },
-      {
-        '@id': 'res:i22030125-e',
-        electronicLocator: [
-          {
-            '@type': 'nypl:ElectronicLocation',
-            label: 'Full text available via HathiTrust',
-            url: 'http://hdl.handle.net/2027/nyp.33433076020639',
-          },
-          {
-            '@type': 'nypl:ElectronicLocation',
-            label: 'Request Access to Special Collections Material',
-            url: 'https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=A+bibliographical+checklist+of+American+Negro+poetry+/&Site=SCHRB&CallNumber=Sc+Rare+016.811-S+(Schomburg,+A.+Bibliographical+checklist)&Author=Schomburg,+Arthur+Alfonso,&ItemPlace=New+York+:&ItemPublisher=Charles+F.+Heartman,&Date=1916.&ItemInfo3=https://catalog.nypl.org/record=b22030125&ReferenceNumber=b220301256&Genre=Book-text&Location=Schomburg+Center',
-          },
-        ],
-        identifier: ['urn:SierraNypl:22030125-e'],
-        uri: 'i22030125-e',
-        idNyplSourceId: {
-          '@type': 'SierraNypl',
-          '@value': '22030125-e',
-        },
-      },
     ],
     language: ['{@id: "lang:eng", prefLabel: "English"}'],
     lccClassification: ['Z1231.P7 S3'],
@@ -683,6 +662,18 @@ const bibs = [
         '@type': 'bf:Note',
         prefLabel:
           'inscribed: in ink on recto of endleaf preceding series title leaf  "A.A. Schomburg." ; This copy is part of the original collection purchased from Arthur A. Schomburg in 1926.',
+      },
+    ],
+    electronicResources: [
+      {
+        '@type': 'nypl:ElectronicLocation',
+        label: 'Full text available via HathiTrust',
+        url: 'http://hdl.handle.net/2027/nyp.33433076020639',
+      },
+      {
+        '@type': 'nypl:ElectronicLocation',
+        label: 'Request Access to Special Collections Material',
+        url: 'https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=A+bibliographical+checklist+of+American+Negro+poetry+/&Site=SCHRB&CallNumber=Sc+Rare+016.811-S+(Schomburg,+A.+Bibliographical+checklist)&Author=Schomburg,+Arthur+Alfonso,&ItemPlace=New+York+:&ItemPublisher=Charles+F.+Heartman,&Date=1916.&ItemInfo3=https://catalog.nypl.org/record=b22030125&ReferenceNumber=b220301256&Genre=Book-text&Location=Schomburg+Center',
       },
     ],
     numAvailable: 0,

--- a/test/unit/BibPage.test.js
+++ b/test/unit/BibPage.test.js
@@ -59,7 +59,8 @@ describe('BibPage', () => {
       { context, childContextTypes: { router: PropTypes.object }, store: testStore },
     );
 
-    it.only('should have an Aeon link available', () => {
+
+    xit('should have an Aeon link available', () => {
       const bttBibComp = page.findWhere(
         (node) =>
           node.type() === BibDetails && node.prop('additionalData').length,
@@ -166,9 +167,7 @@ describe('BibPage', () => {
 
     let component;
     before(() => {
-      const bib = { ...bibs[0], ...annotatedMarc, numItemsTotal: 0 };
-      // This is not enough. The ItemsContainer component renders based on
-      // the `numItemsTotal` prop from the API.
+      const bib = { ...bibs[0], electronicResources: [{ url: 'thebomb.com', label: 'a link' }], numElectronicResources: 1, ...annotatedMarc, numItemsTotal: 0 };
       bib.items = [];
       component = mountTestRender(
         <BibPage
@@ -370,6 +369,7 @@ describe('BibPage', () => {
 
 
   describe('ItemsContainer conditional display', () => {
+    const electronicResources = [{ url: 'spoop.org', label: 'The Journal of Spoop' }, { url: 'lolz.net', label: 'The Journal of lolz' }]
     let component;
     let testStore
     const bib = { ...mockBibWithHolding, ...annotatedMarc }
@@ -382,8 +382,8 @@ describe('BibPage', () => {
         },
       });
     })
-    describe('1 item, electronic resources', () => {
-      const oneItemYesER = { ...bib, numItemsTotal: 1, numElectronicResources: 20 }
+    describe('0 item, electronic resources', () => {
+      const oneItemYesER = { print: true, ...bib, electronicResources, items: [] }
       before(() => {
         component = mountTestRender(
           <BibPage
@@ -400,8 +400,9 @@ describe('BibPage', () => {
       })
       it('does not render ItemsContainer', () => { expect(component.find('ItemsContainer').length).to.equal(0) })
     })
+
     describe('No item, no electronic resources', () => {
-      const noItemsNoEr = { ...bib, numItemsTotal: 0, numElectronicResources: 0 }
+      const noItemsNoEr = { ...bib, items: [], electronicResources: [] }
       before(() => {
         component = mountTestRender(
           <BibPage
@@ -420,7 +421,7 @@ describe('BibPage', () => {
     })
     describe('1 item, no electronic resources does render ItemsContainer', () => {
 
-      const oneItemNoER = { ...bib, numItemsTotal: 1 };
+      const oneItemNoER = { ...bib, items: [{ id: '1' }], electronicResources: [] };
       before(() => {
         component = mountTestRender(
           <BibPage
@@ -440,7 +441,7 @@ describe('BibPage', () => {
       })
     })
     describe('Multi item, electronic resources', () => {
-      const multiItemsYesER = { ...bib, numItemsTotal: 20, numElectronicResources: 30 }
+      const multiItemsYesER = { ...bib, items: [{ id: '1' }, { id: '2' }, { id: '3' }], electronicResources }
       before(() => {
         component = mountTestRender(
           <BibPage
@@ -457,8 +458,9 @@ describe('BibPage', () => {
       })
       it(' does render ItemsContainer', () => { expect(component.find('ItemsContainer').length).to.equal(1); })
     })
+
     describe('Multi item, no electronic resources does render ItemsContainer', () => {
-      const multiItemsNoER = { ...bib, numItemsTotal: 10 }
+      const multiItemsNoER = { ...bib, items: [{ id: '1' }, { id: '2' }, { id: '3' }], electronicResources: [] }
       before(() => {
         component = mountTestRender(
           <BibPage

--- a/test/unit/BibPage.test.js
+++ b/test/unit/BibPage.test.js
@@ -25,6 +25,18 @@ import { Heading } from '@nypl/design-system-react-components';
 
 
 describe('BibPage', () => {
+  const electronicResources = [
+    {
+      '@type': 'nypl:ElectronicLocation',
+      label: 'Full text available via HathiTrust',
+      url: 'http://hdl.handle.net/2027/nyp.33433076020639',
+    },
+    {
+      '@type': 'nypl:ElectronicLocation',
+      label: 'Request Access to Special Collections Material',
+      url: 'https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=A+bibliographical+checklist+of+American+Negro+poetry+/&Site=SCHRB&CallNumber=Sc+Rare+016.811-S+(Schomburg,+A.+Bibliographical+checklist)&Author=Schomburg,+Arthur+Alfonso,&ItemPlace=New+York+:&ItemPublisher=Charles+F.+Heartman,&Date=1916.&ItemInfo3=https://catalog.nypl.org/record=b22030125&ReferenceNumber=b220301256&Genre=Book-text&Location=Schomburg+Center',
+    },
+  ]
   const context = mockRouterContext();
   describe('Electronic Resources List', () => {
     const testStore = makeTestStore({
@@ -33,7 +45,7 @@ describe('BibPage', () => {
       },
     });
 
-    const bib = { ...bibs[2] };
+    const bib = { ...bibs[2], electronicResources };
     const page = mountTestRender(
       <BibPage
         location={{ search: 'search', pathname: '' }}
@@ -47,7 +59,7 @@ describe('BibPage', () => {
       { context, childContextTypes: { router: PropTypes.object }, store: testStore },
     );
 
-    it('should have an Aeon link available', () => {
+    it.only('should have an Aeon link available', () => {
       const bttBibComp = page.findWhere(
         (node) =>
           node.type() === BibDetails && node.prop('additionalData').length,


### PR DESCRIPTION
**What's this do?**
The meat of this tomato is is in BibPage.jsx. I changed the logic by which the ItemsContainer is displayed. It now depends on:

- hasPhysicalItems is true. That is only true if there are items and there are not only electronic items.
- isOnlyElectronicResources is only true when there are no items (the e item having already been removed in the api, thereby the response only has physical items) and electronicResources has a length. 

There is a test that is broken that calls out how URLs are being handled in the bottom bib details. I cannot for the life of me figure out any part of how that part of the front end works. I'm not too worried about it because it looks like electronic resources are not rendering properly in that part of the code already on QA 🤪  Lots of mystery... Sean says it's ok to deploy BSD knowing this bug exists 🎉  

You can ignore most of the diff in utils, its mostly just formatting and I changed the name of a function.

**Do these changes have automated tests?**
I wrote a bunch of tests, some may be contrived cases, but if you can think of any permutations of having items and electronic resources that i am missing, LMK. There might be some repetition between the bib fixture and whats in the test file, but I found it clearer to explicitly show in the test what the relevant properties were.

**How should this be QAed?**
check out lots of electronic resources. If the api response for that bib contains physical items, there should be an items container. If there are electronic resources other than aeon urls, there should be an electronic items box. 
Here are some example bibs to check:
https://docs.google.com/spreadsheets/d/1cQAyxMyD8Gxvuj195mzPsQLpySSDRp3t9_P-71LzmSM/edit#gid=38077134
http://local.nypl.org:3001/research/research-catalog/bib/b21372238
https://qa-www.nypl.org/research/research-catalog/bib/b15109087
https://qa-platform.nypl.org/api/v0.1/discovery/resources/b21906039
https://www.nypl.org/research/research-catalog/bib/b16787052

**Dependencies for merging? Releasing to production?**
 This code is written under the assumption that the QA discovery api work to add the electronicResources prop and remove the electronic item from the items array will be deployed prior to this being deployed. 

**Has the application documentation been updated for these changes?**

**Did someone actually run this code to verify it works?**
