### PR TITLE
Scc 3558 - Update NYPL header and footer

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -20,4 +20,4 @@ LOGIN_BASE_URL=https://[fqdn]/
 CIRCULATING_CATALOG=https://[fqdn]/
 OPEN_LOCATIONS=315,300
 SHEP_BIBS_LIMIT=25
-NYPL_HEADER_URL=https://ds-header.nypl.org/header.min.js
+NYPL_HEADER_URL=https://ds-header.nypl.org

--- a/.env-sample
+++ b/.env-sample
@@ -20,3 +20,4 @@ LOGIN_BASE_URL=https://[fqdn]/
 CIRCULATING_CATALOG=https://[fqdn]/
 OPEN_LOCATIONS=315,300
 SHEP_BIBS_LIMIT=25
+NYPL_HEADER_URL=https://ds-header.nypl.org/header.min.js

--- a/server.js
+++ b/server.js
@@ -26,6 +26,7 @@ const INDEX_PATH = path.resolve(ROOT_PATH, 'src/client');
 const DIST_PATH = path.resolve(ROOT_PATH, 'dist');
 const VIEWS_PATH = path.resolve(ROOT_PATH, 'src/views');
 const WEBPACK_DEV_PORT = appConfig.webpackDevServerPort || 3000;
+const NYPL_HEADER_URL = appConfig.nyplHeaderUrl;
 const isProduction = process.env.NODE_ENV === 'production';
 const isTest = process.env.NODE_ENV === 'test';
 const app = express();
