### PR TITLE
SCC-3505 - Replace hardcoded logout link with base ENV var

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -16,6 +16,7 @@ ITEM_BATCH_SIZE=[some number]
 BASE_URL=/research/research-catalog
 REDIRECT_FROM_BASE_URL=/research/collections/shared-collection-catalog
 WEBPAC_BASE_URL=https://[fqdn]/
+LOGIN_BASE_URL=https://[fqdn]/
 CIRCULATING_CATALOG=https://[fqdn]/
 OPEN_LOCATIONS=315,300
 SHEP_BIBS_LIMIT=25

--- a/ENVIRONMENTVARS.md
+++ b/ENVIRONMENTVARS.md
@@ -50,6 +50,7 @@ These environment variables control how certain elements on the page render and 
 | `LIB_ANSWERS_EMAIL` | string | "email@email.com" | The email used in the `Feedback` component for the destination field. |
 | `loada11y` | boolean | true, false | Used to turn on the `react-a11y` package for accessibility testing. Only use in development mode. |
 | `LOGIN_URL` | string | "" | The URL to log a user into the NYPL Catalog. The user will be redirected to sign in with their NYPL credentials. This needs a valid value in order to sign in successfully, and it needs the "my-account" value in the `FEATURES` environment variable set. |
+| `LOGIN_BASE_URL` | string | "" | The base URL used for user authentication in the NYPL Catalog. The user will be redirected to sign in with their NYPL credentials. This needs a valid value in order to sign in successfully, and it needs the "my-account" value in the `FEATURES` environment variable set. |
 | `NON_RECAP_CLOSED_LOCATIONS` | string | "" | The list of closed locations that are not recap. |
 | `OPEN_LOCATIONS` |  string | "Library of the Performing Arts" | A comma-delimited list of locations. If set to anything other than an empty string, only locations matching one of these strings will be displayed. |
 | `RECAP_CLOSED_LOCATIONS` | string | "" | The list of closed locations that are recap. |

--- a/ENVIRONMENTVARS.md
+++ b/ENVIRONMENTVARS.md
@@ -50,7 +50,7 @@ These environment variables control how certain elements on the page render and 
 | `LIB_ANSWERS_EMAIL` | string | "email@email.com" | The email used in the `Feedback` component for the destination field. |
 | `loada11y` | boolean | true, false | Used to turn on the `react-a11y` package for accessibility testing. Only use in development mode. |
 | `LOGIN_URL` | string | "" | The URL to log a user into the NYPL Catalog. The user will be redirected to sign in with their NYPL credentials. This needs a valid value in order to sign in successfully, and it needs the "my-account" value in the `FEATURES` environment variable set. |
-| `LOGIN_BASE_URL` | string | "" | The base URL used for user authentication in the NYPL Catalog. The user will be redirected to sign in with their NYPL credentials. This needs a valid value in order to sign in successfully, and it needs the "my-account" value in the `FEATURES` environment variable set. |
+| `LOGIN_BASE_URL` | string | "" | The base URL used to construct the environment-dependent logout link. It will soon be used to construct the login URL, replacing the LOGIN_URL env var. |
 | `NON_RECAP_CLOSED_LOCATIONS` | string | "" | The list of closed locations that are not recap. |
 | `OPEN_LOCATIONS` |  string | "Library of the Performing Arts" | A comma-delimited list of locations. If set to anything other than an empty string, only locations matching one of these strings will be displayed. |
 | `RECAP_CLOSED_LOCATIONS` | string | "" | The list of closed locations that are recap. |

--- a/src/app/components/LogoutLink/LogoutLink.jsx
+++ b/src/app/components/LogoutLink/LogoutLink.jsx
@@ -4,6 +4,7 @@ import React, { useContext, useEffect, useState } from 'react';
 
 import { PatronContext } from '../../context/PatronContext';
 import { trackDiscovery } from '../../utils/utils';
