### PR TITLE
SCC-3518: Item results text

### DIFF
--- a/src/app/components/ItemFilters/ItemFilters.jsx
+++ b/src/app/components/ItemFilters/ItemFilters.jsx
@@ -40,24 +40,28 @@ const ItemFilters = (
   useEffect(() => {
     let timeout;
     setSelectedFieldDisplayStr(parsedFilterSelections());
-    // Once the new items are fetched, focus on the filter UI and the
-    // results, but don't do this if the user requested to view all items
-    // until all the items are fetched. It is annoying if the text keeps
-    // getting focused and the page keeps jumping around.
-    if (showAll && finishedLoadingItems) {
-      resultsRef.current && resultsRef.current.focus();
-    } else {
-      // When filtering, delay the focus slightly because
-      // of the loading animation screen.
-      timeout = setTimeout(() => {
+    // Once the new items are filtered and fetched, focus on the filter UI
+    // and the results, but don't do this if the user requested to view all
+    // items until all the items are fetched. It is annoying if the text
+    // keeps getting focused and the page keeps jumping around.
+    // The easiest way to figure out if a filter or year search was done,
+    // is to check if the `selectedFieldDisplayStr` string is not empty.
+    if (selectedFieldDisplayStr) {
+      if (showAll && finishedLoadingItems) {
         resultsRef.current && resultsRef.current.focus();
-      }, 1000);
+      } else {
+        // When filtering, delay the focus slightly because
+        // of the loading animation screen.
+        timeout = setTimeout(() => {
+          resultsRef.current && resultsRef.current.focus();
+        }, 1200);
+      }
     }
 
     return () => {
       clearTimeout(timeout);
     };
-  }, [parsedFilterSelections, showAll, finishedLoadingItems]);
+  }, [showAll, finishedLoadingItems, selectedFieldDisplayStr, parsedFilterSelections]);
 
   /**
    * When filters are applied or cleared, build new filter query
@@ -180,6 +184,7 @@ const ItemFilters = (
   // If there are filters, display the number of items that match the filters.
   // Otherwise, display the total number of items.
   const resultsItemsNumber = numItemsMatched;
+  const madeFilterOrSearch = selectedFieldDisplayStr.length > 0;
 
   return (
     <Fragment>
@@ -223,8 +228,9 @@ const ItemFilters = (
       <div id="view-all-items" className="item-filter-info" tabIndex="-1" ref={resultsRef}>
         <Heading level="three" size="callout">
           <>
-            {resultsItemsNumber > 0 ? resultsItemsNumber : 'No'} Result
-            {resultsItemsNumber !== 1 ? 's' : null} Found
+            {resultsItemsNumber > 0 ? resultsItemsNumber : 'No'}{' '}
+            {madeFilterOrSearch ? 'Matching' : null} Item
+            {resultsItemsNumber !== 1 ? 's' : null}
           </>
         </Heading>
         {selectedFieldDisplayStr ? (

--- a/test/unit/ItemFilters.test.js
+++ b/test/unit/ItemFilters.test.js
@@ -145,7 +145,7 @@ describe('ItemFilters', () => {
       expect(component.find('.item-filter-info').find('span').text()).to.equal("Filtered by format: 'Text'");
     });
     it('should display "5 Results Found"', () => {
-      expect(component.find('h3').text()).to.equal('5 Results Found');
+      expect(component.find('h3').text()).to.equal('5 Matching Items');
     });
   });
   // multiple filters will be an array in the router context
@@ -181,7 +181,7 @@ describe('ItemFilters', () => {
       expect(itemFilterInfo.find('span').text()).to.equal("Filtered by format: 'Text', 'PRINT'");
     });
     it('should display "1 Result Found"', () => {
-      expect(component.find('h3').text()).to.equal('1 Result Found');
+      expect(component.find('h3').text()).to.equal('1 Matching Item');
     });
   });
 
@@ -220,7 +220,7 @@ describe('ItemFilters', () => {
       expect(itemFilterInfo.find('span').text()).to.equal("Filtered by format: 'PRINT', status: 'Available'");
     });
     it('should display "0 Results Found"', () => {
-      expect(component.find('h3').text()).to.equal('No Results Found');
+      expect(component.find('h3').text()).to.equal('No Matching Items');
     });
   });
 

--- a/test/unit/ItemFilters.test.js
+++ b/test/unit/ItemFilters.test.js
@@ -144,7 +144,7 @@ describe('ItemFilters', () => {
       expect(itemFilterInfo.find('span').length).to.equal(1);
       expect(component.find('.item-filter-info').find('span').text()).to.equal("Filtered by format: 'Text'");
     });
-    it('should display "5 Results Found"', () => {
+    it('should display "5 Matching Items"', () => {
       expect(component.find('h3').text()).to.equal('5 Matching Items');
     });
   });
@@ -180,7 +180,7 @@ describe('ItemFilters', () => {
       expect(itemFilterInfo.find('span').length).to.equal(1);
       expect(itemFilterInfo.find('span').text()).to.equal("Filtered by format: 'Text', 'PRINT'");
     });
-    it('should display "1 Result Found"', () => {
+    it('should display "1 Matching Item"', () => {
       expect(component.find('h3').text()).to.equal('1 Matching Item');
     });
   });
@@ -219,7 +219,7 @@ describe('ItemFilters', () => {
       expect(itemFilterInfo.find('span').length).to.equal(1);
       expect(itemFilterInfo.find('span').text()).to.equal("Filtered by format: 'PRINT', status: 'Available'");
     });
-    it('should display "0 Results Found"', () => {
+    it('should display "No Matching Items"', () => {
       expect(component.find('h3').text()).to.equal('No Matching Items');
     });
   });


### PR DESCRIPTION
**What's this do?**
This resolves [SCC-3518](https://jira.nypl.org/browse/SCC-3518).

*Ignore the SCSS files. I think that should be resolved when an opened PR gets merged into `development`. Not sure why it's appearing here but might be a local git issue.*

This updates the results text and its focus on a bib page when making a filter or year search.
- By default when landing on a bib page without making a search or filter, "10 Results Found" turns into "10 Items" and is _not_ focused.
- After making a search or filter, "10 Results Found" turns into "4 Matching Items" and _is_ focused. "Matching" is added and is only displayed after making a search or filter.
- A single item "1 Result Found" becomes "1 Item".

**Why are we doing this? (w/ JIRA link if applicable)**
Better accessibility for the focused text and better copy.

**Do these changes have automated tests?**
Just updated existing tests.

**How should this be QAed?**
Test the examples in the JIRA ticket.

- http://local.nypl.org:3001/research/research-catalog/bib/b21139245
  - The "1 Item" text should not be focused when going to the page.
- http://local.nypl.org:3001/research/research-catalog/bib/b10833141
  - The "799 Items" text should not be focused when going to the page.
  - Search "1945" in the year search. "8 Matching Items" should display and that text should be focused.
  - Clear the search. Filter by location "offsite" and status "loaned" and the result text should be "No Matching Items" and it should be focused.

**Dependencies for merging? Releasing to production?**
[Description of any watchouts, dependencies, or issues we should be aware of]

**Has the application documentation been updated for these changes?**

**Did someone actually run this code to verify it works?**
