### PR TITLE
Scc 3494/fix annotated marc

### DIFF
--- a/src/server/ApiRoutes/Bib.js
+++ b/src/server/ApiRoutes/Bib.js
@@ -35,7 +35,7 @@ const shepApiCall = (bibId) => {
   }, 5000)
   return axios({
     method: 'get',
-    url: `${appConfig.shepApi} / bibs / ${bibId} / subject_headings`,
+    url: `${appConfig.shepApi}/bibs/${bibId}/subject_headings`,
     timeout: 4000,
     cancelToken: source.token
   }).then((response) => {
@@ -71,7 +71,7 @@ export const findUrl = (location, urls) => {
 };
 
 export const fetchLocationUrls = codes => nyplApiClient()
-  .then(client => client.get(`/ locations ? location_codes = ${codes}`));
+  .then(client => client.get(`/locations?location_codes=${codes}`));
 
 const addLocationUrls = (bib) => {
   const { holdings } = bib;
@@ -144,10 +144,10 @@ function fetchBib (bibId, cb, errorcb, reqOptions, res) {
       const status = (!bib || !bib.uri || !bibId.includes(bib.uri)) ? '404' : '200';
       if (status === '404') {
         return nyplApiClient()
-          .then(client => client.get(`/ bibs / sierra - nypl / ${bibId.slice(1)}`))
+          .then(client => client.get(`/bibs/sierra-nypl/${bibId.slice(1)}`))
           .then((resp) => {
             const classic = appConfig.legacyBaseUrl;
-            if (resp.statusCode === 200) { res.redirect(`${appConfig.circulatingCatalog} / iii / encore / record / C__R${bibId}`); }
+            if (resp.statusCode === 200) { res.redirect(`${appConfig.circulatingCatalog}/iii/encore/record/C__R${bibId}`); }
           })
           .catch((err) => {
             console.log('error: ', err);

--- a/src/server/ApiRoutes/Bib.js
+++ b/src/server/ApiRoutes/Bib.js
@@ -19,7 +19,6 @@ const nyplApiClientCall = (query, itemFrom, filterItemsStr = "") => {
     const itemQuery = (filterItemsStr.length ? `&${filterItemsStr}` : '');
     fullQuery = `${query}${queryForItemPage}${itemQuery}&merge_checkin_card_items=true`
   }
-  console.log(query)
   return nyplApiClient()
     .then(client =>
       client.get(

--- a/src/server/ApiRoutes/Bib.js
+++ b/src/server/ApiRoutes/Bib.js
@@ -197,7 +197,7 @@ function bibSearch (req, res, resolve) {
   delete query.items_from;
 
   let filterItemsStr = Object.keys(query)
-    .map((key) => `${key} = ${query[key]}`)
+    .map((key) => `${key}=${query[key]}`)
     .join('&');
 
   return fetchBib(

--- a/test/unit/Bib.test.js
+++ b/test/unit/Bib.test.js
@@ -110,4 +110,25 @@ describe('Bib', () => {
       });
     });
   });
+  describe('nyplApiClientCall', () => {
+    let apiClientStub
+    before(() => {
+      apiClientStub = stub(NyplApiClient.prototype, 'get').returns({ bib: { id: '123' } })
+    });
+    after(() => {
+      apiClientStub.restore();
+    });
+    it('.annotated-marc', () => {
+      const query = 'b12345678.annotated-marc'
+      Bib.nyplApiClientCall(query)
+      expect(apiClientStub.calledWith(`/discovery/resources/${query}`))
+    })
+    it('regular bib call', () => {
+      const query = 'b12345678'
+      const itemFrom = 3
+      const itemFilterStr = 'items_location=loc:123'
+      Bib.nyplApiClientCall(query, itemFrom,)
+      expect(apiClientStub.calledWith(`/discovery/resources/${query}${itemFilterStr}&merge_checkin_card_items=true`))
+    })
+  })
 });


### PR DESCRIPTION
**What's this do?**

- moves the addition of `&merge_checkin_card_items=true` to a later step in the fetch bib process. As it was, that param was being added after the `.annotated-marc` extension, and the request was bypassing the annotated-marc handler in the API. 
- removes obsolete logic around the on-site-edd feature flag, which no longer exists (api is listening for no-onsite-edd to disable). 
- creates basic tests for the nyplApiClientCall function within ApiRoutes/Bib.js

**Why are we doing this? (w/ JIRA link if applicable)**
Annotated marc was not rendering in the front end. 

**How should this be QAed?**
Check that annotated marc details are rendering below the items container, such as Connect To, Additional Authors, Subject, Earliest Publication, Abbreviated Title, etc.
