### PR TITLE
Check for app env variable for logout route

### DIFF
--- a/src/app/data/appConfig.js
+++ b/src/app/data/appConfig.js
@@ -33,7 +33,7 @@ const appConfig = {
   circulatingCatalog: process.env.CIRCULATING_CATALOG,
   shepApi: process.env.SHEP_API,
   loginUrl: process.env.LOGIN_URL || 'https://login.nypl.org/auth/login',
-  logoutUrl: process.env.LOGIN_BASE_URL + '/logout' || 'https://login.nypl.org/auth/logout',
+  logoutUrl: process.env.LOGIN_BASE_URL ? process.env.LOGIN_BASE_URL + '/logout' : 'https://login.nypl.org/auth/logout',
   tokenUrl: 'https://isso.nypl.org/',
   publicKey:
     '-----BEGIN PUBLIC KEY-----\n' +


### PR DESCRIPTION
**What's this do?**
This adds a ternary to check if LOGIN_BASE_URL env variable is set in order to fall back to the prod login route if it's false.

**Why are we doing this? (w/ JIRA link if applicable)**
This caused an issue where prod was using the wrong logout url when the env var wasn't set.
