### PR TITLE
SCC-3525 - Deploy bugfix for definition item links with no href

### DIFF
--- a/src/app/utils/bibDetailsUtils.jsx
+++ b/src/app/utils/bibDetailsUtils.jsx
@@ -57,11 +57,12 @@ const allFields = {
 };
 
 const definitionItem = (value, index = 0) => {
-  const link = (
+  // try to render a link if href is set, if not default to label
+  const link = value.content ? (
     <DSLink href={value.content}>
       {value.label}
     </DSLink>
-  );
+  ) : value.label;
 
   return (
     <div key={index}>

--- a/test/unit/bibDetailsUtils.test.js
+++ b/test/unit/bibDetailsUtils.test.js
@@ -68,7 +68,7 @@ describe('bibDetailsUtils', () => {
     });
   });
 
-  describe('definitionItem empty href', () => {
+  describe('definitionItem with label and blank content', () => {
     const value = {
       label: 'ItemLabel',
       content: '',

--- a/test/unit/bibDetailsUtils.test.js
+++ b/test/unit/bibDetailsUtils.test.js
@@ -77,7 +77,7 @@ describe('bibDetailsUtils', () => {
 
     const item = definitionItem(value);
 
-    it('should not render a link when label is provded without content', () => {
+    it('should not render a link when label is provided without content', () => {
       const dsLink = item.props.children[0];
       expect(dsLink).to.equal('ItemLabel');
     });

--- a/test/unit/bibDetailsUtils.test.js
+++ b/test/unit/bibDetailsUtils.test.js
@@ -68,6 +68,23 @@ describe('bibDetailsUtils', () => {
     });
   });
 
+  describe('definitionItem empty href', () => {
+    const value = {
+      label: 'ItemLabel',
+      content: '',
+      source: { itemSource: 'nypl' },
+    };
+
+    const item = definitionItem(value);
+
+
+    it('should not render a link when label is provded without content', () => {
+      const dsLink = item.props.children[0];
+      expect(dsLink).to.equal('ItemLabel');
+    });
+
+  });
+
   describe('annotatedMarcDetails', () => {
     it('should map fields in annotated marc to term,definition pairs, where term points to field label and definition points to list of definition items populated from field values', () => {
       const mockBib = {

--- a/test/unit/bibDetailsUtils.test.js
+++ b/test/unit/bibDetailsUtils.test.js
@@ -77,7 +77,6 @@ describe('bibDetailsUtils', () => {
 
     const item = definitionItem(value);
 
-
     it('should not render a link when label is provded without content', () => {
       const dsLink = item.props.children[0];
       expect(dsLink).to.equal('ItemLabel');

--- a/test/unit/bibDetailsUtils.test.js
+++ b/test/unit/bibDetailsUtils.test.js
@@ -81,7 +81,6 @@ describe('bibDetailsUtils', () => {
       const dsLink = item.props.children[0];
       expect(dsLink).to.equal('ItemLabel');
     });
-
   });
 
   describe('annotatedMarcDetails', () => {


### PR DESCRIPTION
**What's this do?**
This deploys the error handling fallback for definition items with no hrefs to production.

[SCC-3525](https://jira.nypl.org/browse/SCC-3525)