### PR TITLE
[SCC-3540] Add summary to bib details field list

### DIFF
--- a/src/app/utils/bibDetailsUtils.jsx
+++ b/src/app/utils/bibDetailsUtils.jsx
@@ -31,6 +31,7 @@ const allFields = {
     { label: 'Found In', value: 'partOf' },
     { label: 'Publication Date', value: 'serialPublicationDates' },
     { label: 'Description', value: 'extent' },
+    { label: 'Summary', value: 'description' },
     { label: 'Donor/Sponsor', value: 'donor' },
     { label: 'Series Statement', value: 'seriesStatement' },
     { label: 'Uniform Title', value: 'uniformTitle' },

--- a/test/fixtures/bibs.js
+++ b/test/fixtures/bibs.js
@@ -8,6 +8,7 @@ const bibs = [
     creatorLiteral: ['De Grazia, Margreta.'],
     dateStartYear: 1991,
     dateString: ['1991'],
+    description: [''],
     dimensions: ['23 cm.'],
     extent: ['xi, 244 p., [8] p. of plates : ill. ;'],
     idIsbn: ['0198117787'],
@@ -1547,6 +1548,255 @@ const bibs = [
     uri: 'b21147020',
     suppressed: false,
   },
+  //##### bib with description #####
+  {
+    '@context': 'http://discovery-api-production.us-east-1.elasticbeanstalk.com/api/v0.1/discovery/context_all.jsonld',
+    '@type': [
+      'nypl:Item',
+      'nypl:Resource'
+    ],
+    '@id': 'res:b10049806',
+    'carrierType': [
+      {
+        '@id': 'carriertypes:nc',
+        'prefLabel': 'volume'
+      }
+    ],
+    'contributorLiteral': [
+      'Hurty-Peck & Company.'
+    ],
+    'createdString': [
+      '1971'
+    ],
+    'createdYear': 1971,
+    'creatorLiteral': [
+      'Noling, A. W.,'
+    ],
+    'dateStartYear': 1971,
+    'dateString': [
+      '1971'
+    ],
+    'description': [
+      'Bibliography of literature about drinks and drinking, primarily English-language titles in the Hurty-Peck Library of Beverage Literature. Over 5000 citations are alphabetically arranged by author. Includes topical subject list, short-title list, list of libraries with beverage collections.'
+    ],
+    'dimensions': [
+      '23 cm'
+    ],
+    'electronicResources': [],
+    'extent': [
+      '865 pages ;'
+    ],
+    'idIsbn': [
+      '9780810803527',
+      '0810803526'
+    ],
+    'idLccn': [
+      '   70142238'
+    ],
+    'identifier': [
+      {
+        '@type': 'bf:ShelfMark',
+        '@value': 'JFD 96-18728'
+      },
+      {
+        '@type': 'nypl:Bnumber',
+        '@value': '10049806'
+      },
+      {
+        '@type': 'bf:Isbn',
+        '@value': '9780810803527'
+      },
+      {
+        '@type': 'bf:Isbn',
+        '@value': '0810803526'
+      },
+      {
+        '@type': 'bf:Lccn',
+        '@value': '   70142238'
+      },
+      {
+        '@type': 'bf:Identifier',
+        '@value': '(OCoLC)265488'
+      },
+      {
+        '@type': 'bf:Identifier',
+        '@value': '(OCoLC)38231458 (OCoLC)122693667 (OCoLC)216575974 (OCoLC)247734956 (OCoLC)977272068'
+      }
+    ],
+    'issuance': [
+      {
+        '@id': 'urn:biblevel:m',
+        'prefLabel': 'monograph/item'
+      }
+    ],
+    'itemAggregations': [
+      {
+        '@type': 'nypl:Aggregation',
+        '@id': 'res:location',
+        'id': 'location',
+        'field': 'location',
+        'values': [
+          {
+            'value': 'loc:mal82',
+            'count': 1,
+            'label': 'Schwarzman Building - Main Reading Room 315'
+          }
+        ]
+      },
+      {
+        '@type': 'nypl:Aggregation',
+        '@id': 'res:format',
+        'id': 'format',
+        'field': 'format',
+        'values': []
+      },
+      {
+        '@type': 'nypl:Aggregation',
+        '@id': 'res:status',
+        'id': 'status',
+        'field': 'status',
+        'values': [
+          {
+            'value': 'status:a',
+            'count': 1,
+            'label': 'Available'
+          }
+        ]
+      }
+    ],
+    'items': [
+      {
+        '@id': 'res:i12872246',
+        'accessMessage': [
+          {
+            '@id': 'accessMessage:1',
+            'prefLabel': 'Use in library'
+          }
+        ],
+        'catalogItemType': [
+          {
+            '@id': 'catalogItemType:55',
+            'prefLabel': 'book, limited circ, MaRLI'
+          }
+        ],
+        'eddRequestable': true,
+        'holdingLocation': [
+          {
+            '@id': 'loc:mal82',
+            'prefLabel': 'Schwarzman Building - Main Reading Room 315'
+          }
+        ],
+        'idBarcode': [
+          '33433038947275'
+        ],
+        'identifier': [
+          {
+            '@type': 'bf:ShelfMark',
+            '@value': 'JFD 96-18728'
+          },
+          {
+            '@type': 'bf:Barcode',
+            '@value': '33433038947275'
+          }
+        ],
+        'owner': [
+          {
+            '@id': 'orgs:1101',
+            'prefLabel': 'General Research Division'
+          }
+        ],
+        'physRequestable': false,
+        'physicalLocation': [
+          'JFD 96-18728'
+        ],
+        'requestable': [
+          true
+        ],
+        'shelfMark': [
+          'JFD 96-18728'
+        ],
+        'specRequestable': false,
+        'status': [
+          {
+            '@id': 'status:a',
+            'prefLabel': 'Available'
+          }
+        ],
+        'uri': 'i12872246',
+        'idNyplSourceId': {
+          '@type': 'SierraNypl',
+          '@value': '12872246'
+        }
+      }
+    ],
+    'language': [
+      {
+        '@id': 'lang:eng',
+        'prefLabel': 'English'
+      }
+    ],
+    'lccClassification': [
+      'Z5776.B4 N63'
+    ],
+    'materialType': [
+      {
+        '@id': 'resourcetypes:txt',
+        'prefLabel': 'Text'
+      }
+    ],
+    'mediaType': [
+      {
+        '@id': 'mediatypes:n',
+        'prefLabel': 'unmediated'
+      }
+    ],
+    'note': [
+      {
+        'noteType': 'Note',
+        '@type': 'bf:Note',
+        'prefLabel': 'Includes holdings of the Hurty-Peck Library of Beverage Literature, now the A.W. Noling Hurty-Peck Collection of Beverage Literature in the University of California, Davis, Library.'
+      }
+    ],
+    'numAvailable': 1,
+    'numElectronicResources': 0,
+    'numItems': 1,
+    'numItemsMatched': 1,
+    'numItemsTotal': 1,
+    'nyplSource': [
+      'sierra-nypl'
+    ],
+    'placeOfPublication': [
+      'Metuchen, N.J.,'
+    ],
+    'publicationStatement': [
+      'Metuchen, N.J., Scarecrow Press, 1971.'
+    ],
+    'publisherLiteral': [
+      'Scarecrow Press,'
+    ],
+    'shelfMark': [
+      'JFD 96-18728'
+    ],
+    'subjectLiteral': [
+      'Beverages -- Bibliography.',
+      'Hurty-Peck & Company -- Library -- Catalogs.',
+      'Noling, A. W. -- Library -- Catalogs.'
+    ],
+    'title': [
+      'Beverage literature : a bibliography'
+    ],
+    'titleDisplay': [
+      'Beverage literature : a bibliography / compiled by A.W. Nolan.'
+    ],
+    'type': [
+      'nypl:Item'
+    ],
+    'updatedAt': 1636077649346,
+    'uri': "b10049806",
+    'suppressed': false,
+    'hasItemVolumes': false,
+    'hasItemDates': false
+  }
 ];
 
 export default bibs;

--- a/test/unit/BibDetails.test.js
+++ b/test/unit/BibDetails.test.js
@@ -498,29 +498,5 @@ describe('BibDetails', () => {
       expect(rtlComponent.find('li').at(0).prop('dir')).to.eql('rtl')
       expect(ltrComponent.find('li').at(0).prop('dir')).to.not.eql('rtl')
     })
-
-    it('should render the description field as Summary', () => {
-      const mockBibRtl = { notesGroupedByNoteType: { fakeNote: [{ prefLabel: '\u200F\u00E9' }] } }
-      const mockBibLtr = { notesGroupedByNoteType: { fakeNote: [{ prefLabel: '\u00E9' }] } }
-      const rtlComponent = mount(
-        <RouterProvider value={{ push: () => {} }}>
-          {
-            React.createElement(BibDetails, { bib: mockBibRtl, fields: mockFields, features: ['parallels'] })
-          }
-        </RouterProvider>,
-      );
-      const ltrComponent = mount(
-        <RouterProvider value={{ push: () => {} }}>
-          {
-            React.createElement(BibDetails, { bib: mockBibLtr, fields: mockFields, features: ['parallels'] })
-          }
-        </RouterProvider>,
-      )
-
-      expect(rtlComponent.find('li').at(0).prop('className')).to.eql('rtl')
-      expect(ltrComponent.find('li').at(0).prop('className')).to.not.eql('rtl')
-      expect(rtlComponent.find('li').at(0).prop('dir')).to.eql('rtl')
-      expect(ltrComponent.find('li').at(0).prop('dir')).to.not.eql('rtl')
-    })
   })
 });

