### PR TITLE
SCC-3567/add swapStatusLabels func

### DIFF
--- a/src/server/ApiRoutes/Account.js
+++ b/src/server/ApiRoutes/Account.js
@@ -41,9 +41,23 @@ function getAccountPage(res, req) {
  *  they're not injected into the html sent to the client (lest they generate a
  *  bunch of erroneous 404s or worse.
  */
-function preprocessAccountHtml(html) {
+function removeLinkAndScriptTags(html) {
   html = html.replace(/<link [^>]+\/>/g, '')
   html = html.replace(/<script type="text\/javascript" src=[^>]+>\s*<\/script>/g, '')
+  return html
+}
+/**
+ * Swap actual status labels for something more patron-friendly
+ */
+function swapStatusLabels(html) {
+  html = html.replace(/<td class="patFuncStatus"> AVAILABLE <\/td>/g, '<td class="patFuncStatus"> REQUEST PLACED </td>')
+  html = html.replace(/<td class="patFuncStatus"> READY SOON <\/td>/g, '<td class="patFuncStatus"> READY FOR PICKUP </td>')
+  return html
+}
+
+function preprocessAccountHtml(html) {
+  html = removeLinkAndScriptTags(html)
+  html = swapStatusLabels(html)
   return html
 }
 
@@ -111,10 +125,10 @@ function postToAccountPage(req, res) {
   axios.post(
     `${appConfig.webpacBaseUrl}/dp/patroninfo*eng~Sdefault/${patronId}/${content}`,
     reqBodyString, {
-      headers: {
-        Cookie: req.headers.cookie,
-      },
-    })
+    headers: {
+      Cookie: req.headers.cookie,
+    },
+  })
     .then(resp => res.json(resp.data))
     .catch(resp => res.json({ error: resp }));
 }
@@ -124,9 +138,11 @@ function logError(req) {
 }
 
 export default {
+  removeLinkAndScriptTags,
   preprocessAccountHtml,
   fetchAccountPage,
   postToAccountPage,
   getHomeLibrary,
   logError,
+  swapStatusLabels,
 };

