### PR TITLE
Scc 3966

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2473,7 +2473,7 @@
     "@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
-      "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
+      "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
       "dev": true
     },
     "@types/lodash": {
@@ -7475,7 +7475,7 @@
     "fbemitter": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/fbemitter/-/fbemitter-2.1.1.tgz",
-      "integrity": "sha512-hd8PgD+Q6RQtlcGrkM9oY3MFIjq6CA6wurCK1TKn2eaA76Ww4VAOihmq98NyjRhjJi/axgznZnh9lF8+TcTsNQ==",
+      "integrity": "sha1-Uj4U/a9SSIBbsC9i78M75wP1GGU=",
       "requires": {
         "fbjs": "^0.8.4"
       },
@@ -7483,7 +7483,7 @@
         "core-js": {
           "version": "1.2.7",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-          "integrity": "sha512-ZiPp9pZlgxpWRu0M+YWbm6+aQ84XEfH1JRXvfOc/fILWI0VKhLC2LX13X1NYq4fULzLMq7Hfh43CSo2/aIaUPA=="
+          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
         },
         "fbjs": {
           "version": "0.8.18",
@@ -7504,7 +7504,7 @@
     "fbjs": {
       "version": "0.1.0-alpha.7",
       "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.1.0-alpha.7.tgz",
-      "integrity": "sha512-dJbzq7AfRYmVXZ3a/dsKLe2B00KGmsOlmKeUcyOCKZWixK6F4Fz8JM6btWgEoHxs2uwxJ1bTR9L+OKkVGPOyag==",
+      "integrity": "sha1-rUMIuPIy+zxzYDNJ6nJdHpw5Mjw=",
       "requires": {
         "core-js": "^1.0.0",
         "promise": "^7.0.3",
@@ -7514,12 +7514,12 @@
         "core-js": {
           "version": "1.2.7",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-          "integrity": "sha512-ZiPp9pZlgxpWRu0M+YWbm6+aQ84XEfH1JRXvfOc/fILWI0VKhLC2LX13X1NYq4fULzLMq7Hfh43CSo2/aIaUPA=="
+          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
         },
         "whatwg-fetch": {
           "version": "0.9.0",
           "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-0.9.0.tgz",
-          "integrity": "sha512-DIuh7/cloHxHYwS/oRXGgkALYAntijL63nsgMQsNSnBj825AysosAqA2ZbYXGRqpPRiNH7335dTqV364euRpZw=="
+          "integrity": "sha1-DjaExsuZlbQ+/J3wPkw2XZX9nMA="
         }
       }
     },
@@ -7741,7 +7741,7 @@
     "flux": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/flux/-/flux-2.1.1.tgz",
-      "integrity": "sha512-A1t4GVH4QNxwHN+n/aXHi5xH4FN4gmHMrIRdHZrt011rcuTGfjbx6rdVyOi1+1eE/JautcFgUm4cGGUXYQEKAg==",
+      "integrity": "sha1-LGrGUtQzdIiWhInGWG86/yajjqQ=",
       "requires": {
         "fbemitter": "^2.0.0",
         "fbjs": "0.1.0-alpha.7",
@@ -7871,7 +7871,7 @@
     "format": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
-      "integrity": "sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==",
+      "integrity": "sha1-1hcBB+nv3E7TDJ3DkBbflCtctYs=",
       "dev": true
     },
     "formidable": {
@@ -9351,7 +9351,7 @@
     "is-promise": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-      "integrity": "sha512-NECAi6wp6CgMesHuVUEK8JwjCvm/tvnn5pCbB42JOHp3mgUizN0nagXu4HEqQZBkieGEQ+jVcMKWqoVd6CDbLQ=="
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
     },
     "is-regex": {
       "version": "1.1.4",
@@ -10031,7 +10031,7 @@
     "language-tags": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/language-tags/-/language-tags-1.0.5.tgz",
-      "integrity": "sha512-qJhlO9cGXi6hBGKoxEG/sKZDAHD5Hnu9Hs4WbOY3pCWXDhw0N8x1NenNzm2EnNLkLkk7J2SdxAkDSbb6ftT+UQ==",
+      "integrity": "sha1-0yHbxNowuovzAk4ED6XBRmH5GTo=",
       "dev": true,
       "requires": {
         "language-subtag-registry": "~0.3.2"
@@ -10315,7 +10315,7 @@
     "lodash.truncate": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
-      "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
+      "integrity": "sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=",
       "dev": true
     },
     "log-symbols": {
@@ -10855,7 +10855,7 @@
     "min-document": {
       "version": "2.19.0",
       "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
-      "integrity": "sha512-9Wy1B3m3f66bPPmU5hdA4DR4PB2OfDU/+GS3yAB7IQozE3tqXaVv2zOjgla7MEGSRv95+ILmOuvhLkOK6wJtCQ==",
+      "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
       "dev": true,
       "requires": {
         "dom-walk": "^0.1.0"
@@ -15628,7 +15628,7 @@
     "transmitter": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/transmitter/-/transmitter-1.1.0.tgz",
-      "integrity": "sha512-OkQ9y07aSga2FoKOUm3ZDvAy2I8epBXkx5P4MyjI0mMbLAxSdBlbZNmqjMY6I0Tv6PP+bP1ciw6rdxOzUerMBg=="
+      "integrity": "sha1-Cya33RIxUK4S46hwDgEUnsgaRj4="
     },
     "traverse": {
       "version": "0.6.7",
@@ -15970,7 +15970,7 @@
     "update-section": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/update-section/-/update-section-0.3.3.tgz",
-      "integrity": "sha512-BpRZMZpgXLuTiKeiu7kK0nIPwGdyrqrs6EDSaXtjD/aQ2T+qVo9a5hRC3HN3iJjCMxNT/VxoLGQ7E/OzE5ucnw==",
+      "integrity": "sha1-RY8Xgg03gg3GDiC4bZQ5GwASMVg=",
       "dev": true
     },
     "upper-case": {

--- a/src/app/components/LogoutLink/LogoutLink.jsx
+++ b/src/app/components/LogoutLink/LogoutLink.jsx
@@ -13,7 +13,9 @@ const LogoutLink = ({
   delineate = false
 }) => {
   const logoutLink = `${appConfig.logoutUrl}?redirect_uri=`;
-  const [backLink, setBackLink] = useState('');
+  // Set reasonable default for logout redirect_uri for noscript users,
+  // to be overwritten by useEffect client-side:
+  const [backLink, setBackLink] = useState(`https://www.nypl.org${baseUrl}`);
   const { loggedIn } = useContext(PatronContext);
 
   useEffect(() => {

--- a/src/app/components/TimedLogoutModal/TimedLogoutModal.jsx
+++ b/src/app/components/TimedLogoutModal/TimedLogoutModal.jsx
@@ -20,7 +20,10 @@ const TimedLogoutModal = (props) => {
   const [update, setUpdate] = React.useState(false);
 
   const logOutAndRedirect = () => {
+    // If patron clicked Log Out before natural expiration of cookie,
+    // explicitly delete it:
     deleteCookie('accountPageExp');
+
     const redirectUri = (typeof window !== 'undefined') ? `${window.location.origin}${baseUrl}` : '';
     logoutViaRedirect(redirectUri);
   };
@@ -36,7 +39,7 @@ const TimedLogoutModal = (props) => {
       .find(el => el.includes('accountPageExp'))
       .split('=')[1];
 
-    const timeLeft = new Date(expTime).getTime() - new Date().getTime();
+    const timeLeft = (new Date(expTime).getTime() - new Date().getTime()) / 1000;
 
     React.useEffect(() => {
       const timeout = setTimeout(() => {
@@ -48,10 +51,11 @@ const TimedLogoutModal = (props) => {
       };
     });
 
-    minutes = parseInt(timeLeft / (60 * 1000), 10);
-    seconds = parseInt((timeLeft % (60 * 1000)) / 1000, 10);
+    minutes = Math.max(parseInt(timeLeft / 60), 0);
+    seconds = Math.max(parseInt(timeLeft % 60), 0);
   }
 
+  // Show warning when 2m remaining:
   const open = minutes < 2;
   if (!open) return null;
 

--- a/src/app/components/TimedLogoutModal/TimedLogoutModal.jsx
+++ b/src/app/components/TimedLogoutModal/TimedLogoutModal.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Button } from '@nypl/design-system-react-components';
 
-import { logOutFromEncoreAndCatalogIn } from '../../utils/logoutUtils';
+import { logoutViaRedirect } from '../../utils/logoutUtils';
 import { deleteCookie } from '../../utils/cookieUtils';
 
 /**
@@ -20,10 +20,9 @@ const TimedLogoutModal = (props) => {
   const [update, setUpdate] = React.useState(false);
 
   const logOutAndRedirect = () => {
-    logOutFromEncoreAndCatalogIn(() => {
-      deleteCookie('accountPageExp');
-      window.location.replace(baseUrl);
-    });
+    deleteCookie('accountPageExp');
+    const redirectUri = (typeof window !== 'undefined') ? `${window.location.origin}${baseUrl}` : '';
+    logoutViaRedirect(redirectUri);
   };
 
   let minutes = 0;

--- a/src/app/pages/AccountPage.jsx
+++ b/src/app/pages/AccountPage.jsx
@@ -15,7 +15,7 @@ import LoadingLayer from '../components/LoadingLayer/LoadingLayer';
 import TimedLogoutModal from '../components/TimedLogoutModal/TimedLogoutModal';
 import CancelConfirmationModal from '../components/AccountPage/CancelConfirmationModal';
 import SccContainer from '../components/SccContainer/SccContainer';
-import { logOutFromEncoreAndCatalogIn } from '../utils/logoutUtils';
+import { logoutViaIframe } from '../utils/logoutUtils';
 
 import { manipulateAccountPage, makeRequest, buildReqBody, formatPatronExpirationDate } from '../utils/accountPageUtils';
 import {
@@ -85,7 +85,7 @@ const AccountPage = (props, context) => {
   useEffect(() => {
     if (typeof window !== 'undefined' && (!patron.id || accountHtml.error)) {
       const fullUrl = encodeURIComponent(window.location.href);
-      logOutFromEncoreAndCatalogIn(() => {
+      logoutViaIframe(() => {
         const redirectFromTracker = trackRedirects();
         if (!redirectFromTracker) window.location.replace(`${appConfig.loginUrl}?redirect_uri=${fullUrl}`);
       });

--- a/src/app/utils/logoutUtils.js
+++ b/src/app/utils/logoutUtils.js
@@ -30,7 +30,7 @@ const loadLogoutIframe = (onload) => {
 };
 
 /**
-  * logoutRedirect (redirectUri)
+  * logoutViaRedirect (redirectUri)
   * Immediately enter Logout flow with optional redirectUri
   */
 export const logoutViaRedirect = (redirectUri = '') => {
@@ -38,9 +38,8 @@ export const logoutViaRedirect = (redirectUri = '') => {
 }
 
 /**
-  * logoutInIframe (cb)
-  * The timer to delete log in related cookies and call the method to completely log out from Encore
-  * and Catalog. It is called by setEncoreLoggedInTimer.
+  * logoutViaIframe (cb)
+  * Delete login cookies and load a hidden iframe that loads the Logout route.
   */
 export const logoutViaIframe = (onload) => {
   deleteCookie('PAT_LOGGED_IN');

--- a/src/app/utils/logoutUtils.js
+++ b/src/app/utils/logoutUtils.js
@@ -30,11 +30,19 @@ const loadLogoutIframe = (onload) => {
 };
 
 /**
-  * logOutFromEncoreAndCatalogIn(time, isTest)
+  * logoutRedirect (redirectUri)
+  * Immediately enter Logout flow with optional redirectUri
+  */
+export const logoutViaRedirect = (redirectUri = '') => {
+  window.location.replace(`${appConfig.logoutUrl}?redirect_uri=${redirectUri}`);
+}
+
+/**
+  * logoutInIframe (cb)
   * The timer to delete log in related cookies and call the method to completely log out from Encore
   * and Catalog. It is called by setEncoreLoggedInTimer.
   */
-export const logOutFromEncoreAndCatalogIn = (onload) => {
+export const logoutViaIframe = (onload) => {
   deleteCookie('PAT_LOGGED_IN');
   deleteCookie('VALID_DOMAIN_LAST_VISITED');
   deleteCookie('nyplIdentityPatron');

--- a/test/unit/LogoutLink.test.js
+++ b/test/unit/LogoutLink.test.js
@@ -3,6 +3,7 @@
 import React from 'react';
 import { expect } from 'chai';
 import { mount } from 'enzyme';
+import sinon from 'sinon';
 
 import LogoutLink from './../../src/app/components/LogoutLink/LogoutLink';
 import { PatronProvider } from '../../src/app/context/PatronContext';
@@ -16,6 +17,16 @@ const mountLogoutLink = ({ loggedIn = false, delineate = false }) => mount(
 const logoutLink = `${appConfig.logoutUrl}?redirect_uri=`;
 
 describe('LogoutLink', () => {
+  let sandbox
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
   it('does not render if patron is not logged in', () => {
     const component = mountLogoutLink({ loggedIn : false });
 
@@ -46,30 +57,24 @@ describe('LogoutLink', () => {
   it('links to the logout url with the current location as the redirect param', () => {
     // Try a search results page.
     let currentLocation = 'http://localhost:3001/research/research-catalog/search?q=national%20geographic';
-    Object.defineProperty(window.location, 'href', {
-      writable: true,
-      value: currentLocation
-    });
+    sandbox.stub(window.location, 'href').value(currentLocation);
+
     let component = mountLogoutLink({ loggedIn : true });
 
     expect(component.find('a').prop('href')).to.equal(`${logoutLink}${currentLocation}`);
 
     // Try a bib page.
     currentLocation = 'http://localhost:3001/research/research-catalog/bib/pb5579193';
-    Object.defineProperty(window.location, 'href', {
-      writable: true,
-      value: currentLocation
-    });
+    sandbox.stub(window.location, 'href').value(currentLocation);
+
     component = mountLogoutLink({ loggedIn : true });
 
     expect(component.find('a').prop('href')).to.equal(`${logoutLink}${currentLocation}`);
 
     // Try a SHEP page.
     currentLocation = 'http://localhost:3001/research/research-catalog/subject_headings/74a55648-e93a-4f5f-98fe-1740c4c9c8e8';
-    Object.defineProperty(window.location, 'href', {
-      writable: true,
-      value: currentLocation
-    });
+    sandbox.stub(window.location, 'href').value(currentLocation);
+
     component = mountLogoutLink({ loggedIn : true });
 
     expect(component.find('a').prop('href')).to.equal(`${logoutLink}${currentLocation}`);
@@ -79,27 +84,20 @@ describe('LogoutLink', () => {
     const originUrl = 'http://localhost:3001';
     const homepageUrl = `${originUrl}/research/research-catalog/`;
     // Mock the origin property as localhost.
-    Object.defineProperty(window.location, 'origin', {
-      writable: true,
-      value: originUrl
-    });
+    sandbox.stub(window.location, 'origin').value(originUrl);
 
     // Try a hold page.
     let currentLocation = 'http://localhost:3001/research/research-catalog/hold/request/cb7891544-ci7911509';
-    Object.defineProperty(window.location, 'href', {
-      writable: true,
-      value: currentLocation
-    });
+    sandbox.stub(window.location, 'href').value(currentLocation);
+
     let component = mountLogoutLink({ loggedIn : true });
 
     expect(component.find('a').prop('href')).to.equal(`${logoutLink}${homepageUrl}`);
 
     // Try an account page.
     currentLocation = 'http://localhost:3001/research/research-catalog/account';
-    Object.defineProperty(window.location, 'href', {
-      writable: true,
-      value: currentLocation
-    });
+    sandbox.stub(window.location, 'href').value(currentLocation);
+
     component = mountLogoutLink({ loggedIn : true });
 
     expect(component.find('a').prop('href')).to.equal(`${logoutLink}${homepageUrl}`);


### PR DESCRIPTION
**What's this do?**

Fix broken auto-logout by redirecting directly into the Logout flow instead
of using the hidden iframe, which blocks Vega Logout endpoint, causing the
whole logout to fail.

Also sets default redirect_uri of prod RC Home URL so that noscript users
end up back on RC homepage when logging out instead of Vega (originally part of [this PR](https://github.com/NYPL/discovery-front-end/pull/2138)

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SCC-3966

**Do these changes have automated tests?**
Yes

**How should this be QAed?**
After deployment to QA, verify:
 - patrons can log in
 - patrons can log out
 - when using "Log out", patron is returned to the QA RC page they started on (or home if they started on an Account page)
 - After ~5 mins of inactivity in My Account, timeout modal appears and auto logs the patron out, landing them on the RC home

**Dependencies for merging? Releasing to production?**
No

**Has the application documentation been updated for these changes?**
n/a

**Did someone actually run this code to verify it works?**
I did