### PR TITLE
remove search bar and test

### DIFF
--- a/src/app/pages/AccountPage.jsx
+++ b/src/app/pages/AccountPage.jsx
@@ -22,9 +22,6 @@ import {
   basicQuery,
   ajaxCall,
 } from '../utils/utils';
-import {
-  setCookieWithExpiration,
-} from '../utils/cookieUtils';
 
 const AccountPage = (props, context) => {
   const { patron, accountHtml, appConfig } = useSelector(state => ({
@@ -67,8 +64,8 @@ const AccountPage = (props, context) => {
       if (currentCount > 3) {
         ajaxCall(
           `${baseUrl}/api/accountError?type=redirect_loop&page=${encodeURI(window.location.href)}`,
-          () => {},
-          () => {},
+          () => { },
+          () => { },
         );
         window.location.replace(`${baseUrl}/accountError`);
         return true;
@@ -160,15 +157,6 @@ const AccountPage = (props, context) => {
       activeSection="account"
       pageTitle="Account"
     >
-      <div className="content-header research-search">
-        <div className="research-search__inner-content">
-          <Search
-            router={context.router}
-            createAPIQuery={basicQuery()}
-          />
-          <EDSLink />
-        </div>
-      </div>
       <div className="nypl-patron-page">
         <Heading
           level="two"

--- a/test/unit/AccountPage.test.js
+++ b/test/unit/AccountPage.test.js
@@ -18,7 +18,7 @@ describe('AccountPage', () => {
     // the test from ever terminating.
     // This disables the clock.
     sandbox = sinon.createSandbox();
-    sandbox.stub(global, 'setTimeout').callsFake(() => {});
+    sandbox.stub(global, 'setTimeout').callsFake(() => { });
   });
 
   after(() => {
@@ -32,10 +32,6 @@ describe('AccountPage', () => {
     before(() => {
       mockStore = makeTestStore({});
       component = mountTestRender(<AccountPage params={{}} />, { store: mockStore });
-    });
-
-    it('should render a `Search` component', () => {
-      expect(component.find('Search').length).to.equal(1);
     });
 
     it('should render a <div> with class .nypl-patron-page', () => {
@@ -147,7 +143,7 @@ describe('AccountPage', () => {
       let clock;
       before(() => {
         clock = sinon.useFakeTimers();
-        replaceSpy = sandbox.stub(window.location, 'replace').callsFake(() => {});
+        replaceSpy = sandbox.stub(window.location, 'replace').callsFake(() => { });
         const mockStore = makeTestStore({ accountHtml: { error: true } });
         document.cookie = 'nyplAccountRedirectTracker=25expMon, 05 Apr 2021 20:06:13 GMT';
         component = mountTestRender(<AccountPage params={{}} />, { store: mockStore });


### PR DESCRIPTION
**What's this do?**
Remove Search Bar from my account page

**Why are we doing this? (w/ JIRA link if applicable)**
2ad doesn't handle the client side routing of DFE out of the box. Instead of implementing a similar check for reverse proxy like the RC Links are using, we opted to remove the Search Bar. This is largely because the new My Account designs don't include this search bar anyway, and complications down the line with enhanced browse.

**Do these changes have automated tests?**
[Brief description of new automated tests]

**How should this be QAed?**
[Description of any tests that need to be performed once merged]

**Dependencies for merging? Releasing to production?**
[Description of any watchouts, dependencies, or issues we should be aware of]

**Has the application documentation been updated for these changes?**

**Did someone actually run this code to verify it works?**
