### PR TITLE
[SCC-3233] Redirect to bib page when bibId has a check digit

### DIFF
--- a/src/app/utils/utils.js
+++ b/src/app/utils/utils.js
@@ -733,7 +733,7 @@ function hasCheckDigit(bnum = "") {
 }
 
 /**
- * Given a bnumber, remove check digit (int at 10th position) fif present.
+ * Given a bnumber, remove check digit (int at 10th position) if present.
  * Return the original bnumber if greater than or less than 10 characters.
  */
 function removeCheckDigit(bnum = "") {

--- a/src/app/utils/utils.js
+++ b/src/app/utils/utils.js
@@ -726,6 +726,21 @@ function isNyplBnumber(bnum) {
 }
 
 /**
+ * Given a bnumber, return true if it is an NYPL bnumber and has a 10th character.
+ */
+function hasCheckDigit(bnum = "") {
+  return isNyplBnumber(bnum) && bnum.length === 10;
+}
+
+/**
+ * Given a bnumber, remove check digit (int at 10th position) fif present.
+ * Return the original bnumber if greater than or less than 10 characters.
+ */
+function removeCheckDigit(bnum = "") {
+  return hasCheckDigit(bnum) ? bnum.slice(0, -1) : bnum;
+}
+
+/**
  * Given an item, return Aeon url with params added to pre-populate the form
  */
 
@@ -775,6 +790,8 @@ export {
   institutionNameByNyplSource,
   addSource,
   isNyplBnumber,
+  hasCheckDigit,
+  removeCheckDigit,
   removeAeonLinksFromResource,
   isAeonLink,
   aeonUrl,

--- a/src/server/ApiRoutes/Bib.js
+++ b/src/server/ApiRoutes/Bib.js
@@ -5,7 +5,7 @@ import logger from '../../../logger';
 import appConfig from '../../app/data/appConfig';
 import extractFeatures from '../../app/utils/extractFeatures';
 import { itemBatchSize } from '../../app/data/constants';
-import { isNyplBnumber } from '../../app/utils/utils';
+import { isNyplBnumber, hasCheckDigit, removeCheckDigit } from '../../app/utils/utils';
 import { appendDimensionsToExtent } from '../../app/utils/appendDimensionsToExtent';
 
 const nyplApiClientCall = (query, itemFrom, filterItemsStr = "") => {
@@ -116,6 +116,9 @@ const addLocationUrls = (bib) => {
 };
 
 function fetchBib (bibId, cb, errorcb, reqOptions, res) {
+  // Redirect if bibId has a Check Digit
+  if (hasCheckDigit(bibId)) { res.redirect(`${appConfig.baseUrl}/bib/${removeCheckDigit(bibId)}`); }
+  
   const options = Object.assign({
     fetchSubjectHeadingData: true,
     features: [],

--- a/test/unit/utils.test.js
+++ b/test/unit/utils.test.js
@@ -26,6 +26,8 @@ import {
   camelToShishKabobCase,
   institutionNameByNyplSource,
   isNyplBnumber,
+  hasCheckDigit,
+  removeCheckDigit
 } from '../../src/app/utils/utils';
 
 /**
@@ -862,6 +864,25 @@ describe('isNyplBnumber', () => {
     expect(isNyplBnumber('pb1234')).to.eq(false);
     expect(isNyplBnumber('hb1234')).to.eq(false);
     expect(isNyplBnumber('cb1234')).to.eq(false);
+  });
+});
+
+describe('hasCheckDigit', () => {
+  it('determine if bib id is NYPL bnumber and is 10 characters long', () => {
+    expect(hasCheckDigit('b123456789')).to.eq(true);
+    expect(hasCheckDigit('b12345678')).to.eq(false);
+    expect(hasCheckDigit('b1234567891')).to.eq(false);
+    expect(hasCheckDigit('cb12345678')).to.eq(false);
+  });
+});
+
+describe('removeCheckDigit', () => {
+  it('should remove check digit from bnumber when present', () => {
+    expect(removeCheckDigit('b123456789')).to.eq('b12345678');
+  });
+  it('should return original bnumber when check digit is absent', () => {
+    expect(removeCheckDigit('b12345678')).to.eq('b12345678');
+    expect(removeCheckDigit('b1234567891')).to.eq('b1234567891');
   });
 });
 


### PR DESCRIPTION
What's this do?
This PR adds a redirect to the correct bib page when the bib number has a check digit (10th character in an NYPL bnumber)

It also adds the helper functions hasCheckDigit and removeCheckDigit to determine if bibId has a check digit and to remove it if present.

Why are we doing this? (w/ JIRA link if applicable)
https://jira.nypl.org/browse/SCC-3233

When exporting data from Sierra, we very often get a spreadsheet full of 9-digit bnumbers because they've been exported with the check digit. This leads to a lot of 404s, counting digits, and copy-paste-delete-the-last-number-ing.

Do these changes have automated tests?
I've added an automated test for the helper functions.