### PR TITLE
add standardize bib method

### DIFF
--- a/src/app/components/Search/Search.jsx
+++ b/src/app/components/Search/Search.jsx
@@ -5,6 +5,7 @@ import { connect } from 'react-redux';
 import { Link } from 'react-router';
 
 import {
+  standardizeBibId,
   trackDiscovery,
 } from '../../utils/utils';
 import appConfig from '../../data/appConfig';
@@ -16,7 +17,7 @@ import {
 /**
  * The main container for the top Search section.
  */
-function Search (props) {
+function Search(props) {
   const {
     field,
     searchKeywords,
@@ -86,11 +87,15 @@ function Search (props) {
       trackDiscovery('Search', `Field - ${selectField}`);
     }
 
-    const searchKeywords = userSearchKeywords === '*' ? '' : userSearchKeywords;
+    let searchKeywords = userSearchKeywords === '*' ? '' : userSearchKeywords;
 
     if (selectField === 'subject') {
       router.push(`${appConfig.baseUrl}/subject_headings?filter=${keywords.charAt(0).toUpperCase() + keywords.slice(1)}`);
       return;
+    }
+
+    if (selectField === 'standard_number') {
+      searchKeywords = standardizeBibId(searchKeywords)
     }
 
     const apiQuery = createAPIQuery({
@@ -107,7 +112,7 @@ function Search (props) {
 
     router.push(`${appConfig.baseUrl}/search?${apiQuery}`);
   }
-  
+
   /* 
     Temporary input element override until the Design System's TextInput
     allows for external clearing via value prop.
@@ -148,12 +153,12 @@ function Search (props) {
           labelText: 'Select a category',
           name: 'search_scope',
           optionsData: [
-            { text:"All fields", value: "all" },
-            { text:"Title", value: "title" },
-            { text:"Journal Title", value: "journal_title" },
-            { text:"Author/Contributor", value: "contributor" },
-            { text:"Standard Numbers", value: "standard_number" },
-            { text:"Subject", value: "subject" },
+            { text: "All fields", value: "all" },
+            { text: "Title", value: "title" },
+            { text: "Journal Title", value: "journal_title" },
+            { text: "Author/Contributor", value: "contributor" },
+            { text: "Standard Numbers", value: "standard_number" },
+            { text: "Subject", value: "subject" },
           ],
           onChange: onFieldChange,
           value: selectField

--- a/src/app/utils/utils.js
+++ b/src/app/utils/utils.js
@@ -817,9 +817,9 @@ function aeonUrl(item) {
 function standardizeBibId(bibId) {
   // nypl bib ids could have a 9th digit, a check digit which can be 0-9 or x.
   const nypl = bibId.match(/^([bB])(\d{8})[\dxX]?$/)
-  const princeton = bibId.match(/^([pP][bB])(\d{16})$/)
+  const princeton = bibId.match(/^([pP][bB])(\d{6,16})$/)
   const columbia = bibId.match(/^([cC][bB])(\d{6,9})$/)
-  const harvard = bibId.match(/^([hH][bB])(\d{18})$/)
+  const harvard = bibId.match(/^([hH][bB])(\d{6,18})$/)
   const matches = [nypl, princeton, columbia, harvard]
     .find((match) => match?.length === 3)
   if (matches) {

--- a/src/app/utils/utils.js
+++ b/src/app/utils/utils.js
@@ -813,7 +813,24 @@ function aeonUrl(item) {
   return AeonUrl.toString();
 }
 
+// transform bib id to have lower case prefix (b, hb, cb, pb) and trim check digit
+function standardizeBibId(bibId) {
+  const nypl = bibId.match(/^([bB])(\d{8})[\dxX]?$/)
+  const princeton = bibId.match(/^([pP][bB])(\d{16})$/)
+  const columbia = bibId.match(/^([cC][bB])(\d{6,9})$/)
+  const harvard = bibId.match(/^([hH][bB])(\d{18})$/)
+  const matches = [nypl, princeton, columbia, harvard]
+    .find((match) => match?.length === 3)
+  if (matches) {
+    const prefix = matches[1].toLowerCase()
+    const number = matches[2]
+    return prefix + number
+  }
+  return bibId
+}
+
 export {
+  standardizeBibId,
   trackDiscovery,
   adobeAnalyticsRouteToPageName,
   trackVirtualPageView,

--- a/src/app/utils/utils.js
+++ b/src/app/utils/utils.js
@@ -815,6 +815,7 @@ function aeonUrl(item) {
 
 // transform bib id to have lower case prefix (b, hb, cb, pb) and trim check digit
 function standardizeBibId(bibId) {
+  // nypl bib ids could have a 9th digit, a check digit which can be 0-9 or x.
   const nypl = bibId.match(/^([bB])(\d{8})[\dxX]?$/)
   const princeton = bibId.match(/^([pP][bB])(\d{16})$/)
   const columbia = bibId.match(/^([cC][bB])(\d{6,9})$/)

--- a/src/server/ApiRoutes/Bib.js
+++ b/src/server/ApiRoutes/Bib.js
@@ -5,7 +5,7 @@ import logger from '../../../logger';
 import appConfig from '../../app/data/appConfig';
 import extractFeatures from '../../app/utils/extractFeatures';
 import { itemBatchSize } from '../../app/data/constants';
-import { isNyplBnumber, hasCheckDigit, removeCheckDigit } from '../../app/utils/utils';
+import { isNyplBnumber, standardizeBibId } from '../../app/utils/utils';
 import { appendDimensionsToExtent } from '../../app/utils/appendDimensionsToExtent';
 
 const nyplApiClientCall = (query, itemFrom, filterItemsStr = "") => {
@@ -23,7 +23,8 @@ const nyplApiClientCall = (query, itemFrom, filterItemsStr = "") => {
     .then(client => {
       return client.get(
         `/discovery/resources/${fullQuery}`
-      )}
+      )
+    }
     );
 };
 
@@ -117,10 +118,11 @@ const addLocationUrls = (bib) => {
     .catch((err) => { console.log('catching nypl client ', err); });
 };
 
-function fetchBib (bibId, cb, errorcb, reqOptions, res) {
+function fetchBib(bibId, cb, errorcb, reqOptions, res) {
   // Redirect if bibId has a Check Digit
-  if (hasCheckDigit(bibId)) { res.redirect(`${appConfig.baseUrl}/bib/${removeCheckDigit(bibId)}`); }
-  
+  const standardBibId = standardizeBibId(bibId)
+  if (standardBibId !== bibId) { res.redirect(`${appConfig.baseUrl}/bib/${standardBibId}`); }
+
   const options = Object.assign({
     fetchSubjectHeadingData: true,
     features: [],
@@ -191,7 +193,7 @@ function fetchBib (bibId, cb, errorcb, reqOptions, res) {
     }); /* end axios call */
 }
 
-function bibSearch (req, res, resolve) {
+function bibSearch(req, res, resolve) {
   const bibId = req.params.bibId;
   const query = req.query;
   const { features, item_page = 1, items_from } = req.query;

--- a/src/server/ApiRoutes/Search.js
+++ b/src/server/ApiRoutes/Search.js
@@ -7,6 +7,7 @@ import {
   getReqParams,
   basicQuery,
   parseServerSelectedFilters,
+  standardizeBibId
 } from '../../app/utils/utils';
 import extractFeatures from '../../app/utils/extractFeatures';
 import { buildQueryDataFromForm } from '../../app/utils/advancedSearchUtils';
@@ -38,6 +39,10 @@ const nyplApiClientCall = (query, urlEnabledFeatures = []) => {
 };
 
 function fetchResults(searchKeywords = '', contributor, title, subject, page, sortBy, order, field, filters, identifierNumbers, expressRes, cb, errorcb, features) {
+  if (field === 'standard_number') {
+    searchKeywords = standardizeBibId(searchKeywords)
+  }
+
   const encodedQueryString = createAPIQuery({
     searchKeywords,
     contributor,
@@ -136,7 +141,7 @@ function fetchResults(searchKeywords = '', contributor, title, subject, page, so
               item.holdingLocation[0].url = findUrl({ code: item.holdingLocation[0]['@id'] }, resp);
               item.locationUrl = item.holdingLocation[0].url
             }
-            if (item.location) item.locationUrl = findUrl({code: item.holdingLocationCode }, resp);
+            if (item.location) item.locationUrl = findUrl({ code: item.holdingLocationCode }, resp);
           });
         });
         return results;

--- a/test/unit/utils.test.js
+++ b/test/unit/utils.test.js
@@ -150,7 +150,7 @@ describe.only('standardizeBib', () => {
     expect(standardizeBibId('Hb123456789123456789')).to.equal('hb123456789123456789')
     expect(standardizeBibId('PB1234567812345678')).to.equal('pb1234567812345678')
   })
-  it('returns undefined if a non bibid value is provided', () => {
+  it('returns value provided if input does not match bib id regexes', () => {
     expect(standardizeBibId('b1234567899')).to.equal('b1234567899')
     expect(standardizeBibId('i am not a bib id hb123')).to.equal('i am not a bib id hb123')
   })

--- a/test/unit/utils.test.js
+++ b/test/unit/utils.test.js
@@ -28,7 +28,8 @@ import {
   isNyplBnumber,
   hasCheckDigit,
   removeCheckDigit,
-  adobeAnalyticsRouteToPageName
+  adobeAnalyticsRouteToPageName,
+  standardizeBibId
 } from '../../src/app/utils/utils';
 
 /**
@@ -133,6 +134,27 @@ describe('getDefaultFilters', () => {
   });
 });
 
+describe.only('standardizeBib', () => {
+  it('doesn\'t mess with kosher id', () => {
+    expect(standardizeBibId('b12345678')).to.equal('b12345678')
+    expect(standardizeBibId('hb123456789123456789')).to.equal('hb123456789123456789')
+  })
+  it('removes check digit', () => {
+    expect(standardizeBibId('b12345678x')).to.equal('b12345678')
+    expect(standardizeBibId('b12345678X')).to.equal('b12345678')
+    expect(standardizeBibId('b123456781')).to.equal('b12345678')
+  })
+  it('lower cases everything', () => {
+    expect(standardizeBibId('B12345678')).to.equal('b12345678')
+    expect(standardizeBibId('CB1234567')).to.equal('cb1234567')
+    expect(standardizeBibId('Hb123456789123456789')).to.equal('hb123456789123456789')
+    expect(standardizeBibId('PB1234567812345678')).to.equal('pb1234567812345678')
+  })
+  it('returns undefined if a non bibid value is provided', () => {
+    expect(standardizeBibId('b1234567899')).to.equal('b1234567899')
+    expect(standardizeBibId('i am not a bib id hb123')).to.equal('i am not a bib id hb123')
+  })
+})
 /**
  * destructureFilters
  */

--- a/test/unit/utils.test.js
+++ b/test/unit/utils.test.js
@@ -148,6 +148,7 @@ describe.only('standardizeBib', () => {
     expect(standardizeBibId('B12345678')).to.equal('b12345678')
     expect(standardizeBibId('CB1234567')).to.equal('cb1234567')
     expect(standardizeBibId('Hb123456789123456789')).to.equal('hb123456789123456789')
+    expect(standardizeBibId('PB1234567')).to.equal('pb1234567')
     expect(standardizeBibId('PB1234567812345678')).to.equal('pb1234567812345678')
   })
   it('returns value provided if input does not match bib id regexes', () => {


### PR DESCRIPTION
**What's this do?**

- Creates a method to standardize bibs with check digits and capitalize bib prefixes. 
- Adds same method to search page and fetchBib method. 

NB: 

- @dgcohen i ended up overwriting your similar changes for a prior ticket. Reviewers for that work (@me lol) did not catch that the ticket silently wanted to cover capitalization for partner records. Standard number searches as well as urls now reformat bibs with check digits and lower casify id prefixes. 
- I'm not 100% confident about having the function call happening in the front end component, so if anyone feels strongly that it should be on the server side, I'm open to that changing. The only issue with that is if you make a standard number search from the search results page that would need to be formatted, (CB1234567), `Displaying 1-1 of 1 results for standard number "CB1234567"` is displayed, when in fact it is showing results for cb1234567. Sean said it is preferable to have the reformatted bibId displayed that is actually being queried. It would not be impossible, but I have a feeling it will be annoying, to have the reformatting happen on the server side and have the correct string display on the search results page.

**Why are we doing this? (w/ JIRA link if applicable)**
So B12345678x, a valid bib id, does not return no results on standard number search

**How should this be QAed?**
Please go ahead and run this! Try searching a variety of bib ids starting with partner prefixes and having different amounts of digits after. make sure you are doing a standard number search. Ditto for hitting url `http://local.nypl.org:3001/research/research-catalog/bib/{bibId}`