--- a/test/unit/BibDetails.test.js
+++ b/test/unit/BibDetails.test.js
@@ -195,7 +195,6 @@ describe('BibDetails', () => {
         </RouterProvider>,
       );
       const bibDetailsComponent = component.children();
-      console.log(bibDetailsComponent.find('dd').length);
       const description = bibs[4].description[0];
       expect(bibDetailsComponent.find('dt').at(0).text()).to.equal(
         "Summary",

--- a/test/unit/BibDetails.test.js
+++ b/test/unit/BibDetails.test.js
@@ -179,58 +179,6 @@ describe('BibDetails', () => {
           lccn['@value'],
         );
       });
-      xit(`should display publication, extent, subjects, shelfMark, and other identifiers [${spec.description}]`, () => {
-        component = mount(
-          <RouterProvider value={{ push: () => {} }}>
-            {React.createElement(BibDetails, { bib: spec.bib, fields })}
-          </RouterProvider>,
-        );
-        const bibDetailsComponent = component.children();
-
-        expect(bibDetailsComponent.type()).to.equal(BibDetails);
-
-        expect(bibDetailsComponent.find('dd')).to.have.lengthOf(8);
-        console.log(
-          'logging dds length',
-          bibDetailsComponent.find('dd').length,
-        );
-        expect(bibDetailsComponent.find('dt')).to.have.lengthOf(8);
-        expect(bibDetailsComponent.find('dd').at(0).text()).to.equal(
-          bibs[0].publicationStatement[0],
-        );
-        expect(bibDetailsComponent.find('dd').at(1).text()).to.equal(
-          bibs[0].extent[0],
-        );
-        // Note with noteType=Bibliography:
-        expect(bibDetailsComponent.find('dd').at(3).text()).to.equal(
-          bibs[0].note[0].prefLabel,
-        );
-        expect(bibDetailsComponent.find('dd').at(4).text()).to.equal(
-          bibs[0].shelfMark[0],
-        );
-        // Isbn:
-        const [isbn, incorrectIsbn] = bibs[0].identifier.filter(
-          (ident) => ident['@type'] === 'bf:Isbn',
-        );
-        expect(
-          bibDetailsComponent.find('dd').at(5).find('li').at(0).text(),
-        ).to.equal(isbn['@value']);
-        // Only check for identityStatus message if serialization supports it (urn: style does not):
-        if (typeof bibs[0].identifier[0] === 'string') {
-          expect(
-            bibDetailsComponent.find('dd').at(5).find('li').at(1).text(),
-          ).to.equal(
-            `${incorrectIsbn['@value']} (${incorrectIsbn.identifierStatus})`,
-          );
-        }
-        // Lccn:
-        const lccn = bibs[0].identifier
-          .filter((ident) => ident['@type'] === 'bf:Lccn')
-          .pop();
-        expect(bibDetailsComponent.find('dd').at(6).text()).to.equal(
-          lccn['@value'],
-        );
-      });
     });
   });
 


### PR DESCRIPTION
**What's this do?**
This PR renders the 'description' field from the Discovery API bib endpoint as "Summary"

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SCC-3540
We were previously rendering the description field returned in the annotated-marc endpoint, but this was not being rendered on partner bibs, which was causing confusion because the Bib description field is indexed for search without being rendered.

**Do these changes have automated tests?**
The unit test for general bottom field checking is disabled so I added one just for the Summary field. This should be refactored when we move over to RTL.

**How should this be QAed?**
The Summary field should be rendered on Bib detail pages for partner bibs when one is being returned in the "description" field in the API response.
