### PR TITLE
SCC-3379: Removing json object from link's title attribute

### DIFF
--- a/src/app/utils/bibDetailsUtils.jsx
+++ b/src/app/utils/bibDetailsUtils.jsx
@@ -59,7 +59,7 @@ const allFields = {
 const definitionItem = (value, index = 0) => {
   const link = (
     <DSLink>
-      <Link to={value.content} title={JSON.stringify(value.source, null, 2)}>
+      <Link to={value.content} title={value.label}>
         {value.label}
       </Link>
     </DSLink>

--- a/test/unit/bibDetailsUtils.test.js
+++ b/test/unit/bibDetailsUtils.test.js
@@ -38,7 +38,6 @@ describe('bibDetailsUtils', () => {
       const link = dsLink.props.children;
 
       expect(link.props.to).to.equal('ItemContent');
-      expect(link.props.title).to.equal(JSON.stringify(value.source, null, 2));
       expect(link.props.children).to.equal('ItemLabel');
     });
 


### PR DESCRIPTION
**What's this do?**
Resolves [SCC-3379](https://jira.nypl.org/browse/SCC-3379).

Removes a stringified object from an anchor's `title` attribute. I'm not sure why it was there to begin with so it would be good to know if it was intentional and why. Otherwise, it seems unlikely that JSON metadata will benefit a user.

Another concern for keeping it here is that the `title` attribute in an anchor element is read by screenreaders besides the text it contains. The JSON blurb would not make sense. With this change, it still doesn't make sense to keep the `title` attribute since the link's text is the same and it may be redundant. We should get Clare to review this but I'm leaning towards removing the `title` attribute altogether.

Just want to make sure there's a reason to keep it around.
 
<img width="742" alt="Screen Shot 2023-03-17 at 3 16 55 PM" src="https://user-images.githubusercontent.com/1280564/226001196-c7607eae-21d6-4db0-9e50-ae9fa6c8b5e1.png">

**Why are we doing this? (w/ JIRA link if applicable)**
Bug report from user.

**Do these changes have automated tests?**
It had but was removed.

**How should this be QAed?**
The reported URL is `/research/research-catalog/bib/b15408523` but any bib with marc info can be used.

**Dependencies for merging? Releasing to production?**
[Description of any watchouts, dependencies, or issues we should be aware of]

**Has the application documentation been updated for these changes?**

**Did someone actually run this code to verify it works?**
