### PR TITLE
[SCC-3529] Fix blank page issue on development

### DIFF
--- a/src/app/components/ResultsList/ResultsList.jsx
+++ b/src/app/components/ResultsList/ResultsList.jsx
@@ -104,7 +104,8 @@ const ResultsList = ({
     const eResources = result.electronicResources
     const totalPhysicalItems = result.numItemsTotal
     const hasPhysicalItems = totalPhysicalItems > 0;
-    const itemCount = hasPhysicalItems ? totalPhysicalItems : eResources.length
+    const numElectronicResources = eResources?.length || 0;
+    const itemCount = hasPhysicalItems ? totalPhysicalItems : numElectronicResources;
     const resourceType = hasPhysicalItems ? 'Item' : 'Resource';
     const itemMessage = `${itemCount} ${resourceType}${itemCount !== 1 ? 's' : ''}`;
     return (
@@ -131,18 +132,20 @@ const ResultsList = ({
               <li className="nypl-results-publication">{publicationStatement}</li>
               {yearPublished}
               {
-                totalPhysicalItems > 0 || eResources.length > 0 ?
+                totalPhysicalItems > 0 || numElectronicResources > 0 ?
                   <li className="nypl-results-info">
                     {itemMessage}
                   </li>
                   : ''
               }
             </ul>
-            <ElectronicResourcesResultsItem
-              resources={eResources}
-              onClick={resourcesOnClick}
-              bibUrl={bibUrl}
-            />
+            {eResources && (
+              <ElectronicResourcesResultsItem
+                resources={eResources}
+                onClick={resourcesOnClick}
+                bibUrl={bibUrl}
+              />
+            )}
             {
               hasRequestTable &&
               <>

--- a/src/app/components/SubjectHeading/BibsList.jsx
+++ b/src/app/components/SubjectHeading/BibsList.jsx
@@ -26,7 +26,7 @@ class BibsList extends React.Component {
     this.updateBibPage = this.updateBibPage.bind(this);
     this.lastBib = this.lastBib.bind(this);
     this.firstBib = this.firstBib.bind(this);
-    this.perPage = appConfig.shepBibsLimit;
+    this.perPage = parseInt(appConfig.shepBibsLimit);
     this.changeBibSorting = this.changeBibSorting.bind(this);
     this.fetchBibs = this.fetchBibs.bind(this);
     this.pagination = this.pagination.bind(this);

--- a/src/app/data/appConfig.js
+++ b/src/app/data/appConfig.js
@@ -80,7 +80,7 @@ const appConfig = {
   libAnswersEmail: process.env.LIB_ANSWERS_EMAIL,
   itemBatchSize: process.env.ITEM_BATCH_SIZE || 100,
   webpacBaseUrl: process.env.WEBPAC_BASE_URL,
-  shepBibsLimit: process.env.SHEP_BIBS_LIMIT || 50,
+  shepBibsLimit: parseInt(process.env.SHEP_BIBS_LIMIT) || 50,
 };
 
 export default appConfig;

--- a/src/app/data/appConfig.js
+++ b/src/app/data/appConfig.js
@@ -80,7 +80,7 @@ const appConfig = {
   libAnswersEmail: process.env.LIB_ANSWERS_EMAIL,
   itemBatchSize: process.env.ITEM_BATCH_SIZE || 100,
   webpacBaseUrl: process.env.WEBPAC_BASE_URL,
-  shepBibsLimit: parseInt(process.env.SHEP_BIBS_LIMIT) || 50,
+  shepBibsLimit: process.env.SHEP_BIBS_LIMIT || 50,
 };
 
 export default appConfig;


### PR DESCRIPTION
**What's this do?**
This PR fixes a bug that was introduced recently with some changes to the structure of eResources ([relevant commit](https://github.com/NYPL/discovery-front-end/commit/213f3971c68f1dab93c570444906512ef43e4a3f))

My fix sets the fallback of numElectronicResources to 0 when the electronicResources attribute of the bib is empty or undefined.

This PR also fixes an unrelated console error where perPage is expected to be a number when passed into the Pagination component, though it's defined as a string elsewhere.

**Why are we doing this? (w/ JIRA link if applicable)**
Some of the recent changes to the parsing of eResources introduced [this bug](https://jira.nypl.org/browse/SCC-3529) in the development branch and we want to fix before deploying to production. 