@@ -107,6 +108,7 @@ app.get('/*', (req, res) => {
           appTitle: title,
           favicon: appConfig.favIconPath,
           webpackPort: WEBPACK_DEV_PORT,
+          nyplHeaderUrl: NYPL_HEADER_URL,
           path: req.url,
           isProduction,
           baseUrl: appConfig.baseUrl,

--- a/src/app/components/Application/Application.jsx
+++ b/src/app/components/Application/Application.jsx
@@ -1,8 +1,6 @@
 /* global window */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Header, navConfig } from '@nypl/dgx-header-component';
-import Footer from '@nypl/dgx-react-footer';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router';
 import { union as _union } from 'underscore';
@@ -86,11 +84,8 @@ export class Application extends React.Component {
         <FeedbackBoxProvider>
           <MediaContext.Provider value={this.state.media}>
             <div className="app-wrapper">
-              <Header
-                navData={navConfig.current}
-                patron={this.props.patron}
-                skipNav={{ target: 'mainContent' }}
-              />
+              <div id="nypl-header" />
+              <script type="module" src={`${appConfig.nyplHeaderUrl}/header.min.js?containerId=nypl-header`} async></script> 
               <DataLoader
                 location={this.context.router.location}
                 query={this.context.router.location.query}
@@ -98,7 +93,8 @@ export class Application extends React.Component {
               >
                 {React.cloneElement(this.props.children)}
               </DataLoader>
-              <Footer />
+              <div id="nypl-footer" />
+              <script type="module" src={`${appConfig.nyplHeaderUrl}/footer.min.js?containerId=nypl-footer`} async></script> 
               <Feedback />
             </div>
           </MediaContext.Provider>

--- a/src/app/components/Application/Application.jsx
+++ b/src/app/components/Application/Application.jsx
@@ -7,7 +7,6 @@ import { union as _union } from 'underscore';
 
 import Feedback from '../Feedback/Feedback';
 import DataLoader from '../DataLoader/DataLoader';
-import appConfig from '../../data/appConfig';
 import { updateFeatures } from '../../actions/Actions';
 import { breakpoints } from '../../data/constants';
 import { PatronProvider } from '../../context/PatronContext';
@@ -84,8 +83,6 @@ export class Application extends React.Component {
         <FeedbackBoxProvider>
           <MediaContext.Provider value={this.state.media}>
             <div className="app-wrapper">
-              <div id="nypl-header" />
-              <script type="module" src={`${appConfig.nyplHeaderUrl}/header.min.js?containerId=nypl-header`} async></script> 
               <DataLoader
                 location={this.context.router.location}
                 query={this.context.router.location.query}
@@ -93,8 +90,6 @@ export class Application extends React.Component {
               >
                 {React.cloneElement(this.props.children)}
               </DataLoader>
-              <div id="nypl-footer" />
-              <script type="module" src={`${appConfig.nyplHeaderUrl}/footer.min.js?containerId=nypl-footer`} async></script> 
               <Feedback />
             </div>
           </MediaContext.Provider>

--- a/src/app/components/Application/Application.jsx
+++ b/src/app/components/Application/Application.jsx
@@ -7,6 +7,7 @@ import { union as _union } from 'underscore';
 
 import Feedback from '../Feedback/Feedback';
 import DataLoader from '../DataLoader/DataLoader';
+import appConfig from '../../data/appConfig';
 import { updateFeatures } from '../../actions/Actions';
 import { breakpoints } from '../../data/constants';
 import { PatronProvider } from '../../context/PatronContext';

--- a/src/app/data/appConfig.js
+++ b/src/app/data/appConfig.js
@@ -82,7 +82,7 @@ const appConfig = {
   itemBatchSize: process.env.ITEM_BATCH_SIZE || 100,
   webpacBaseUrl: process.env.WEBPAC_BASE_URL,
   shepBibsLimit: process.env.SHEP_BIBS_LIMIT || 50,
-  headerUrl: process.env.NYPL_HEADER_URL || 'https://ds-header.nypl.org'
+  nyplHeaderUrl: process.env.NYPL_HEADER_URL || 'https://qa-ds-header.nypl.org'
 };
 
 export default appConfig;

--- a/src/app/data/appConfig.js
+++ b/src/app/data/appConfig.js
@@ -82,6 +82,7 @@ const appConfig = {
   itemBatchSize: process.env.ITEM_BATCH_SIZE || 100,
   webpacBaseUrl: process.env.WEBPAC_BASE_URL,
   shepBibsLimit: process.env.SHEP_BIBS_LIMIT || 50,
+  headerUrl: process.env.NYPL_HEADER_URL || 'https://ds-header.nypl.org/header.min.js'
 };
 
 export default appConfig;

--- a/src/app/data/appConfig.js
+++ b/src/app/data/appConfig.js
@@ -82,7 +82,7 @@ const appConfig = {
   itemBatchSize: process.env.ITEM_BATCH_SIZE || 100,
   webpacBaseUrl: process.env.WEBPAC_BASE_URL,
   shepBibsLimit: process.env.SHEP_BIBS_LIMIT || 50,
-  headerUrl: process.env.NYPL_HEADER_URL || 'https://ds-header.nypl.org/header.min.js'
+  headerUrl: process.env.NYPL_HEADER_URL || 'https://ds-header.nypl.org'
 };
 
 export default appConfig;

--- a/src/client/styles/style-v2.scss
+++ b/src/client/styles/style-v2.scss
@@ -1,5 +1,19 @@
 // discovery-item.v2.html
 // item info / the full item record
+
+// min height on header container to avoid jump on page load
+#nypl-header {
+  min-height: 60px;
+
+  @include media($nypl-breakpoint-medium) {
+    min-height: 160px;
+  }
+
+  @include media($nypl-breakpoint-large) {
+    min-height: 205px;
+  }
+}
+
 .nypl-item-details {
 
   &__heading {

--- a/src/views/index.ejs
+++ b/src/views/index.ejs
@@ -30,7 +30,11 @@
 
   </head>
   <body>
+    <div id="nypl-header"></div>
+    <script type="module" src="<%- nyplHeaderUrl %>/header.min.js?containerId=nypl-header" async></script> 
     <div id="app"><%- application %></div>
+    <div id="nypl-footer"></div>
+    <script type="module" src="<%- nyplHeaderUrl %>/footer.min.js?containerId=nypl-footer" async></script> 
     <script>
       // WARNING: See the following for security issues around embedding JSON in HTML:
       // http://redux.js.org/recipes/ServerRendering.html#security-considerations

--- a/test/unit/Application.test.js
+++ b/test/unit/Application.test.js
@@ -40,23 +40,6 @@ describe('Application', () => {
     expect(component.find('.app-wrapper')).to.have.length(1);
   });
 
-  it('should render the NYPL header', () => {
-    expect(component.find('#nyplHeader')).to.have.length(1);
-  });
-
-  it('should have the skip navigation link enabled,', () => {
-    expect(component.contains(
-      <Header
-        navData={navConfig.current}
-        skipNav={{ target: 'mainContent' }}
-        patron={component.state.patron}
-      />)).to.equal(true);
-  });
-
-  it('should render a <Footer /> components', () => {
-    expect(component.find('Footer')).to.have.length(1);
-  });
-
   describe('should set media type in context', () => {
     const breakpointObj = {};
     breakpoints.forEach(breakpoint => breakpointObj[breakpoint.media] = breakpoint.maxValue);


### PR DESCRIPTION
**What's this do?**
This PR removes the Design system header and footer components from discovery-front-end and implements the new header and footer js snippets from this repo: https://github.com/NYPL/nypl-header-app. The url is changed conditionally based on an env variable.

The header app is currently not deployed properly to production, so this PR shouldn't be merged in until that's completed in the next week or two.

**Why are we doing this? (w/ JIRA link if applicable)**
[[Quick blurb about why the code is needed and Jira link/ Do these changes meet the business requirements of the story?]](https://jira.nypl.org/browse/SCC-3558)

**Do these changes have automated tests?**
We are removing automated tests since these will be managed separately by the header app.