### PR TITLE
Enable Express trust-proxy

### DIFF
--- a/server.js
+++ b/server.js
@@ -49,7 +49,9 @@ app.set('port', process.env.PORT || appConfig.port || 3001);
 // by the trusted proxy (Imperva). This is essential for building a valid login
 // redirect_uri
 // See https://expressjs.com/en/4x/api.html#trust.proxy.options.table
-app.set('trust proxy', 'uniquelocal')
+const trustProxy = process.env.TRUST_PROXY || true
+app.set('trust proxy', trustProxy)
+logger.info(`Using Express 'trust proxy' setting '${trustProxy}'`)
 
 app.use(cookieParser());
 // to support JSON-encoded bodies

--- a/server.js
+++ b/server.js
@@ -49,7 +49,13 @@ app.set('port', process.env.PORT || appConfig.port || 3001);
 // by the trusted proxy (Imperva). This is essential for building a valid login
 // redirect_uri
 // See https://expressjs.com/en/4x/api.html#trust.proxy.options.table
-const trustProxy = process.env.TRUST_PROXY || true
+let trustProxy = process.env.TRUST_PROXY || 'log ip'
+if (trustProxy === 'log ip') {
+  trustProxy = (ip) => {
+    logger.info(`Express 'trust proxy' considering ip ${ip}`)
+    return false
+  }
+}
 app.set('trust proxy', trustProxy)
 logger.info(`Using Express 'trust proxy' setting '${trustProxy}'`)
 

--- a/server.js
+++ b/server.js
@@ -44,20 +44,12 @@ app.set('views', VIEWS_PATH);
 app.set('port', process.env.PORT || appConfig.port || 3001);
 
 // Tell express to trust x-forwarded-proto and x-forwarded-host headers when
-// forwarded by a 10.* IP. This means req.get('host') and req.protocol will
+// origin is local. This means req.hostname and req.protocol will
 // return the actual host and proto of the original request when forwarded
 // by the trusted proxy (Imperva). This is essential for building a valid login
 // redirect_uri
 // See https://expressjs.com/en/4x/api.html#trust.proxy.options.table
-let trustProxy = process.env.TRUST_PROXY || 'log ip'
-if (trustProxy === 'log ip') {
-  trustProxy = (ip) => {
-    logger.info(`Express 'trust proxy' considering ip ${ip}`)
-    return false
-  }
-}
-app.set('trust proxy', trustProxy)
-logger.info(`Using Express 'trust proxy' setting '${trustProxy}'`)
+app.set('trust proxy', 'loopback')
 
 app.use(cookieParser());
 // to support JSON-encoded bodies

--- a/server.js
+++ b/server.js
@@ -43,6 +43,14 @@ app.set('views', VIEWS_PATH);
 
 app.set('port', process.env.PORT || appConfig.port || 3001);
 
+// Tell express to trust x-forwarded-proto and x-forwarded-host headers when
+// forwarded by a 10.* IP. This means req.get('host') and req.protocol will
+// return the actual host and proto of the original request when forwarded
+// by the trusted proxy (Imperva). This is essential for building a valid login
+// redirect_uri
+// See https://expressjs.com/en/4x/api.html#trust.proxy.options.table
+app.set('trust proxy', 'uniquelocal')
+
 app.use(cookieParser());
 // to support JSON-encoded bodies
 app.use(bodyParser.json());

--- a/src/server/ApiRoutes/User.js
+++ b/src/server/ApiRoutes/User.js
@@ -7,7 +7,7 @@ function requireUser(req, res) {
     !req.patronTokenResponse.decodedPatron || !req.patronTokenResponse.decodedPatron.sub) {
     // redirect to login
     const originalUrl = req.originalUrl.replace(new RegExp(`^${appConfig.baseUrl}/api/`), `${appConfig.baseUrl}/`)
-    const fullUrl = encodeURIComponent(`${req.protocol}://${req.get('host')}${originalUrl}`);
+    const fullUrl = encodeURIComponent(`${req.protocol}://${req.hostname}${originalUrl}`);
     redirect = `${appConfig.loginUrl}?redirect_uri=${fullUrl}`;
     if (!req.originalUrl.includes('/api/')) {
       res.redirect(redirect);

--- a/test/unit/User.test.js
+++ b/test/unit/User.test.js
@@ -18,7 +18,7 @@ let mockPatronTokenResponse = {
   errorCode: null,
 };
 const renderMockReq = data => ({
-  get: n => n,
+  hostname: 'host',
   protocol: 'http',
   originalUrl: '/hold/request/b11995345-i14211097',
   patronTokenResponse: data,


### PR DESCRIPTION
Fixes issue where Login redirect_uri is built incorrectly for apps fronted by Imperva due to the app's use of `req.get('host')` in determining the current domain. The fix is:
 - Enable Express ["trust proxy" setting](https://expressjs.com/en/4x/api.html#trust.proxy.options.table), instructing it to accept the forwarded host and proto for traffic from "loopback" (matching 127.0.* traffic?)
 - Update the code that generates the redirect_uri to use `req.hostname` instead of `req.get('host')` to ensure we use the forwarded hostname instead of the literal header.