### PR TITLE
NOREF fix disappearing item table

### DIFF
--- a/src/app/pages/BibPage.jsx
+++ b/src/app/pages/BibPage.jsx
@@ -65,8 +65,17 @@ export const BibPage = (
   const allElectronicLocatorsWithAeon = bib.electronicResources
   const { eResources: eResourcesWithoutAeon } = getElectronicResources(bib);
 
-  const hasItems = (bib.numItemsTotal || bib.numItems) > 0
-  const isOnlyElectronicResources = !hasItems && bib.electronicResources && bib.electronicResources.length > 0
+  const hasElectronicResources = bib.electronicResources && bib.electronicResources.length > 0
+  let numPhysicalItems
+  if (bib.numItemsTotal !== undefined) {
+    numPhysicalItems = bib.numItemsTotal
+  } else if (hasElectronicResources) {
+    numPhysicalItems = bib.numItems - 1
+  } else {
+    numPhysicalItems = bib.numItems
+  }
+  const hasItems = numPhysicalItems > 0
+  const isOnlyElectronicResources = !hasItems && hasElectronicResources
   const hasPhysicalItems = !isOnlyElectronicResources && hasItems
 
   // Related to removing MarcRecord because the webpack MarcRecord is not working. Sep/28/2017

--- a/src/app/pages/BibPage.jsx
+++ b/src/app/pages/BibPage.jsx
@@ -65,8 +65,11 @@ export const BibPage = (
   const allElectronicLocatorsWithAeon = bib.electronicResources
   const { eResources: eResourcesWithoutAeon } = getElectronicResources(bib);
   console.log('bib: ', bib);
-  const isOnlyElectronicResources = (!bib.items || bib.items.length === 0) && bib.electronicResources && bib.electronicResources.length > 0
-  const hasPhysicalItems = !isOnlyElectronicResources && bib.items && bib.items.length > 0
+
+  const hasItems = (bib.numItemsTotal || bib.numItems) > 0
+  const isOnlyElectronicResources = !hasItems && bib.electronicResources && bib.electronicResources.length > 0
+  const hasPhysicalItems = !isOnlyElectronicResources && hasItems
+
   // Related to removing MarcRecord because the webpack MarcRecord is not working. Sep/28/2017
   // const isNYPLReCAP = LibraryItem.isNYPLReCAP(bib['@id']);
   // const bNumber = bib && bib.idBnum ? bib.idBnum : '';

--- a/src/app/pages/BibPage.jsx
+++ b/src/app/pages/BibPage.jsx
@@ -64,7 +64,6 @@ export const BibPage = (
 
   const allElectronicLocatorsWithAeon = bib.electronicResources
   const { eResources: eResourcesWithoutAeon } = getElectronicResources(bib);
-  console.log('bib: ', bib);
 
   const hasItems = (bib.numItemsTotal || bib.numItems) > 0
   const isOnlyElectronicResources = !hasItems && bib.electronicResources && bib.electronicResources.length > 0

--- a/src/app/pages/BibPage.jsx
+++ b/src/app/pages/BibPage.jsx
@@ -67,9 +67,17 @@ export const BibPage = (
 
   const hasElectronicResources = bib.electronicResources && bib.electronicResources.length > 0
   let numPhysicalItems
+  // TODO: This is a temporary fix to handle records that may or may not have
+  // been recently indexed. When the API consistently serves bib.numItemsTotal,
+  // this can be simplified.
+  //
+  // Determine number of physical items:
+  // Newly indexed bibs have .numItemsTotal, which excludes electronic resource items:
   if (bib.numItemsTotal !== undefined) {
     numPhysicalItems = bib.numItemsTotal
   } else if (hasElectronicResources) {
+    // Older bibs do not have .numItemsTotal, so we should use .numItems
+    // Decrement 1 when they have an e-resources item:
     numPhysicalItems = bib.numItems - 1
   } else {
     numPhysicalItems = bib.numItems

--- a/test/unit/BibPage.test.js
+++ b/test/unit/BibPage.test.js
@@ -167,7 +167,7 @@ describe('BibPage', () => {
 
     let component;
     before(() => {
-      const bib = { ...bibs[0], electronicResources: [{ url: 'thebomb.com', label: 'a link' }], numElectronicResources: 1, ...annotatedMarc, numItemsTotal: 0 };
+      const bib = { ...bibs[0], electronicResources: [{ url: 'thebomb.com', label: 'a link' }], numElectronicResources: 1, ...annotatedMarc, numItemsTotal: 0, numItems: 0 };
       bib.items = [];
       component = mountTestRender(
         <BibPage
@@ -383,7 +383,7 @@ describe('BibPage', () => {
       });
     })
     describe('0 item, electronic resources', () => {
-      const oneItemYesER = { print: true, ...bib, electronicResources, items: [] }
+      const oneItemYesER = { print: true, ...bib, electronicResources, items: [], numItems: 0, numItemsTotal: 0 }
       before(() => {
         component = mountTestRender(
           <BibPage

--- a/test/unit/BibPage.test.js
+++ b/test/unit/BibPage.test.js
@@ -402,7 +402,7 @@ describe('BibPage', () => {
     })
 
     describe('No item, no electronic resources', () => {
-      const noItemsNoEr = { ...bib, items: [], electronicResources: [] }
+      const noItemsNoEr = { ...bib, items: [], electronicResources: [], numItems: 0 }
       before(() => {
         component = mountTestRender(
           <BibPage


### PR DESCRIPTION
**What's this do?**
Draft fix to address disappearing item table when item filters produce an empty `.items`
