### PR TITLE
SCC-3639  - Remove google analytics config, tracking util, and event emissions

### DIFF
--- a/ENVIRONMENTVARS.md
+++ b/ENVIRONMENTVARS.md
@@ -28,7 +28,6 @@ These variables are used to configure server settings and application-wide setti
 | `BASE_URL` | string | `/research/research-catalog` | The base URL for the application. |
 | `BUNDLE_ANALYZER` | boolean | true, false | Whether or not to run the `webpack-visualizer-plugin` plugin in webpack. |
 | `DISPLAY_TITLE` | string | "Research Catalog" | The title of the application displayed throughout the UI. |
-| `GA_ENV` | string | `development`, `production` | Used to decide what Google Analytics code should be used. |
 | `LEGACY_BASE_URL` | string | "" | The base url for the legacy catalog. |
 | `NODE_ENV` | string | `development`, `test`, `production` | The environment in which the application is running. When running `npm test`, the value is `test`. When running locally, the default is `development` but it should be `production` for the "production" build and server. |
 | `REDIRECT_FROM_BASE_URL` | string | "/research/collections/shared-collection-catalog" | The old base URL of the app. If a user goes to the old URL, the server redirects the user. |

--- a/package-lock.json
+++ b/package-lock.json
@@ -2186,6 +2186,7 @@
         "axios": "0.21.1",
         "classnames": "2.1.3",
         "dgx-feature-flags": "git+https://git@bitbucket.org/NYPL/dgx-feature-flags.git#master",
+        "dgx-react-ga": "git+https://git@bitbucket.org/NYPL/dgx-react-ga.git#master",
         "dgx-skip-navigation-link": "git+https://git@bitbucket.org/NYPL/dgx-skip-navigation-link.git#master",
         "focus-trap-react": "3.0.3",
         "moment": "2.24.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2186,7 +2186,6 @@
         "axios": "0.21.1",
         "classnames": "2.1.3",
         "dgx-feature-flags": "git+https://git@bitbucket.org/NYPL/dgx-feature-flags.git#master",
-        "dgx-react-ga": "git+https://git@bitbucket.org/NYPL/dgx-react-ga.git#master",
         "dgx-skip-navigation-link": "git+https://git@bitbucket.org/NYPL/dgx-skip-navigation-link.git#master",
         "focus-trap-react": "3.0.3",
         "moment": "2.24.0",

--- a/package.json
+++ b/package.json
@@ -103,7 +103,6 @@
     "core-js": "3.23.3",
     "cross-env": "^7.0.3",
     "css-loader": "1.0.0",
-    "dgx-react-ga": "git+https://git@bitbucket.org/NYPL/dgx-react-ga.git#master",
     "dotenv": "^10.0.0",
     "ejs": "3.1.6",
     "express": "^4.16.3",

--- a/src/app/components/BibPage/BibDetails.jsx
+++ b/src/app/components/BibPage/BibDetails.jsx
@@ -82,9 +82,14 @@ const BibDetails = (props) => {
             fieldLabel,
           );
 
-          const direction = (liInner.props && liInner.props.dir) ? liInner.props.dir : null;
+          const direction =
+            liInner.props && liInner.props.dir ? liInner.props.dir : null;
           const listElement = (
-            <li key={`filter${fieldValue}-${index}`} dir={direction} className={direction}>
+            <li
+              key={`filter${fieldValue}-${index}`}
+              dir={direction}
+              className={direction}
+            >
               {liInner}
             </li>
           );
@@ -129,13 +134,11 @@ const BibDetails = (props) => {
       return searchRouterLink({
         query: url,
         label: bibValue,
-        analyticsLabel: fieldLabel,
-        analyticsValue: bibValue,
       });
     }
 
     if (fieldSelfLinkable) {
-      const linkText = bibValue.prefLabel || bibValue.label || bibValue.url
+      const linkText = bibValue.prefLabel || bibValue.label || bibValue.url;
       return (
         <DSLink
           href={bibValue.url}
@@ -146,7 +149,9 @@ const BibDetails = (props) => {
       );
     }
 
-    return <span dir={stringDirection(bibValue, useParallels)}>{bibValue}</span>;
+    return (
+      <span dir={stringDirection(bibValue, useParallels)}>{bibValue}</span>
+    );
   };
 
   /**
@@ -211,16 +216,14 @@ const BibDetails = (props) => {
       }
 
       // For each group of notes, add them to the definition list individually.
-      if (
-        fieldLabel === 'Notes' &&
-        !_isEmpty(bib.notesGroupedByNoteType)
-      ) {
+      if (fieldLabel === 'Notes' && !_isEmpty(bib.notesGroupedByNoteType)) {
         const notesGroupedByNoteType = props.bib.notesGroupedByNoteType;
         Object.keys(notesGroupedByNoteType).forEach((noteType) => {
           const notesList = (
             <ul>
               {notesGroupedByNoteType[noteType].map((note, index) => (
-                <li key={index}
+                <li
+                  key={index}
                   dir={stringDirection(note.prefLabel, useParallels)}
                   className={stringDirection(note.prefLabel, useParallels)}
                 >
@@ -261,8 +264,6 @@ const BibDetails = (props) => {
       const subjectHeadingLink = searchRouterLink({
         query: urlWithFilterQuery,
         label: heading,
-        analyticsLabel: fieldLabel,
-        analyticsValue: urlArray[index],
       });
 
       returnArray.push(subjectHeadingLink);
@@ -282,16 +283,9 @@ const BibDetails = (props) => {
    *
    * @param {string} query - the search query to add in the URL
    * @param {string} label - the visible label for the anchor element
-   * @param {string} analyticsLabel - label text used for Google Analytics
-   * @param {string} analyticsValue - value text used for Google Analytics
    * @returns React-router `Link` component.
    */