--- a/test/fixtures/account-markup.html
+++ b/test/fixtures/account-markup.html
@@ -1,0 +1,297 @@
+<!DOCTYPE html
+   PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!-- VERSION = $Id$ $Rev: 202541 $ $Date: 2013-02-08 13:48:24 -0800 (Fri, 08 Feb 2013) $ -->
+<html>
+
+<head>
+   <link rel="stylesheet" type="text/css" href="/scripts/ProStyles.css" />
+   <link rel="stylesheet" type="text/css" href="/screens/styles.css" />
+   <script type="text/javascript" src="/scripts/elcontent.js">
+   </script>
+   <script type="text/javascript" src="/scripts/common.js">
+   </script>
+   <script type="text/javascript" src="/scripts/features.js">
+   </script>
+   <script type="text/javascript" src="/scripts/webbridge.js">
+   </script>
+
+</head>
+
+<body>
+   <div class="patFuncArea">
+      <form name="hold_form" method="POST" id="hold_form"><input type="HIDDEN" id="holdpagecmd" />
+
+         <input type="SUBMIT" name="sortByRequest" value="Sort by Hold Requested Date" />
+         <input type="SUBMIT" name="sortByStatus" value="Sort by Status" />
+         <input type="HIDDEN" name="currentsortorder" value="current_pickup" />
+         <a href="#" onClick="return submitHold( 'requestCancelAll', 'requestCancelAll' )">
+            <div style="display:none" onmousedown="this.className='pressedState';" onmouseout="this.className='';"
+               onmouseup="this.className='';">
+               <div class="buttonSpriteDiv"><span class="buttonSpriteSpan1"><span class="buttonSpriteSpan2">Cancel
+                        All</span></span></div>
+            </div>
+         </a>
+         <input type="SUBMIT" name="requestUpdateHoldsSome" value="UPDATE LIST" />
+         <table border="0" class="patFunc">
+            <tr class="patFuncTitle">
+               <th colspan="7" class="patFuncTitle">
+                  <label id="items_count">4 HOLDS</label>
+               </th>
+            </tr>
+
+            <tr class="patFuncHeaders">
+               <th class="patFuncHeaders"> CANCEL </th>
+               <th class="patFuncHeaders"> TITLE </th>
+               <th class="patFuncHeaders"> Ratings </th>
+               <th class="patFuncHeaders"> STATUS </th>
+               <th class="patFuncHeaders">PICKUP LOCATION</th>
+               <th class="patFuncHeaders"> CANCEL IF NOT FILLED BY </th>
+               <th class="patFuncHeaders"> FREEZE </th>
+            </tr>
+
+
+            <style type="text/css">
+               <!--
+               #ratemy1 {
+                  display: inline
+               }
+
+               #rateneed1 {
+                  display: none
+               }
+
+               #ratemy2 {
+                  display: inline
+               }
+
+               #rateneed2 {
+                  display: none
+               }
+
+               #ratemy3 {
+                  display: inline
+               }
+
+               #rateneed3 {
+                  display: none
+               }
+
+               #ratemy4 {
+                  display: inline
+               }
+
+               #rateneed4 {
+                  display: none
+               }
+               -->
+            </style>
+            <tr class="patFuncEntry">
+               <td class="patFuncMark">
+                  <input type="checkbox" name="canceli38562763x00" id="canceli38562763x00" />
+               </td>
+               <td class="patFuncTitle">
+                  <label for="canceli38562763x00"><a
+                        href="https://browse.nypl.org/iii/encore/record/C__Rb22541895?lang=eng&suite=def"><span
+                           class="patFuncTitleMain">[Standard NYPL restrictions apply] TOAST / JOZEF HEN.
+                           [RECAP]</span></a></label>
+                  <br />
+               </td>
+               <td nowrap class="patFuncRating">
+
+                  <span id="ratemy1" onmouseover="setToolVisibility  ('ratemy1', 'none', 'rateneed1', 'inline')">_____
+                  </span>
+                  <span id="rateneed1" onmouseout="setToolVisibility  ('ratemy1', 'inline', 'rateneed1', 'none')"><a
+                        href="/patroninfo~S1*eng/5035845/sortedbypudateholds?changerating1=b22541895">?</a><a
+                        href="/patroninfo~S1*eng/5035845/sortedbypudateholds?changerating2=b22541895">?</a><a
+                        href="/patroninfo~S1*eng/5035845/sortedbypudateholds?changerating3=b22541895">?</a><a
+                        href="/patroninfo~S1*eng/5035845/sortedbypudateholds?changerating4=b22541895">?</a><a
+                        href="/patroninfo~S1*eng/5035845/sortedbypudateholds?changerating5=b22541895">?</a>
+                  </span>
+               </td>
+               <td class="patFuncStatus"> Ready. Must pick up by 08-30-21 </td>
+               <td class="patFuncPickup">SCHWARZMAN 300 - ONSITE USE</td>
+               <td class="patFuncCancel">08-11-22</td>
+               <td class="patFuncFreeze">&nbsp;</td>
+            </tr>
+
+            <tr class="patFuncEntry">
+               <td class="patFuncMark">
+                  <input type="checkbox" name="canceli38574968x01" id="canceli38574968x01" />
+               </td>
+               <td class="patFuncTitle">
+                  <label for="canceli38574968x01"><a
+                        href="https://browse.nypl.org/iii/encore/record/C__Rb22544628?lang=eng&suite=def"><span
+                           class="patFuncTitleMain">[HD] [Standard NYPL restrictions apply] AVAILABLE
+                           [HD]</span></a></label>
+                  <br />
+               </td>
+               <td nowrap class="patFuncRating">
+
+                  <span id="ratemy2" onmouseover="setToolVisibility  ('ratemy2', 'none', 'rateneed2', 'inline')">_____
+                  </span>
+                  <span id="rateneed2" onmouseout="setToolVisibility  ('ratemy2', 'inline', 'rateneed2', 'none')"><a
+                        href="/patroninfo~S1*eng/5035845/sortedbypudateholds?changerating1=b22544628">?</a><a
+                        href="/patroninfo~S1*eng/5035845/sortedbypudateholds?changerating2=b22544628">?</a><a
+                        href="/patroninfo~S1*eng/5035845/sortedbypudateholds?changerating3=b22544628">?</a><a
+                        href="/patroninfo~S1*eng/5035845/sortedbypudateholds?changerating4=b22544628">?</a><a
+                        href="/patroninfo~S1*eng/5035845/sortedbypudateholds?changerating5=b22544628">?</a>
+                  </span>
+               </td>
+               <td class="patFuncStatus"> Ready. Must pick up by 09-07-21 </td>
+               <td class="patFuncPickup">SCHWARZMAN 300 - ONSITE USE</td>
+               <td class="patFuncCancel">08-17-22</td>
+               <td class="patFuncFreeze">&nbsp;</td>
+            </tr>
+
+            <tr class="patFuncEntry">
+               <td class="patFuncMark">
+                  <input type="checkbox" name="canceli38575038x02" id="canceli38575038x02" />
+               </td>
+               <td class="patFuncTitle">
+                  <label for="canceli38575038x02"><a
+                        href="https://browse.nypl.org/iii/encore/record/C__Rb22544635?lang=eng&suite=def"><span
+                           class="patFuncTitleMain">[Standard NYPL restrictions apply] SFARINN SOFANDI / ORSTEINN FRA
+                           HAMRI.
+                           [RECAP]</span></a></label>
+                  <br />
+               </td>
+               <td nowrap class="patFuncRating">
+
+                  <span id="ratemy3" onmouseover="setToolVisibility  ('ratemy3', 'none', 'rateneed3', 'inline')">_____
+                  </span>
+                  <span id="rateneed3" onmouseout="setToolVisibility  ('ratemy3', 'inline', 'rateneed3', 'none')"><a
+                        href="/patroninfo~S1*eng/5035845/sortedbypudateholds?changerating1=b22544635">?</a><a
+                        href="/patroninfo~S1*eng/5035845/sortedbypudateholds?changerating2=b22544635">?</a><a
+                        href="/patroninfo~S1*eng/5035845/sortedbypudateholds?changerating3=b22544635">?</a><a
+                        href="/patroninfo~S1*eng/5035845/sortedbypudateholds?changerating4=b22544635">?</a><a
+                        href="/patroninfo~S1*eng/5035845/sortedbypudateholds?changerating5=b22544635">?</a>
+                  </span>
+               </td>
+               <td class="patFuncStatus"> Ready. Must pick up by 09-07-21 </td>
+               <td class="patFuncPickup">SCHWARZMAN 121 - ONSITE USE</td>
+               <td class="patFuncCancel">08-17-22</td>
+               <td class="patFuncFreeze">&nbsp;</td>
+            </tr>
+
+            <tr class="patFuncEntry">
+               <td class="patFuncMark">
+                  <input type="checkbox" name="canceli11703515x03" id="canceli11703515x03" />
+               </td>
+               <td class="patFuncTitle">
+                  <label for="canceli11703515x03"><a
+                        href="https://browse.nypl.org/iii/encore/record/C__Rb15347721?lang=eng&suite=def"><span
+                           class="patFuncTitleMain">A table / Jean Follain.</span></a></label>
+                  <br />
+               </td>
+               <td nowrap class="patFuncRating">
+
+                  <span id="ratemy4" onmouseover="setToolVisibility  ('ratemy4', 'none', 'rateneed4', 'inline')">_____
+                  </span>
+                  <span id="rateneed4" onmouseout="setToolVisibility  ('ratemy4', 'inline', 'rateneed4', 'none')"><a
+                        href="/patroninfo~S1*eng/5035845/sortedbypudateholds?changerating1=b15347721">?</a><a
+                        href="/patroninfo~S1*eng/5035845/sortedbypudateholds?changerating2=b15347721">?</a><a
+                        href="/patroninfo~S1*eng/5035845/sortedbypudateholds?changerating3=b15347721">?</a><a
+                        href="/patroninfo~S1*eng/5035845/sortedbypudateholds?changerating4=b15347721">?</a><a
+                        href="/patroninfo~S1*eng/5035845/sortedbypudateholds?changerating5=b15347721">?</a>
+                  </span>
+               </td>
+               <td class="patFuncStatus"> AVAILABLE </td>
+               <td class="patFuncPickup">SCHWARZMAN 315 - ONSITE USE</td>
+               <td class="patFuncCancel">08-24-22</td>
+               <td class="patFuncFreeze">
+                  <div class="patFuncFreezeLabel">
+                     <label for="freezei11703515x03">Freeze</label>
+                  </div>
+                  <input type="checkbox" name="freezei11703515x03" />
+               </td>
+            </tr>
+            <tr class="patFuncEntry">
+               <td class="patFuncMark">
+                  <input type="checkbox" name="canceli11703515x03" id="canceli11703515x03" />
+               </td>
+               <td class="patFuncTitle">
+                  <label for="canceli11703515x03"><a
+                        href="https://browse.nypl.org/iii/encore/record/C__Rb15347721?lang=eng&suite=def"><span
+                           class="patFuncTitleMain">A table / Jean Follain.</span></a></label>
+                  <br />
+               </td>
+               <td nowrap class="patFuncRating">
+
+                  <span id="ratemy4" onmouseover="setToolVisibility  ('ratemy4', 'none', 'rateneed4', 'inline')">_____
+                  </span>
+                  <span id="rateneed4" onmouseout="setToolVisibility  ('ratemy4', 'inline', 'rateneed4', 'none')"><a
+                        href="/patroninfo~S1*eng/5035845/sortedbypudateholds?changerating1=b15347721">?</a><a
+                        href="/patroninfo~S1*eng/5035845/sortedbypudateholds?changerating2=b15347721">?</a><a
+                        href="/patroninfo~S1*eng/5035845/sortedbypudateholds?changerating3=b15347721">?</a><a
+                        href="/patroninfo~S1*eng/5035845/sortedbypudateholds?changerating4=b15347721">?</a><a
+                        href="/patroninfo~S1*eng/5035845/sortedbypudateholds?changerating5=b15347721">?</a>
+                  </span>
+               </td>
+               <td class="patFuncStatus"> AVAILABLE </td>
+               <td class="patFuncPickup">SCHWARZMAN 315 - ONSITE USE</td>
+               <td class="patFuncCancel">08-24-22</td>
+               <td class="patFuncFreeze">
+                  <div class="patFuncFreezeLabel">
+                     <label for="freezei11703515x03">Freeze</label>
+                  </div>
+                  <input type="checkbox" name="freezei11703515x03" />
+               </td>
+            </tr>
+            <tr class="patFuncEntry">
+               <td class="patFuncMark">
+                  <input type="checkbox" name="canceli11703515x03" id="canceli11703515x03" />
+               </td>
+               <td class="patFuncTitle">
+                  <label for="canceli11703515x03"><a
+                        href="https://browse.nypl.org/iii/encore/record/C__Rb15347721?lang=eng&suite=def"><span
+                           class="patFuncTitleMain">A table / Jean Follain.</span></a></label>
+                  <br />
+               </td>
+               <td nowrap class="patFuncRating">
+
+                  <span id="ratemy4" onmouseover="setToolVisibility  ('ratemy4', 'none', 'rateneed4', 'inline')">_____
+                  </span>
+                  <span id="rateneed4" onmouseout="setToolVisibility  ('ratemy4', 'inline', 'rateneed4', 'none')"><a
+                        href="/patroninfo~S1*eng/5035845/sortedbypudateholds?changerating1=b15347721">?</a><a
+                        href="/patroninfo~S1*eng/5035845/sortedbypudateholds?changerating2=b15347721">?</a><a
+                        href="/patroninfo~S1*eng/5035845/sortedbypudateholds?changerating3=b15347721">?</a><a
+                        href="/patroninfo~S1*eng/5035845/sortedbypudateholds?changerating4=b15347721">?</a><a
+                        href="/patroninfo~S1*eng/5035845/sortedbypudateholds?changerating5=b15347721">?</a>
+                  </span>
+               </td>
+               <td class="patFuncStatus"> READY SOON </td>
+               <td class="patFuncPickup">SCHWARZMAN 315 - ONSITE USE</td>
+               <td class="patFuncCancel">08-24-22</td>
+               <td class="patFuncFreeze">
+                  <div class="patFuncFreezeLabel">
+                     <label for="freezei11703515x03">Freeze</label>
+                  </div>
+                  <input type="checkbox" name="freezei11703515x03" />
+               </td>
+            </tr>
+
+         </table>
+
+         <input type="SUBMIT" name="sortByRequest" value="Sort by Hold Requested Date" />
+         <input type="SUBMIT" name="sortByStatus" value="Sort by Status" />
+         <input type="HIDDEN" name="currentsortorder" value="current_pickup" />
+         <a href="#" onClick="return submitHold( 'requestCancelAll', 'requestCancelAll' )">
+            <div style="display:none" onmousedown="this.className='pressedState';" onmouseout="this.className='';"
+               onmouseup="this.className='';">
+               <div class="buttonSpriteDiv"><span class="buttonSpriteSpan1"><span class="buttonSpriteSpan2">Cancel
+                        All</span></span></div>
+            </div>
+         </a>
+         <input type="SUBMIT" name="requestUpdateHoldsSome" value="UPDATE LIST" />
+      </form>
+      <script type="text/JavaScript">
+<!--Hide the JS
+document.getElementById( 'items_count' ).innerHTML = '4 HOLDS';
+// Unhide the JS --></script>
+      <!--this is customized <screens/patronview_encore.html>-->
+   </div>
+   <!-- this script must be included for this template to display properly in encore -->
+   <script type="text/javascript" src="/screens/setdomain.js"></script>
+</body>
+
+</html>

