### PR TITLE
[SCC-3287] Show "Container" heading on items table when Bib is an archive collection.

### DIFF
--- a/src/app/components/Item/ItemTable.jsx
+++ b/src/app/components/Item/ItemTable.jsx
@@ -7,7 +7,7 @@ import StatusLinks from './StatusLinks';
 import appConfig from '../../data/appConfig';
 import { MediaContext } from '../Application/Application';
 
-const ItemTable = ({ items, bibId, id, searchKeywords, page }) => {
+const ItemTable = ({ items, bibId, id, searchKeywords, page, isArchiveCollection }) => {
   const media = React.useContext(MediaContext)
   if (
     !_isArray(items) ||
@@ -32,6 +32,9 @@ const ItemTable = ({ items, bibId, id, searchKeywords, page }) => {
     [items]
   );
   const volText = isDesktop ? 'Vol/Date' : 'Vol/\nDate'
+  const archiveColumnText = 'Container';
+  const volColumnHeading = isArchiveCollection ? archiveColumnText : volText;
+
   return (
     itemGroups.map(group => (
       <div key={`item-${group[0].id}-div`} className={ `results-items-element${page === 'SearchResults' ? ' search-results-table-div' : null}`}>
@@ -40,7 +43,7 @@ const ItemTable = ({ items, bibId, id, searchKeywords, page }) => {
           <thead>
             <tr>
               {isBibPage ? <th className={`status-links ${isDesktop ? '' : 'mobile'}`} scope="col">Status</th> : null}
-              {includeVolColumn ? <th scope="col">{volText}</th> : null}
+              {includeVolColumn ? <th scope="col">{volColumnHeading}</th> : null}
               <th scope="col">Format</th>
               { (!includeVolColumn && !isDesktop) ? <th scope="col">Call Number</th> : null }
               {isBibPage && isDesktop ? <th scope="col">Access</th> : null}
@@ -88,6 +91,7 @@ ItemTable.propTypes = {
   searchKeywords: PropTypes.string,
   holdings: PropTypes.array,
   page: PropTypes.string,
+  isArchiveCollection: PropTypes.bool,
 };
 
 ItemTable.defaultProps = {

--- a/src/app/components/Item/ItemTable.jsx
+++ b/src/app/components/Item/ItemTable.jsx
@@ -96,6 +96,7 @@ ItemTable.propTypes = {
 
 ItemTable.defaultProps = {
   id: '',
+  isArchiveCollection: false
 };
 
 export default ItemTable;

--- a/src/app/components/Item/ItemsContainer.jsx
+++ b/src/app/components/Item/ItemsContainer.jsx
@@ -202,7 +202,8 @@ ItemsContainer.propTypes = {
 ItemsContainer.defaultProps = {
   shortenItems: false,
   searchKeywords: '',
-  itemPage: '0'
+  itemPage: '0',
+  isArchiveCollection: false,
 };
 
 ItemsContainer.contextTypes = {

--- a/src/app/components/Item/ItemsContainer.jsx
+++ b/src/app/components/Item/ItemsContainer.jsx
@@ -47,7 +47,7 @@ class ItemsContainer extends React.Component {
      * we need to shorten it to the page limit AND
      * not show all
      */
-    const { bibId, holdings, searchKeywords, showAll } = this.props;
+    const { bibId, holdings, searchKeywords, showAll, isArchiveCollection } = this.props;
     const itemsToDisplay =
       items && shortenItems && !showAll
         ? items.slice(0, itemsListPageLimit)
@@ -62,6 +62,7 @@ class ItemsContainer extends React.Component {
         id="bib-item-table"
         searchKeywords={searchKeywords}
         holdings={holdings}
+        isArchiveCollection={isArchiveCollection}
       />
     ) : null;
   }
@@ -195,6 +196,7 @@ ItemsContainer.propTypes = {
   shortenItems: PropTypes.bool,
   showAll: PropTypes.bool,
   finishedLoadingItems: PropTypes.bool,
+  isArchiveCollection: PropTypes.bool,
 };
 
 ItemsContainer.defaultProps = {

--- a/src/app/pages/BibPage.jsx
+++ b/src/app/pages/BibPage.jsx
@@ -74,6 +74,9 @@ export const BibPage = (
   const { eResources: eResourcesWithoutAeon } = getElectronicResources(bib);
 
   const hasElectronicResources = bib.electronicResources && bib.electronicResources.length > 0
+
+  const isArchiveCollection = Array.isArray(bib.issuance) && bib.issuance.some(issuance => issuance['@id'] === 'urn:biblevel:c');
+
   let numPhysicalItems
   // TODO: This is a temporary fix to handle records that may or may not have
   // been recently indexed. When the API consistently serves bib.numItemsTotal,
@@ -156,6 +159,7 @@ export const BibPage = (
               shortenItems={location.pathname.indexOf('all') !== -1}
               showAll={showAll}
               finishedLoadingItems={bib.done}
+              isArchiveCollection={isArchiveCollection}
             />
           </section>
           : null

--- a/src/app/pages/BibPage.jsx
+++ b/src/app/pages/BibPage.jsx
@@ -73,6 +73,9 @@ export const BibPage = (
   const hasElectronicResources = bib.electronicResources && bib.electronicResources.length > 0
   const numPhysicalItems = bib.numItemsTotal
   const hasItems = numPhysicalItems > 0
+
+  const isArchiveCollection = Array.isArray(bib.issuance) && bib.issuance.some(issuance => issuance['@id'] === 'urn:biblevel:c');
+  
   const isOnlyElectronicResources = !hasItems && hasElectronicResources
   const hasPhysicalItems = !isOnlyElectronicResources && hasItems
 

--- a/test/unit/ItemTable.test.js
+++ b/test/unit/ItemTable.test.js
@@ -107,5 +107,12 @@ describe('ItemTable', () => {
       component = mount(<ItemTable page='not search results' items={data} />);
       expect(component.find('th').length).to.equal(5)
     })
+
+    it('should have Container column heading if it is an archive collection', () => {
+      component.unmount()
+      component = mount(<ItemTable page='not search results' isArchiveCollection items={data.map((item, i) => ({ volume: `${i}`, ...item }))} />);
+      const header = component.find('thead').at(0);
+      expect(header.find('th').at(1).text()).to.equal('Container');
+    })
   });
 });

--- a/test/unit/SearchResultsItems.test.jsx
+++ b/test/unit/SearchResultsItems.test.jsx
@@ -81,6 +81,7 @@ describe('SearchResultsItems', () => {
         items: [],
         bibId: "b1234",
         id: "1234",
+        isArchiveCollection: false,
         searchKeywords: "word1 word2 word3",
         page: "SearchResults"
       })


### PR DESCRIPTION
**What's this do?**
This PR introduces a check at the Bib Page level to see if Bib is an archive collection based on the issuance id.
It then passes it as a prop down to ItemsTable and conditionally shows the "Container" label if it is true.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SCC-3287

**Do these changes have automated tests?**
No

**How should this be QAed?**
Check to see if Archive Collection bibs have the "Container" label in the volumes column header.
