### PR TITLE
SCC-3517: Removing DS resource.scss file

### DIFF
--- a/src/client/styles/main.scss
+++ b/src/client/styles/main.scss
@@ -1,8 +1,6 @@
 /* Import style rules from NYPL Design System */
 // This imports system-font styles and DatePicker styles.
 @import '~@nypl/design-system-react-components/dist/styles.css';
-// This imports DS breakpoints and mixins.
-@import '~@nypl/design-system-react-components/dist/resources.scss';
 
 /*
 App-specific utilities and defaults
@@ -18,9 +16,7 @@ Import style rules from NYPL React module components
 */
 @import "~@nypl/dgx-header-component/dist/styles/main";
 @import "~@nypl/dgx-react-footer/dist/styles/styles";
-
 @import "components/**/*.scss";
-
 @import "style-v2.scss";
 
 // From older DS version

--- a/src/client/styles/utils/mixins.scss
+++ b/src/client/styles/utils/mixins.scss
@@ -70,3 +70,20 @@
     }
   }
 }
+
+
+// TODO: remove after a DS update.
+// Mixin - Wrapper
+// Outer container mixin for large screens
+@mixin wrapper(
+  $container-max-width: $max-width,
+  $outer-container-break: $nypl-breakpoint-small,
+  $v-margin: 0,
+  $v-padding: 0,
+  $h-padding: var(--nypl-space-s)
+) {
+  margin: #{$v-margin} auto;
+  max-width: #{$container-max-width};
+  padding: #{$v-padding} #{$h-padding};
+  width: 100%;
+}

--- a/src/client/styles/utils/variables.scss
+++ b/src/client/styles/utils/variables.scss
@@ -1,9 +1,10 @@
 // Reservoir DS breakpoint note. There are four SCSS variables for
 // breakpoint values imported from the DS `resources.scss` file:
-//  $nypl-breakpoint-small: 320px;
-//  $nypl-breakpoint-medium: 600px;
-//  $nypl-breakpoint-large: 960px;
-//  $nypl-breakpoint-xl: 1280px;
+$nypl-breakpoint-small: 320px;
+$nypl-breakpoint-medium: 600px;
+$nypl-breakpoint-large: 960px;
+$nypl-breakpoint-xl: 1280px;
+$nypl-max-width: $nypl-breakpoint-xl;
 
 $basefontraw: 16;
 $max-width-raw: 1315;


### PR DESCRIPTION
**What's this do?**
Resolves [SCC-3517](https://jira.nypl.org/browse/SCC-3517). Removes the DS' `resource.scss` file and moves needed CSS variables and mixin into the DFE codebase.

**Why are we doing this? (w/ JIRA link if applicable)**
The file is a remnant of an older scss file pattern and the DS will remove it in the future. DFE can remove it now before it gets removed from the DS and cause issues.

**Do these changes have automated tests?**
N/A

**How should this be QAed?**
All pages should display as expected.

**Dependencies for merging? Releasing to production?**
[Description of any watchouts, dependencies, or issues we should be aware of]

**Has the application documentation been updated for these changes?**

**Did someone actually run this code to verify it works?**
