### PR TITLE
SCC-3923 - Fix items sorting

### DIFF
--- a/src/app/utils/item.js
+++ b/src/app/utils/item.js
@@ -251,6 +251,7 @@ function LibraryItem() {
       holdingLocationCode: holdingLocation['@id'] || '',
       callNumber,
       url,
+      uri: item.uri,
       requestable,
       suppressed,
       barcode,

--- a/src/app/utils/itemSorter.js
+++ b/src/app/utils/itemSorter.js
@@ -52,7 +52,7 @@ ItemSorter.itemWithSortableShelfMark = (item) => {
   let shelfMarkSort;
   // Order by id if we have no call numbers, but make sure these items
   // go after items with call numbers
-  if (!item.shelfMark || item.shelfMark.length === 0) {
+  if (!item.callNumber || item.callNumber.length === 0) {
     if (item.uri) {
       shelfMarkSort = `b${item.uri}`;
     } else {
@@ -60,7 +60,7 @@ ItemSorter.itemWithSortableShelfMark = (item) => {
     }
   } else {
     // order by call number, put these items first
-    shelfMarkSort = `a${ItemSorter.sortableShelfMark(item.shelfMark[0])}`;
+    shelfMarkSort = `a${ItemSorter.sortableShelfMark(item.callNumber)}`;
   }
 
   return { item, shelfMarkSort };


### PR DESCRIPTION
**What's this do?**
Ticket: https://jira.nypl.org/browse/SCC-3923

This fixes an issue where item sorting is not working correctly in DFE

**Why are we doing this? (w/ JIRA link if applicable)**
We noticed a discrepancy in item sorting in DFE and research catalog and it turns out this is broken in DFE.

The problem was caused by the itemWithSortableShelfMark (which generates the sort string) invoking shelfMark and uri which are not set in the output of mapItems. I replaced shelfMark with callNumber and output the uri attribute to fix the issue.

**Do these changes have automated tests?**
No

**How should this be QAed?**
Item sorting should match that of research-catalog.