### PR TITLE
SCC-3369 - Details Misaligned

### DIFF
--- a/src/client/styles/style-v2.scss
+++ b/src/client/styles/style-v2.scss
@@ -27,13 +27,9 @@
     font-size: 0.95rem;
     padding-left: 0;
 
-    &::after,
-    &::before {
-      content: "";
-      display: table;
-    }
-    &::after {
-      clear: both;
+    @include media($nypl-breakpoint-medium) {
+      display: grid;
+      grid-template-columns: 20% auto;
     }
 
     dt {
@@ -47,9 +43,8 @@
       clear: both;
       
       @include media($nypl-breakpoint-medium) {
-        float: left;
-        width: 20%;
         margin-bottom: 1rem;
+        padding-right: .75em;
       }
     }
 


### PR DESCRIPTION
**What's this do?**
This PR adjusts the styling of the Bib Details to prevent detail text from floating under the heading.

**Why are we doing this? (w/ JIRA link if applicable)**
This change was requested in this ticket: https://jira.nypl.org/browse/SCC-3369

**Do these changes have automated tests?**
We currently don't have regression tests for styling adjustments

**How should this be QAed?**
QA should verify that the text no longer floats under the heading and that the details styling is unaffected on mobile.

**Dependencies for merging? Releasing to production?**
This PR is based on SCC-3281/serial-date-filter and should be merged in to that branch.

**Has the application documentation been updated for these changes?**
 Not necessary.

**Did someone actually run this code to verify it works?**
 So far only myself.
