### PR TITLE
Scc 3842

### DIFF
--- a/server.js
+++ b/server.js
@@ -20,6 +20,7 @@ import configureStore from './src/app/stores/configureStore';
 import initialState from './src/app/stores/InitialState';
 import { updateLoadingStatus } from './src/app/actions/Actions';
 import initializeReduxReact from './src';
+import { nyTimezoneOffsets } from './src/app/utils/nyTImezoneOffsets';
 
 const ROOT_PATH = __dirname;
 const INDEX_PATH = path.resolve(ROOT_PATH, 'src/client');
@@ -135,7 +136,8 @@ app.get('/*', (req, res) => {
           path: req.url,
           isProduction,
           baseUrl: appConfig.baseUrl,
-          launchEmbedUrl: appConfig.launchEmbedUrl
+          launchEmbedUrl: appConfig.launchEmbedUrl,
+          nyOffsets: nyTimezoneOffsets()
         });
       } else {
         res.status(404).redirect(`${appConfig.baseUrl}/`);

--- a/server.js
+++ b/server.js
@@ -20,7 +20,7 @@ import configureStore from './src/app/stores/configureStore';
 import initialState from './src/app/stores/InitialState';
 import { updateLoadingStatus } from './src/app/actions/Actions';
 import initializeReduxReact from './src';
-import { nyTimezoneOffsets } from './src/app/utils/nyTImezoneOffsets';
+import { nyTimezoneOffsets } from './src/app/utils/nyTimezoneOffsets';
 
 const ROOT_PATH = __dirname;
 const INDEX_PATH = path.resolve(ROOT_PATH, 'src/client');

--- a/src/app/utils/nyTimezoneOffsets.js
+++ b/src/app/utils/nyTimezoneOffsets.js
@@ -1,0 +1,48 @@
+const MS_PER_DAY = 1000 * 60 * 60 * 24
+
+/**
+ *  Get current and future NY TZ offsets over the next week.
+ *
+ *  Returns an array of objects, each defining:
+ *   - offset {int} - Hours offset from UTC
+ *   - from {string} - ISO8601 timestamp indicating when the offset was/will be
+ *     active
+ *
+ *  Most of the time, this will return a single entry representing the current
+ *  offset. On the week leading up to a DST change, it will return two entries,
+ *  the first giving the current offset and the second giving the new offset
+ *  and the time it will become active.
+ */
+export const nyTimezoneOffsets = (from = new Date(), numDays = 7) => {
+  let currentOffset = null
+
+  // Make a copy of the `from` date because we're going to change it:
+  from = new Date(from)
+  // DST shifts happen at 2am:
+  from.setHours(2, 0, 0, 0)
+  // Backdate to yesterday just in case we're called before 2am on a DST
+  // change day:
+  from = new Date(from.getTime() - MS_PER_DAY)
+
+  // Build an array reprsenting current TZ offset and all changes over the next
+  // `numDays` days
+  return Array(numDays)
+    .fill()
+    .map((_, index) => {
+      // Create a new date offset by `index` numbers of days
+      const time = from.getTime() + index * MS_PER_DAY
+      const date = new Date(time)
+
+      // Calculate TZ offset of this future date:
+      const offset = date.getTimezoneOffset() / 60
+
+      // If TZ offset hasn't changed since the last one seen, ignore it:
+      if (currentOffset === offset) return null
+
+      // Otherwise, register the date as the start of the new offset:
+      currentOffset = offset
+      const day = date.toISOString()
+      return { from: day, offset }
+    })
+    .filter((entry) => entry)
+}

--- a/src/app/utils/nyTimezoneOffsets.js
+++ b/src/app/utils/nyTimezoneOffsets.js
@@ -24,8 +24,8 @@ export const nyTimezoneOffsets = (from = new Date(), numDays = 7) => {
   // change day:
   from = new Date(from.getTime() - MS_PER_DAY)
 
-  // Build an array reprsenting current TZ offset and all changes over the next
-  // `numDays` days
+  // Build an array representing current TZ offset and all changes over the
+  // next `numDays` days
   return Array(numDays)
     .fill()
     .map((_, index) => {

--- a/src/app/utils/pickupTimeEstimator.js
+++ b/src/app/utils/pickupTimeEstimator.js
@@ -352,18 +352,22 @@ estimator._addMinutes = (dateString, minutes) => {
  *  calculating estimates just before/after Daylight Savings days)
  */
 estimator._nyOffset = (timestamp = estimator._now()) => {
-  // TODO: This should be driven by server time, i.e.:
-  //
-  // Assume we build a nyOffsets var on the server representing the next week
-  // of offsets and make it available as:
-  //   window.nyOffsets = { '2023-01-01': 5, '2023-01-02': 5, ...}
-  // Then this function can determine the NY offset for the requested
-  // timestamp via:
-  //   const day = timestamp.split('T').shift()
-  //   const offset = window && window.nyOffsets ? window.nyOffsets[day] : new Date(timestamp).getTimezoneOffset() / 60
+  if (window.nyOffsets && window.nyOffsets.length) {
+    // Identify the offset that starts before timestamp:
+    const currentOffset = window.nyOffsets
+      .filter((offset) => new Date(offset.from) < new Date(timestamp))
+      .pop()
+    if (currentOffset) {
+      return currentOffset.offset
+    } else {
+      // If no matching offset found, local clock is out of sync with server
+      // time; return first server offset:
+      return window.nyOffsets[0].offset
+    }
+  }
 
-  const offset = new Date(timestamp).getTimezoneOffset() / 60
-  return offset
+  // If server.js is failing to populate window.nyOffsets, default to 5:
+  return 5
 }
 
 /**

--- a/src/views/index.ejs
+++ b/src/views/index.ejs
@@ -31,6 +31,11 @@
       });
     </script>
 
+    <script>
+      <% // Pass NY TZ offsets for this week to the client: %>
+      window.nyOffsets = <%- JSON.stringify(nyOffsets, null, 2) %>;
+    </script>
+
     <script src="<%- launchEmbedUrl %>" async></script>
 
     <% if (isProduction) { %>

--- a/test/unit/pickupTimeEstimator.test.js
+++ b/test/unit/pickupTimeEstimator.test.js
@@ -112,6 +112,15 @@ describe('pickupTimeEstimator', () => {
     ]
   }
 
+  before(() => {
+    // Add window global nyOffsets var, emulating a global var set by server
+    // for the client, giving the current and future NY TZ offsets
+    window.nyOffsets = [
+      { from: '2023-03-10T06:00:00.000Z', offset: 4 },
+      { from: '2023-11-05T06:00:00.000Z', offset: 5 }
+    ]
+  })
+
   beforeEach(() => {
     nowTimestamp = '2023-06-01T12:00:00'
 
@@ -321,12 +330,16 @@ describe('pickupTimeEstimator', () => {
 
   describe('_setHoursMinutes', () => {
     it('should set hours and minutes', () => {
-      // This is the zulu representation of 230 eastern:
+      // This is the zulu representation of 230 eastern (DST):
       const local230 = '2023-06-07T18:30:00.000Z'
       // Eastern:
       expect(estimator._setHoursMinutes('2023-06-07T18:00:00-04:00', 14, 30)).to.equal(local230)
       // Zulu time; return Eastern:
       expect(estimator._setHoursMinutes('2023-06-07T22:00:00+00:00', 14, 30)).to.equal(local230)
+
+      // Check that hour is set to 14:30 + 5 after DST end:
+      expect(estimator._setHoursMinutes('2023-11-15T22:00:00+00:00', 14, 30))
+        .to.equal('2023-11-15T19:30:00.000Z')
     })
   })
 
@@ -476,6 +489,42 @@ describe('pickupTimeEstimator', () => {
     it('should round date to next quarter hour', () => {
       expect(estimator._roundToQuarterHour(new Date('2023-06-01T14:31:00.000Z')).toISOString())
         .to.equal('2023-06-01T14:45:00.000Z')
+    })
+  })
+
+  describe('_nyOffset', () => {
+
+    it('should return default offset of 5 when window.nyOffsets is unset', () => {
+      delete window.nyOffsets
+      expect(window.nyOffsets).to.be.a('undefined')
+      expect(estimator._nyOffset()).to.equal(5)
+    })
+
+    it('should return offset based on window.nyOffsets', () => {
+      window.nyOffsets = [ { from: '2023-11-01T06:00:00.000Z', offset: 4 } ]
+      nowTimestamp = '2023-11-01T14:10:00.000Z'
+      expect(estimator._nyOffset()).to.equal(4)
+    })
+
+    it('should return appropriate offset based on how requested time relates to registered offsets', () => {
+      window.nyOffsets = [
+        { from: '2023-11-01T06:00:00.000Z', offset: 4 },
+        { from: '2023-11-05T06:00:00.000Z', offset: 5 }
+      ]
+      // When requesting the NY offset for Nov 2, should use first window.nyOffsets entry:
+      nowTimestamp = '2023-11-02T14:10:00.000Z'
+      expect(estimator._nyOffset()).to.equal(4)
+
+      // When requesting the NY offset for Nov 5, should use second window.nyOffsets entry:
+      nowTimestamp = '2023-11-05T14:10:00.000Z'
+      expect(estimator._nyOffset()).to.equal(5)
+      // Equivalently, should honor time given as param:
+      expect(estimator._nyOffset('2023-11-15T14:10:00.000Z')).to.equal(5)
+
+      // If requested time is less than all registered offsets (indicating
+      // server time and client time are out of sync), should return first
+      // offset:
+      expect(estimator._nyOffset('2023-01-00T00:00:00.000Z')).to.equal(4)
     })
   })
 


### PR DESCRIPTION
**What's this do?**
Generate NY TZ offsets on the server so that client knows what the current (and near future) TZ offset for NY is. Important for some date math and for determining whether or not the client is in a different TZ from NY.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SCC-3842

**Do these changes have automated tests?**
yep