### PR TITLE
SCC-3808 - Change link placement on EDSLink

### DIFF
--- a/src/app/components/EDSLink/EDSLink.jsx
+++ b/src/app/components/EDSLink/EDSLink.jsx
@@ -8,8 +8,8 @@ const EDSLink = () => {
   return (
     <Box mt="s" mb="s">
       <Text size="body2" className="eds-link">
-        <span style={{color: "var(--nypl-colors-ui-success-primary)"}}>New!</span> Try our <strong>Article Search</strong> to discover online journals, books, and more from home{" "}
-        <DSLink href="https://research.ebsco.com/c/2styhb" target="_blank">with your library card</DSLink>.
+        <span style={{color: "var(--nypl-colors-ui-success-primary)"}}>New!</span> Try our <DSLink href="https://research.ebsco.com/c/2styhb" target="_blank"><strong>Article Search</strong></DSLink> to discover online journals, books, and more from home{" "}
+        with your library card.
       </Text>
     </Box>
 

--- a/test/unit/EDSLink.test.js
+++ b/test/unit/EDSLink.test.js
@@ -17,6 +17,7 @@ describe('EDSLink', () => {
   it('should have the right text', () => {
     const html = component.html();
     expect(html).to.include('<span>New!</span> Try our');
+    expect(html).to.include('<strong>Article Search</strong>');
     expect(html).to.include('to discover online journals, books, and more from home with your library card.')
   });
 

--- a/test/unit/EDSLink.test.js
+++ b/test/unit/EDSLink.test.js
@@ -16,12 +16,13 @@ describe('EDSLink', () => {
 
   it('should have the right text', () => {
     const html = component.html();
-    expect(html).to.include('<span>New!</span> Try our <strong>Article Search</strong> to discover online journals, books, and more from home');
+    expect(html).to.include('<span>New!</span> Try our');
+    expect(html).to.include('to discover online journals, books, and more from home with your library card.')
   });
 
   it('should have a link with the correct text and href', () => {
     const edsLink = component.find('a')
-    expect(edsLink.text()).to.include('with your library card');
+    expect(edsLink.text()).to.include('Article Search');
     expect(edsLink.prop('href')).to.equal(
       'https://research.ebsco.com/c/2styhb'
     );


### PR DESCRIPTION
**What's this do?**
This moves the link in the EDSLink component from "with your library card" to "Article Search"

**Why are we doing this? (w/ JIRA link if applicable)**
Change request - https://jira.nypl.org/browse/SCC-3808