### PR TITLE
Add support for alternate base URL for discovery-api

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -2,6 +2,7 @@ KMS_ENV=unencrypted
 PLATFORM_API_CLIENT_ID=discovery_api
 PLATFORM_API_CLIENT_SECRET=[secret]
 PLATFORM_API_BASE_URL=https://[fqdn]/api/v0.1
+DISCOVERY_API_BASE_URL=https://[fqdn]/api/v0.1
 SHEP_API=http://[fqdn shep api]/api/v0.1
 HOLD_REQUEST_NOTIFICATION="notification"
 CLOSED_LOCATIONS="all;Library for the Performing Arts"

--- a/ENVIRONMENTVARS.md
+++ b/ENVIRONMENTVARS.md
@@ -59,21 +59,22 @@ These environment variables control how certain elements on the page render and 
 | `SHEP_API` | string | "" | The base URL for the Subject Heading Explorer API. |
 | `SHEP_BIBS_LIMIT` | string | 25 | The number of bibs to fetch from the SHEP API. |
 | `SOURCE_EMAIL` | string | "email@email.com" | The email used in the `Feedback` component for the source field. |
+| `PLATFORM_API_BASE_URL` | Platform api base url (e.g. "http://example.com/api/v0.1") |
+| `DISCOVERY_API_BASE_URL` | "Discovery API" base URL. Optional. If not set, discovery-api requests will use PLATFORM_API_BASE_URL. Should resemble 'https://example.com/api/v0.1' |
+| `KMS_ENV` | Determines whether to interpret ..CLIENT_ID and ..CLIENT_SECRET variables as "encrypted" or "unencrypted". Default "encrypted". |
 
 ## Testing
 
 When tests are run through the `npm test` command, the setup configuration file at `/test/helpers/browser.js` reads environment variables from the `test.env` file.
 
-## AWS Elastic Beanstalk Environment Variables
+## Encrypted Variables
 
 As previously mentioned in the [README](README.md), we are using environment variables to make authorized requests to NYPL's API platform. In order to be secure, we are encrypting and decrypting those environment variables using AWS KMS. Please get these variables from someone in the NYPL Digital Department.
 
 | Variable | Description |
 | -------- | ----------- |
-| `KMS_ENV` | Determines whether to interpret ..CLIENT_ID and ..CLIENT_SECRET variables as "encrypted" or "unencrypted". Default "encrypted". | 
 | `PLATFORM_API_CLIENT_ID` | Platform client id. If KMS_ENV is "encrypted", this value must be encrypted. |
 | `PLATFORM_API_CLIENT_SECRET` | Platform client secret. If KMS_ENV is "encrypted", this value must be encrypted. |
-| `PLATFORM_API_BASE_URL` | Platform api base url (e.g. "http://example.com/api/v0.1") |
 
 ### Encrypting
 

--- a/src/app/data/appConfig.js
+++ b/src/app/data/appConfig.js
@@ -14,11 +14,24 @@ const appConfig = {
   webpackDevServerPort: 3000,
   environment: process.env.APP_ENV || 'production',
   api: {
-    discovery: {
+    platform: {
       development:
         process.env.PLATFORM_API_BASE_URL ||
         'https://qa-platform.nypl.org/api/v0.1',
       production:
+        process.env.PLATFORM_API_BASE_URL ||
+        'https://platform.nypl.org/api/v0.1',
+    },
+    // The 'discovery' base URL should use DISCOVERY_API_BASE_URL if set,
+    // falling back on PLATFORM_API_BASE_URL if set,
+    // and finally falling back on a sensible default.
+    discovery: {
+      development:
+        process.env.DISCOVERY_API_BASE_URL ||
+        process.env.PLATFORM_API_BASE_URL ||
+        'https://qa-platform.nypl.org/api/v0.1',
+      production:
+        process.env.DISCOVERY_API_BASE_URL ||
         process.env.PLATFORM_API_BASE_URL ||
         'https://platform.nypl.org/api/v0.1',
     },

--- a/src/server/ApiRoutes/Bib.js
+++ b/src/server/ApiRoutes/Bib.js
@@ -19,7 +19,7 @@ const nyplApiClientCall = (query, itemFrom, filterItemsStr = "") => {
     itemRelatedQueries.push('merge_checkin_card_items=true')
     fullQuery = `${query}?${itemRelatedQueries.join('&')}`
   }
-  return nyplApiClient()
+  return nyplApiClient({ apiName: 'discovery' })
     .then(client => {
       return client.get(
         `/discovery/resources/${fullQuery}`

--- a/src/server/ApiRoutes/Search.js
+++ b/src/server/ApiRoutes/Search.js
@@ -31,7 +31,7 @@ const createAPIQuery = basicQuery({
 
 const nyplApiClientCall = (query, urlEnabledFeatures = []) => {
   const requestOptions = appConfig.features.includes('on-site-edd') || urlEnabledFeatures.includes('on-site-edd') ? { headers: { 'X-Features': 'on-site-edd' } } : {};
-  return nyplApiClient()
+  return nyplApiClient({ apiName: 'discovery' })
     .then(client =>
       client.get(`/discovery/resources${query}`, requestOptions),
     );

--- a/src/server/routes/nyplApiClient/index.js
+++ b/src/server/routes/nyplApiClient/index.js
@@ -37,7 +37,7 @@ const clientSecret = process.env.clientSecret || process.env.PLATFORM_API_CLIENT
 const keys = [clientId, clientSecret];
 const CACHE = { clients: [] };
 
-function nyplApiClient(options = { apiName: 'discovery' }) {
+function nyplApiClient(options = { apiName: 'platform' }) {
   const { apiName } = options;
   if (CACHE.clients[apiName]) {
     return Promise.resolve(CACHE.clients[apiName]);


### PR DESCRIPTION
**What's this do?**
Add support for configuring the app to use a different base URL for discovery-api requests (searches and bib retrieval). Currently, all Platform API calls (e.g. discovery-api, hold-requests, bib-service, etc) use the same base URL configured by PLATFORM_API_BASE_URL. With this change, deployments (and locally running apps) can optionally set a DISCOVERY_API_BASE_URL to override that base URL for discovery-api requests.

This should have no change for any deployments. If approved, I plan to add a custom DISCOVERY_API_BASE_URL to the edd-training deployment so we can use that app to test a new discovery-api-qa app.


**Why are we doing this? (w/ JIRA link if applicable)**

We're doing this to allow us to run the app on top of new discovery-api candidates before we integrate them into the Platform API Gateway.


**Do these changes have automated tests?**
n/a

**How should this be QAed?**
Will be deployed to edd-training if approved

**Dependencies for merging? Releasing to production?**
 No additional config is needed. App should behave exactly as it currently does.

**Has the application documentation been updated for these changes?**
Yes

**Did someone actually run this code to verify it works?**
I did