### PR TITLE
SCC-3233 - Strip check digit from bibId if present in URL

### DIFF
--- a/src/app/components/Item/ItemsDefinitionLists.jsx
+++ b/src/app/components/Item/ItemsDefinitionLists.jsx
@@ -7,8 +7,7 @@ const ItemsDefinitionLists = ({ items, holdings, bibId, id, searchKeywords, page
 
   if (
     !_isArray(items) ||
-    !items.length ||
-    items.every(item => item.isElectronicResource)
+    !items.length
   ) {
     return null;
   }
@@ -18,47 +17,43 @@ const ItemsDefinitionLists = ({ items, holdings, bibId, id, searchKeywords, page
       {
         items.map(item => {
 
-            if (_isEmpty(item)) {
-              return null;
-            }
+          if (_isEmpty(item)) {
+            return null;
+          }
 
-            if (item.isElectronicResource) {
-              return null;
-            }
+          let itemLocation;
+          if (item.location && item.locationUrl) {
+            itemLocation = (
+              <a href={item.locationUrl} className="itemLocationLink">{item.location}</a>
+            );
+          } else if (item.location) {
+            itemLocation = item.location;
+          } else {
+            itemLocation = ' ';
+          }
 
-            let itemLocation;
-            if (item.location && item.locationUrl) {
-              itemLocation = (
-                <a href={item.locationUrl} className="itemLocationLink">{item.location}</a>
-              );
-            } else if (item.location) {
-              itemLocation = item.location;
-            } else {
-              itemLocation = ' ';
-            }
-
-            return (
-              <div key={`item-${item.id}-div`} id={`item-${item.id}-div`} className="results-items-element">
-                <dl key={`item-${item.id}-dl`} id={`item-${item.id}-dl`}>
-                  <dt key={`item-${item.id}-format-dt`} id={`item-${item.id}-format-dt`}>Format</dt>
-                  <dd key={`item-${item.id}-format-dd`} id={`item-${item.id}-format-dd`}>{item.format || ' '}</dd>
-                  <dt key={`item-${item.id}-callnumber-dt`} id={`item-${item.id}-callnumber-dt`}>Call Number</dt>
-                  <dd key={`item-${item.id}-callnumber-dd`} id={`item-${item.id}-callnumber-dd`}>{item.callNumber || ' '}</dd>
-                  <dt key={`item-${item.id}-location-dt`} id={`item-${item.id}-location-dt`}>Item Location</dt>
-                  <dd key={`item-${item.id}-location-dd`} id={`item-${item.id}-location-dd`}>{itemLocation}</dd>
-                </dl>
-                {
-                  page === 'SearchResults' &&
-                  <StatusLinks
-                    item={item}
-                    bibId={bibId}
-                    searchKeywords={searchKeywords}
-                    appConfig={appConfig}
-                    page={page}
-                  />
-                }
-              </div>
-            )
+          return (
+            <div key={`item-${item.id}-div`} id={`item-${item.id}-div`} className="results-items-element">
+              <dl key={`item-${item.id}-dl`} id={`item-${item.id}-dl`}>
+                <dt key={`item-${item.id}-format-dt`} id={`item-${item.id}-format-dt`}>Format</dt>
+                <dd key={`item-${item.id}-format-dd`} id={`item-${item.id}-format-dd`}>{item.format || ' '}</dd>
+                <dt key={`item-${item.id}-callnumber-dt`} id={`item-${item.id}-callnumber-dt`}>Call Number</dt>
+                <dd key={`item-${item.id}-callnumber-dd`} id={`item-${item.id}-callnumber-dd`}>{item.callNumber || ' '}</dd>
+                <dt key={`item-${item.id}-location-dt`} id={`item-${item.id}-location-dt`}>Item Location</dt>
+                <dd key={`item-${item.id}-location-dd`} id={`item-${item.id}-location-dd`}>{itemLocation}</dd>
+              </dl>
+              {
+                page === 'SearchResults' &&
+                <StatusLinks
+                  item={item}
+                  bibId={bibId}
+                  searchKeywords={searchKeywords}
+                  appConfig={appConfig}
+                  page={page}
+                />
+              }
+            </div>
+          )
         })
       }
     </div>

--- a/src/app/components/ResultsList/ResultsList.jsx
+++ b/src/app/components/ResultsList/ResultsList.jsx
@@ -10,8 +10,7 @@ import { useSelector, useDispatch } from 'react-redux';
 
 import LibraryItem from '../../utils/item';
 import {
-  trackDiscovery,
-  getElectronicResources,
+  trackDiscovery
 } from '../../utils/utils';
 import SearchResultsItems from '../Item/SearchResultsItems';
 import appConfig from '../../data/appConfig';
@@ -92,11 +91,9 @@ const ResultsList = ({
     const publicationStatement = result.publicationStatement && result.publicationStatement.length ?
       result.publicationStatement[0] : '';
     const items = ItemSorter.sortItems(LibraryItem.getItems(result));
-    const totalItems = result.numItems;
     const hasRequestTable = items.length > 0;
     const { baseUrl } = appConfig;
     const bibUrl = `${baseUrl}/bib/${bibId}`;
-    const { totalPhysicalItems, eResources, eResourcesTotal } = getElectronicResources(result);
     const resourcesOnClick = () => {
       updateResultSelection({
         fromUrl: `${pathname}${search}`,
@@ -104,8 +101,10 @@ const ResultsList = ({
       })
     }
 
+    const eResources = result.electronicResources
+    const totalPhysicalItems = result.numItemsTotal
     const hasPhysicalItems = totalPhysicalItems > 0;
-    const itemCount = hasPhysicalItems ? totalPhysicalItems : eResourcesTotal;
+    const itemCount = hasPhysicalItems ? totalPhysicalItems : eResources.length
     const resourceType = hasPhysicalItems ? 'Item' : 'Resource';
     const itemMessage = `${itemCount} ${resourceType}${itemCount !== 1 ? 's' : ''}`;
     return (
@@ -132,7 +131,7 @@ const ResultsList = ({
               <li className="nypl-results-publication">{publicationStatement}</li>
               {yearPublished}
               {
-                totalItems > 0 ?
+                totalPhysicalItems > 0 || eResources.length > 0 ?
                   <li className="nypl-results-info">
                     {itemMessage}
                   </li>

--- a/src/app/components/ResultsList/ResultsList.jsx
+++ b/src/app/components/ResultsList/ResultsList.jsx
@@ -101,7 +101,7 @@ const ResultsList = ({
       })
     }
 
-    const eResources = result.electronicResources
+    const eResources = result.electronicResources || [];
     const totalPhysicalItems = result.numItemsTotal
     const hasPhysicalItems = totalPhysicalItems > 0;
     const itemCount = hasPhysicalItems ? totalPhysicalItems : eResources.length

--- a/src/app/pages/BibPage.jsx
+++ b/src/app/pages/BibPage.jsx
@@ -25,9 +25,7 @@ import {
   matchParallels,
 } from '../utils/bibDetailsUtils';
 import {
-  getAggregatedElectronicResources,
-  isNyplBnumber,
-  getElectronicResources
+  isNyplBnumber
 } from '../utils/utils';
 import {
   buildFieldToOptionsMap,
@@ -62,26 +60,10 @@ export const BibPage = (
   const fieldToOptionsMap = buildFieldToOptionsMap(reducedItemsAggregations)
   const items = LibraryItem.getItems(bib);
 
-  const allElectronicLocatorsWithAeon = bib.electronicResources
-  const { eResources: eResourcesWithoutAeon } = getElectronicResources(bib);
+  const eResources = bib.electronicResources
 
   const hasElectronicResources = bib.electronicResources && bib.electronicResources.length > 0
-  let numPhysicalItems
-  // TODO: This is a temporary fix to handle records that may or may not have
-  // been recently indexed. When the API consistently serves bib.numItemsTotal,
-  // this can be simplified.
-  //
-  // Determine number of physical items:
-  // Newly indexed bibs have .numItemsTotal, which excludes electronic resource items:
-  if (bib.numItemsTotal !== undefined) {
-    numPhysicalItems = bib.numItemsTotal
-  } else if (hasElectronicResources) {
-    // Older bibs do not have .numItemsTotal, so we should use .numItems
-    // Decrement 1 when they have an e-resources item:
-    numPhysicalItems = bib.numItems - 1
-  } else {
-    numPhysicalItems = bib.numItems
-  }
+  const numPhysicalItems = bib.numItemsTotal
   const hasItems = numPhysicalItems > 0
   const isOnlyElectronicResources = !hasItems && hasElectronicResources
   const hasPhysicalItems = !isOnlyElectronicResources && hasItems
@@ -121,12 +103,12 @@ export const BibPage = (
 
         <section style={{ marginTop: '20px' }}>
           <BibDetails
-            electronicResources={allElectronicLocatorsWithAeon}
+            electronicResources={eResources}
             bib={newBibModel}
             fields={topFields}
             features={features}
           />
-          {eResourcesWithoutAeon.length ? <ElectronicResources electronicResources={eResourcesWithoutAeon} id="electronic-resources" /> : null}
+          {eResources.length ? <ElectronicResources electronicResources={eResources} id="electronic-resources" /> : null}
         </section>
 
         {/*

--- a/src/app/pages/BibPage.jsx
+++ b/src/app/pages/BibPage.jsx
@@ -43,7 +43,7 @@ export const BibPage = (
   context,
 ) => {
   const useParallels = features && features.includes('parallels');
-  const numItemsMatched = bib.numItemsMatched;
+  const numItemsMatched = bib?.numItemsMatched || 0;
   const hash = location.hash || '';
   const showAll = hash === '#view-all-items';
 

--- a/src/app/utils/item.js
+++ b/src/app/utils/item.js
@@ -163,19 +163,6 @@ function LibraryItem() {
   };
 
   /**
-   * getElectronicResources(item)
-   * @param {object} items The item to get an electronic resource from.
-   * @return {array}
-   */
-  this.getElectronicResources = (item = {}) => {
-    if (item.electronicLocator) {
-      return item.electronicLocator;
-    }
-
-    return [];
-  };
-
-  /**
    * mapItem(item, title)
    * Massage data and update an item's properties.
    * @param {object} item The item to update the data for.

--- a/src/app/utils/item.js
+++ b/src/app/utils/item.js
@@ -198,10 +198,6 @@ function LibraryItem() {
     // Taking the first value in the array;
     const suppressed =
       item.suppressed && item.suppressed.length ? item.suppressed[0] : false;
-    const isElectronicResource = this.isElectronicResource(item);
-    const electronicResources = isElectronicResource
-      ? this.getElectronicResources(item)
-      : null;
     // Taking the first status object in the array.
     const status = item.status && item.status.length ? item.status[0] : {};
     const volume =
@@ -268,8 +264,6 @@ function LibraryItem() {
       available,
       aeonUrl: item.aeonUrl,
       accessMessage,
-      isElectronicResource,
-      electronicResources,
       location: holdingLocation.prefLabel,
       locationUrl: holdingLocation.url,
       branchEndpoint: holdingLocation.branchEndpoint,

--- a/src/app/utils/utils.js
+++ b/src/app/utils/utils.js
@@ -369,28 +369,6 @@ function parseServerSelectedFilters(filters, dateAfter, dateBefore) {
   return selectedFilters;
 }
 
-/**
- * getAggregatedElectronicResources(items)
- * Get an aggregated array of electronic items from each item if available.
- * @param {array} items
- * @return {object}
- */
-function getAggregatedElectronicResources(items = []) {
-  if (!items && !items.length) {
-    return [];
-  }
-
-  const electronicResources = [];
-
-  _forEach(items, (item) => {
-    if (item.isElectronicResource) {
-      electronicResources.push(item.electronicResources);
-    }
-  });
-
-  return _flatten(electronicResources);
-}
-
 // TODO: [SCC-2996] Define Resources
 // interface Resources {
 //   @type: string;
@@ -751,16 +729,14 @@ function isNyplBnumber(bnum) {
  * Given a bib, return the electronic resources and the number of physical items
  */
 function getElectronicResources(bib) {
-  const items = LibraryItem.getItems(bib);
-  const electronicResources = bib.electronicResources || getAggregatedElectronicResources(items)
+  const electronicResources = bib.electronicResources
   const eResourcesWithoutAeonLinks = removeAeonLinksFromResource(electronicResources, bib.items);
   // totalPhysicalItems should be numItemsTotal (physical items including checkin card items).
   // if data is stale, it does not have that property. Fall back on numItems. But!
   // if there are electronic resources on the bib, we need to decrement numItems. Even though the items array is 
   // empty in updated api response, numItems still includes the electronic item in the count.
-  const totalPhysicalItems = bib.numItemsTotal || (eResourcesWithoutAeonLinks.length ?
-    bib.numItems - 1 : bib.numItems)
-  const eResourcesTotal = bib.numElectronicResources || eResourcesWithoutAeonLinks.length
+  const totalPhysicalItems = bib.numItemsTotal
+  const eResourcesTotal = bib.numElectronicResources
   return {
     eResources: eResourcesWithoutAeonLinks, totalPhysicalItems, eResourcesTotal
   }
@@ -806,7 +782,6 @@ export {
   basicQuery,
   getReqParams,
   parseServerSelectedFilters,
-  getAggregatedElectronicResources,
   getElectronicResources,
   getUpdatedFilterValues,
   displayContext,

--- a/src/app/utils/utils.js
+++ b/src/app/utils/utils.js
@@ -748,7 +748,8 @@ function isNyplBnumber(bnum) {
 }
 
 /**
- * Remove check digit from bnumber. Typically the 9th integer in the bibId.
+ * Strip check digit (int at 10th position) from bnumber if present
+ * Return the original bnumber if greater than or less than 10 characters.
  */
 function removeCheckDigit(bnum) {
   return bnum.length === 10 ? bnum.slice(0, -1) : bnum;

--- a/src/app/utils/utils.js
+++ b/src/app/utils/utils.js
@@ -726,23 +726,6 @@ function isNyplBnumber(bnum) {
 }
 
 /**
- * Given a bib, return the electronic resources and the number of physical items
- */
-function getElectronicResources(bib) {
-  const electronicResources = bib.electronicResources
-  const eResourcesWithoutAeonLinks = removeAeonLinksFromResource(electronicResources, bib.items);
-  // totalPhysicalItems should be numItemsTotal (physical items including checkin card items).
-  // if data is stale, it does not have that property. Fall back on numItems. But!
-  // if there are electronic resources on the bib, we need to decrement numItems. Even though the items array is 
-  // empty in updated api response, numItems still includes the electronic item in the count.
-  const totalPhysicalItems = bib.numItemsTotal
-  const eResourcesTotal = bib.numElectronicResources
-  return {
-    eResources: eResourcesWithoutAeonLinks, totalPhysicalItems, eResourcesTotal
-  }
-}
-
-/**
  * Given an item, return Aeon url with params added to pre-populate the form
  */
 
@@ -782,7 +765,6 @@ export {
   basicQuery,
   getReqParams,
   parseServerSelectedFilters,
-  getElectronicResources,
   getUpdatedFilterValues,
   displayContext,
   truncateStringOnWhitespace,

--- a/src/app/utils/utils.js
+++ b/src/app/utils/utils.js
@@ -748,6 +748,13 @@ function isNyplBnumber(bnum) {
 }
 
 /**
+ * Remove check digit from bnumber. Typically the 9th integer in the bibId.
+ */
+function removeCheckDigit(bnum) {
+  return bnum.length === 10 ? bnum.slice(0, -1) : bnum;
+}
+
+/**
  * Given a bib, return the electronic resources and the number of physical items
  */
 function getElectronicResources(bib) {
@@ -818,6 +825,7 @@ export {
   institutionNameByNyplSource,
   addSource,
   isNyplBnumber,
+  removeCheckDigit,
   removeAeonLinksFromResource,
   isAeonLink,
   aeonUrl,

--- a/src/app/utils/utils.js
+++ b/src/app/utils/utils.js
@@ -726,11 +726,18 @@ function isNyplBnumber(bnum) {
 }
 
 /**
- * Strip check digit (int at 10th position) from bnumber if present
+ * Given a bnumber, return true if it is an NYPL bnumber and has a 10th character.
+ */
+function hasCheckDigit(bnum = "") {
+  return isNyplBnumber(bnum) && bnum.length === 10;
+}
+
+/**
+ * Given a bnumber, remove check digit (int at 10th position) fif present.
  * Return the original bnumber if greater than or less than 10 characters.
  */
-function removeCheckDigit(bnum) {
-  return bnum.length === 10 ? bnum.slice(0, -1) : bnum;
+function removeCheckDigit(bnum = "") {
+  return hasCheckDigit(bnum) ? bnum.slice(0, -1) : bnum;
 }
 
 /**
@@ -803,6 +810,7 @@ export {
   addSource,
   isNyplBnumber,
   removeCheckDigit,
+  hasCheckDigit,
   removeAeonLinksFromResource,
   isAeonLink,
   aeonUrl,

--- a/src/server/ApiRoutes/Bib.js
+++ b/src/server/ApiRoutes/Bib.js
@@ -5,7 +5,7 @@ import logger from '../../../logger';
 import appConfig from '../../app/data/appConfig';
 import extractFeatures from '../../app/utils/extractFeatures';
 import { itemBatchSize } from '../../app/data/constants';
-import { isNyplBnumber } from '../../app/utils/utils';
+import { isNyplBnumber, removeCheckDigit } from '../../app/utils/utils';
 import { appendDimensionsToExtent } from '../../app/utils/appendDimensionsToExtent';
 
 const nyplApiClientCall = (query, itemFrom, filterItemsStr = "") => {
@@ -122,6 +122,7 @@ function fetchBib (bibId, cb, errorcb, reqOptions, res) {
   }, reqOptions);
   // Determine if it's an NYPL bibId:
   const isNYPL = isNyplBnumber(bibId);
+  bibId = removeCheckDigit(bibId);
   return Promise.all([
     nyplApiClientCall(bibId, reqOptions.itemFrom || 0, reqOptions.filterItemsStr),
     // Don't fetch annotated-marc for partner records:

--- a/test/fixtures/bibs.js
+++ b/test/fixtures/bibs.js
@@ -181,8 +181,12 @@ const bibs = [
     updatedAt: 1524665261653,
     uri: 'b11417539',
     suppressed: false,
+    numElectronicResources: 0,
+    electronicResources: []
   },
   {
+    numElectronicResources: 0,
+    electronicResources: [],
     '@type': ['nypl:Item', 'nypl:Resource'],
     '@id': 'res:b11417539',
     carrierType: [{ '@id': 'carriertypes:nc', prefLabel: 'volume' }],
@@ -669,12 +673,7 @@ const bibs = [
         '@type': 'nypl:ElectronicLocation',
         label: 'Full text available via HathiTrust',
         url: 'http://hdl.handle.net/2027/nyp.33433076020639',
-      },
-      {
-        '@type': 'nypl:ElectronicLocation',
-        label: 'Request Access to Special Collections Material',
-        url: 'https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=A+bibliographical+checklist+of+American+Negro+poetry+/&Site=SCHRB&CallNumber=Sc+Rare+016.811-S+(Schomburg,+A.+Bibliographical+checklist)&Author=Schomburg,+Arthur+Alfonso,&ItemPlace=New+York+:&ItemPublisher=Charles+F.+Heartman,&Date=1916.&ItemInfo3=https://catalog.nypl.org/record=b22030125&ReferenceNumber=b220301256&Genre=Book-text&Location=Schomburg+Center',
-      },
+      }
     ],
     numAvailable: 0,
     numItems: 6,
@@ -1345,6 +1344,8 @@ const bibs = [
       'http://discovery-api-qa.us-east-1.elasticbeanstalk.com/api/v0.1/discovery/context_all.jsonld',
     '@type': ['nypl:Item', 'nypl:Resource'],
     '@id': 'res:b21147020',
+    numElectronicResources: 0,
+    electronicResources: [],
     carrierType: [
       {
         '@id': 'carriertypes:nc',

--- a/test/fixtures/electronicAndPhysicalItemsBib.js
+++ b/test/fixtures/electronicAndPhysicalItemsBib.js
@@ -2,7 +2,8 @@ const sampleBib = {
   '@id': 'res:b15523285',
   numItems: 3,
   numItemsTotal: 1,
-  numElectronicResources: 2,
+  numElectronicResources: 1,
+  electronicResources: [{ url: 'hathitrust.com', label: 'Full text available via HathiTrust' }],
   items: [
     {
       "@id": "res:i11829350",
@@ -65,43 +66,6 @@ const sampleBib = {
       "idNyplSourceId": {
         "@type": "SierraNypl",
         "@value": "11829350"
-      }
-    },
-    {
-      "@id": "res:i15523285-e",
-      "electronicLocator": [
-        {
-          "@type": "nypl:ElectronicLocation",
-          "label": "Full text available via HathiTrust",
-          "url": "http://hdl.handle.net/2027/nyp.33433031805108"
-        }
-      ],
-      "identifier": [
-        "urn:SierraNypl:15523285-e"
-      ],
-      "uri": "i15523285-e",
-      "idNyplSourceId": {
-        "@type": "SierraNypl",
-        "@value": "15523285-e"
-      }
-    },
-    {
-      "@id": "res:i987654321-e",
-      "electronicLocator": [
-        {
-          "@type": "nypl:ElectronicLocation",
-          "label": "Aeon available via HathiTrust",
-          "url": "https://nypl-aeon-test.aeon.atlas-sys.com.33433031805108"
-        }
-      ],
-      aeonUrl: "https://nypl-aeon-test.aeon.atlas-sys.com.33433031805108",
-      "identifier": [
-        "urn:SierraNypl:987654321-e"
-      ],
-      "uri": "i987654321-e",
-      "idNyplSourceId": {
-        "@type": "SierraNypl",
-        "@value": "987654321-e"
       }
     }
   ]

--- a/test/fixtures/mockBibWithHolding.json
+++ b/test/fixtures/mockBibWithHolding.json
@@ -4,6 +4,9 @@
     "nypl:Item",
     "nypl:Resource"
   ],
+  "numElectronicResources": 0,
+  "electronicResources": [],
+  "numItemsTotal": 53,
   "@id": "res:b11254422",
   "carrierType": [
     {

--- a/test/fixtures/resultsBibs.js
+++ b/test/fixtures/resultsBibs.js
@@ -28,6 +28,7 @@ const resultsBibs = [
       numItems: 2,
       numItemsTotal: 4,
       numElectronicResources: 0,
+      electronicResources: [],
       numAvailable: 0,
       uris: [
         'b17692265',
@@ -112,6 +113,7 @@ const resultsBibs = [
       numItems: 2,
       numItemsTotal: 1,
       numElectronicResources: 0,
+      electronicResources: [],
       numAvailable: 0,
       uris: [
         'b17692265',
@@ -144,6 +146,8 @@ const resultsBibs = [
     result: {
       '@type': ['nypl:Item', 'nypl:Resource'],
       '@id': 'res:b11417539',
+      numElectronicResources: 0,
+      electronicResources: [],
       carrierType: [{ '@id': 'carriertypes:nc', prefLabel: 'volume' }],
       createdString: ['1991'],
       createdYear: 1991,
@@ -231,6 +235,7 @@ const resultsBibs = [
           },
         },
       ],
+      numItemsTotal: 1,
       language: [{ '@id': 'lang:eng', prefLabel: 'English' }],
       lccClassification: ['PR3071 .D4 1991'],
       materialType: [{ '@id': 'resourcetypes:txt', prefLabel: 'Text' }],
@@ -249,10 +254,10 @@ const resultsBibs = [
       publisherLiteral: ['Clarendon Press ; Oxford University Press,'],
       shelfMark: ['JFD 91-4064'],
       subjectLiteral:
-       ['Editing -- History -- 18th century.',
-         'Malone, Edmond, 1741-1812.',
-         'Shakespeare, William, 1564-1616 -- Criticism, Textual.',
-         'Shakespeare, William, 1564-1616.'],
+        ['Editing -- History -- 18th century.',
+          'Malone, Edmond, 1741-1812.',
+          'Shakespeare, William, 1564-1616 -- Criticism, Textual.',
+          'Shakespeare, William, 1564-1616.'],
       title: ['Shakespeare verbatim : the reproduction of authenticity and the 1790 apparatus'],
       titleDisplay: ['Shakespeare verbatim : the reproduction of authenticity and the 1790 apparatus / Margreta de Grazia.'],
       type: ['nypl:Item'],

--- a/test/unit/BibPage.test.js
+++ b/test/unit/BibPage.test.js
@@ -30,12 +30,7 @@ describe('BibPage', () => {
       '@type': 'nypl:ElectronicLocation',
       label: 'Full text available via HathiTrust',
       url: 'http://hdl.handle.net/2027/nyp.33433076020639',
-    },
-    {
-      '@type': 'nypl:ElectronicLocation',
-      label: 'Request Access to Special Collections Material',
-      url: 'https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=A+bibliographical+checklist+of+American+Negro+poetry+/&Site=SCHRB&CallNumber=Sc+Rare+016.811-S+(Schomburg,+A.+Bibliographical+checklist)&Author=Schomburg,+Arthur+Alfonso,&ItemPlace=New+York+:&ItemPublisher=Charles+F.+Heartman,&Date=1916.&ItemInfo3=https://catalog.nypl.org/record=b22030125&ReferenceNumber=b220301256&Genre=Book-text&Location=Schomburg+Center',
-    },
+    }
   ]
   const context = mockRouterContext();
   describe('Electronic Resources List', () => {
@@ -50,7 +45,7 @@ describe('BibPage', () => {
       <BibPage
         location={{ search: 'search', pathname: '' }}
         bib={bib}
-        dispatch={() => {}}
+        dispatch={() => { }}
         resultSelection={{
           fromUrl: '',
           bibId: '',
@@ -402,7 +397,7 @@ describe('BibPage', () => {
     })
 
     describe('No item, no electronic resources', () => {
-      const noItemsNoEr = { ...bib, items: [], electronicResources: [], numItems: 0 }
+      const noItemsNoEr = { ...bib, items: [], electronicResources: [], numItemsTotal: 0 }
       before(() => {
         component = mountTestRender(
           <BibPage
@@ -417,11 +412,11 @@ describe('BibPage', () => {
           { context, childContextTypes: { router: PropTypes.object }, store: testStore },
         )
       })
-      it(' does not render ItemsContainer', () => { expect(component.find('ItemsContainer').length).to.equal(0) });
+      it('does not render ItemsContainer', () => { expect(component.find('ItemsContainer').length).to.equal(0) });
     })
     describe('1 item, no electronic resources does render ItemsContainer', () => {
 
-      const oneItemNoER = { ...bib, items: [{ id: '1' }], electronicResources: [] };
+      const oneItemNoER = { ...bib, electronicResources: [], items: [{ id: '123' }], numItemsTotal: 1 };
       before(() => {
         component = mountTestRender(
           <BibPage
@@ -436,12 +431,12 @@ describe('BibPage', () => {
           { context, childContextTypes: { router: PropTypes.object }, store: testStore },
         )
       })
-      it(' does render ItemsContainer', () => {
+      it('does render ItemsContainer', () => {
         expect(component.find('ItemsContainer').length).to.equal(1)
       })
     })
     describe('Multi item, electronic resources', () => {
-      const multiItemsYesER = { ...bib, items: [{ id: '1' }, { id: '2' }, { id: '3' }], electronicResources }
+      const multiItemsYesER = { ...bib, electronicResources }
       before(() => {
         component = mountTestRender(
           <BibPage
@@ -460,7 +455,7 @@ describe('BibPage', () => {
     })
 
     describe('Multi item, no electronic resources does render ItemsContainer', () => {
-      const multiItemsNoER = { ...bib, items: [{ id: '1' }, { id: '2' }, { id: '3' }], electronicResources: [] }
+      const multiItemsNoER = { ...bib, electronicResources: [] }
       before(() => {
         component = mountTestRender(
           <BibPage
@@ -475,7 +470,7 @@ describe('BibPage', () => {
           { context, childContextTypes: { router: PropTypes.object }, store: testStore },
         )
       })
-      it(' does render ItemsContainer', () => { expect(component.find('ItemsContainer').length).to.equal(1); })
+      it('does render ItemsContainer', () => { expect(component.find('ItemsContainer').length).to.equal(1); })
     })
   })
 });

--- a/test/unit/ItemsDefinitionLists.test.js
+++ b/test/unit/ItemsDefinitionLists.test.js
@@ -7,33 +7,9 @@ import StatusLinks from './../../src/app/components/Item/StatusLinks';
 import ItemsDefinitionLists from './../../src/app/components/Item/ItemsDefinitionLists';
 import appConfig from './../../src/app/data/appConfig'
 
-describe('ItemsDefinitionLists', () => {
+describe.only('ItemsDefinitionLists', () => {
 
-  const fullItems =  [
-    {
-      isElectronicResource: true,
-      id: '1234',
-      location: 'SASB',
-      locationUrl: 'www.fake.com',
-      format: 'Text',
-      callNumber: 'ABCDE1234'
-    },
-    {
-      isElectronicResource: true,
-      id: '5678',
-      location: 'SASB',
-      locationUrl: 'www.fake.com',
-      format: 'Text',
-      callNumber: 'ABCDE1234'
-    },
-    {
-      isElectronicResource: true,
-      id: '91011',
-      location: 'SASB',
-      locationUrl: 'www.fake.com',
-      format: 'Text',
-      callNumber: 'ABCDE1234'
-    },
+  const fullItems = [
     {},
     {
       id: '0123',
@@ -99,49 +75,6 @@ describe('ItemsDefinitionLists', () => {
         expect(component.html()).to.equal(null)
       })
     })
-
-    describe('only electronic items', () => {
-      const component = shallow(
-        <ItemsDefinitionLists
-          holdings={[]}
-          bibId="b12345"
-          id="1234"
-          searchKeywords={[]}
-          page="Search Results"
-          items={
-            [
-              {
-                isElectronicResource: true,
-                id: '1234',
-                location: 'SASB',
-                locationUrl: 'www.fake.com',
-                format: 'Text',
-                callNumber: 'ABCDE1234'
-              },
-              {
-                isElectronicResource: true,
-                id: '5678',
-                location: 'SASB',
-                locationUrl: 'www.fake.com',
-                format: 'Text',
-                callNumber: 'ABCDE1234'
-              },
-              {
-                isElectronicResource: true,
-                id: '91011',
-                location: 'SASB',
-                locationUrl: 'www.fake.com',
-                format: 'Text',
-                callNumber: 'ABCDE1234'
-              }
-            ]
-          }
-        />
-      )
-      it('should not display anything', () => {
-        expect(component.html()).to.equal(null)
-      })
-    })
   })
 
   describe('rendering items', () => {
@@ -167,14 +100,14 @@ describe('ItemsDefinitionLists', () => {
         expect(root.prop('className')).to.equal('items-definition-list results-items-element')
       })
 
-      it('should filter out empty items and electronic resources', () => {
+      it('should filter out empty items', () => {
         const divs = component.first().children().find('div')
         expect(divs.length).to.equal(5)
       })
 
       it('should have a div with correct props for each item', () => {
         const divs = component.first().children().find('div').map(div => ([div.key(), div.prop('id')]));
-        expect(divs).to.deep.equal(items.slice(4).map(item => [`item-${item.id}-div`, `item-${item.id}-div`]))
+        expect(divs).to.deep.equal(items.slice(1).map(item => [`item-${item.id}-div`, `item-${item.id}-div`]))
       })
 
       it('should have a dl with correct id and key for each item', () => {
@@ -182,7 +115,7 @@ describe('ItemsDefinitionLists', () => {
           .map(div => div.find('dl'))
           .map(dl => [dl.key(), dl.prop('id')])
 
-        expect(dls).to.deep.equal(items.slice(4).map(item => [`item-${item.id}-dl`, `item-${item.id}-dl`]))
+        expect(dls).to.deep.equal(items.slice(1).map(item => [`item-${item.id}-dl`, `item-${item.id}-dl`]))
       })
 
       it('should have correct number of dt and dd cells with correct props', () => {
@@ -194,14 +127,14 @@ describe('ItemsDefinitionLists', () => {
           }))
 
         expect(dlcells).to.deep.equal(
-            items.slice(4).map(item =>
-              [['dt', `item-${item.id}-format-dt`, `item-${item.id}-format-dt`],
-               ['dd', `item-${item.id}-format-dd`, `item-${item.id}-format-dd`],
-               ['dt', `item-${item.id}-callnumber-dt`, `item-${item.id}-callnumber-dt`],
-               ['dd', `item-${item.id}-callnumber-dd`, `item-${item.id}-callnumber-dd`],
-               ['dt', `item-${item.id}-location-dt`, `item-${item.id}-location-dt`],
-               ['dd', `item-${item.id}-location-dd`, `item-${item.id}-location-dd`]
-             ]
+          items.slice(1).map(item =>
+            [['dt', `item-${item.id}-format-dt`, `item-${item.id}-format-dt`],
+            ['dd', `item-${item.id}-format-dd`, `item-${item.id}-format-dd`],
+            ['dt', `item-${item.id}-callnumber-dt`, `item-${item.id}-callnumber-dt`],
+            ['dd', `item-${item.id}-callnumber-dd`, `item-${item.id}-callnumber-dd`],
+            ['dt', `item-${item.id}-location-dt`, `item-${item.id}-location-dt`],
+            ['dd', `item-${item.id}-location-dd`, `item-${item.id}-location-dd`]
+            ]
           )
         )
 
@@ -257,46 +190,46 @@ describe('ItemsDefinitionLists', () => {
 
 
     describe('StatusLinks rendering', () => {
-       describe('on Search Results page', () => {
-         const component = shallow(
-           <ItemsDefinitionLists
-             holdings={[]}
-             bibId="b12345"
-             id="1234"
-             searchKeywords={[]}
-             page="SearchResults"
-             items={fullItems}
-           />
-         )
-         it('should render status links in case page is Search Results', () => {
-           const statusLinks = component.find(StatusLinks)
-           expect(statusLinks.length).to.equal(5)
-           expect(statusLinks.at(0).props()).to.deep.equal({
-             item: fullItems[4],
-             bibId: "b12345",
-             searchKeywords: [],
-             page: "SearchResults",
-             appConfig: appConfig
-           })
-         })
-       })
+      describe('on Search Results page', () => {
+        const component = shallow(
+          <ItemsDefinitionLists
+            holdings={[]}
+            bibId="b12345"
+            id="1234"
+            searchKeywords={[]}
+            page="SearchResults"
+            items={fullItems}
+          />
+        )
+        it('should render status links in case page is Search Results', () => {
+          const statusLinks = component.find(StatusLinks)
+          expect(statusLinks.length).to.equal(5)
+          expect(statusLinks.at(3).props()).to.deep.equal({
+            item: fullItems[4],
+            bibId: "b12345",
+            searchKeywords: [],
+            page: "SearchResults",
+            appConfig: appConfig
+          })
+        })
+      })
 
-       describe('Not on Search Results page', () => {
-         const component = shallow(
-           <ItemsDefinitionLists
-             holdings={[]}
-             bibId="b12345"
-             id="1234"
-             searchKeywords={[]}
-             page="BibPage"
-             items={fullItems}
-           />
-         )
-         it('should not render status links', () => {
-           const statusLinks = component.find(StatusLinks)
-           expect(statusLinks.length).to.equal(0)
-         })
-       })
+      describe('Not on Search Results page', () => {
+        const component = shallow(
+          <ItemsDefinitionLists
+            holdings={[]}
+            bibId="b12345"
+            id="1234"
+            searchKeywords={[]}
+            page="BibPage"
+            items={fullItems}
+          />
+        )
+        it('should not render status links', () => {
+          const statusLinks = component.find(StatusLinks)
+          expect(statusLinks.length).to.equal(0)
+        })
+      })
     })
 
   })

--- a/test/unit/ItemsDefinitionLists.test.js
+++ b/test/unit/ItemsDefinitionLists.test.js
@@ -7,7 +7,7 @@ import StatusLinks from './../../src/app/components/Item/StatusLinks';
 import ItemsDefinitionLists from './../../src/app/components/Item/ItemsDefinitionLists';
 import appConfig from './../../src/app/data/appConfig'
 
-describe.only('ItemsDefinitionLists', () => {
+describe('ItemsDefinitionLists', () => {
 
   const fullItems = [
     {},

--- a/test/unit/ResultsList.test.js
+++ b/test/unit/ResultsList.test.js
@@ -199,9 +199,9 @@ describe('ResultsList', () => {
     });
 
     it('should have a total items description', () => {
-      const yearPublished = component.find('.nypl-results-info');
-      expect(yearPublished.length).to.equal(1);
-      expect(yearPublished.text()).to.equal('4 Items');
+      const itemsDescription = component.find('.nypl-results-info');
+      expect(itemsDescription.length).to.equal(1);
+      expect(itemsDescription.text()).to.equal('4 Items');
     });
 
     it('should have a table', () => {

--- a/test/unit/utils.test.js
+++ b/test/unit/utils.test.js
@@ -131,22 +131,6 @@ describe('getDefaultFilters', () => {
 });
 
 /**
- * getElectronicResources
- */
-describe('getElectronicResources', () => {
-
-  it('should return object with eResources, and count of physical items', () => {
-    const eResources = getElectronicResources(sampleBib);
-    // the sample bib has 1 checkinitem, 1 regular physical item, 1 electronic item, and
-    // 1 aeon link
-    expect(eResources.eResources.length).to.equal(1)
-    expect(eResources.eResources[0].label).to.equal('Full text available via HathiTrust')
-    expect(eResources.totalPhysicalItems).to.equal(1)
-  });
-
-});
-
-/**
  * createAppHistory
  */
 describe('createAppHistory', () => {

--- a/test/unit/utils.test.js
+++ b/test/unit/utils.test.js
@@ -133,18 +133,18 @@ describe('getDefaultFilters', () => {
 /**
  * getElectronicResources
  */
- describe('getElectronicResources', () => {
+describe('getElectronicResources', () => {
 
-   it('should return object with eResources, and count of physical items', () => {
-     const eResources = getElectronicResources(sampleBib);
-     // the sample bib has 1 checkinitem, 1 regular physical item, 1 electronic item, and
-     // 1 aeon link
-     expect(eResources.eResources.length).to.equal(1)
-     expect(eResources.eResources[0].label).to.equal('Full text available via HathiTrust')
-     expect(eResources.totalPhysicalItems).to.equal(1)
-   });
+  it('should return object with eResources, and count of physical items', () => {
+    const eResources = getElectronicResources(sampleBib);
+    // the sample bib has 1 checkinitem, 1 regular physical item, 1 electronic item, and
+    // 1 aeon link
+    expect(eResources.eResources.length).to.equal(1)
+    expect(eResources.eResources[0].label).to.equal('Full text available via HathiTrust')
+    expect(eResources.totalPhysicalItems).to.equal(1)
+  });
 
- });
+});
 
 /**
  * createAppHistory
@@ -167,30 +167,33 @@ describe('createAppHistory', () => {
  */
 describe('destructureFilters', () => {
 
-  const apiFilters = { '@context':
-   'http://discovery-api-qa.us-east-1.elasticbeanstalk.com/api/v0.1/discovery/context_all.jsonld',
-  '@type': 'itemList',
-  itemListElement:
-   [
-     { '@type': 'nypl:Aggregation',
-       '@id': 'res:subjectLiteral',
-       id: 'subjectLiteral',
-       field: 'subjectLiteral',
-       values: [
-         {
-           count: 130,
-           label: 'Animals -- Fiction.',
-           value: 'Animals -- Fiction.',
-         },
-         {
-           count: 89,
-           label: 'Awards.',
-           value: 'Awards.',
-         },
-       ],
-     },
-   ],
-  totalResults: 665 };
+  const apiFilters = {
+    '@context':
+      'http://discovery-api-qa.us-east-1.elasticbeanstalk.com/api/v0.1/discovery/context_all.jsonld',
+    '@type': 'itemList',
+    itemListElement:
+      [
+        {
+          '@type': 'nypl:Aggregation',
+          '@id': 'res:subjectLiteral',
+          id: 'subjectLiteral',
+          field: 'subjectLiteral',
+          values: [
+            {
+              count: 130,
+              label: 'Animals -- Fiction.',
+              value: 'Animals -- Fiction.',
+            },
+            {
+              count: 89,
+              label: 'Awards.',
+              value: 'Awards.',
+            },
+          ],
+        },
+      ],
+    totalResults: 665
+  };
   describe('Default call', () => {
     it('should return an empty object', () => {
       const filters = destructureFilters();
@@ -740,128 +743,6 @@ describe('getReqParams', () => {
   });
 });
 
-/**
- * getAggregatedElectronicResources()
- */
-describe('getAggregatedElectronicResources', () => {
-  describe('No input', () => {
-    it('should return an empty array with no input or an empty array', () => {
-      expect(getAggregatedElectronicResources()).to.eql([]);
-      expect(getAggregatedElectronicResources([])).to.eql([]);
-    });
-  });
-
-  describe('Collected Electronic Resources', () => {
-    it('should return an array with one electronic resource', () => {
-      const mockedItems = [
-        {},
-        {},
-        {
-          isElectronicResource: true,
-          electronicResources: [{
-            id: 'someId',
-            title: 'someTitle',
-            url: 'someUrl',
-          }],
-        },
-      ];
-      expect(getAggregatedElectronicResources(mockedItems))
-        .to.eql([
-          {
-            id: 'someId',
-            title: 'someTitle',
-            url: 'someUrl',
-          },
-        ]);
-    });
-
-    it('should return an array with two electronic resources from the same item', () => {
-      const mockedItems = [
-        {},
-        {},
-        {
-          isElectronicResource: true,
-          electronicResources: [
-            {
-              id: 'someId',
-              title: 'someTitle',
-              url: 'someUrl',
-            },
-            {
-              id: 'someId2',
-              title: 'someTitle2',
-              url: 'someUrl2',
-            },
-          ],
-        },
-      ];
-      expect(getAggregatedElectronicResources(mockedItems))
-        .to.eql([
-          {
-            id: 'someId',
-            title: 'someTitle',
-            url: 'someUrl',
-          },
-          {
-            id: 'someId2',
-            title: 'someTitle2',
-            url: 'someUrl2',
-          },
-        ]);
-    });
-
-    it('should return an array with three electronic resources, two from one item and' +
-      ' another from another item in the same array', () => {
-      const mockedItems = [
-        {},
-        {
-          isElectronicResource: true,
-          electronicResources: [
-            {
-              id: 'someId',
-              title: 'someTitle',
-              url: 'someUrl',
-            },
-          ],
-        },
-        {
-          isElectronicResource: true,
-          electronicResources: [
-            {
-              id: 'someId2',
-              title: 'someTitle2',
-              url: 'someUrl2',
-            },
-            {
-              id: 'someId3',
-              title: 'someTitle3',
-              url: 'someUrl3',
-            },
-          ],
-        },
-      ];
-      expect(getAggregatedElectronicResources(mockedItems))
-        .to.eql([
-          {
-            id: 'someId',
-            title: 'someTitle',
-            url: 'someUrl',
-          },
-          {
-            id: 'someId2',
-            title: 'someTitle2',
-            url: 'someUrl2',
-          },
-          {
-            id: 'someId3',
-            title: 'someTitle3',
-            url: 'someUrl3',
-          },
-        ]);
-    });
-  });
-});
-
 describe('truncateStringOnWhitespace()', () => {
   it('Should return a short title as-is', () => {
     expect(truncateStringOnWhitespace('Test Title', 25)).to.equal('Test Title');
@@ -935,13 +816,13 @@ describe('extractNoticePreference', () => {
     expect(extractNoticePreference({ '123': 'nonsense' })).to.equal('None');
   });
   it('should return "Email" if "268" field value is "z"', () => {
-    expect(extractNoticePreference({ '268': {'value': 'z'} })).to.equal('Email');
+    expect(extractNoticePreference({ '268': { 'value': 'z' } })).to.equal('Email');
   });
   it('should return "Telephone" if "268" field value is "p"', () => {
-    expect(extractNoticePreference({ '268': {'value': 'p'} })).to.equal('Telephone');
+    expect(extractNoticePreference({ '268': { 'value': 'p' } })).to.equal('Telephone');
   });
   it('should return "None" if "268" field value is "-"', () => {
-    expect(extractNoticePreference({ '268': {'value': '-'} })).to.equal('None');
+    expect(extractNoticePreference({ '268': { 'value': '-' } })).to.equal('None');
   });
 });
 

--- a/test/unit/utils.test.js
+++ b/test/unit/utils.test.js
@@ -26,6 +26,7 @@ import {
   camelToShishKabobCase,
   institutionNameByNyplSource,
   isNyplBnumber,
+  removeCheckDigit,
 } from '../../src/app/utils/utils';
 
 /**
@@ -1008,5 +1009,15 @@ describe('getIdentifierQuery', () => {
       oclc: '34567',
       lccn: '45678',
     })).to.equal('&issn=1234&isbn=23456&oclc=34567&lccn=45678');
+  });
+});
+
+describe('removeCheckDigit', () => {
+  it('should return original bibId when not 10 characters long', () => {
+    expect(removeCheckDigit('b12345678')).to.eq('b12345678');
+    expect(removeCheckDigit('b1234567890')).to.eq('b1234567890');
+  });
+  it('should strip the last character when bibId is 10 characters long', () => {
+    expect(removeCheckDigit('b123456789')).to.eq('b12345678');
   });
 });


### PR DESCRIPTION
**What's this do?**
This PR adds a helper function removeCheckDigit to utils and uses it to sanitize the BibId passed into the url.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SCC-3233

When exporting data from Sierra, we very often get a spreadsheet full of 9-digit bnumbers because they've been exported with the check digit. This leads to a lot of 404s, counting digits, and copy-paste-delete-the-last-number-ing.

**Do these changes have automated tests?**
I've added an automated test for the helper function.