### PR TITLE
Fix list-style-type for search results

### DIFF
--- a/src/client/styles/components/Drbb/Drbb.scss
+++ b/src/client/styles/components/Drbb/Drbb.scss
@@ -119,7 +119,6 @@ a.drbb-download-pdf {
   display: inline-block;
   padding-right: 0;
   width: 100%;
-  list-style-type: none;
 }
 
 .nypl-select-field-results {

--- a/src/client/styles/style-v2.scss
+++ b/src/client/styles/style-v2.scss
@@ -105,6 +105,7 @@
   }
 }
 .nypl-results-list {
+  list-style-type: none;
   .nypl-results-item {
     .title {
       text-decoration: none;


### PR DESCRIPTION
**What's this do?**
Fix bug where `list-style-type: none` is only applied to RC search results when drb-integration feature is enabled.

**Why are we doing this? (w/ JIRA link if applicable)**
May need to disable drb integration. In testing it, found search results are rendered with a bullet.

**Do these changes have automated tests?**
No

**How should this be QAed?**
Visual inspection

**Dependencies for merging? Releasing to production?**
None. 

**Has the application documentation been updated for these changes?**

**Did someone actually run this code to verify it works?**
I did