--- a/test/unit/Account.test.js
+++ b/test/unit/Account.test.js
@@ -150,7 +150,7 @@ describe('`fetchAccountPage`', () => {
   });
 });
 
-describe('preprocessAccountHtml', () => {
+describe('removeLinkAndScriptTags', () => {
   it('removes <link> and <script> tags from 5.1 markup (1)', () => {
     const html = fs.readFileSync('./test/fixtures/sierra-5.1-patron-5035845-webpac-holds-markup.html', 'utf8');
     let dom = jsdom(html);
@@ -160,7 +160,7 @@ describe('preprocessAccountHtml', () => {
     // and 5 remote <script> tags
     expect(dom.querySelectorAll('script[src]')).to.have.lengthOf(5);
 
-    dom = jsdom(Account.preprocessAccountHtml(html))
+    dom = jsdom(Account.removeLinkAndScriptTags(html))
 
     // It now has no <link> or remote <script> tags:
     expect(dom.querySelectorAll('link,script[src]')).to.have.lengthOf(0);
@@ -177,7 +177,7 @@ describe('preprocessAccountHtml', () => {
     // and 5 remote <script> tags
     expect(dom.querySelectorAll('script[src]')).to.have.lengthOf(5);
 
-    dom = jsdom(Account.preprocessAccountHtml(html))
+    dom = jsdom(Account.removeLinkAndScriptTags(html))
 
     // It now has no <link> or remote <script> tags:
     expect(dom.querySelectorAll('link,script[src]')).to.have.lengthOf(0);
@@ -194,11 +194,27 @@ describe('preprocessAccountHtml', () => {
     // And 5.3 markup has remote 5 script tags
     expect(dom.querySelectorAll('script[src]')).to.have.lengthOf(5);
 
-    dom = jsdom(Account.preprocessAccountHtml(html))
+    dom = jsdom(Account.removeLinkAndScriptTags(html))
 
     // It now has no <link> or remote <script> tags:
     expect(dom.querySelectorAll('link,script[src]')).to.have.lengthOf(0);
     // Ensure other critical parts of document remain
     expect(dom.querySelectorAll('.patFuncBibTitle a')).to.have.lengthOf(13);
   });
+
+  describe('swapStatusLabels', () => {
+    let html = fs.readFileSync('./test/fixtures/account-markup.html', 'utf8')
+    html = Account.swapStatusLabels(html)
+    it('does not remove AVAILABLE from title element', () => {
+      expect(html).to.include('class="patFuncTitleMain">[HD] [Standard NYPL restrictions apply] AVAILABLE')
+    })
+    it('replaces AVAILABLE in multiple status cells', () => {
+      expect(html).to.include('<td class="patFuncStatus"> REQUEST PLACED </td>')
+      expect(html).to.not.include('<td class="patFuncStatus"> AVAILABLE </td>')
+    })
+    it('replaces READY SOON in status cell', () => {
+      expect(html).to.include('READY FOR PICKUP')
+      expect(html).to.not.include('READY SOON')
+    })
+  })
 });


### PR DESCRIPTION
**What's this do?**
- Extracts the logic that was originally in preprocessAccountHtml into removeLinkAndScriptTags
- create swapStatusLabel. This iteration is swapping all READY SOON for READY FOR PICKUP, regardless of circ/research-ness
- add html file for testing
- tests!

**Why are we doing this? (w/ JIRA link if applicable)**
to avoid patron confusion around Available and Ready Soon

**Do these changes have automated tests?**
yes

**How should this be QAed?**
holds placed on items, check that status says Request placed, perform fake reading room checkin, ensure that status says ready for pickup.