### PR TITLE
SCC-4062 - Update vega paths in anticipation of move to borrow.nypl.org

### DIFF
--- a/src/app/utils/accountPageUtils.js
+++ b/src/app/utils/accountPageUtils.js
@@ -39,7 +39,7 @@ export const defaultHtml = '<div> Unable to load your account information. ' +
   'Please try again after a few minutes. ' +
   'You can also view your account in our <a href="' +
   appConfig.circulatingCatalog +
-  '/iii/encore/myaccount" > Circulating Catalog</a></div>'
+  '/?openAccount=checkouts" > Circulating Catalog</a></div>'
 
 export const preprocessAccountHtml = (html) => {
   try {

--- a/src/server/ApiRoutes/Bib.js
+++ b/src/server/ApiRoutes/Bib.js
@@ -95,7 +95,7 @@ function fetchBib(bibId, cb, errorcb, reqOptions, res) {
           .then(client => client.get(`/bibs/sierra-nypl/${bibId.slice(1)}`))
           .then((resp) => {
             const classic = appConfig.legacyBaseUrl;
-            if (resp.statusCode === 200) { res.redirect(`${appConfig.circulatingCatalog}/iii/encore/record/C__R${bibId}`); }
+            if (resp.statusCode === 200) { res.redirect(`${appConfig.circulatingCatalog}/search/card?recordId=${bibId.replace(/^b/, "")}`); }
           })
           .catch((err) => {
             console.log('error: ', err);


### PR DESCRIPTION
**What's this do?**
This PR updates the paths of links to vega urls to match their equivalents on borrow.nypl.org.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SCC-4062

Although the domain itself is in an environment variable, the paths following the domain are different.