-  const searchRouterLink = ({
-    query,
-    label,
-    analyticsLabel,
-    analyticsValue,
-  }) => {
+  const searchRouterLink = ({ query, label }) => {
     const onClick = (event) => {
       event.preventDefault();
       router.push(`${appConfig.baseUrl}/search?${query}`);

--- a/src/app/components/BibPage/BibDetails.jsx
+++ b/src/app/components/BibPage/BibDetails.jsx
@@ -18,7 +18,6 @@ import {
   stringDirection,
 } from '../../utils/bibDetailsUtils';
 import { RouterContext } from '../../context/RouterContext';
-import { trackDiscovery } from '../../utils/utils';
 
 const BibDetails = (props) => {
   const { router } = React.useContext(RouterContext);
@@ -140,12 +139,6 @@ const BibDetails = (props) => {
       return (
         <DSLink
           href={bibValue.url}
-          onClick={() =>
-            trackDiscovery(
-              'Bib fields',
-              `${fieldLabel} - ${bibValue.prefLabel}`,
-            )
-          }
           dir={stringDirection(linkText, useParallels)}
         >
           {linkText}
@@ -301,8 +294,6 @@ const BibDetails = (props) => {
   }) => {
     const onClick = (event) => {
       event.preventDefault();
-
-      trackDiscovery('Bib fields', `${analyticsLabel} - ${analyticsValue}`);
       router.push(`${appConfig.baseUrl}/search?${query}`);
     };
 

--- a/src/app/components/BibPage/MarcRecord.jsx
+++ b/src/app/components/BibPage/MarcRecord.jsx
@@ -2,17 +2,14 @@ import { Link } from '@nypl/design-system-react-components';
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { trackDiscovery } from '../../utils/utils';
-
 const MarcRecord = ({ bNumber }) => {
   if (!bNumber) {
     return null;
   }
-  const onClick = () => trackDiscovery('MARC Record', `Click - ${bNumber}`);
   const marcRecordLink =
     `https://catalog.nypl.org/search~S1?/.b${bNumber}/.b${bNumber}/1%2C1%2C1%2CB/marc`;
 
-  return (<Link href={marcRecordLink} onClick={onClick}>MARC Record</Link>);
+  return (<Link href={marcRecordLink}>MARC Record</Link>);
 };
 
 MarcRecord.propTypes = {

--- a/src/app/components/BibPage/Tabbed.jsx
+++ b/src/app/components/BibPage/Tabbed.jsx
@@ -2,8 +2,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { trackDiscovery } from '../../utils/utils';
-
 class Tabbed extends React.Component {
   constructor(props) {
     super(props);
@@ -38,10 +36,6 @@ class Tabbed extends React.Component {
 
   // switches tabs by updating state and href
   switchTab(newTabIndex) {
-    if (newTabIndex !== this.state.tabNumber) {
-      const tabChoices = ['Availability Tab1', 'Details Tab2', 'Full Description Tab3'];
-      trackDiscovery('BibPage Tabs Switch', tabChoices[newTabIndex - 1]);
-    }
     this.setState({ tabNumber: newTabIndex.toString() });
     const newTab = this.links[newTabIndex];
     window.location.replace(`${window.location.href.split('#')[0]}#tab${newTabIndex}`);

--- a/src/app/components/Feedback/Feedback.jsx
+++ b/src/app/components/Feedback/Feedback.jsx
@@ -2,7 +2,6 @@ import React, { useContext, useState } from 'react'
 import axios from 'axios'
 
 import { FeedbackBoxContext } from '../../context/FeedbackContext'
-import { trackDiscovery } from '../../utils/utils';
 import appConfig from '../../data/appConfig'
 
 /**
@@ -14,12 +13,10 @@ const Feedback = () => {
   const { FeedbackBox, isOpen, onClose, onOpen, itemMetadata, setItemMetadata } = useContext(FeedbackBoxContext)
   const closeAndResetItemMetadata = () => {
     if (itemMetadata) setItemMetadata(null)
-    trackDiscovery('Feedback', 'Close');
     onClose();
     setScreen('form');
   }
   const submitFeedback = async (metadataAndComment) => {
-    trackDiscovery('Feedback', 'Submit')
     try {
       const res = await axios.post(`${appConfig.baseUrl}/api/feedback`,
         { fields: metadataAndComment })

--- a/src/app/components/FilterPopup/FilterPopup.jsx
+++ b/src/app/components/FilterPopup/FilterPopup.jsx
@@ -15,9 +15,6 @@ import {
   union as _union,
 } from 'underscore';
 
-import {
-  trackDiscovery,
-} from '../../utils/utils';
 import appConfig from '@appConfig';
 
 import FieldsetDate from '../Filters/FieldsetDate';
@@ -121,7 +118,6 @@ export class FilterPopup extends React.Component {
     };
     if (filter.selected) {
       clickedFilters[filterId].push(filter);
-      trackDiscovery('Filters - Select', `${filterId} - ${filter.label}`);
     } else {
       clickedFilters[filterId] =
         _reject(
@@ -133,7 +129,6 @@ export class FilterPopup extends React.Component {
           selectedFilters[filterId],
           selectedFilter => selectedFilter.value === filter.value,
         );
-      trackDiscovery('Filters - Deselect', `${filterId} - ${filter.label}`);
     }
 
     this.setState({ provisionalSelectedFilters: clickedFilters });
@@ -232,10 +227,6 @@ export class FilterPopup extends React.Component {
       provisionalSelectedFilters,
     } = this.state;
 
-    if (position) {
-      trackDiscovery(`Filters - ${position}`, 'Apply Filters');
-    }
-
     const { dateAfter, dateBefore } = selectedFilters;
     const filtersToApply = {
       materialType: _union(provisionalSelectedFilters.materialType, selectedFilters.materialType),
@@ -247,13 +238,6 @@ export class FilterPopup extends React.Component {
     };
 
     const apiQuery = this.props.createAPIQuery({ selectedFilters: filtersToApply });
-
-    if (dateAfter) {
-      trackDiscovery('Filters - Date', `After - ${dateAfter}`);
-    }
-    if (dateBefore) {
-      trackDiscovery('Filters - Date', `Before - ${dateBefore}`);
-    }
 
     this.closeForm(e);
 
@@ -268,7 +252,6 @@ export class FilterPopup extends React.Component {
   clearFilters(e, position) {
     e.persist();
 
-    trackDiscovery(`Filters - ${position}`, 'Clear Filters');
     const resetFilters = {
       materialType: [],
       language: [],
@@ -288,7 +271,6 @@ export class FilterPopup extends React.Component {
 
   openForm() {
     if (!this.state.showForm) {
-      trackDiscovery('Filters', 'Open Dropdown');
       this.setState({ showForm: true });
       this.props.updateDropdownState(true);
 
@@ -302,10 +284,6 @@ export class FilterPopup extends React.Component {
 
   closeForm(e, position = '') {
     e.preventDefault();
-
-    if (position) {
-      trackDiscovery(`Filters - ${position}`, 'Close Dropdown');
-    }
 
     this.setState({
       showForm: false,

--- a/src/app/components/Filters/SelectedFilters.jsx
+++ b/src/app/components/Filters/SelectedFilters.jsx
@@ -16,9 +16,6 @@ import {
 } from 'underscore';
 
 import appConfig from '../../data/appConfig';
-import {
-  trackDiscovery,
-} from '../../utils/utils';
 
 class SelectedFilters extends React.Component {
   constructor(props) {
@@ -54,16 +51,12 @@ class SelectedFilters extends React.Component {
     }
 
     const apiQuery = this.props.createAPIQuery({ selectedFilters });
-    trackDiscovery('Filters - Selected list', `Remove - ${filter.field} ${filter.label}`);
 
     this.context.router.push(`${appConfig.baseUrl}/search?${apiQuery}`);
   }
 
   clearFilters() {
     const apiQuery = this.props.createAPIQuery({ selectedFilters: {} });
-
-    trackDiscovery('Filters - Selected list', 'Clear Filters');
-
     this.context.router.push(`${appConfig.baseUrl}/search?${apiQuery}`);
   }
 

--- a/src/app/components/Item/ItemsContainer.jsx
+++ b/src/app/components/Item/ItemsContainer.jsx
@@ -9,7 +9,6 @@ import appConfig from '../../data/appConfig';
 import {
   bibPageItemsListLimit as itemsListPageLimit,
 } from '../../data/constants';
-import { trackDiscovery } from '../../utils/utils';
 import Pagination from '../Pagination/Pagination';
 import ItemFilters from '../ItemFilters/ItemFilters';
 import ItemTable from './ItemTable';
@@ -75,7 +74,6 @@ class ItemsContainer extends React.Component {
    */
   updatePage(page, type) {
     this.setState({ page });
-    trackDiscovery('Pagination', `${type} - page ${page}`);
     this.context.router.push({
       pathname: `${appConfig.baseUrl}/bib/${this.props.bibId}`,
       query: {
@@ -90,7 +88,6 @@ class ItemsContainer extends React.Component {
    * @description Display all items on the page.
    */
   showAll() {
-    trackDiscovery('View All Items', `Click - ${this.props.bibId}`);
     if (this.query && this.query.item_page) {
       delete this.query.item_page;
     }
@@ -167,9 +164,6 @@ class ItemsContainer extends React.Component {
                 <Link
                   to={`${appConfig.baseUrl}/bib/${bibId}/all`}
                   className="view-all-items"
-                  onClick={() =>
-                    trackDiscovery('View All Items', `Click - ${bibId}`)
-                  }
                 >
                   View All Items
                 </Link>

--- a/src/app/components/Item/RequestButtons.jsx
+++ b/src/app/components/Item/RequestButtons.jsx
@@ -1,43 +1,40 @@
 import React from 'react';
 import { Link } from 'react-router';
-import {
-  aeonUrl,
-} from '../../utils/utils';
+import { aeonUrl } from '../../utils/utils';
 import { MediaContext } from '../Application/Application';
 
-const ifAvailableHandler = (handler, available) => (available ? handler : (e) => { e.preventDefault() })
+const RequestButtons = ({ item, bibId, searchKeywords, appConfig, page }) => {
+  const media = React.useContext(MediaContext);
 
-const RequestButtons = ({item, bibId, searchKeywords, appConfig, page}) => {
-  const media = React.useContext(MediaContext)
-
-  const { closedLocations, recapClosedLocations, nonRecapClosedLocations, features } = appConfig;
+  const {
+    closedLocations,
+    recapClosedLocations,
+    nonRecapClosedLocations,
+    features,
+  } = appConfig;
   const isRecap = item.isRecap;
-  const allClosed = closedLocations.concat((isRecap ? recapClosedLocations : nonRecapClosedLocations)).includes('');
-  const isAeon = item.aeonUrl && features.includes('aeon-links')
-
-  const getItemRecord = (e) => {
-    if (page === 'SearchResults') gaLabel = 'Search Results';
-    if (page === 'BibPage') gaLabel = 'Item Details';
-    if (page === 'SubjectHeadingShowPage') gaLabel = 'Subject Heading Details';
-  }
+  const allClosed = closedLocations
+    .concat(isRecap ? recapClosedLocations : nonRecapClosedLocations)
+    .includes('');
+  const isAeon = item.aeonUrl && features.includes('aeon-links');
 
   const physRequestButton = () => {
     if (isAeon || allClosed || !item.physRequestable) {
       return null;
     }
     return (
-        <Link
-          to={
-            `${appConfig.baseUrl}/hold/request/${bibId}-${item.id}?searchKeywords=${searchKeywords}`
-          }
-          onClick={ifAvailableHandler(e => getItemRecord(e, bibId, item.id), item.available)}
-          tabIndex="0"
-          aria-disabled={!item.available}
-          className={ item.available ? 'avail-request-button' : 'unavail-request-button' }
-        >
-          Request for On-site Use
-        </Link>)
-  }
+      <Link
+        to={`${appConfig.baseUrl}/hold/request/${bibId}-${item.id}?searchKeywords=${searchKeywords}`}
+        tabIndex='0'
+        aria-disabled={!item.available}
+        className={
+          item.available ? 'avail-request-button' : 'unavail-request-button'
+        }
+      >
+        Request for On-site Use
+      </Link>
+    );
+  };
 
   const eddRequestButton = () => {
     if (isAeon || allClosed || !item.eddRequestable) {
@@ -46,41 +43,47 @@ const RequestButtons = ({item, bibId, searchKeywords, appConfig, page}) => {
 
     return (
       <Link
-        to={
-          `${appConfig.baseUrl}/hold/request/${bibId}-${item.id}/edd?searchKeywords=${searchKeywords}`
-        }
-        onClick={ifAvailableHandler(e => getItemRecord(e, bibId, item.id), item.available)}
-        tabIndex="0"
+        to={`${appConfig.baseUrl}/hold/request/${bibId}-${item.id}/edd?searchKeywords=${searchKeywords}`}
+        tabIndex='0'
         aria-disabled={!item.available}
-        className={ item.available ? 'avail-request-button' : 'unavail-request-button' }
+        className={
+          item.available ? 'avail-request-button' : 'unavail-request-button'
+        }
       >
         Request Scan
       </Link>
-    )
-  }
+    );
+  };
 
   const aeonRequestButton = () => {
-    if (!isAeon || allClosed) { return null }
+    if (!isAeon || allClosed) {
+      return null;
+    }
     return (
       <a
         href={aeonUrl(item)}
-        tabIndex="0"
-        onClick={ifAvailableHandler(() => { return null }, item.available)}
+        tabIndex='0'
         aria-disabled={!item.available}
-        className={`aeonRequestButton ${item.available ? 'avail-request-button' : 'unavail-request-button'}`}
+        className={`aeonRequestButton ${
+          item.available ? 'avail-request-button' : 'unavail-request-button'
+        }`}
       >
         Request Appointment
       </a>
     );
-  }
+  };
 
   return (
-    <div className={`request-buttons-container ${page === 'SearchResults' ? '' : 'bib-details'} ${media}`}>
-        {physRequestButton()}
-        {eddRequestButton()}
-        {aeonRequestButton()}
-      </div>
-  )
-}
+    <div
+      className={`request-buttons-container ${
+        page === 'SearchResults' ? '' : 'bib-details'
+      } ${media}`}
+    >
+      {physRequestButton()}
+      {eddRequestButton()}
+      {aeonRequestButton()}
+    </div>
+  );
+};
 
 export default RequestButtons;

--- a/src/app/components/Item/RequestButtons.jsx
+++ b/src/app/components/Item/RequestButtons.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router';
 import {
-  trackDiscovery,
   aeonUrl,
 } from '../../utils/utils';
 import { MediaContext } from '../Application/Application';
@@ -17,11 +16,9 @@ const RequestButtons = ({item, bibId, searchKeywords, appConfig, page}) => {
   const isAeon = item.aeonUrl && features.includes('aeon-links')
 
   const getItemRecord = (e) => {
-    let gaLabel = 'Item Holding';
     if (page === 'SearchResults') gaLabel = 'Search Results';
     if (page === 'BibPage') gaLabel = 'Item Details';
     if (page === 'SubjectHeadingShowPage') gaLabel = 'Subject Heading Details';
-    trackDiscovery('Item Request', gaLabel);
   }
 
   const physRequestButton = () => {

--- a/src/app/components/ItemFilters/ItemFilters.jsx
+++ b/src/app/components/ItemFilters/ItemFilters.jsx
@@ -2,7 +2,6 @@ import { Button, Heading, Text } from '@nypl/design-system-react-components';
 import PropTypes from 'prop-types';
 import React, { Fragment, useEffect, useState, useRef, useCallback } from 'react';
 
-import { trackDiscovery } from '../../utils/utils';
 import { getLabelsForValues, initialLocations } from './itemFilterUtils';
 import { MediaContext } from '../Application/Application';
 import ItemFilter from './ItemFilter';
@@ -100,14 +99,8 @@ const ItemFilters = (
     // reset `selectFilters` to `initialFilters` any time `openFilter` changes
     setSelectedFields(initialFilters);
     if (filterType === openFilter) {
-      trackDiscovery('Search Filters', `Close Filter - ${filterType}`);
       setOpenFilter('none');
     } else {
-      if (filterType === 'none')
-        trackDiscovery('Search Filters', `Close Filter - ${openFilter}`);
-      else {
-        trackDiscovery('Search Filters', `Open Filter - ${openFilter}`);
-      }
       setOpenFilter(filterType);
     }
   };
@@ -166,10 +159,6 @@ const ItemFilters = (
         search: '',
       },
     });
-    trackDiscovery(
-      'Search Filters',
-      `Apply Filter - ${JSON.stringify(selectedFields)}`,
-    );
     router.push(href);
   };
 

--- a/src/app/components/LogoutLink/LogoutLink.jsx
+++ b/src/app/components/LogoutLink/LogoutLink.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import React, { useContext, useEffect, useState } from 'react';
 
 import { PatronContext } from '../../context/PatronContext';
-import { trackDiscovery } from '../../utils/utils';
 import appConfig from '../../data/appConfig';
 
 /**
@@ -36,7 +35,6 @@ const LogoutLink = ({
     <>
       {delineate ? <>&nbsp;|&nbsp;</> : null}
       <DSLink
-        onClick={() => trackDiscovery("Click", "Log Out")}
         href={`${logoutLink}${backLink}`}
         sx={{
           color: 'ui.white', textDecoration: 'none',

--- a/src/app/components/ResultsList/ResultsList.jsx
+++ b/src/app/components/ResultsList/ResultsList.jsx
@@ -9,9 +9,6 @@ import {
 import { useSelector, useDispatch } from 'react-redux';
 
 import LibraryItem from '../../utils/item';
-import {
-  trackDiscovery
-} from '../../utils/utils';
 import SearchResultsItems from '../Item/SearchResultsItems';
 import appConfig from '../../data/appConfig';
 import { searchResultItemsListLimit as itemTableLimit } from '../../data/constants';
@@ -118,7 +115,6 @@ const ResultsList = ({
                   fromUrl: `${pathname}${search}`,
                   bibId,
                 });
-                trackDiscovery('Bib', bibTitle);
               }
             }
               to={bibUrl}

--- a/src/app/components/Search/Search.jsx
+++ b/src/app/components/Search/Search.jsx
@@ -6,7 +6,6 @@ import { Link } from 'react-router';
 
 import {
   standardizeBibId,
-  trackDiscovery,
 } from '../../utils/utils';
 import appConfig from '../../data/appConfig';
 import {
@@ -78,14 +77,7 @@ function Search(props) {
   function submitSearchRequest(e) {
     e.preventDefault();
     // Store the data that the user entered
-
     const userSearchKeywords = keywords.trim();
-
-    // Track the submitted keyword search.
-    trackDiscovery('Search', userSearchKeywords);
-    if (selectField) {
-      trackDiscovery('Search', `Field - ${selectField}`);
-    }
 
     let searchKeywords = userSearchKeywords === '*' ? '' : userSearchKeywords;
 

--- a/src/app/components/SearchResults/SearchResultsContainer.jsx
+++ b/src/app/components/SearchResults/SearchResultsContainer.jsx
@@ -6,7 +6,6 @@ import ResultsList from '../ResultsList/ResultsList';
 import Pagination from '../Pagination/Pagination';
 import DrbbContainer from '../Drbb/DrbbContainer';
 import {
-  trackDiscovery,
   displayContext,
 } from '../../utils/utils';
 import appConfig from '../../data/appConfig';
@@ -26,8 +25,6 @@ const SearchResultsContainer = (props) => {
 
   const updatePage = (nextPage, pageType) => {
     const apiQuery = createAPIQuery({ page: nextPage });
-
-    trackDiscovery('Pagination - Search Results', `${pageType} - page ${nextPage}`);
     props.router.push(`${appConfig.baseUrl}/search?${apiQuery}`);
   };
 

--- a/src/app/components/SearchResults/SearchResultsSorter.jsx
+++ b/src/app/components/SearchResults/SearchResultsSorter.jsx
@@ -1,10 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-
-import {
-  trackDiscovery,
-} from '../../utils/utils';
 import appConfig from '../../data/appConfig';
 
 const sortingOpts = [
@@ -58,7 +54,6 @@ export class SearchResultsSorter extends React.Component {
   sortResultsBy(sortBy) {
     // const apiQuery = this.props.createAPIQuery({ sortBy, page: this.props.page });
     const apiQuery = this.props.createAPIQuery({ sortBy });
-    trackDiscovery('Sort by', sortBy);
     this.context.router.push(`${appConfig.baseUrl}/search?${apiQuery}`);
   }
 

--- a/src/app/context/FeedbackContext.jsx
+++ b/src/app/context/FeedbackContext.jsx
@@ -1,8 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { useState, createContext } from 'react';
 import { useFeedbackBox } from '@nypl/design-system-react-components';
-import { trackDiscovery } from '../utils/utils';
-
 
 /**
  * Wrapper context component that controls state for the Feedback component
@@ -13,7 +11,6 @@ export const FeedbackBoxProvider = ({ children, value }) => {
   const [itemMetadata, setItemMetadata] = useState(value && value.itemMetadata ? value.itemMetadata : null)
   const { FeedbackBox, isOpen, onOpen, onClose } = useFeedbackBox()
   const openFeedbackBox = () => {
-    trackDiscovery('Feedback', 'Open')
     onOpen()
   }
   return (

--- a/src/app/pages/ElectronicDelivery.jsx
+++ b/src/app/pages/ElectronicDelivery.jsx
@@ -18,7 +18,7 @@ import Notification from '../components/Notification/Notification';
 import SccContainer from '../components/SccContainer/SccContainer';
 import appConfig from '../data/appConfig';
 import LibraryItem from '../utils/item';
-import { institutionNameByNyplSource, trackDiscovery } from '../utils/utils';
+import { institutionNameByNyplSource } from '../utils/utils';
 
 class ElectronicDelivery extends React.Component {
   constructor(props) {
@@ -155,7 +155,6 @@ class ElectronicDelivery extends React.Component {
 
     // This is to remove the error box on the top of the page on a successfull submission.
     this.setState({ raiseError: null });
-    trackDiscovery(`Submit Request EDD${partnerEvent}`, `${title} - ${itemId}`);
 
     const formData = new FormData(document.getElementById('place-edd-hold-form'));
     axios.post(
@@ -185,7 +184,6 @@ class ElectronicDelivery extends React.Component {
    */
   raiseError(error) {
     this.setState({ raiseError: error });
-    trackDiscovery('Error', 'EDD');
   }
 
   render() {
@@ -218,7 +216,6 @@ class ElectronicDelivery extends React.Component {
             <DSLink>
               <Link
                 to={`${appConfig.baseUrl}/bib/${bibId}`}
-                onClick={() => trackDiscovery('EDD - Bib', title)}
               >
                 {title}
               </Link>

--- a/src/app/pages/ElectronicDelivery.jsx
+++ b/src/app/pages/ElectronicDelivery.jsx
@@ -214,9 +214,7 @@ class ElectronicDelivery extends React.Component {
         <div className="nypl-request-item-summary">
           <h2>
             <DSLink>
-              <Link
-                to={`${appConfig.baseUrl}/bib/${bibId}`}
-              >
+              <Link to={`${appConfig.baseUrl}/bib/${bibId}`}>
                 {title}
               </Link>
             </DSLink>

--- a/src/app/pages/HoldConfirmation.jsx
+++ b/src/app/pages/HoldConfirmation.jsx
@@ -13,9 +13,6 @@ import { connect } from 'react-redux';
 
 import appConfig from '../data/appConfig';
 import SccContainer from '../components/SccContainer/SccContainer';
-import {
-  trackDiscovery,
-} from '../utils/utils';
 
 export class HoldConfirmation extends React.Component {
   componentDidMount() {
@@ -106,8 +103,6 @@ export class HoldConfirmation extends React.Component {
    */
   backToHome(event) {
     event.preventDefault();
-
-    trackDiscovery('Discovery Search', 'New Search');
     this.context.router.push(`${appConfig.baseUrl}/`);
   }
 
@@ -119,8 +114,6 @@ export class HoldConfirmation extends React.Component {
    */
   goToSearchResults(event) {
     event.preventDefault();
-
-    trackDiscovery('Discovery Search', 'Existing Search');
     this.context.router.push(`${appConfig.baseUrl}/search?q=${this.props.searchKeywords}`);
   }
 
@@ -238,15 +231,11 @@ export class HoldConfirmation extends React.Component {
       <span id="go-back-catalog">
         <DSLink
           href={this.props.location.query.fromUrl}
-          onClick={() => trackDiscovery('Catalog Link', 'Existing Search')}
         >
           Go back to your search results
         </DSLink>
         {' '}or{' '}
-        <DSLink
-          href="https://catalog.nypl.org/search"
-          onClick={() => trackDiscovery('Catalog Link', 'New Search')}
-        >
+        <DSLink href="https://catalog.nypl.org/search">
           start a new search
         </DSLink>.
       </span>
@@ -384,11 +373,6 @@ export class HoldConfirmation extends React.Component {
           {this.renderStartOverLink()}
         </div>
       );
-    }
-
-    // If running client-side, generate GA event
-    if ((typeof window !== 'undefined') && errorStatus && errorMessage) {
-      trackDiscovery('Error', 'Hold Confirmation');
     }
 
     return (

--- a/src/app/pages/HoldConfirmation.jsx
+++ b/src/app/pages/HoldConfirmation.jsx
@@ -229,9 +229,7 @@ export class HoldConfirmation extends React.Component {
 
     return (
       <span id="go-back-catalog">
-        <DSLink
-          href={this.props.location.query.fromUrl}
-        >
+        <DSLink href={this.props.location.query.fromUrl}>
           Go back to your search results
         </DSLink>
         {' '}or{' '}

--- a/src/app/pages/HoldRequest.jsx
+++ b/src/app/pages/HoldRequest.jsx
@@ -17,7 +17,6 @@ import LoadingLayer from '../components/LoadingLayer/LoadingLayer';
 import appConfig from '../data/appConfig';
 import LibraryItem from '../utils/item';
 import {
-  trackDiscovery,
   institutionNameByNyplSource,
 } from '../utils/utils';
 import { updateLoadingStatus } from '../actions/Actions';
@@ -65,7 +64,6 @@ export class HoldRequest extends React.Component {
   }
 
   onRadioSelect(e, i) {
-    trackDiscovery('Delivery Location', e.target.value);
     this.setState({
       delivery: e.target.value,
       checkedLocNum: i,
@@ -83,8 +81,6 @@ export class HoldRequest extends React.Component {
     const searchKeywordsQueryPhysical = searchKeywordsQuery ? `&${searchKeywordsQuery}` : '';
     const fromUrlQuery = this.props.location.query && this.props.location.query.fromUrl ?
       `&fromUrl=${encodeURIComponent(this.props.location.query.fromUrl)}` : '';
-    const partnerEvent = itemSource !== 'sierra-nypl' ?
-      ` - Partner item - ${institutionNameByNyplSource(itemSource)}` : '';
     let path = `${appConfig.baseUrl}/hold/confirmation/${bibId}-${itemId}`;
 
     if (this.state.delivery === 'edd') {
@@ -95,7 +91,6 @@ export class HoldRequest extends React.Component {
       return;
     }
 
-    trackDiscovery(`Submit Request${partnerEvent}`, `${title} - ${itemId}`);
     const formData = new FormData(document.getElementById('place-hold-form'));
     this.props.updateLoadingStatus(true);
     axios.post(
@@ -240,7 +235,6 @@ export class HoldRequest extends React.Component {
           <Link
             id='item-link'
             to={`${appConfig.baseUrl}/bib/${bibId}`}
-            onClick={() => trackDiscovery('Hold Request - Bib', title)}
           >
             {title}
           </Link>

--- a/src/app/pages/Home.jsx
+++ b/src/app/pages/Home.jsx
@@ -9,12 +9,7 @@ import PropTypes from 'prop-types';
 import Search from '../components/Search/Search';
 import Notification from '../components/Notification/Notification';
 import SccContainer from '../components/SccContainer/SccContainer';
-import appConfig from '../data/appConfig';
-
-import {
-  basicQuery,
-  trackDiscovery,
-} from '../utils/utils';
+import { basicQuery } from '../utils/utils';
 
 const Home = (props, context) => (
   <SccContainer
@@ -53,7 +48,7 @@ const Home = (props, context) => (
         </div>
         <div className="nypl-column-three-quarters image-column-three-quarters">
           <Heading level="four">
-            <Link href="/research/collections" onClick={() => trackDiscovery('Research Links', 'Collections')}>Collections</Link>
+            <Link href="/research/collections">Collections</Link>
           </Heading>
           <p>Discover our world-renowned research collections, featuring more than 46
             million items.
@@ -67,7 +62,7 @@ const Home = (props, context) => (
         </div>
         <div className="nypl-column-three-quarters image-column-three-quarters">
           <Heading level="four">
-            <Link href="/locations/map?libraries=research" onClick={() => trackDiscovery('Research Links', 'Locations')}>Locations</Link>
+            <Link href="/locations/map?libraries=research">Locations</Link>
           </Heading>
           <p>Access items, one-on-one reference help, and dedicated research study rooms.</p>
         </div>
@@ -79,7 +74,7 @@ const Home = (props, context) => (
         </div>
         <div className="nypl-column-three-quarters image-column-three-quarters">
           <Heading level="four">
-            <Link href="/about/divisions" onClick={() => trackDiscovery('Research Links', 'Divisions')}>Divisions</Link>
+            <Link href="/about/divisions">Divisions</Link>
           </Heading>
           <p>Learn about the subject and media specializations of our research divisions.</p>
         </div>
@@ -91,7 +86,7 @@ const Home = (props, context) => (
         </div>
         <div className="nypl-column-three-quarters image-column-three-quarters">
           <Heading level="four">
-            <Link href="/research/support" onClick={() => trackDiscovery('Research Links', 'Support')}>Support</Link>
+            <Link href="/research/support">Support</Link>
           </Heading>
           <p>
             Plan your in-person research visit and discover resources for scholars and
@@ -106,7 +101,7 @@ const Home = (props, context) => (
         </div>
         <div className="nypl-column-three-quarters image-column-three-quarters">
           <Heading level="four">
-            <Link href="/research/services" onClick={() => trackDiscovery('Research Links', 'Services')}>Services</Link>
+            <Link href="/research/services">Services</Link>
           </Heading>
           <p>
             Explore services for online and remote researchers,

--- a/src/app/utils/electronicResources.js
+++ b/src/app/utils/electronicResources.js
@@ -12,12 +12,6 @@ const generateElectronicResourceLinksList = (electronicResources) => {
     <Link
       href={href}
       target='_blank'
-      onClick={() =>
-        trackDiscovery(
-          'Bib fields',
-          `Electronic Resource - ${label} - ${href}`,
-        )
-      }
       rel='noreferrer'
     >
       {label || prefLabel || href}

--- a/src/app/utils/utils.js
+++ b/src/app/utils/utils.js
@@ -1,5 +1,4 @@
 import axios from 'axios';
-import { gaUtils } from 'dgx-react-ga';
 import { createHistory, createMemoryHistory, useQueries } from 'history';
 import {
   chain as _chain,
@@ -178,15 +177,6 @@ const getIdentifierQuery = (identifierNumbers = {}) =>
   Object.entries(identifierNumbers)
     .map(([key, value]) => (value ? `&${key}=${value}` : ''))
     .join('');
-
-/**
- * Tracks Google Analytics (GA) events. `.trackEvent` returns a function with
- * 'Discovery' set as the GA Category. `trackDiscovery` will then log the defined
- * actions and labels under the 'Discovery' category.
- * @param {string} action The GA action.
- * @param {string} label The GA label.
- */
-const trackDiscovery = gaUtils.trackEvent('Discovery');
 
 // Maps routes to the appropriate page name for Adobe Analytics.
 const adobeAnalyticsRouteToPageName = (route = '') => {
@@ -832,7 +822,6 @@ function standardizeBibId(bibId) {
 
 export {
   standardizeBibId,
-  trackDiscovery,
   adobeAnalyticsRouteToPageName,
   trackVirtualPageView,
   ajaxCall,

--- a/src/client/App.jsx
+++ b/src/client/App.jsx
@@ -6,7 +6,6 @@ import { DSProvider } from '@nypl/design-system-react-components';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Router, browserHistory, applyRouterMiddleware } from 'react-router';
-import { config, gaUtils } from 'dgx-react-ga';
 import a11y from 'react-a11y';
 import { Provider } from 'react-redux';
 import useScroll from 'react-router-scroll/lib/useScroll';
@@ -23,12 +22,6 @@ if (loadA11y) {
 }
 
 window.onload = () => {
-  if (!window.ga) {
-    const isProd = process.env.GA_ENV === 'development' ? false : process.env.NODE_ENV === 'production';
-    const gaOpts = { debug: !isProd, titleCase: false };
-
-    gaUtils.initialize(config.google.code(isProd), gaOpts);
-  }
   const appElement = global.document.getElementById('app');
   ReactDOM.render(
     <DSProvider>
@@ -43,6 +36,5 @@ window.onload = () => {
     </DSProvider>,
     appElement,
   );
-  gaUtils.trackPageview(window.location.pathname);
   trackVirtualPageView(window.location.pathname);
 };

--- a/test/unit/RequestButtons.test.js
+++ b/test/unit/RequestButtons.test.js
@@ -5,117 +5,97 @@ import { Link } from 'react-router';
 import { expect } from 'chai';
 import { spy } from 'sinon';
 import { shallow, mount } from 'enzyme';
-import RequestButtons from './../../src/app/components/Item/RequestButtons'
+import RequestButtons from './../../src/app/components/Item/RequestButtons';
 import appConfig from '../../src/app/data/appConfig';
 import item from '../fixtures/libraryItems';
 
-
-
 describe('Request Buttons', () => {
   describe('Search Page', () => {
-    let page = 'SearchResults'
+    let page = 'SearchResults';
     describe('Physical Request', () => {
       describe('should be present when item eligible for physical request', () => {
         describe('should be enabled when item available', () => {
           let component;
           before(() => {
-            const data = Object.assign(
-              {},
-              item.full,
-              { physRequestable: true }
-            );
+            const data = Object.assign({}, item.full, {
+              physRequestable: true,
+            });
 
             component = mount(
               <RequestButtons
                 item={data}
-                bibId="b12345"
+                bibId='b12345'
                 page={page}
                 appConfig={appConfig}
                 searchKeywords={'fakesearchkeyword'}
-              />
+              />,
             );
-          })
+          });
 
           it('should have a link with avail-request-button class', () => {
-            const links = component.find(Link)
+            const links = component.find(Link);
             expect(links.length).to.equal(1);
             const link = links.at(0);
-            expect(link.prop('className')).to.equal('avail-request-button')
-          })
+            expect(link.prop('className')).to.equal('avail-request-button');
+          });
 
           it('should have link with aria-disabled false', () => {
-            const links = component.find(Link)
+            const links = component.find(Link);
             const link = links.at(0);
-            expect(link.prop('aria-disabled')).to.equal(false)
-          })
-
-          it('should have a link with non-disabling handler', () => {
-            const link = component.find(Link).at(0)
-            const handler = link.prop('onClick')
-            const event = { preventDefault: () => {event.called = true } }
-            handler(event)
-            expect(!!event.called).to.equal(false);
-          })
+            expect(link.prop('aria-disabled')).to.equal(false);
+          });
 
           it('should have a link pointing to hold request page', () => {
-            const link = component.find(Link).at(0)
-            expect(link.prop('to')).to.include('/hold/request/b12345-i17326129?searchKeywords=fakesearchkeyword')
-          })
+            const link = component.find(Link).at(0);
+            expect(link.prop('to')).to.include(
+              '/hold/request/b12345-i17326129?searchKeywords=fakesearchkeyword',
+            );
+          });
 
           it('should say Request for On-site Use', () => {
-            const link = component.find(Link).at(0)
-            expect(link.text()).to.equal('Request for On-site Use')
-          })
-        })
+            const link = component.find(Link).at(0);
+            expect(link.text()).to.equal('Request for On-site Use');
+          });
+        });
 
         describe('should be disabled when item not available', () => {
           let component;
           before(() => {
-            const data = Object.assign(
-              {},
-              item.full,
-              { physRequestable: true, available: false }
-            );
+            const data = Object.assign({}, item.full, {
+              physRequestable: true,
+              available: false,
+            });
 
             component = mount(
               <RequestButtons
                 item={data}
-                bibId="b12345"
+                bibId='b12345'
                 page={page}
                 appConfig={appConfig}
                 searchKeywords={'fakesearchkeyword'}
-              />
+              />,
             );
-          })
+          });
 
           it('should have a link with unavail-request-button class', () => {
-            const links = component.find(Link)
+            const links = component.find(Link);
             expect(links.length).to.equal(1);
             const link = links.at(0);
-            expect(link.prop('className')).to.equal('unavail-request-button')
-          })
+            expect(link.prop('className')).to.equal('unavail-request-button');
+          });
 
           it('should have a link with aria-disabled true', () => {
-            const links = component.find(Link)
+            const links = component.find(Link);
             const link = links.at(0);
-            expect(link.prop('aria-disabled')).to.equal(true)
-          })
-
-          it('should have a link with click handler to prevent default', () => {
-            const link = component.find(Link).at(0)
-            const handler = link.prop('onClick')
-            const event = { preventDefault: () => { event.called = true } }
-            handler(event)
-            expect(!!event.called).to.equal(true);
-          })
+            expect(link.prop('aria-disabled')).to.equal(true);
+          });
 
           it('should say Request for On-site Use', () => {
-            const link = component.find(Link).at(0)
-            expect(link.text()).to.equal('Request for On-site Use')
-          })
-        })
-
-      })
+            const link = component.find(Link).at(0);
+            expect(link.text()).to.equal('Request for On-site Use');
+          });
+        });
+      });
 
       describe('should not be present when item not eligible for physical request', () => {
         describe('should not be present in case it is an Aeon item', () => {
@@ -123,468 +103,421 @@ describe('Request Buttons', () => {
           let mockAppConfig;
 
           before(() => {
-            mockAppConfig = Object.assign({}, appConfig, { features : ['aeon-links'] });
-            const data = Object.assign(
-              {},
-              item.full,
-              { physRequestable: true, aeonUrl: 'http://www.aeon.com' }
-            );
+            mockAppConfig = Object.assign({}, appConfig, {
+              features: ['aeon-links'],
+            });
+            const data = Object.assign({}, item.full, {
+              physRequestable: true,
+              aeonUrl: 'http://www.aeon.com',
+            });
 
             component = mount(
               <RequestButtons
                 item={data}
-                bibId="b12345"
+                bibId='b12345'
                 page={page}
                 appConfig={mockAppConfig}
                 searchKeywords={'fakesearchkeyword'}
-              />
+              />,
             );
-          })
+          });
 
           it('should not have a link', () => {
-            expect(component.find(Link).length).to.equal(0)
-          })
-        })
+            expect(component.find(Link).length).to.equal(0);
+          });
+        });
 
         describe('should not be present in case of closure', () => {
-          let mockAppConfig = Object.assign({}, appConfig)
+          let mockAppConfig = Object.assign({}, appConfig);
           let component;
 
           before(() => {
-            mockAppConfig.closedLocations = ['']
-            const data = Object.assign(
-              {},
-              item.full,
-              { physRequestable: true }
-            );
+            mockAppConfig.closedLocations = [''];
+            const data = Object.assign({}, item.full, {
+              physRequestable: true,
+            });
 
             component = mount(
               <RequestButtons
                 item={data}
-                bibId="b12345"
+                bibId='b12345'
                 page={page}
                 appConfig={mockAppConfig}
                 searchKeywords={'fakesearchkeyword'}
-              />
+              />,
             );
-          })
+          });
 
           it('should not have a link', () => {
-            expect(component.find(Link).length).to.equal(0)
-          })
-        })
+            expect(component.find(Link).length).to.equal(0);
+          });
+        });
 
         describe('should not be present if not physRequestable', () => {
-          let mockAppConfig = Object.assign({}, appConfig)
+          let mockAppConfig = Object.assign({}, appConfig);
           let component;
 
           before(() => {
-            const data = Object.assign(
-              {},
-              item.full,
-              { physRequestable: false }
-            );
+            const data = Object.assign({}, item.full, {
+              physRequestable: false,
+            });
 
             component = mount(
               <RequestButtons
                 item={data}
-                bibId="b12345"
+                bibId='b12345'
                 page={page}
                 appConfig={mockAppConfig}
                 searchKeywords={'fakesearchkeyword'}
-              />
+              />,
             );
-          })
+          });
 
           it('should not have a link', () => {
-            expect(component.find(Link).length).to.equal(0)
-          })
-        })
-      })
+            expect(component.find(Link).length).to.equal(0);
+          });
+        });
+      });
     });
 
     describe('EDD Request', () => {
       describe('should be present when item eligible for edd request', () => {
         describe('should be enabled when item available', () => {
           let component;
-          let mockAppConfig = Object.assign({}, appConfig)
+          let mockAppConfig = Object.assign({}, appConfig);
           before(() => {
-            const data = Object.assign(
-              {},
-              item.full,
-              { eddRequestable: true }
-            );
+            const data = Object.assign({}, item.full, { eddRequestable: true });
 
             component = mount(
               <RequestButtons
                 item={data}
-                bibId="b12345"
+                bibId='b12345'
                 page={page}
                 appConfig={mockAppConfig}
                 searchKeywords={'fakesearchkeyword'}
-              />
+              />,
             );
-          })
+          });
 
           it('should have a link with avail-request-button class', () => {
-            const links = component.find(Link)
+            const links = component.find(Link);
             expect(links.length).to.equal(1);
             const link = links.at(0);
-            expect(link.prop('className')).to.equal('avail-request-button')
-          })
+            expect(link.prop('className')).to.equal('avail-request-button');
+          });
 
           it('should have link with aria-disabled false', () => {
-            const links = component.find(Link)
+            const links = component.find(Link);
             const link = links.at(0);
-            expect(link.prop('aria-disabled')).to.equal(false)
-          })
-
-          it('should have a link with non-disabling handler', () => {
-            const link = component.find(Link).at(0)
-            const handler = link.prop('onClick')
-            const event = { preventDefault: () => {event.called = true } }
-            handler(event)
-            expect(!!event.called).to.equal(false);
-          })
+            expect(link.prop('aria-disabled')).to.equal(false);
+          });
 
           it('should have a link pointing to hold request page', () => {
-            const link = component.find(Link).at(0)
-            expect(link.prop('to')).to.include('/hold/request/b12345-i17326129/edd?searchKeywords=fakesearchkeyword')
-          })
+            const link = component.find(Link).at(0);
+            expect(link.prop('to')).to.include(
+              '/hold/request/b12345-i17326129/edd?searchKeywords=fakesearchkeyword',
+            );
+          });
 
           it('should say Request Scan', () => {
-            const link = component.find(Link).at(0)
-            expect(link.text()).to.equal('Request Scan')
-          })
-        })
+            const link = component.find(Link).at(0);
+            expect(link.text()).to.equal('Request Scan');
+          });
+        });
 
         describe('should be disabled when item not available', () => {
           let component;
-          let mockAppConfig = Object.assign({}, appConfig)
+          let mockAppConfig = Object.assign({}, appConfig);
           before(() => {
-            const data = Object.assign(
-              {},
-              item.full,
-              { eddRequestable: true, available: false }
-            );
+            const data = Object.assign({}, item.full, {
+              eddRequestable: true,
+              available: false,
+            });
 
             component = mount(
               <RequestButtons
                 item={data}
-                bibId="b12345"
+                bibId='b12345'
                 page={page}
                 appConfig={mockAppConfig}
                 searchKeywords={'fakesearchkeyword'}
-              />
+              />,
             );
-          })
+          });
 
           it('should have a link with unavail-request-button class', () => {
-            const links = component.find(Link)
+            const links = component.find(Link);
             expect(links.length).to.equal(1);
             const link = links.at(0);
-            expect(link.prop('className')).to.equal('unavail-request-button')
-          })
+            expect(link.prop('className')).to.equal('unavail-request-button');
+          });
 
           it('should have a link with aria-disabled true', () => {
-            const links = component.find(Link)
+            const links = component.find(Link);
             const link = links.at(0);
-            expect(link.prop('aria-disabled')).to.equal(true)
-          })
-
-          it('should have a link with click handler to prevent default', () => {
-            const link = component.find(Link).at(0)
-            const handler = link.prop('onClick')
-            const event = { preventDefault: () => { event.called = true } }
-            handler(event)
-            expect(!!event.called).to.equal(true);
-          })
+            expect(link.prop('aria-disabled')).to.equal(true);
+          });
 
           it('should say Request Scan', () => {
-            const link = component.find(Link).at(0)
-            expect(link.text()).to.equal('Request Scan')
-          })
-        })
-
-      })
+            const link = component.find(Link).at(0);
+            expect(link.text()).to.equal('Request Scan');
+          });
+        });
+      });
 
       describe('should not be present when item not eligible for EDD request', () => {
         describe('should not be present in case it is an Aeon item', () => {
-          let mockAppConfig = Object.assign({}, appConfig)
+          let mockAppConfig = Object.assign({}, appConfig);
           let component;
 
           before(() => {
-            mockAppConfig.features = ['aeon-links']
-            const data = Object.assign(
-              {},
-              item.full,
-              { eddRequestable: true, aeonUrl: 'http://www.aeon.com' }
-            );
+            mockAppConfig.features = ['aeon-links'];
+            const data = Object.assign({}, item.full, {
+              eddRequestable: true,
+              aeonUrl: 'http://www.aeon.com',
+            });
 
             component = mount(
               <RequestButtons
                 item={data}
-                bibId="b12345"
+                bibId='b12345'
                 page={page}
                 appConfig={mockAppConfig}
                 searchKeywords={'fakesearchkeyword'}
-              />
+              />,
             );
-          })
+          });
 
           it('should not have a link', () => {
-            expect(component.find(Link).length).to.equal(0)
-          })
-        })
+            expect(component.find(Link).length).to.equal(0);
+          });
+        });
 
         describe('should not be present in case of closure', () => {
-          let mockAppConfig = Object.assign({}, appConfig)
+          let mockAppConfig = Object.assign({}, appConfig);
           let component;
 
           before(() => {
-            mockAppConfig.closedLocations = ['']
-            const data = Object.assign(
-              {},
-              item.full,
-              { eddRequestable: true }
-            );
+            mockAppConfig.closedLocations = [''];
+            const data = Object.assign({}, item.full, { eddRequestable: true });
 
             component = mount(
               <RequestButtons
                 item={data}
-                bibId="b12345"
+                bibId='b12345'
                 page={page}
                 appConfig={mockAppConfig}
                 searchKeywords={'fakesearchkeyword'}
-              />
+              />,
             );
-          })
+          });
 
           it('should not have a link', () => {
-            expect(component.find(Link).length).to.equal(0)
-          })
-        })
+            expect(component.find(Link).length).to.equal(0);
+          });
+        });
 
         describe('should not be present if not eddRequestable', () => {
-          let mockAppConfig = Object.assign({}, appConfig)
+          let mockAppConfig = Object.assign({}, appConfig);
           let component;
 
           before(() => {
-            const data = Object.assign(
-              {},
-              item.full,
-              { eddRequestable: false }
-            );
+            const data = Object.assign({}, item.full, {
+              eddRequestable: false,
+            });
 
             component = mount(
               <RequestButtons
                 item={data}
-                bibId="b12345"
+                bibId='b12345'
                 page={page}
                 appConfig={mockAppConfig}
                 searchKeywords={'fakesearchkeyword'}
-              />
+              />,
             );
-          })
+          });
 
           it('should not have a link', () => {
-            expect(component.find(Link).length).to.equal(0)
-          })
-        })
-      })
+            expect(component.find(Link).length).to.equal(0);
+          });
+        });
+      });
     });
 
     describe('Aeon Request', () => {
       describe('should be present when item eligible for aeon request', () => {
         describe('should be enabled when item available', () => {
           let component;
-          let mockAppConfig = Object.assign({}, appConfig)
+          let mockAppConfig = Object.assign({}, appConfig);
           before(() => {
-            const data = Object.assign(
-              {},
-              item.full,
-              { aeonUrl: 'http://www.aeon.com' }
-            );
+            const data = Object.assign({}, item.full, {
+              aeonUrl: 'http://www.aeon.com',
+            });
 
             component = mount(
               <RequestButtons
                 item={data}
-                bibId="b12345"
+                bibId='b12345'
                 page={page}
                 appConfig={mockAppConfig}
                 searchKeywords={'fakesearchkeyword'}
-              />
+              />,
             );
-          })
+          });
 
           it('should have a link with avail-request-button class', () => {
-            const links = component.find('a')
+            const links = component.find('a');
             expect(links.length).to.equal(1);
             const link = links.at(0);
-            expect(link.prop('className')).to.equal('aeonRequestButton avail-request-button')
-          })
+            expect(link.prop('className')).to.equal(
+              'aeonRequestButton avail-request-button',
+            );
+          });
 
           it('should have link with aria-disabled false', () => {
-            const links = component.find('a')
+            const links = component.find('a');
             const link = links.at(0);
-            expect(link.prop('aria-disabled')).to.equal(false)
-          })
-
-          it('should have a link with non-disabling handler', () => {
-            const link = component.find('a').at(0)
-            const handler = link.prop('onClick')
-            const event = { preventDefault: () => {event.called = true } }
-            handler(event)
-            expect(!!event.called).to.equal(false);
-          })
+            expect(link.prop('aria-disabled')).to.equal(false);
+          });
 
           it('should have a link pointing to hold aeon url', () => {
-            const link = component.find('a').at(0)
-            expect(link.prop('href')).to.include('http://www.aeon.com')
-          })
+            const link = component.find('a').at(0);
+            expect(link.prop('href')).to.include('http://www.aeon.com');
+          });
 
           it('should say Request Appointment', () => {
-            const link = component.find('a').at(0)
-            expect(link.text()).to.equal('Request Appointment')
-          })
-        })
+            const link = component.find('a').at(0);
+            expect(link.text()).to.equal('Request Appointment');
+          });
+        });
 
         describe('should be disabled when item not available', () => {
           let component;
-          let mockAppConfig = Object.assign({}, appConfig)
+          let mockAppConfig = Object.assign({}, appConfig);
           before(() => {
-            const data = Object.assign(
-              {},
-              item.full,
-              { aeonUrl: 'http://www.aeon.com', available: false }
-            );
+            const data = Object.assign({}, item.full, {
+              aeonUrl: 'http://www.aeon.com',
+              available: false,
+            });
 
             component = mount(
               <RequestButtons
                 item={data}
-                bibId="b12345"
+                bibId='b12345'
                 page={page}
                 appConfig={mockAppConfig}
                 searchKeywords={'fakesearchkeyword'}
-              />
+              />,
             );
-          })
+          });
 
           it('should have a link with unavail-request-button class', () => {
-            const links = component.find('a')
+            const links = component.find('a');
             expect(links.length).to.equal(1);
             const link = links.at(0);
-            expect(link.prop('className')).to.equal('aeonRequestButton unavail-request-button')
-          })
+            expect(link.prop('className')).to.equal(
+              'aeonRequestButton unavail-request-button',
+            );
+          });
 
           it('should have a link with aria-disabled true', () => {
-            const links = component.find('a')
+            const links = component.find('a');
             const link = links.at(0);
-            expect(link.prop('aria-disabled')).to.equal(true)
-          })
-
-          it('should have a link with click handler to prevent default', () => {
-            const link = component.find('a').at(0)
-            const handler = link.prop('onClick')
-            const event = { preventDefault: () => { event.called = true } }
-            handler(event)
-            expect(!!event.called).to.equal(true);
-          })
+            expect(link.prop('aria-disabled')).to.equal(true);
+          });
 
           it('should say Request Appointment', () => {
-            const link = component.find('a').at(0)
-            expect(link.text()).to.equal('Request Appointment')
-          })
-        })
+            const link = component.find('a').at(0);
+            expect(link.text()).to.equal('Request Appointment');
+          });
+        });
       });
 
       describe('should not be present when item not eligible for Aeon request', () => {
         describe('should not be present in case it is not an Aeon item', () => {
-          let mockAppConfig = Object.assign({}, appConfig)
+          let mockAppConfig = Object.assign({}, appConfig);
           let component;
 
           before(() => {
-            mockAppConfig.features = ['aeon-links']
-            const data = Object.assign(
-              {},
-              item.full,
-              { eddRequestable: true }
-            );
+            mockAppConfig.features = ['aeon-links'];
+            const data = Object.assign({}, item.full, { eddRequestable: true });
 
             component = mount(
               <RequestButtons
                 item={data}
-                bibId="b12345"
+                bibId='b12345'
                 page={page}
                 appConfig={mockAppConfig}
                 searchKeywords={'fakesearchkeyword'}
-              />
+              />,
             );
-          })
+          });
 
           it('should not have an aeon link', () => {
-            expect(component.find('a').length).to.equal(1)
-            expect(component.find('a').at(0).text()).to.not.equal('Request Appointment')
-          })
-        })
+            expect(component.find('a').length).to.equal(1);
+            expect(component.find('a').at(0).text()).to.not.equal(
+              'Request Appointment',
+            );
+          });
+        });
 
         describe('should not be present in case Aeon is not being displayed', () => {
-          const mockAppConfig = Object.assign({}, appConfig)
+          const mockAppConfig = Object.assign({}, appConfig);
           let component;
 
           before(() => {
-            mockAppConfig.features = []
-            const data = Object.assign(
-              {},
-              item.full,
-              { aeonUrl: 'http://www.aeon.com', eddRequestable: true }
-            );
+            mockAppConfig.features = [];
+            const data = Object.assign({}, item.full, {
+              aeonUrl: 'http://www.aeon.com',
+              eddRequestable: true,
+            });
 
             component = mount(
               <RequestButtons
                 item={data}
-                bibId="b12345"
+                bibId='b12345'
                 page={page}
                 appConfig={mockAppConfig}
                 searchKeywords={'fakesearchkeyword'}
-              />
+              />,
             );
-          })
+          });
 
           it('should not have an aeon link', () => {
-            expect(component.find('a').length).to.equal(1)
-            expect(component.find('a').at(0).text()).to.not.equal('Request Appointment')
-          })
-        })
+            expect(component.find('a').length).to.equal(1);
+            expect(component.find('a').at(0).text()).to.not.equal(
+              'Request Appointment',
+            );
+          });
+        });
 
         describe('should not be present in case of closure', () => {
-          let mockAppConfig = Object.assign({}, appConfig)
+          let mockAppConfig = Object.assign({}, appConfig);
           let component;
 
           before(() => {
-            mockAppConfig.closedLocations = ['']
-            const data = Object.assign(
-              {},
-              item.full,
-              { aeonUrl: 'http://www.aeon.com', available: false }
-            );
+            mockAppConfig.closedLocations = [''];
+            const data = Object.assign({}, item.full, {
+              aeonUrl: 'http://www.aeon.com',
+              available: false,
+            });
 
             component = mount(
               <RequestButtons
                 item={data}
-                bibId="b12345"
+                bibId='b12345'
                 page={page}
                 appConfig={mockAppConfig}
                 searchKeywords={'fakesearchkeyword'}
-              />
+              />,
             );
-          })
+          });
 
           it('should not have a link', () => {
-            expect(component.find('a').length).to.equal(0)
-          })
-        })
-      })
+            expect(component.find('a').length).to.equal(0);
+          });
+        });
+      });
     });
