### PR TITLE
SCC-4184  - Pass reverse proxy enabled prop to MyAccount links in SubNav

### DIFF
--- a/src/app/components/SubNav/SubNav.jsx
+++ b/src/app/components/SubNav/SubNav.jsx
@@ -59,6 +59,7 @@ const SubNav = (props) => {
               <SubNavLink
                 type="account"
                 href={`${baseUrl}/account`}
+                reverseProxyEnabled={reverseProxyEnabled}
                 {...props}
               >
                 My Account


### PR DESCRIPTION
**What's this do?**
Ticket in Jira: [SCC-4184](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4184)

**Why are we doing this? (w/ JIRA link if applicable)**
The links in the subnav default to React router links, which don't hit the reverse proxy.

We already added the infrastructure to use generic links for DFE links that should route to the new app when we released the Search pages, so this simply passes the correct prop to the MyAccount link to get those to work in the same way.

**How should this be QAed?**
Ensure that links to the MyAccount links in the Subnav on DFE pages (SHEP and hold pages) go to Next app.

[SCC-4184]: https://newyorkpubliclibrary.atlassian.net/browse/SCC-4184?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