### PR TITLE
e resources hotfix

### DIFF
--- a/src/app/pages/BibPage.jsx
+++ b/src/app/pages/BibPage.jsx
@@ -100,7 +100,7 @@ export const BibPage = (
   const isElectronicResources = items.every(
     (item) => item.isElectronicResource,
   );
-  const aggregatedElectronicResources = getAggregatedElectronicResources(items);
+  const aggregatedElectronicResources = bib.electronicResources || getAggregatedElectronicResources(items);
 
   // Related to removing MarcRecord because the webpack MarcRecord is not working. Sep/28/2017
   // const isNYPLReCAP = LibraryItem.isNYPLReCAP(bib['@id']);

--- a/src/app/pages/BibPage.jsx
+++ b/src/app/pages/BibPage.jsx
@@ -94,12 +94,12 @@ export const BibPage = (
     // NOTE: I'm not entirely sure what this is doing yet, but I believe it should be
     // done in an effect.
   }
-
   const bibId = bib['@id'] ? bib['@id'].substring(4) : '';
   const items = (bib.checkInItems || []).concat(LibraryItem.getItems(bib));
   const isElectronicResources = items.every(
     (item) => item.isElectronicResource,
   );
+
   const aggregatedElectronicResources = bib.electronicResources || getAggregatedElectronicResources(items);
 
   // Related to removing MarcRecord because the webpack MarcRecord is not working. Sep/28/2017

--- a/src/app/utils/electronicResources.js
+++ b/src/app/utils/electronicResources.js
@@ -8,7 +8,7 @@ import { Link } from '@nypl/design-system-react-components'
  */
 const generateElectronicResourceLinksList = (electronicResources) => {
   if (!electronicResources) return null
-  const electronicResourcesLink = ({ href, label }) => (
+  const electronicResourcesLink = ({ href, label, prefLabel }) => (
     <Link
       href={href}
       target='_blank'
@@ -20,7 +20,7 @@ const generateElectronicResourceLinksList = (electronicResources) => {
       }
       rel='noreferrer'
     >
-      {label || href}
+      {label || prefLabel || href}
     </Link>
   );
   let electronicElem;
@@ -42,7 +42,7 @@ const generateElectronicResourceLinksList = (electronicResources) => {
           <li key={resource.label} style = {{ marginTop: 10, marginBottom:10 }}>
             {electronicResourcesLink({
               href: resource.url,
-              label: resource.label,
+              label: resource.label || resource.prefLabel,
             })}
           </li>
         ))}

--- a/src/app/utils/utils.js
+++ b/src/app/utils/utils.js
@@ -764,7 +764,7 @@ function isNyplBnumber(bnum) {
  */
  function getElectronicResources(bib) {
    const items = (bib.checkInItems || []).concat(LibraryItem.getItems(bib));
-   const aggregatedElectronicResources = getAggregatedElectronicResources(items);
+   const aggregatedElectronicResources = bib.electronicResources || getAggregatedElectronicResources(items);
    const eResources = pluckAeonLinksFromResource(aggregatedElectronicResources, items);
    const totalPhysicalItems = items.filter(item => !item.isElectronicResource).length;
    return { eResources, totalPhysicalItems }


### PR DESCRIPTION
**What's this do?**
Incorporate minor changes to utilize new electronicResources bib property.

**Do these changes have automated tests?**
No tests add or changed.

here are some sample electronic resources with different permutations of special collections, physical, and electronic resources: 
http://local.nypl.org:3001/research/research-catalog/bib/b21372238
https://qa-www.nypl.org/research/research-catalog/bib/b15109087
https://qa-platform.nypl.org/api/v0.1/discovery/resources/b21906039
https://www.nypl.org/research/research-catalog/bib/b16787052

These should be checked on the bib page and search results