-  })
+  });
 });

--- a/test/unit/utils.test.js
+++ b/test/unit/utils.test.js
@@ -375,21 +375,6 @@ describe('getFieldParam', () => {
 });
 
 /**
- * trackDiscovery()
- */
-// describe('trackDiscovery', () => {
-//   it('should make a call to gaUtils', () => {
-//     const trackEventSpy = sinon.spy(gaUtils, 'trackEvent');
-//
-//     trackDiscovery('action', 'label');
-//
-//     expect(trackEventSpy.callCount).to.equal(1);
-//
-//     trackEventSpy.restore();
-//   });
-// });
-
-/**
  * basicQuery()
  */
 describe('basicQuery', () => {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -233,7 +233,6 @@ if (ENV === 'production') {
       new webpack.DefinePlugin({
         'process.env': {
           NODE_ENV: JSON.stringify('production'),
-          GA_ENV: JSON.stringify(process.env.GA_ENV),
           SHEP_API: process.env.SHEP_API,
           LOGIN_URL: process.env.LOGIN_URL,
           LOGIN_BASE_URL: process.env.LOGIN_BASE_URL,


### PR DESCRIPTION
**What's this do?**
This PR removes all Google Analytics code from the research catalog since they are no longer processing events. Going forward we will be moving some of these events to Adobe Analytics.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SCC-3639

**Do these changes have automated tests?**
We should ensure that Chris' test suite passes in all environments to ensure no regressions.

**How should this be QAed?**
All basic app functionality should be manually tested.