### PR TITLE
Noref/fix nypl api client call for shep

### DIFF
--- a/src/server/ApiRoutes/Bib.js
+++ b/src/server/ApiRoutes/Bib.js
@@ -9,20 +9,24 @@ import { isNyplBnumber } from '../../app/utils/utils';
 import { appendDimensionsToExtent } from '../../app/utils/appendDimensionsToExtent';
 
 const nyplApiClientCall = (query, itemFrom, filterItemsStr = "") => {
-  const queryForItemPage = typeof itemFrom !== 'undefined' ? `items_size=${itemBatchSize}&items_from=${itemFrom}` : '';
+  const itemRelatedQueries = []
+  if (typeof itemFrom !== 'undefined') itemRelatedQueries.push(`items_size=${itemBatchSize}&items_from=${itemFrom}`)
   let fullQuery;
   if (query.includes('.annotated-marc')) {
     fullQuery = query;
   } else {
-    const itemQuery = (filterItemsStr.length ? `&${filterItemsStr}` : '');
-    const pageAndItemQuery = queryForItemPage || itemQuery ? `?${queryForItemPage}${itemQuery}&merge_checkin_card_items=true` : ''
-    fullQuery = `${query}${pageAndItemQuery}`
+    if (filterItemsStr.length) itemRelatedQueries.push(`${filterItemsStr}`)
+    if (itemRelatedQueries.length) {
+      itemRelatedQueries.push('merge_checkin_card_items=true')
+    }
+    const itemQuery = itemRelatedQueries.length ? '?' + itemRelatedQueries.join('&') : ''
+    fullQuery = `${query}${itemQuery}`
   }
   return nyplApiClient()
-    .then(client =>
-      client.get(
+    .then(client => {
+      return client.get(
         `/discovery/resources/${fullQuery}`
-      )
+      )}
     );
 };
 

--- a/src/server/ApiRoutes/Bib.js
+++ b/src/server/ApiRoutes/Bib.js
@@ -9,13 +9,14 @@ import { isNyplBnumber } from '../../app/utils/utils';
 import { appendDimensionsToExtent } from '../../app/utils/appendDimensionsToExtent';
 
 const nyplApiClientCall = (query, itemFrom, filterItemsStr = "") => {
-  const queryForItemPage = typeof itemFrom !== 'undefined' ? `?items_size=${itemBatchSize}&items_from=${itemFrom}` : '';
+  const queryForItemPage = typeof itemFrom !== 'undefined' ? `items_size=${itemBatchSize}&items_from=${itemFrom}` : '';
   let fullQuery;
   if (query.includes('.annotated-marc')) {
     fullQuery = query;
   } else {
     const itemQuery = (filterItemsStr.length ? `&${filterItemsStr}` : '');
-    fullQuery = `${query}${queryForItemPage}${itemQuery}&merge_checkin_card_items=true`
+    const pageAndItemQuery = queryForItemPage || itemQuery ? `?${queryForItemPage}${itemQuery}&merge_checkin_card_items=true` : ''
+    fullQuery = `${query}${pageAndItemQuery}`
   }
   return nyplApiClient()
     .then(client =>

--- a/src/server/ApiRoutes/Bib.js
+++ b/src/server/ApiRoutes/Bib.js
@@ -16,11 +16,8 @@ const nyplApiClientCall = (query, itemFrom, filterItemsStr = "") => {
     fullQuery = query;
   } else {
     if (filterItemsStr.length) itemRelatedQueries.push(`${filterItemsStr}`)
-    if (itemRelatedQueries.length) {
-      itemRelatedQueries.push('merge_checkin_card_items=true')
-    }
-    const itemQuery = itemRelatedQueries.length ? '?' + itemRelatedQueries.join('&') : ''
-    fullQuery = `${query}${itemQuery}`
+    itemRelatedQueries.push('merge_checkin_card_items=true')
+    fullQuery = `${query}?${itemRelatedQueries.join('&')}`
   }
   return nyplApiClient()
     .then(client => {

--- a/test/unit/Bib.test.js
+++ b/test/unit/Bib.test.js
@@ -152,7 +152,7 @@ describe('Bib', () => {
     it('with neither itemFrom nor itemFilterStr', async function () {
       const query = 'b12345678'
       await Bib.nyplApiClientCall(query, undefined,)
-      expect(urlRecord).to.equal('/discovery/resources/b12345678')
+      expect(urlRecord).to.equal('/discovery/resources/b12345678?merge_checkin_card_items=true')
     })
   })
 });

--- a/test/unit/Bib.test.js
+++ b/test/unit/Bib.test.js
@@ -112,9 +112,16 @@ describe('Bib', () => {
   });
   describe('nyplApiClientCall', () => {
     let apiClientStub
+    let urlRecord
     before(() => {
-      apiClientStub = stub(NyplApiClient.prototype, 'get').returns({ bib: { id: '123' } })
+      apiClientStub = stub(NyplApiClient.prototype, 'get').callsFake((url) => {
+        urlRecord = url
+        return { bib: { id: '123' } }
+      })
     });
+    afterEach(() => {
+      urlRecord = null
+    })
     after(() => {
       apiClientStub.restore();
     });
@@ -123,12 +130,29 @@ describe('Bib', () => {
       Bib.nyplApiClientCall(query)
       expect(apiClientStub.calledWith(`/discovery/resources/${query}`))
     })
-    it('regular bib call', () => {
+    it('regular bib call', async function () {
       const query = 'b12345678'
       const itemFrom = 3
       const itemFilterStr = 'items_location=loc:123'
-      Bib.nyplApiClientCall(query, itemFrom,)
-      expect(apiClientStub.calledWith(`/discovery/resources/${query}${itemFilterStr}&merge_checkin_card_items=true`))
+      await Bib.nyplApiClientCall(query, itemFrom, itemFilterStr)
+      expect(urlRecord).to.equal('/discovery/resources/b12345678?items_size=20&items_from=3&items_location=loc:123&merge_checkin_card_items=true')
+    })
+    it('with no itemFrom', async function () {
+      const query = 'b12345678'
+      const itemFilterStr = 'items_location=loc:123'
+      await Bib.nyplApiClientCall(query, undefined, itemFilterStr)
+      expect(urlRecord).to.equal('/discovery/resources/b12345678?items_location=loc:123&merge_checkin_card_items=true')
+    })
+    it('with no itemFilterStr', async function () {
+      const query = 'b12345678'
+      const itemFrom = 3
+      await Bib.nyplApiClientCall(query, itemFrom,)
+      expect(urlRecord).to.equal('/discovery/resources/b12345678?items_size=20&items_from=3&merge_checkin_card_items=true')
+    })
+    it('with neither itemFrom nor itemFilterStr', async function () {
+      const query = 'b12345678'
+      await Bib.nyplApiClientCall(query, undefined,)
+      expect(urlRecord).to.equal('/discovery/resources/b12345678')
     })
   })
 });


### PR DESCRIPTION
This is a hotfix to deal with the large number of single letter titles in SHEP. The issue is currently being caused by queries to Discovery API of the form `../resources/b13977072&merge_checkin_card_items=true`, which 404s.

- Changes the way we build queries so that it works even with missing values
- Fixes tests which were previously broken and adds full test coverage for nyplApiClientCall