+import appConfig from '../../data/appConfig';
 
 /**
  * Renders a simple link to log out the user out from the Catalog.
@@ -12,7 +13,7 @@ const LogoutLink = ({
   baseUrl = '/research/research-catalog',
   delineate = false
 }) => {
-  const logoutLink = "https://login.nypl.org/auth/logout?redirect_uri=";
+  const logoutLink = `${appConfig.logoutUrl}?redirect_uri=`;
   const [backLink, setBackLink] = useState('');
   const { loggedIn } = useContext(PatronContext);
 

--- a/src/app/data/appConfig.js
+++ b/src/app/data/appConfig.js
@@ -33,6 +33,7 @@ const appConfig = {
   circulatingCatalog: process.env.CIRCULATING_CATALOG,
   shepApi: process.env.SHEP_API,
   loginUrl: process.env.LOGIN_URL || 'https://login.nypl.org/auth/login',
+  logoutUrl: process.env.LOGIN_BASE_URL + '/logout' || 'https://login.nypl.org/auth/logout',
   tokenUrl: 'https://isso.nypl.org/',
   publicKey:
     '-----BEGIN PUBLIC KEY-----\n' +

--- a/test/unit/LogoutLink.test.js
+++ b/test/unit/LogoutLink.test.js
@@ -6,13 +6,14 @@ import { mount } from 'enzyme';
 
 import LogoutLink from './../../src/app/components/LogoutLink/LogoutLink';
 import { PatronProvider } from '../../src/app/context/PatronContext';
+import appConfig from '../../src/app/data/appConfig';
 
 const mountLogoutLink = ({ loggedIn = false, delineate = false }) => mount(
   <PatronProvider patron={{ loggedIn }}>
     <LogoutLink delineate={delineate} />
   </PatronProvider>
 );
-const logoutLink = "https://login.nypl.org/auth/logout?redirect_uri=";
+const logoutLink = `${appConfig.logoutUrl}?redirect_uri=`;
 
 describe('LogoutLink', () => {
   it('does not render if patron is not logged in', () => {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -54,6 +54,7 @@ const commonSettings = {
       'process.env': {
         SHEP_API: JSON.stringify(process.env.SHEP_API),
         LOGIN_URL: JSON.stringify(process.env.LOGIN_URL),
+        LOGIN_BASE_URL: JSON.stringify(process.env.LOGIN_BASE_URL),
         LEGACY_BASE_URL: JSON.stringify(process.env.LEGACY_BASE_URL),
         CLOSED_LOCATIONS: JSON.stringify(process.env.CLOSED_LOCATIONS),
         RECAP_CLOSED_LOCATIONS: JSON.stringify(
@@ -235,6 +236,7 @@ if (ENV === 'production') {
           GA_ENV: JSON.stringify(process.env.GA_ENV),
           SHEP_API: process.env.SHEP_API,
           LOGIN_URL: process.env.LOGIN_URL,
+          LOGIN_BASE_URL: process.env.LOGIN_BASE_URL,
           LEGACY_BASE_URL: process.env.LEGACY_BASE_URL,
           CLOSED_LOCATIONS: process.env.CLOSED_LOCATIONS,
           RECAP_CLOSED_LOCATIONS: JSON.stringify(


### PR DESCRIPTION
**What's this do?**
This PR adds an env var LOGIN_BASE_URL that will allow for an environment dependent authentication url to be used for both login and logout.

It also adds a logoutUrl app config attribute that's used to replace the hardcoded value in the LogoutLink component.

It currently does not replace the old LOGIN_URL env var, but this will be addressed as a follow-up.

**Why are we doing this? (w/ JIRA link if applicable)**
Full context: https://jira.nypl.org/browse/SCC-3505

**Do these changes have automated tests?**
There is an update to the automated test for LogoutLink

**How should this be QAed?**
Ensure that the logout functionality is still working and points to the correct route for qa and prod respectively.

**Dependencies for merging? Releasing to production?**
The ENV var should be set on production before this change is deployed. It is currently set on QA.

**Has the application documentation been updated for these changes?**
Yes
