### PR TITLE
Scc 3650/rm location api call

### DIFF
--- a/src/server/ApiRoutes/Search.js
+++ b/src/server/ApiRoutes/Search.js
@@ -17,9 +17,7 @@ import ResearchNow from './ResearchNow';
 import createSelectedFiltersHash from '../../app/utils/createSelectedFiltersHash';
 import { searchResultItemsListLimit as itemTableLimit } from '../../app/data/constants';
 import {
-  addHoldingDefinition,
-  fetchLocationUrls,
-  findUrl,
+  addHoldingDefinition
 } from './Bib';
 
 const createAPIQuery = basicQuery({
@@ -129,23 +127,7 @@ function fetchResults(searchKeywords = '', contributor, title, subject, page, so
           });
         }
       });
-      const codes = Array.from(locationCodes).join(',');
-      return fetchLocationUrls(codes).then((resp) => {
-        itemListElement.forEach((resultObj) => {
-          const { result } = resultObj;
-          const items = result.items;
-          if (!items) return results;
-          items.slice(0, itemTableLimit).forEach((item) => {
-            if (!item) return;
-            if (item.holdingLocation) {
-              item.holdingLocation[0].url = findUrl({ code: item.holdingLocation[0]['@id'] }, resp);
-              item.locationUrl = item.holdingLocation[0].url
-            }
-            if (item.location) item.locationUrl = findUrl({ code: item.holdingLocationCode }, resp);
-          });
-        });
-        return results;
-      })
+      return Promise.resolve(results)
         .then(processedResults => cb(
           aggregations,
           processedResults,

--- a/src/server/ApiRoutes/Search.js
+++ b/src/server/ApiRoutes/Search.js
@@ -96,47 +96,11 @@ function fetchResults(searchKeywords = '', contributor, title, subject, page, so
         const bnumber = results.itemListElement[0].result.uri;
         return expressRes.redirect(`${appConfig.baseUrl}/bib/${bnumber}`);
       }
-      const locationCodes = new Set();
-      const { itemListElement } = results;
-      if (!itemListElement) {
-        return cb(
-          aggregations,
-          results,
-          page,
-          drbbResults);
-      }
-      itemListElement.forEach((resultObj) => {
-        const { result } = resultObj;
-        const { holdings } = resultObj.result;
-        if (!result.items && !result.holdings) return;
-        if (holdings) {
-          holdings.slice(0, itemTableLimit).forEach((holding) => {
-            addHoldingDefinition(holding);
-            if (holding.location) locationCodes.add(holding.location[0].code);
-          });
-          if (holdings.length < itemTableLimit) {
-            result.items.slice(0, itemTableLimit - holdings.length).forEach((item) => {
-              if (item.holdingLocation) item.holdingLocation.forEach((holdingLocation) => {
-                locationCodes.add(holdingLocation['@id']);
-              });
-            });
-          }
-        } else if (result.items) {
-          result.items.slice(0, itemTableLimit).forEach((item) => {
-            if (item.holdingLocation) locationCodes.add(item.holdingLocation[0]['@id']);
-          });
-        }
-      });
-      return Promise.resolve(results)
-        .then(processedResults => cb(
-          aggregations,
-          processedResults,
-          page,
-          drbbResults))
-        .catch((error) => {
-          logger.error('Error making server search call in search function', error);
-          errorcb(error);
-        });
+      return cb(
+        aggregations,
+        results,
+        page,
+        drbbResults);
     })
     .catch(console.error);
 }

--- a/test/unit/Bib.test.js
+++ b/test/unit/Bib.test.js
@@ -54,62 +54,6 @@ describe('Bib', () => {
     ],
   };
 
-  describe('addLocationUrls', () => {
-    before(() => {
-      stub(NyplApiClient.prototype, 'get').callsFake(() => Promise.resolve(
-        JSON.parse(
-          fs.readFileSync(
-            './test/fixtures/locations-service-mm.json', 'utf8'))));
-    });
-    after(() => {
-      NyplApiClient.prototype.get.restore();
-    });
-    it('should add location URLs', () => {
-      Bib.addLocationUrls(mockBib).then((resp) => {
-        expect(resp.holdings).to.deep.equal([
-          {
-            location: [{
-              label: 'Mid-Manhattan',
-              code: 'mm',
-              url: 'http://www.nypl.org/locations/mid-manhattan-library',
-            }],
-            format: 'Text',
-            checkInBoxes: [
-              {
-                position: 1,
-                status: 'available',
-                coverage: '1000',
-                shelfMark: 'abcd',
-              },
-              {
-                position: 3,
-                status: 'available',
-                coverage: '1001',
-                shelfMark: 'efgh',
-              },
-            ],
-          },
-          {
-            format: 'AV',
-            checkInBoxes: [
-              {
-                position: 2,
-                status: 'available',
-                coverage: '1002',
-                shelfMark: 'ijkl',
-              },
-              {
-                position: 4,
-                status: 'Expected',
-                coverage: '1003',
-                shelfMark: 'mnop',
-              },
-            ],
-          },
-        ]);
-      });
-    });
-  });
   describe('nyplApiClientCall', () => {
     let apiClientStub
     let urlRecord

--- a/test/unit/utils.test.js
+++ b/test/unit/utils.test.js
@@ -134,7 +134,7 @@ describe('getDefaultFilters', () => {
   });
 });
 
-describe.only('standardizeBib', () => {
+describe('standardizeBib', () => {
   it('doesn\'t mess with kosher id', () => {
     expect(standardizeBibId('b12345678')).to.equal('b12345678')
     expect(standardizeBibId('hb123456789123456789')).to.equal('hb123456789123456789')


### PR DESCRIPTION
**What's this do?**
Removes locations service calls for urls, because urls are not being used anywhere.

**Why are we doing this? (w/ JIRA link if applicable)**
I started this as a refactor to remove 'loc:' from the beginning of location code queries to the locations service, but then I noticed that the API call was totally superfluous because the urls are not used. Looking into removing the API call revealed that there was a whole chunk of code that could be totally eliminated from `Search.js`. Removing this block is dependent on addHoldingsDefinitions not being needed on the search results page, which I'm pretty sure is the case. 

**Do these changes have automated tests?**
I removed a test for a function that is no longer used (fetchLocationUrls)

**How should this be QAed?**
Confirm that search and bib details page work as expected.

**Dependencies for merging? Releasing to production?**
[Description of any watchouts, dependencies, or issues we should be aware of]

**Has the application documentation been updated for these changes?**

**Did someone actually run this code to verify it works?**
