### PR TITLE
Add override to production request host and proto

### DIFF
--- a/server.js
+++ b/server.js
@@ -86,6 +86,20 @@ nyplApiClient();
 app.use('/*', initializePatronTokenAuth, getPatronData);
 app.use('/', apiRoutes);
 
+// Special debugging route - for investigating LB/proxy issues:
+app.get('/research/research-requests/__request_debug', (req, res) => {
+  res.json(
+    {
+      baseUrl: req.baseUrl,
+      'get(host)': req.get('host'),
+      hostname: req.hostname,
+      originalUrl: req.originalUrl,
+      path: req.path,
+      protocol: req.protocol
+    }
+  )
+});
+
 app.get('/*', (req, res) => {
   const appRoutes =
     req.url.indexOf(appConfig.baseUrl) !== -1 ? routes.client : routes.server;

--- a/server.js
+++ b/server.js
@@ -87,7 +87,7 @@ app.use('/*', initializePatronTokenAuth, getPatronData);
 app.use('/', apiRoutes);
 
 // Special debugging route - for investigating LB/proxy issues:
-app.get('/research/research-requests/__request_debug', (req, res) => {
+app.get('/research/research-catalog/__request_debug', (req, res) => {
   res.json(
     {
       baseUrl: req.baseUrl,

--- a/server.js
+++ b/server.js
@@ -92,6 +92,7 @@ app.get('/research/research-catalog/__request_debug', (req, res) => {
     {
       baseUrl: req.baseUrl,
       'get(host)': req.get('host'),
+      headers: req.headers,
       hostname: req.hostname,
       originalUrl: req.originalUrl,
       path: req.path,

--- a/src/server/ApiRoutes/User.js
+++ b/src/server/ApiRoutes/User.js
@@ -7,7 +7,17 @@ function requireUser(req, res) {
     !req.patronTokenResponse.decodedPatron || !req.patronTokenResponse.decodedPatron.sub) {
     // redirect to login
     const originalUrl = req.originalUrl.replace(new RegExp(`^${appConfig.baseUrl}/api/`), `${appConfig.baseUrl}/`)
-    const fullUrl = encodeURIComponent(`${req.protocol}://${req.get('host')}${originalUrl}`);
+
+    let protocol = req.protocol
+    let host = req.get('host')
+
+    // Override production LB request host and proto:
+    if (/^discovery\.nypl\.org/.test(host)) {
+      host = 'www.nypl.org'
+      protocol = 'https'
+    }
+
+    const fullUrl = encodeURIComponent(`${protocol}://${host}${originalUrl}`);
     redirect = `${appConfig.loginUrl}?redirect_uri=${fullUrl}`;
     if (!req.originalUrl.includes('/api/')) {
       res.redirect(redirect);


### PR DESCRIPTION
**What's this do?**
Add override to production request host and proto to fix issue where it appears production LB is passing discovery.nypl.org and proto 'http' in production (even though users are accessing the app via www. and https)

**Why are we doing this? (w/ JIRA link if applicable)**
We notice issues logging in due to server-side building a redirect_uri having host "discovery.nypl.org". Ops is investigating a fix at the server/imperva side. This fix is a back-up if that doesn't work.