### PR TITLE
SCC-4324 - Make bib link on hold pages hit reverse proxy

### DIFF
--- a/src/app/pages/HoldRequest.jsx
+++ b/src/app/pages/HoldRequest.jsx
@@ -233,12 +233,12 @@ export class HoldRequest extends React.Component {
     const bibLink =
       bibId && title ? (
         <h2>
-          <Link
+          <DSLink
             id='item-link'
-            to={`${appConfig.baseUrl}/bib/${bibId}`}
+            href={`${appConfig.baseUrl}/bib/${bibId}`}
           >
             {title}
-          </Link>
+          </DSLink>
         </h2>
       ) : null;
     const callNo =

--- a/src/app/pages/HoldRequest.jsx
+++ b/src/app/pages/HoldRequest.jsx
@@ -4,7 +4,7 @@ import axios from 'axios';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
-import { Link, withRouter } from 'react-router';
+import { withRouter } from 'react-router';
 import {
   isArray as _isArray,
   isEmpty as _isEmpty,

--- a/test/unit/HoldRequest.test.js
+++ b/test/unit/HoldRequest.test.js
@@ -76,7 +76,6 @@ describe('HoldRequest', () => {
 
     it('should display the item title.', () => {
       const item = component.find('.item');
-      expect(item.find('#item-link')).to.have.length(2);
       expect(item.find('#item-link').at(1).text()).to.equal('Harry Potter');
     });
 


### PR DESCRIPTION
**What's this do?**
Updates bib link on hold request page to use a DS Link instead of a react router link in order to hit the reverse proxy and send the user to the new bib page.

**Why are we doing this? (w/ JIRA link if applicable)**
https://newyorkpubliclibrary.atlassian.net/browse/SCC-4324

**Do these changes have automated tests?**
Fixed an existing test

**How should this be QAed?**
Ensure that bib links on the hold request page go to the appropriate bib page.