### PR TITLE
Add hard redirect when timeout modal times out

### DIFF
--- a/src/app/components/TimedLogoutModal/TimedLogoutModal.jsx
+++ b/src/app/components/TimedLogoutModal/TimedLogoutModal.jsx
@@ -53,6 +53,13 @@ const TimedLogoutModal = (props) => {
 
     minutes = Math.max(parseInt(timeLeft / 60), 0);
     seconds = Math.max(parseInt(timeLeft % 60), 0);
+
+    // Theoretically, accountPageExp should disappear after 5mins, causing
+    // logOutAndRedirect() to be fired above, but let's make sure a failure
+    // there never allows the timer to pass zero:
+    if (timeLeft <= 0) {
+      logOutAndRedirect();
+    }
   }
 
   // Show warning when 2m remaining:

--- a/src/server/ApiRoutes/User.js
+++ b/src/server/ApiRoutes/User.js
@@ -7,6 +7,8 @@ function requireUser(req, res) {
     !req.patronTokenResponse.decodedPatron || !req.patronTokenResponse.decodedPatron.sub) {
     // redirect to login
     const originalUrl = req.originalUrl.replace(new RegExp(`^${appConfig.baseUrl}/api/`), `${appConfig.baseUrl}/`)
+    // TODO: Express 4.x strips the port from req.hostname, inconveniencing
+    // local development. May cautiously retrieve it from headers or local config
     const fullUrl = encodeURIComponent(`${req.protocol}://${req.hostname}${originalUrl}`);
     redirect = `${appConfig.loginUrl}?redirect_uri=${fullUrl}`;
     if (!req.originalUrl.includes('/api/')) {


### PR DESCRIPTION
**What's this do?**
Fixes bug: The timeout modal depends on `accountPageExp` disappearing. If it does not (prob due to dupe cross-domain cookies, some created incorrectly), modal may hit zero and linger. This changes the timeout to hard logout if the timer hits zero.

**Why are we doing this? (w/ JIRA link if applicable)**
Additional QA from https://jira.nypl.org/browse/SCC-3966

**Do these changes have automated tests?**
No

**How should this be QAed?**
Test auto logout in QA

**Dependencies for merging? Releasing to production?**
No

**Has the application documentation been updated for these changes?**

**Did someone actually run this code to verify it works?**
✋