### PR TITLE
Hold request footer hotfix

### DIFF
--- a/src/app/pages/HoldRequest.jsx
+++ b/src/app/pages/HoldRequest.jsx
@@ -327,7 +327,7 @@ export class HoldRequest extends React.Component {
           pageTitle="Item Request"
         >
           <Notification notificationType="holdRequestNotification" />
-          <div className="row">
+          <div className="row nypl-column-full">
             <div className="nypl-column-three-quarters">
               <div className="nypl-request-item-summary">
                 <div className="item">


### PR DESCRIPTION
**What's this do?**
Fixes the Footer floating to the top of the page on the hold request page.

This only seems to happen on this page and _not_ the EDD hold request page or the request confirmation page.

**Why are we doing this? (w/ JIRA link if applicable)**
[Quick blurb about why the code is needed and Jira link/ Do these changes meet the business requirements of the story?]

**Do these changes have automated tests?**
[Brief description of new automated tests]

**How should this be QAed?**
[Description of any tests that need to be performed once merged]

**Dependencies for merging? Releasing to production?**
[Description of any watchouts, dependencies, or issues we should be aware of]

**Has the application documentation been updated for these changes?**

**Did someone actually run this code to verify it works?**
