### PR TITLE
move loading layer to bibpage

### DIFF
--- a/src/app/pages/BibPage.jsx
+++ b/src/app/pages/BibPage.jsx
@@ -36,6 +36,7 @@ import {
 import getOwner from '../utils/getOwner';
 import { useViewAllItems } from '../utils/bibPage';
 import { RouterProvider } from '../context/RouterContext';
+import LoadingLayer from '../components/LoadingLayer/LoadingLayer';
 
 const ItemsContainer = itemsContainerModule.ItemsContainer;
 
@@ -54,6 +55,7 @@ export const BibPage = (
   if (!bib || parseInt(bib.status, 10) === 404) {
     return <BibNotFound404 context={context} />;
   }
+  if (!bib.items) return <LoadingLayer loading={true} />
 
   const bibId = bib['@id'] ? bib['@id'].substring(4) : '';
   const itemsAggregations = bib['itemAggregations'] || [];

--- a/src/app/pages/BibPage.jsx
+++ b/src/app/pages/BibPage.jsx
@@ -55,6 +55,12 @@ export const BibPage = (
   if (!bib || parseInt(bib.status, 10) === 404) {
     return <BibNotFound404 context={context} />;
   }
+  // this is a temporary fix to address a data loader async issue.
+  // !bib.items indicates that the bib in state is undefined, which
+  // should mean that we are still waiting on an api response. 
+  // The loading layer is rendered here as a safeguard 
+  // against accessing undefined bib properties before the api response
+  // has loaded.
   if (!bib.items) return <LoadingLayer loading={true} />
 
   const bibId = bib['@id'] ? bib['@id'].substring(4) : '';


### PR DESCRIPTION
This is an extra fix to address the breaking bug we found when trying to access `bib.items.length`
here's my assessment of what's going wrong (thanks to edwin and diego for helping me with debugging this):

- the loading layer is currently written to render within the SCC container
- it renders when `loading` is true
- `loading` is supposed to be set to true in a `componentDidMount` in the data loader
- bib page is rendering before the data loader is able to dispatch that state change, so:
- `loading` is `false`, bib page renders with no data, and `bib.items` is undefined

I added the loading layer rendering to happen as early as possible in the bib page, using the absence of a `bib.items` to indicate that the data is still loading. This should prevent a similar breaking error from occurring, but does not address the deeper issue wherein `loading` needs to be set to `true` earlier in the dataLoader workflow. 