### PR TITLE
Set default redirect_uri on Logout link

### DIFF
--- a/src/app/components/LogoutLink/LogoutLink.jsx
+++ b/src/app/components/LogoutLink/LogoutLink.jsx
@@ -13,7 +13,9 @@ const LogoutLink = ({
   delineate = false
 }) => {
   const logoutLink = `${appConfig.logoutUrl}?redirect_uri=`;
-  const [backLink, setBackLink] = useState('');
+  // Set reasonable default for logout redirect_uri for noscript users,
+  // to be overwritten by useEffect client-side:
+  const [backLink, setBackLink] = useState(`https://www.nypl.org${baseUrl}`);
   const { loggedIn } = useContext(PatronContext);
 
   useEffect(() => {


### PR DESCRIPTION
**What's this do?**
Sets default redirect_uri of prod RC Home URL so that noscript users end up back on RC homepage when logging out instead of Vega

**Why are we doing this? (w/ JIRA link if applicable)**
Supports https://jira.nypl.org/browse/SCC-3903 , which ensures patrons are logged out of both Vega and RC on logout. This PR simply fixes a bug in DFE in building the logout URL whereby noscript users had empty redirect_uri, resulting in them ultimately being dumped to Vega, which requires JS

**Do these changes have automated tests?**
No

**How should this be QAed?**
Log out of QA RC with and without JS

**Dependencies for merging? Releasing to production?**
No

**Has the application documentation been updated for these changes?**
n/a

**Did someone actually run this code to verify it works?**
✋ locally.